### PR TITLE
fix(bench): preserve sanitized Fly build diagnostics

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -175,6 +175,13 @@ requires empty Machine, volume, and secret inventories; afterwards it requires
 the app absent and leaves a cleared ledger. The logged-in `flyctl` credential
 is used directly: the executor creates no secret or temporary token material.
 
+Remote-build failures emit only a closed provider cause code: billing
+unavailable, remote builder unavailable, invalid build configuration,
+Dockerfile/build-step failure, timeout, or unknown. Provider output is inspected
+only through a bounded in-memory window and is never copied into the result;
+unknown or sensitive text collapses to `provider_build_unknown`. The build
+image's Rust major/minor version is kept in parity with `rust-toolchain.toml`.
+
 The tiny smoke records phase peak RSS but authorizes no scale run. Its
 `performance-1x` selection is not an S18 sizing result. Subsequent ladder
 Machines must use same-phase RSS plateau evidence and measured headroom;

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -433,7 +433,7 @@ def classify_provider_build_failure(error: BaseException) -> str:
             fragments.append(value[:8_192])
     text = "\n".join(fragments).lower()
     patterns = (
-        ("provider_billing_unavailable", ("payment method", "payment required", "billing")),
+        ("provider_billing_unavailable", ("payment method", "payment required")),
         (
             "provider_remote_builder_unavailable",
             (

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -14,6 +14,7 @@ import json
 from pathlib import Path, PurePosixPath
 import re
 import shlex
+import subprocess
 from typing import Any
 
 
@@ -56,6 +57,16 @@ FAILURE_TYPES = frozenset(
         "teardown_failed",
         "inventory_not_empty",
         "qualification_failed",
+    }
+)
+PROVIDER_BUILD_CAUSES = frozenset(
+    {
+        "provider_billing_unavailable",
+        "provider_remote_builder_unavailable",
+        "provider_build_config_invalid",
+        "provider_dockerfile_failed",
+        "provider_build_timeout",
+        "provider_build_unknown",
     }
 )
 
@@ -407,12 +418,57 @@ def verify_empty_inventory(*, machines: Any, volumes: Any, secrets: Any, app_exi
     _refuse(app_exists, "provider inventory is not empty")
 
 
-def sanitized_failure(failure: str) -> dict[str, Any]:
+def classify_provider_build_failure(error: BaseException) -> str:
+    """Map bounded provider output to a closed code without returning raw text."""
+    if isinstance(error, (TimeoutError, subprocess.TimeoutExpired)):
+        return "provider_build_timeout"
+    fragments: list[str] = []
+    for raw_value in (getattr(error, "stdout", None), getattr(error, "stderr", None)):
+        value = (
+            raw_value[:8_192].decode("utf-8", errors="replace")
+            if isinstance(raw_value, bytes)
+            else raw_value
+        )
+        if isinstance(value, str):
+            fragments.append(value[:8_192])
+    text = "\n".join(fragments).lower()
+    patterns = (
+        ("provider_billing_unavailable", ("payment method", "payment required", "billing")),
+        (
+            "provider_remote_builder_unavailable",
+            (
+                "remote builder unavailable",
+                "failed to connect to remote builder",
+                "depot unavailable",
+            ),
+        ),
+        (
+            "provider_build_config_invalid",
+            ("configuration is invalid", "invalid fly.toml", "could not find fly.toml"),
+        ),
+        (
+            "provider_dockerfile_failed",
+            ("dockerfile parse error", "failed to solve", "did not complete successfully"),
+        ),
+    )
+    for cause, markers in patterns:
+        if any(marker in text for marker in markers):
+            return cause
+    return "provider_build_unknown"
+
+
+def sanitized_failure(failure: str, *, cause: str | None = None) -> dict[str, Any]:
     _refuse(failure not in FAILURE_TYPES, "failure type is invalid")
+    if failure == "build_failed":
+        cause = cause or "provider_build_unknown"
+        _refuse(cause not in PROVIDER_BUILD_CAUSES, "provider build cause is invalid")
+    else:
+        _refuse(cause is not None, "provider build cause is invalid")
     return {
-        "schema": "graphforge-fly-adapter-result/1",
+        "schema": "graphforge-fly-adapter-result/2",
         "status": "failed",
         "failure": failure,
+        "cause": cause,
     }
 
 

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -26,6 +26,7 @@ import urllib.request
 from graphforge_bench.fly_adapter import (
     AdapterError,
     ResourceLedger,
+    classify_provider_build_failure,
     pin_remote_image,
     remote_build_command,
     sanitized_failure,
@@ -58,9 +59,10 @@ TEARDOWN_POLL_INTERVAL_SECONDS = 2
 class QualificationError(RuntimeError):
     """A typed, sanitized terminal failure."""
 
-    def __init__(self, failure: str, message: str):
+    def __init__(self, failure: str, message: str, *, cause: str | None = None):
         super().__init__(message)
         self.failure = failure
+        self.cause = cause
 
 
 class Transport(Protocol):
@@ -813,7 +815,14 @@ def execute(
             dockerfile=DOCKERFILE,
             commit=invocation.commit,
         )
-        transport.run(build.argv, timeout=BUILD_TIMEOUT_SECONDS)
+        try:
+            transport.run(build.argv, timeout=BUILD_TIMEOUT_SECONDS)
+        except (subprocess.SubprocessError, OSError) as error:
+            raise QualificationError(
+                "build_failed",
+                "remote provider build failed",
+                cause=classify_provider_build_failure(error),
+            ) from None
         image = transport.resolve_image(
             invocation.app, invocation.commit, timeout=CREATE_TIMEOUT_SECONDS
         )
@@ -895,11 +904,12 @@ def execute(
             failure = cleanup_error
 
     if failure is not None:
-        return sanitized_failure(failure.failure)
+        return sanitized_failure(failure.failure, cause=failure.cause)
     return {
-        "schema": "graphforge-fly-adapter-result/1",
+        "schema": "graphforge-fly-adapter-result/2",
         "status": "passed",
         "failure": None,
+        "cause": None,
     }
 
 

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from pathlib import Path
 import shlex
+import subprocess
 import tempfile
 import unittest
 
@@ -13,6 +14,7 @@ from graphforge_bench.fly_adapter import (
     LifecycleInvocation,
     ResourceLedger,
     accepted_rung_reclamation,
+    classify_provider_build_failure,
     cleanup_commands,
     inventory_commands,
     pin_remote_image,
@@ -197,14 +199,40 @@ class FlyAdapterTests(unittest.TestCase):
         self.assertEqual(
             value,
             {
-                "schema": "graphforge-fly-adapter-result/1",
+                "schema": "graphforge-fly-adapter-result/2",
                 "status": "failed",
                 "failure": "lifecycle_failed",
+                "cause": None,
             },
         )
         self.assertNotIn("id", json.dumps(value))
         with self.assertRaisesRegex(AdapterError, "failure type"):
             sanitized_failure("provider said machine-123 failed")
+
+    def test_provider_build_diagnostics_map_only_to_closed_codes(self) -> None:
+        cases = {
+            "payment method is required": "provider_billing_unavailable",
+            "remote builder unavailable": "provider_remote_builder_unavailable",
+            "configuration is invalid": "provider_build_config_invalid",
+            "failed to solve: process did not complete successfully": "provider_dockerfile_failed",
+        }
+        for stderr, expected in cases.items():
+            with self.subTest(stderr=stderr):
+                error = subprocess.CalledProcessError(1, ("flyctl", "deploy"), stderr=stderr)
+                self.assertEqual(classify_provider_build_failure(error), expected)
+        timeout = subprocess.TimeoutExpired(("flyctl", "deploy"), 30)
+        self.assertEqual(classify_provider_build_failure(timeout), "provider_build_timeout")
+
+        sensitive = (
+            "unknown failure token=secret Bearer auth@example.com "
+            "https://provider.invalid/apps/gf-private /Users/private vol_abc123 1234abcd567890"
+        )
+        error = subprocess.CalledProcessError(1, ("flyctl", "deploy"), stderr=sensitive)
+        value = sanitized_failure("build_failed", cause=classify_provider_build_failure(error))
+        self.assertEqual(value["cause"], "provider_build_unknown")
+        encoded = json.dumps(value)
+        for leaked in ("secret", "Bearer", "example.com", "gf-private", "vol_", "/Users"):
+            self.assertNotIn(leaked, encoded)
 
     def test_profile_digest_is_verified_from_repository(self) -> None:
         root = Path(__file__).resolve().parents[2]

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -222,6 +222,14 @@ class FlyAdapterTests(unittest.TestCase):
                 self.assertEqual(classify_provider_build_failure(error), expected)
         timeout = subprocess.TimeoutExpired(("flyctl", "deploy"), 30)
         self.assertEqual(classify_provider_build_failure(timeout), "provider_build_timeout")
+        unrelated_billing = subprocess.CalledProcessError(
+            1,
+            ("flyctl", "deploy"),
+            stderr="compiler error: unresolved import billing::invoice",
+        )
+        self.assertEqual(
+            classify_provider_build_failure(unrelated_billing), "provider_build_unknown"
+        )
 
         sensitive = (
             "unknown failure token=secret Bearer auth@example.com "

--- a/benchmarks/tests/test_fly_tiny_qualification.py
+++ b/benchmarks/tests/test_fly_tiny_qualification.py
@@ -265,6 +265,16 @@ class FlyTinyQualificationTests(unittest.TestCase):
         self.assertNotIn("services", config)
         self.assertNotIn("http_service", config)
 
+    def test_docker_builder_matches_checked_in_rust_toolchain(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        toolchain = tomllib.loads((root / "rust-toolchain.toml").read_text(encoding="utf-8"))
+        channel = toolchain["toolchain"]["channel"]
+        major_minor = ".".join(channel.split(".")[:2])
+        dockerfile = (
+            root / "containers" / "fly-filesystem-qualification" / "Dockerfile"
+        ).read_text(encoding="utf-8")
+        self.assertIn(f"FROM rust:{major_minor}-bookworm AS build", dockerfile)
+
     @patch("graphforge_bench.fly_tiny_qualification.check_source")
     def test_success_persists_ledger_retrieves_only_evidence_and_tears_down(
         self, check_source: object
@@ -311,6 +321,8 @@ class FlyTinyQualificationTests(unittest.TestCase):
                 dry_run=False,
             )
             self.assertEqual(result["failure"], "build_failed")
+            self.assertEqual(result["cause"], "provider_build_unknown")
+            self.assertEqual(result["schema"], "graphforge-fly-adapter-result/2")
             deploy = next(
                 command for command in transport.commands if command[:2] == ("flyctl", "deploy")
             )

--- a/containers/fly-filesystem-qualification/Dockerfile
+++ b/containers/fly-filesystem-qualification/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.90-bookworm AS build
+FROM rust:1.96-bookworm AS build
 WORKDIR /source
 COPY . .
 RUN cargo build --locked --release -p graphforge-api --bin graphforge-fly-filesystem-smoke


### PR DESCRIPTION
## Summary
- preserve a bounded, fail-closed diagnostic for Fly remote-build failures using closed cause codes only
- keep raw provider output, tokens, identities, resource names, paths, and URLs out of persisted evidence
- align the tiny qualification image builder with the repository-pinned Rust toolchain

## Validation
- Ruff format and lint on changed Python files
- make -C benchmarks fly-adapter-static (31 tests)
- make -C benchmarks smoke-python (85 tests plus smoke)
- Python Fly filesystem safety-contract checks
- git diff hygiene

## Scope
Focused follow-up for issue 958. This PR intentionally does not close the issue; live tiny qualification and teardown evidence remain outstanding after merge. No Fly resources were created by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790659699&installation_model_id=20486&pr_number=1002&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1002&signature=5443dd65ef91e9b485dac793e7603469bd2411640f9df0c3a06e77391429bff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build-failure reporting with consistent, sanitized cause classifications.
  - Added timeout detection and protected sensitive provider error details from result output.
  - Updated qualification results to include a cause field for clearer diagnostics.

- **Compatibility**
  - Results now use schema version 2.

- **Maintenance**
  - Updated the qualification environment to Rust 1.96 for alignment with the configured toolchain.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->