### PR TITLE
build(bench): add hosted Fly qualification path

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -147,6 +147,17 @@ journal. Provider, SKU, runner registration, cost approval, and teardown remain
 explicit maintainer decisions; see the
 [certification runbook](../../docs/development/g500-certification.md).
 
+### `fly-tiny-qualification.yml` — Disposable Fly environment smoke
+
+This protected manual workflow checks out the exact current `main` commit and
+runs the non-ladder #958 qualification on a Blacksmith Linux runner. It builds
+the commit-pinned image with hosted Docker, pushes it to the disposable app's
+Fly registry path, resolves the immutable digest, runs only the 10 GiB
+`performance-1x` filesystem smoke, and independently verifies teardown. A
+separate always-on recovery step handles interrupted executions. The workflow
+uploads only one-day sanitized plan/result documents and qualified evidence;
+the ownership ledger and provider resource identifiers are never uploaded.
+
 ### CodeRabbit
 
 CodeRabbit automatic review is disabled to preserve its limited quota. After

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -154,9 +154,21 @@ runs the non-ladder #958 qualification on a Blacksmith Linux runner. It builds
 the commit-pinned image with hosted Docker, pushes it to the disposable app's
 Fly registry path, resolves the immutable digest, runs only the 10 GiB
 `performance-1x` filesystem smoke, and independently verifies teardown. A
-separate always-on recovery step handles interrupted executions. The workflow
-uploads only one-day sanitized plan/result documents and qualified evidence;
-the ownership ledger and provider resource identifiers are never uploaded.
+separate recovery job has its own timeout budget after execution, and
+`fly-tiny-recovery.yml` provides receipt-bound manual orphan cleanup. The
+workflow uploads a one-day pre-creation ownership receipt plus sanitized
+plan/result documents and qualified evidence. The receipt binds the commit to
+a fresh 128-bit app-name nonce and never contains provider resource identifiers
+or credentials.
+
+### `fly-tiny-recovery.yml` — Manual Fly orphan recovery
+
+This protected manual janitor downloads the one-day ownership receipt from a
+specified qualification run and refuses deletion unless its exact nonce-bound
+app and commit match. It runs the trusted controller from current `main` and
+shares the qualification concurrency lock, so it cannot race the source run.
+It exists for runner loss, workflow cancellation, or a failed independent
+recovery job; it cannot infer ownership from an app prefix.
 
 ### CodeRabbit
 

--- a/.github/workflows/fly-tiny-qualification.yml
+++ b/.github/workflows/fly-tiny-qualification.yml
@@ -1,0 +1,155 @@
+name: Fly tiny qualification
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Exact current main commit to qualify
+        required: true
+        type: string
+      organization:
+        description: Fly organization slug
+        required: true
+        default: personal
+        type: string
+      region:
+        description: Fixed admitted Fly region
+        required: true
+        default: dfw
+        type: string
+      confirm_disposable:
+        description: Authorize one tiny app, 10 GiB volume, and performance-1x Machine
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fly-tiny-qualification
+  cancel-in-progress: false
+
+jobs:
+  qualify:
+    name: Hosted image and tiny Fly smoke
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: scale-certification
+    timeout-minutes: 75
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      COMMIT_SHA: ${{ inputs.commit_sha }}
+      FLY_ORGANIZATION: ${{ inputs.organization }}
+      FLY_REGION: ${{ inputs.region }}
+      APP_NAME: gf-q958-${{ github.run_id }}-${{ github.run_attempt }}
+      VOLUME_NAME: gf_q958_${{ github.run_id }}_${{ github.run_attempt }}
+      MACHINE_NAME: gf-q958-machine-${{ github.run_id }}
+    steps:
+      - name: Require explicit authorization and credential
+        env:
+          CONFIRMED: ${{ inputs.confirm_disposable }}
+        run: |
+          test "$CONFIRMED" = true
+          test -n "$FLY_API_TOKEN"
+          case "$COMMIT_SHA" in
+            (????????????????????????????????????????) ;;
+            (*) exit 2 ;;
+          esac
+          case "$COMMIT_SHA" in (*[!0-9a-f]*) exit 2 ;; esac
+
+      - name: Checkout exact commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
+
+      - name: Require exact current main
+        run: |
+          test "$(git rev-parse HEAD)" = "$COMMIT_SHA"
+          git fetch --no-tags --depth=1 origin main
+          test "$(git rev-parse FETCH_HEAD)" = "$COMMIT_SHA"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.10.9"
+          enable-cache: false
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
+
+      - name: Install locked benchmark environment
+        working-directory: benchmarks
+        run: uv sync --locked
+
+      - name: Run no-spend admission
+        run: >-
+          PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m
+          graphforge_bench.fly_tiny_qualification
+          --expected-sha "$COMMIT_SHA"
+          --org "$FLY_ORGANIZATION"
+          --app "$APP_NAME"
+          --region "$FLY_REGION"
+          --volume-name "$VOLUME_NAME"
+          --machine-name "$MACHINE_NAME"
+          --prerequisite-955 merged
+          --prerequisite-956 merged
+          --prerequisite-957 merged
+          --build-authority hosted-docker
+          --ledger "$RUNNER_TEMP/fly-q958-ledger.json"
+          --evidence-out "$RUNNER_TEMP/fly-q958-evidence.json"
+          --result-out "$RUNNER_TEMP/fly-q958-plan.json"
+
+      - name: Execute one tiny qualification
+        run: >-
+          PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m
+          graphforge_bench.fly_tiny_qualification
+          --expected-sha "$COMMIT_SHA"
+          --org "$FLY_ORGANIZATION"
+          --app "$APP_NAME"
+          --region "$FLY_REGION"
+          --volume-name "$VOLUME_NAME"
+          --machine-name "$MACHINE_NAME"
+          --prerequisite-955 merged
+          --prerequisite-956 merged
+          --prerequisite-957 merged
+          --build-authority hosted-docker
+          --ledger "$RUNNER_TEMP/fly-q958-ledger.json"
+          --evidence-out "$RUNNER_TEMP/fly-q958-evidence.json"
+          --result-out "$RUNNER_TEMP/fly-q958-result.json"
+          --execute
+          --confirm-disposable
+
+      - name: Recover and verify teardown
+        if: always()
+        run: >-
+          PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m
+          graphforge_bench.fly_tiny_qualification
+          --expected-sha "$COMMIT_SHA"
+          --org "$FLY_ORGANIZATION"
+          --app "$APP_NAME"
+          --region "$FLY_REGION"
+          --volume-name "$VOLUME_NAME"
+          --machine-name "$MACHINE_NAME"
+          --prerequisite-955 merged
+          --prerequisite-956 merged
+          --prerequisite-957 merged
+          --build-authority hosted-docker
+          --ledger "$RUNNER_TEMP/fly-q958-ledger.json"
+          --evidence-out "$RUNNER_TEMP/fly-q958-evidence.json"
+          --result-out "$RUNNER_TEMP/fly-q958-cleanup-result.json"
+          --cleanup-only
+          --confirm-disposable
+
+      - name: Upload sanitized result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fly-tiny-result-${{ inputs.commit_sha }}
+          path: |
+            ${{ runner.temp }}/fly-q958-plan.json
+            ${{ runner.temp }}/fly-q958-result.json
+            ${{ runner.temp }}/fly-q958-cleanup-result.json
+            ${{ runner.temp }}/fly-q958-evidence.json
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/fly-tiny-qualification.yml
+++ b/.github/workflows/fly-tiny-qualification.yml
@@ -30,24 +30,27 @@ concurrency:
   group: fly-tiny-qualification
   cancel-in-progress: false
 
+env:
+  COMMIT_SHA: ${{ inputs.commit_sha }}
+  FLY_ORGANIZATION: ${{ inputs.organization }}
+  FLY_REGION: ${{ inputs.region }}
+  PREFLIGHT_ARTIFACT: fly-tiny-preflight-${{ github.run_id }}-${{ github.run_attempt }}
+
 jobs:
-  qualify:
-    name: Hosted image and tiny Fly smoke
+  prepare:
+    name: Admit and persist cleanup ownership
+    outputs:
+      app_name: ${{ steps.identity.outputs.app_name }}
+      machine_name: ${{ steps.identity.outputs.machine_name }}
+      volume_name: ${{ steps.identity.outputs.volume_name }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: scale-certification
-    timeout-minutes: 75
-    env:
-      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      COMMIT_SHA: ${{ inputs.commit_sha }}
-      FLY_ORGANIZATION: ${{ inputs.organization }}
-      FLY_REGION: ${{ inputs.region }}
-      APP_NAME: gf-q958-${{ github.run_id }}-${{ github.run_attempt }}
-      VOLUME_NAME: gf_q958_${{ github.run_id }}_${{ github.run_attempt }}
-      MACHINE_NAME: gf-q958-machine-${{ github.run_id }}
+    timeout-minutes: 20
     steps:
       - name: Require explicit authorization and credential
         env:
           CONFIRMED: ${{ inputs.confirm_disposable }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           test "$CONFIRMED" = true
           test -n "$FLY_API_TOKEN"
@@ -82,7 +85,27 @@ jobs:
         working-directory: benchmarks
         run: uv sync --locked
 
+      - name: Create collision-resistant disposable identity
+        id: identity
+        run: |
+          python - "$GITHUB_OUTPUT" <<'PY'
+          from pathlib import Path
+          import secrets
+          import sys
+
+          nonce = secrets.token_hex(16)
+          with Path(sys.argv[1]).open("a", encoding="utf-8") as output:
+              output.write(f"app_name=gf-q958-{nonce}\n")
+              output.write(f"volume_name=gfq958_{nonce[:20]}\n")
+              output.write(f"machine_name=gf-q958-machine-{nonce[:16]}\n")
+          PY
+
       - name: Run no-spend admission
+        env:
+          APP_NAME: ${{ steps.identity.outputs.app_name }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          MACHINE_NAME: ${{ steps.identity.outputs.machine_name }}
+          VOLUME_NAME: ${{ steps.identity.outputs.volume_name }}
         run: >-
           PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m
           graphforge_bench.fly_tiny_qualification
@@ -100,28 +123,137 @@ jobs:
           --evidence-out "$RUNNER_TEMP/fly-q958-evidence.json"
           --result-out "$RUNNER_TEMP/fly-q958-plan.json"
 
+      - name: Persist pre-creation ownership receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.PREFLIGHT_ARTIFACT }}
+          path: |
+            ${{ runner.temp }}/fly-q958-ledger.json
+            ${{ runner.temp }}/fly-q958-plan.json
+          if-no-files-found: error
+          retention-days: 1
+
+  execute:
+    name: Hosted image and tiny Fly smoke
+    needs: prepare
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: scale-certification
+    timeout-minutes: 55
+    env:
+      APP_NAME: ${{ needs.prepare.outputs.app_name }}
+      MACHINE_NAME: ${{ needs.prepare.outputs.machine_name }}
+      VOLUME_NAME: ${{ needs.prepare.outputs.volume_name }}
+    steps:
+      - name: Checkout exact commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.10.9"
+          enable-cache: false
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
+
+      - name: Install locked benchmark environment
+        working-directory: benchmarks
+        run: uv sync --locked
+
+      - name: Restore pre-creation ownership receipt
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PREFLIGHT_ARTIFACT }}
+          path: ${{ runner.temp }}
+
       - name: Execute one tiny qualification
-        run: >-
-          PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m
-          graphforge_bench.fly_tiny_qualification
-          --expected-sha "$COMMIT_SHA"
-          --org "$FLY_ORGANIZATION"
-          --app "$APP_NAME"
-          --region "$FLY_REGION"
-          --volume-name "$VOLUME_NAME"
-          --machine-name "$MACHINE_NAME"
-          --prerequisite-955 merged
-          --prerequisite-956 merged
-          --prerequisite-957 merged
-          --build-authority hosted-docker
-          --ledger "$RUNNER_TEMP/fly-q958-ledger.json"
-          --evidence-out "$RUNNER_TEMP/fly-q958-evidence.json"
-          --result-out "$RUNNER_TEMP/fly-q958-result.json"
-          --execute
-          --confirm-disposable
+        timeout-minutes: 50
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          DOCKER_CONFIG: ${{ runner.temp }}/fly-q958-docker
+        run: |
+          git fetch --no-tags --depth=1 origin main
+          test "$(git rev-parse HEAD)" = "$COMMIT_SHA"
+          test "$(git rev-parse FETCH_HEAD)" = "$COMMIT_SHA"
+          mkdir -p "$DOCKER_CONFIG"
+          PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m \
+            graphforge_bench.fly_tiny_qualification \
+            --expected-sha "$COMMIT_SHA" \
+            --org "$FLY_ORGANIZATION" \
+            --app "$APP_NAME" \
+            --region "$FLY_REGION" \
+            --volume-name "$VOLUME_NAME" \
+            --machine-name "$MACHINE_NAME" \
+            --prerequisite-955 merged \
+            --prerequisite-956 merged \
+            --prerequisite-957 merged \
+            --build-authority hosted-docker \
+            --ledger "$RUNNER_TEMP/fly-q958-ledger.json" \
+            --evidence-out "$RUNNER_TEMP/fly-q958-evidence.json" \
+            --result-out "$RUNNER_TEMP/fly-q958-result.json" \
+            --execute \
+            --confirm-disposable
+
+      - name: Remove temporary Docker credentials
+        if: always()
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/fly-q958-docker
+        run: rm -rf -- "$DOCKER_CONFIG"
+
+      - name: Upload sanitized execution result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fly-tiny-execution-${{ inputs.commit_sha }}
+          path: |
+            ${{ runner.temp }}/fly-q958-result.json
+            ${{ runner.temp }}/fly-q958-evidence.json
+          if-no-files-found: error
+          retention-days: 1
+
+  recover:
+    name: Independent orphan recovery
+    if: ${{ always() && needs.prepare.result == 'success' }}
+    needs: [prepare, execute]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: scale-certification
+    timeout-minutes: 30
+    env:
+      APP_NAME: ${{ needs.prepare.outputs.app_name }}
+      MACHINE_NAME: ${{ needs.prepare.outputs.machine_name }}
+      VOLUME_NAME: ${{ needs.prepare.outputs.volume_name }}
+    steps:
+      - name: Checkout exact commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.10.9"
+          enable-cache: false
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
+
+      - name: Install locked benchmark environment
+        working-directory: benchmarks
+        run: uv sync --locked
+
+      - name: Restore pre-creation ownership receipt
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PREFLIGHT_ARTIFACT }}
+          path: ${{ runner.temp }}
 
       - name: Recover and verify teardown
-        if: always()
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: >-
           PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m
           graphforge_bench.fly_tiny_qualification
@@ -141,15 +273,11 @@ jobs:
           --cleanup-only
           --confirm-disposable
 
-      - name: Upload sanitized result
+      - name: Upload sanitized cleanup result
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: fly-tiny-result-${{ inputs.commit_sha }}
-          path: |
-            ${{ runner.temp }}/fly-q958-plan.json
-            ${{ runner.temp }}/fly-q958-result.json
-            ${{ runner.temp }}/fly-q958-cleanup-result.json
-            ${{ runner.temp }}/fly-q958-evidence.json
+          name: fly-tiny-cleanup-${{ inputs.commit_sha }}
+          path: ${{ runner.temp }}/fly-q958-cleanup-result.json
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/fly-tiny-recovery.yml
+++ b/.github/workflows/fly-tiny-recovery.yml
@@ -1,0 +1,140 @@
+name: Fly tiny orphan recovery
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Qualification workflow run ID that owns the app
+        required: true
+        type: string
+      source_run_attempt:
+        description: Qualification workflow run attempt
+        required: true
+        default: "1"
+        type: string
+      organization:
+        description: Fly organization slug used by the qualification run
+        required: true
+        default: personal
+        type: string
+      region:
+        description: Fly region used by the qualification run
+        required: true
+        default: dfw
+        type: string
+      confirm_recovery:
+        description: Authorize cleanup of the receipt-bound disposable app
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: fly-tiny-qualification
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    name: Receipt-bound manual recovery
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: scale-certification
+    timeout-minutes: 30
+    env:
+      FLY_ORGANIZATION: ${{ inputs.organization }}
+      FLY_REGION: ${{ inputs.region }}
+      PREFLIGHT_ARTIFACT: fly-tiny-preflight-${{ inputs.source_run_id }}-${{ inputs.source_run_attempt }}
+    steps:
+      - name: Require explicit recovery authorization
+        env:
+          CONFIRMED: ${{ inputs.confirm_recovery }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
+        run: |
+          test "$CONFIRMED" = true
+          test -n "$FLY_API_TOKEN"
+          case "$SOURCE_RUN_ID:$SOURCE_RUN_ATTEMPT" in (*[!0-9:]*) exit 2 ;; esac
+
+      - name: Checkout trusted recovery controller
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.10.9"
+          enable-cache: false
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
+
+      - name: Install locked benchmark environment
+        working-directory: benchmarks
+        run: uv sync --locked
+
+      - name: Restore durable ownership receipt
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PREFLIGHT_ARTIFACT }}
+          path: ${{ runner.temp }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Read validated receipt identity
+        id: identity
+        run: |
+          PYTHONPATH=benchmarks/harness python - \
+            "$RUNNER_TEMP/fly-q958-ledger.json" "$GITHUB_OUTPUT" <<'PY'
+          from pathlib import Path
+          import sys
+
+          from graphforge_bench.fly_adapter import ResourceLedger
+
+          ledger = ResourceLedger.load(Path(sys.argv[1]))
+          if ledger.owner_app is None or ledger.owner_commit is None:
+              raise SystemExit("ownership receipt is already consumed")
+          with Path(sys.argv[2]).open("a", encoding="utf-8") as output:
+              output.write(f"app_name={ledger.owner_app}\n")
+              output.write(f"commit_sha={ledger.owner_commit}\n")
+          PY
+
+      - name: Recover and verify teardown
+        env:
+          APP_NAME: ${{ steps.identity.outputs.app_name }}
+          COMMIT_SHA: ${{ steps.identity.outputs.commit_sha }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          MACHINE_NAME: gf-q958-recovery
+          VOLUME_NAME: gfq958_recovery
+        run: >-
+          PYTHONPATH=benchmarks/harness uv run --project benchmarks python -m
+          graphforge_bench.fly_tiny_qualification
+          --expected-sha "$COMMIT_SHA"
+          --org "$FLY_ORGANIZATION"
+          --app "$APP_NAME"
+          --region "$FLY_REGION"
+          --volume-name "$VOLUME_NAME"
+          --machine-name "$MACHINE_NAME"
+          --prerequisite-955 merged
+          --prerequisite-956 merged
+          --prerequisite-957 merged
+          --build-authority hosted-docker
+          --ledger "$RUNNER_TEMP/fly-q958-ledger.json"
+          --evidence-out "$RUNNER_TEMP/fly-q958-evidence.json"
+          --result-out "$RUNNER_TEMP/fly-q958-manual-cleanup-result.json"
+          --cleanup-only
+          --confirm-disposable
+
+      - name: Upload sanitized recovery result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fly-tiny-manual-cleanup-${{ inputs.source_run_id }}
+          path: ${{ runner.temp }}/fly-q958-manual-cleanup-result.json
+          if-no-files-found: error
+          retention-days: 1

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -189,6 +189,16 @@ continued material memory growth is an architectural failure. Persistent graph
 size remains expected to be disk/I/O-bound, with Fly's 500 GiB/425 GiB usable
 storage envelope evaluated only by the real ladder.
 
+If Fly's provider builder is unavailable, the protected manual
+`fly-tiny-qualification.yml` workflow may select `hosted-docker`. That mode
+executes the same owner/controller on a Linux GitHub Actions runner, uses the
+runner's Docker daemon with `flyctl deploy --local-only --build-only --push`,
+and resolves the same immutable `registry.fly.io/<app>@sha256:...` identity
+before creating a volume or Machine. Runtime admission refuses hosted Docker
+outside Linux GitHub Actions so the disk-constrained Mac cannot accidentally
+become the image builder. The workflow runs an always-on cleanup recovery step
+and uploads only the closed result plus qualified evidence when present.
+
 ## Smoke
 
 From the repository root:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -196,8 +196,13 @@ runner's Docker daemon with `flyctl deploy --local-only --build-only --push`,
 and resolves the same immutable `registry.fly.io/<app>@sha256:...` identity
 before creating a volume or Machine. Runtime admission refuses hosted Docker
 outside Linux GitHub Actions so the disk-constrained Mac cannot accidentally
-become the image builder. The workflow runs an always-on cleanup recovery step
-and uploads only the closed result plus qualified evidence when present.
+become the image builder. A separate recovery job uses a durable pre-creation
+app/commit ownership receipt with a fresh 128-bit app-name nonce and an
+independent timeout; cleanup refuses to delete a present app without that exact
+binding. The protected
+`fly-tiny-recovery.yml` janitor can replay the same receipt manually after
+runner loss or cancellation. Uploaded artifacts are one-day, closed results,
+the credential-free ownership receipt, and qualified evidence when present.
 
 ## Smoke
 

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -106,7 +106,10 @@ class Command:
 class ResourceLedger:
     """Local ownership ledger. IDs are never copied into evidence/diagnostics."""
 
-    schema: str = "graphforge-fly-resource-ledger/1"
+    schema: str = "graphforge-fly-resource-ledger/3"
+    owner_app: str | None = None
+    owner_commit: str | None = None
+    owner_nonce: str | None = None
     app_owned: bool = False
     volume_id: str | None = None
     machine_id: str | None = None
@@ -124,7 +127,7 @@ class ResourceLedger:
         except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
             raise AdapterError("resource ledger is malformed") from error
         _refuse(not isinstance(value, dict), "resource ledger is malformed")
-        if value.pop("schema", None) != "graphforge-fly-resource-ledger/1":
+        if value.pop("schema", None) != "graphforge-fly-resource-ledger/3":
             raise AdapterError("resource ledger schema is invalid")
         expected = {item.name for item in fields(cls)} - {"schema"}
         _refuse(set(value) != expected, "resource ledger fields are invalid")
@@ -142,6 +145,42 @@ def _refuse(condition: bool, message: str) -> None:
 
 
 def validate_ledger(ledger: ResourceLedger) -> None:
+    _refuse(
+        len({item is None for item in (ledger.owner_app, ledger.owner_commit, ledger.owner_nonce)})
+        != 1,
+        "resource ledger ownership binding is incomplete",
+    )
+    _refuse(
+        ledger.owner_app is not None
+        and (not isinstance(ledger.owner_app, str) or not SAFE_NAME.fullmatch(ledger.owner_app)),
+        "resource ledger owner app is invalid",
+    )
+    _refuse(
+        ledger.owner_commit is not None
+        and (not isinstance(ledger.owner_commit, str) or not COMMIT.fullmatch(ledger.owner_commit)),
+        "resource ledger owner commit is invalid",
+    )
+    _refuse(
+        ledger.owner_nonce is not None
+        and (
+            not isinstance(ledger.owner_nonce, str)
+            or not re.fullmatch(r"[0-9a-f]{32}", ledger.owner_nonce)
+            or ledger.owner_app != f"gf-q958-{ledger.owner_nonce}"
+        ),
+        "resource ledger owner nonce is invalid",
+    )
+    _refuse(
+        ledger.owner_app is None
+        and (
+            ledger.app_owned
+            or ledger.volume_id is not None
+            or ledger.machine_id is not None
+            or ledger.image_digest is not None
+            or bool(ledger.secret_names)
+            or ledger.token_material_present
+        ),
+        "resource ledger has unowned resource state",
+    )
     _refuse(type(ledger.app_owned) is not bool, "resource ledger ownership is invalid")
     _refuse(
         type(ledger.token_material_present) is not bool, "resource ledger token state is invalid"
@@ -280,7 +319,7 @@ def remote_build_command(
     *, app: str, source: Path, config: Path, dockerfile: Path, commit: str
 ) -> Command:
     """Retain the provider-builder command used by existing ladder planning."""
-    return image_build_command(
+    command = image_build_command(
         app=app,
         source=source,
         config=config,
@@ -288,6 +327,7 @@ def remote_build_command(
         commit=commit,
         authority="provider",
     )
+    return Command("remote_build", command.argv)
 
 
 def provisioning_commands(attempt: FlyAttempt) -> tuple[Command, ...]:

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -69,6 +69,7 @@ PROVIDER_BUILD_CAUSES = frozenset(
         "provider_build_unknown",
     }
 )
+BUILD_AUTHORITIES = frozenset({"provider", "hosted-docker"})
 
 
 @dataclass(frozen=True)
@@ -232,17 +233,26 @@ def verify_checked_in_profile(root: Path, lifecycle: LifecycleInvocation) -> Non
     _refuse(lifecycle.profile_sha256 != f"sha256:{actual}", "checked-in profile digest mismatch")
 
 
-def remote_build_command(
-    *, app: str, source: Path, config: Path, dockerfile: Path, commit: str
+def image_build_command(
+    *,
+    app: str,
+    source: Path,
+    config: Path,
+    dockerfile: Path,
+    commit: str,
+    authority: str,
 ) -> Command:
+    """Build and push one commit-pinned image through the selected authority."""
     _refuse(not SAFE_NAME.fullmatch(app), "app name is invalid")
     _refuse(not COMMIT.fullmatch(commit), "build commit is invalid")
+    _refuse(authority not in BUILD_AUTHORITIES, "image build authority is invalid")
     _refuse(
         not all(path.is_absolute() for path in (source, config, dockerfile)),
         "build paths must be absolute",
     )
+    builder_flag = "--remote-only" if authority == "provider" else "--local-only"
     return Command(
-        "remote_build",
+        "image_build",
         (
             "flyctl",
             "deploy",
@@ -253,7 +263,7 @@ def remote_build_command(
             str(config),
             "--dockerfile",
             str(dockerfile),
-            "--remote-only",
+            builder_flag,
             "--build-only",
             "--push",
             "--no-public-ips",
@@ -263,6 +273,20 @@ def remote_build_command(
             f"GRAPHFORGE_COMMIT={commit}",
             "--yes",
         ),
+    )
+
+
+def remote_build_command(
+    *, app: str, source: Path, config: Path, dockerfile: Path, commit: str
+) -> Command:
+    """Retain the provider-builder command used by existing ladder planning."""
+    return image_build_command(
+        app=app,
+        source=source,
+        config=config,
+        dockerfile=dockerfile,
+        commit=commit,
+        authority="provider",
     )
 
 

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -42,6 +42,7 @@ COMMIT = re.compile(r"^[0-9a-f]{40}$")
 SAFE_NAME = re.compile(r"^[a-z][a-z0-9-]{2,62}$")
 SAFE_VOLUME = re.compile(r"^[a-z][a-z0-9_]{0,29}$")
 SAFE_REGION = re.compile(r"^[a-z]{3}$")
+OWNED_APP = re.compile(r"^gf-q958-([0-9a-f]{32})$")
 MACHINE_ID = re.compile(r"^[0-9a-f]{14}$")
 VOLUME_ID = re.compile(r"^vol_[a-z0-9]+$")
 SMOKE_EVIDENCE = "/work/fly-qualification-evidence.json"
@@ -162,9 +163,9 @@ class TinyQualificationInvocation:
     volume_name: str
     machine_name: str
     prerequisites: Mapping[int, str]
-    build_authority: str = "provider"
     machine_class: str = "performance-1x"
     volume_gib: int = 10
+    build_authority: str = "provider"
 
 
 @dataclass(frozen=True)
@@ -190,6 +191,8 @@ def validate_invocation(invocation: TinyQualificationInvocation) -> None:
             raise AdapterError("provider name is invalid")
     if not SAFE_VOLUME.fullmatch(invocation.volume_name):
         raise AdapterError("volume name is invalid")
+    if not OWNED_APP.fullmatch(invocation.app):
+        raise AdapterError("qualification app lacks a collision-resistant ownership nonce")
     if not SAFE_REGION.fullmatch(invocation.region):
         raise AdapterError("fixed region is invalid")
     if invocation.machine_class != "performance-1x":
@@ -214,6 +217,18 @@ def validate_build_environment(invocation: TinyQualificationInvocation) -> None:
         )
     if shutil.which("docker") is None:
         raise QualificationError("authorization_refused", "hosted Docker is unavailable")
+    try:
+        subprocess.run(
+            ("docker", "info"),
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError):
+        raise QualificationError(
+            "authorization_refused", "hosted Docker daemon is unavailable"
+        ) from None
 
 
 def check_source(root: Path, commit: str) -> None:
@@ -333,6 +348,9 @@ def _save_ledger(path: Path, ledger: ResourceLedger) -> None:
         path,
         {
             "schema": ledger.schema,
+            "owner_app": ledger.owner_app,
+            "owner_commit": ledger.owner_commit,
+            "owner_nonce": ledger.owner_nonce,
             "app_owned": ledger.app_owned,
             "volume_id": ledger.volume_id,
             "machine_id": ledger.machine_id,
@@ -582,6 +600,13 @@ def _cleanup(
         failures = True
     app_exists = invocation.app in current_names
 
+    if app_exists and (
+        ledger.owner_app != invocation.app or ledger.owner_commit != invocation.commit
+    ):
+        raise QualificationError(
+            "authorization_refused", "cleanup ownership binding is unavailable"
+        )
+
     if app_exists:
         # The app was proven absent before creation, so every child in this
         # owned app belongs to this attempt even if a crash preceded ID capture.
@@ -771,6 +796,9 @@ def _cleanup(
         raise QualificationError("teardown_failed", "provider teardown was not independently empty")
 
     ledger.app_owned = False
+    ledger.owner_app = None
+    ledger.owner_commit = None
+    ledger.owner_nonce = None
     ledger.volume_id = None
     ledger.machine_id = None
     ledger.image_digest = None
@@ -793,6 +821,14 @@ def execute(
     check_source(root, invocation.commit)
     validate_build_environment(invocation)
     live_size = verify_live_capacity(transport, invocation)
+    owner = OWNED_APP.fullmatch(invocation.app)
+    assert owner is not None
+    ledger = ResourceLedger(
+        owner_app=invocation.app,
+        owner_commit=invocation.commit,
+        owner_nonce=owner.group(1),
+    )
+    _save_ledger(ledger_path, ledger)
     if dry_run:
         return {
             "schema": "graphforge-fly-tiny-plan/1",
@@ -803,8 +839,6 @@ def execute(
             "full_run_authorized": False,
         }
 
-    ledger = ResourceLedger()
-    _save_ledger(ledger_path, ledger)
     failure: QualificationError | None = None
     failure_kind = "provision_failed"
     try:
@@ -959,6 +993,20 @@ def cleanup_only(
         not isinstance(name, str) or not SAFE_NAME.fullmatch(name) for name in names
     ):
         raise QualificationError("teardown_failed", "provider app inventory is malformed")
+    if invocation.app not in names:
+        if ledger.owner_app == invocation.app and ledger.owner_commit == invocation.commit:
+            ledger = ResourceLedger()
+            _save_ledger(ledger_path, ledger)
+        return {
+            "schema": "graphforge-fly-adapter-result/2",
+            "status": "passed",
+            "failure": None,
+            "cause": None,
+        }
+    if ledger.owner_app != invocation.app or ledger.owner_commit != invocation.commit:
+        raise QualificationError(
+            "authorization_refused", "cleanup ownership binding is unavailable"
+        )
     baseline = names - {invocation.app}
     _cleanup(transport, invocation, ledger, ledger_path, baseline)
     return {
@@ -1035,7 +1083,9 @@ def main() -> int:
                 evidence_out=args.evidence_out,
                 dry_run=not args.execute,
             )
-    except (AdapterError, QualificationError, subprocess.SubprocessError, OSError):
+    except QualificationError as error:
+        result = sanitized_failure(error.failure, cause=error.cause)
+    except (AdapterError, subprocess.SubprocessError, OSError):
         result = sanitized_failure("authorization_refused")
     _atomic_json(args.result_out, result)
     print(json.dumps(result, sort_keys=True))

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -15,7 +15,9 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import platform
 import re
+import shutil
 import subprocess
 import tempfile
 import time
@@ -27,8 +29,8 @@ from graphforge_bench.fly_adapter import (
     AdapterError,
     ResourceLedger,
     classify_provider_build_failure,
+    image_build_command,
     pin_remote_image,
-    remote_build_command,
     sanitized_failure,
 )
 
@@ -160,6 +162,7 @@ class TinyQualificationInvocation:
     volume_name: str
     machine_name: str
     prerequisites: Mapping[int, str]
+    build_authority: str = "provider"
     machine_class: str = "performance-1x"
     volume_gib: int = 10
 
@@ -191,8 +194,26 @@ def validate_invocation(invocation: TinyQualificationInvocation) -> None:
         raise AdapterError("fixed region is invalid")
     if invocation.machine_class != "performance-1x":
         raise AdapterError("tiny qualification must use the smallest performance preset")
+    if invocation.build_authority not in {"provider", "hosted-docker"}:
+        raise AdapterError("image build authority is invalid")
     if not 1 <= invocation.volume_gib <= 20:
         raise AdapterError("tiny qualification volume is outside its small bound")
+
+
+def validate_build_environment(invocation: TinyQualificationInvocation) -> None:
+    """Keep hosted Docker builds off developer machines and require a real daemon."""
+    if invocation.build_authority != "hosted-docker":
+        return
+    if (
+        platform.system() != "Linux"
+        or os.environ.get("CI") != "true"
+        or os.environ.get("GITHUB_ACTIONS") != "true"
+    ):
+        raise QualificationError(
+            "authorization_refused", "hosted Docker build requires GitHub Actions Linux"
+        )
+    if shutil.which("docker") is None:
+        raise QualificationError("authorization_refused", "hosted Docker is unavailable")
 
 
 def check_source(root: Path, commit: str) -> None:
@@ -770,6 +791,7 @@ def execute(
     """Run the bounded one-app qualification and return sanitized status."""
     validate_invocation(invocation)
     check_source(root, invocation.commit)
+    validate_build_environment(invocation)
     live_size = verify_live_capacity(transport, invocation)
     if dry_run:
         return {
@@ -777,6 +799,7 @@ def execute(
             "status": "admitted",
             "machine_class": invocation.machine_class,
             "volume_gib": invocation.volume_gib,
+            "build_authority": invocation.build_authority,
             "full_run_authorized": False,
         }
 
@@ -808,12 +831,13 @@ def execute(
         )
 
         failure_kind = "build_failed"
-        build = remote_build_command(
+        build = image_build_command(
             app=invocation.app,
             source=root,
             config=FLY_BUILD_CONFIG,
             dockerfile=DOCKERFILE,
             commit=invocation.commit,
+            authority=invocation.build_authority,
         )
         try:
             transport.run(build.argv, timeout=BUILD_TIMEOUT_SECONDS)
@@ -913,6 +937,38 @@ def execute(
     }
 
 
+def cleanup_only(
+    invocation: TinyQualificationInvocation,
+    *,
+    transport: Transport,
+    ledger_path: Path,
+) -> dict[str, Any]:
+    """Recover a hosted job after interruption and verify the owned app is absent."""
+    validate_invocation(invocation)
+    if not invocation.app.startswith("gf-q958-"):
+        raise AdapterError("cleanup app is not a disposable qualification app")
+    ledger = ResourceLedger.load(ledger_path) if ledger_path.is_file() else ResourceLedger()
+    apps = _list(
+        transport.json(("flyctl", "apps", "list", "--json"), timeout=CREATE_TIMEOUT_SECONDS),
+        "app",
+    )
+    names = frozenset(
+        item.get("Name") or item.get("name") for item in apps if isinstance(item, dict)
+    )
+    if len(names) != len(apps) or any(
+        not isinstance(name, str) or not SAFE_NAME.fullmatch(name) for name in names
+    ):
+        raise QualificationError("teardown_failed", "provider app inventory is malformed")
+    baseline = names - {invocation.app}
+    _cleanup(transport, invocation, ledger, ledger_path, baseline)
+    return {
+        "schema": "graphforge-fly-adapter-result/2",
+        "status": "passed",
+        "failure": None,
+        "cause": None,
+    }
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     result.add_argument("--expected-sha", required=True)
@@ -925,18 +981,25 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--prerequisite-956", choices=("merged",), required=True)
     result.add_argument("--prerequisite-957", choices=("merged",), required=True)
     result.add_argument("--machine-class", default="performance-1x")
+    result.add_argument(
+        "--build-authority",
+        choices=("provider", "hosted-docker"),
+        default="provider",
+    )
     result.add_argument("--volume-gib", type=int, default=10)
     result.add_argument("--ledger", type=Path, required=True)
     result.add_argument("--evidence-out", type=Path, required=True)
     result.add_argument("--result-out", type=Path, required=True)
-    result.add_argument("--execute", action="store_true")
+    mode = result.add_mutually_exclusive_group()
+    mode.add_argument("--execute", action="store_true")
+    mode.add_argument("--cleanup-only", action="store_true")
     result.add_argument("--confirm-disposable", action="store_true")
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
-    if args.execute and not args.confirm_disposable:
+    if (args.execute or args.cleanup_only) and not args.confirm_disposable:
         result = sanitized_failure("authorization_refused")
         _atomic_json(args.result_out, result)
         return 1
@@ -952,18 +1015,26 @@ def main() -> int:
             956: args.prerequisite_956,
             957: args.prerequisite_957,
         },
+        build_authority=args.build_authority,
         machine_class=args.machine_class,
         volume_gib=args.volume_gib,
     )
     try:
-        result = execute(
-            invocation,
-            transport=FlyctlTransport(),
-            root=ROOT,
-            ledger_path=args.ledger,
-            evidence_out=args.evidence_out,
-            dry_run=not args.execute,
-        )
+        if args.cleanup_only:
+            result = cleanup_only(
+                invocation,
+                transport=FlyctlTransport(),
+                ledger_path=args.ledger,
+            )
+        else:
+            result = execute(
+                invocation,
+                transport=FlyctlTransport(),
+                root=ROOT,
+                ledger_path=args.ledger,
+                evidence_out=args.evidence_out,
+                dry_run=not args.execute,
+            )
     except (AdapterError, QualificationError, subprocess.SubprocessError, OSError):
         result = sanitized_failure("authorization_refused")
     _atomic_json(args.result_out, result)

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -78,6 +78,7 @@ class FlyAdapterTests(unittest.TestCase):
             dockerfile=Path("/repo/Dockerfile"),
             commit="a" * 40,
         )
+        self.assertEqual(command.operation, "remote_build")
         self.assertIn("--remote-only", command.argv)
         self.assertIn("--build-only", command.argv)
         self.assertIn("--push", command.argv)
@@ -173,23 +174,29 @@ class FlyAdapterTests(unittest.TestCase):
 
     def test_cleanup_is_owned_ordered_and_idempotent(self) -> None:
         ledger = ResourceLedger(
+            owner_app="gf-q958-" + "c" * 32,
+            owner_commit="a" * 40,
+            owner_nonce="c" * 32,
             app_owned=True,
             volume_id="vol_fixture123",
             machine_id="abcdef01234567",
             secret_names=["temporary-token"],
         )
-        first = cleanup_commands("gf-fixture", ledger)
+        first = cleanup_commands("gf-q958-" + "c" * 32, ledger)
         self.assertEqual(
             [c.operation for c in first],
             ["destroy_machine", "destroy_volume", "unset_secret", "destroy_app"],
         )
         self.assertEqual(cleanup_commands("gf-fixture", ResourceLedger()), ())
-        self.assertEqual(first, cleanup_commands("gf-fixture", ledger))
+        self.assertEqual(first, cleanup_commands("gf-q958-" + "c" * 32, ledger))
 
     def test_ledger_load_closes_shape_types_and_identifiers(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "ledger.json"
             ledger = ResourceLedger(
+                owner_app="gf-q958-" + "c" * 32,
+                owner_commit="a" * 40,
+                owner_nonce="c" * 32,
                 app_owned=True,
                 volume_id="vol_fixture123",
                 machine_id="abcdef01234567",

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -16,6 +16,7 @@ from graphforge_bench.fly_adapter import (
     accepted_rung_reclamation,
     classify_provider_build_failure,
     cleanup_commands,
+    image_build_command,
     inventory_commands,
     pin_remote_image,
     provisioning_commands,
@@ -95,6 +96,29 @@ class FlyAdapterTests(unittest.TestCase):
                 config=Path("fly.build.toml"),
                 dockerfile=Path("Dockerfile"),
                 commit="a" * 40,
+            )
+
+    def test_hosted_build_uses_local_docker_and_pushes_the_same_identity(self) -> None:
+        command = image_build_command(
+            app="gf-fixture",
+            source=Path("/repo"),
+            config=Path("/repo/fly.build.toml"),
+            dockerfile=Path("/repo/Dockerfile"),
+            commit="a" * 40,
+            authority="hosted-docker",
+        )
+        self.assertIn("--local-only", command.argv)
+        self.assertNotIn("--remote-only", command.argv)
+        self.assertIn("--build-only", command.argv)
+        self.assertIn("--push", command.argv)
+        with self.assertRaisesRegex(AdapterError, "authority"):
+            image_build_command(
+                app="gf-fixture",
+                source=Path("/repo"),
+                config=Path("/repo/fly.build.toml"),
+                dockerfile=Path("/repo/Dockerfile"),
+                commit="a" * 40,
+                authority="developer-laptop",
             )
 
     def test_provisioning_is_private_fixed_and_thin(self) -> None:

--- a/benchmarks/tests/test_fly_tiny_qualification.py
+++ b/benchmarks/tests/test_fly_tiny_qualification.py
@@ -15,6 +15,7 @@ from graphforge_bench.fly_tiny_qualification import (
     _machine_command,
     cleanup_only,
     execute,
+    main,
     validate_build_environment,
     validate_invocation,
     verify_live_capacity,
@@ -22,14 +23,15 @@ from graphforge_bench.fly_tiny_qualification import (
 import tomllib
 
 DIGEST = "sha256:" + "b" * 64
-IMAGE = "registry.fly.io/gf-q958-test@" + DIGEST
+APP = "gf-q958-" + "c" * 32
+IMAGE = f"registry.fly.io/{APP}@" + DIGEST
 
 
 def invocation(**changes: object) -> TinyQualificationInvocation:
     values = {
         "commit": "a" * 40,
         "organization": "personal",
-        "app": "gf-q958-test",
+        "app": APP,
         "region": "dfw",
         "volume_name": "gf_q958_test",
         "machine_name": "gf-q958-machine",
@@ -113,7 +115,7 @@ class FakeTransport:
 
     def machine_state(self, app: str, machine_id: str, *, timeout: int) -> object:
         self.commands.append(("machine-state", app, machine_id))
-        if app != "gf-q958-test" or machine_id != "abcdef01234567" or timeout <= 0:
+        if app != APP or machine_id != "abcdef01234567" or timeout <= 0:
             raise AssertionError("unexpected Machine state lookup")
         return {
             "id": "abcdef01234567",
@@ -130,7 +132,7 @@ class FakeTransport:
 
     @staticmethod
     def assert_resolution(app: str, tag: str, timeout: int) -> None:
-        if app != "gf-q958-test" or tag != "a" * 40 or timeout <= 0:
+        if app != APP or tag != "a" * 40 or timeout <= 0:
             raise AssertionError("unexpected image resolution")
 
     def json(self, argv: tuple[str, ...], *, timeout: int) -> object:
@@ -172,7 +174,7 @@ class FakeTransport:
         if argv[1:3] in {("volumes", "list"), ("secrets", "list")}:
             return []
         if argv[1:3] == ("apps", "list"):
-            return [{"Name": "gf-q958-test"}] if self.app_created else []
+            return [{"Name": APP}] if self.app_created else []
         raise AssertionError(f"unexpected JSON command: {argv}")
 
 
@@ -211,9 +213,9 @@ class FlyTinyQualificationTests(unittest.TestCase):
             return Response({"id": "abcdef01234567", "config": {}})
 
         with patch("graphforge_bench.fly_tiny_qualification.urllib.request.urlopen", open_request):
-            self.assertEqual(transport.resolve_image("gf-q958-test", "fixture", timeout=30), IMAGE)
+            self.assertEqual(transport.resolve_image(APP, "fixture", timeout=30), IMAGE)
             self.assertEqual(
-                transport.machine_state("gf-q958-test", "abcdef01234567", timeout=30)["id"],
+                transport.machine_state(APP, "abcdef01234567", timeout=30)["id"],
                 "abcdef01234567",
             )
         self.assertTrue(
@@ -245,6 +247,22 @@ class FlyTinyQualificationTests(unittest.TestCase):
                 "graphforge_bench.fly_tiny_qualification.shutil.which",
                 return_value="/bin/docker",
             ),
+            patch("graphforge_bench.fly_tiny_qualification.subprocess.run"),
+        ):
+            validate_build_environment(hosted)
+
+        with (
+            patch.dict("os.environ", {"CI": "true", "GITHUB_ACTIONS": "true"}, clear=True),
+            patch("graphforge_bench.fly_tiny_qualification.platform.system", return_value="Linux"),
+            patch(
+                "graphforge_bench.fly_tiny_qualification.shutil.which",
+                return_value="/bin/docker",
+            ),
+            patch(
+                "graphforge_bench.fly_tiny_qualification.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, ("docker", "info")),
+            ),
+            self.assertRaisesRegex(QualificationError, "daemon"),
         ):
             validate_build_environment(hosted)
 
@@ -253,23 +271,99 @@ class FlyTinyQualificationTests(unittest.TestCase):
             root = Path(directory)
             transport = FakeTransport()
             transport.app_created = True
-            result = cleanup_only(
-                invocation(),
-                transport=transport,
-                ledger_path=root / "ledger.json",
-            )
+            ledger_path = root / "ledger.json"
+            with self.assertRaisesRegex(QualificationError, "ownership binding"):
+                cleanup_only(invocation(), transport=transport, ledger_path=ledger_path)
+            self.assertTrue(transport.app_created)
+
+            ResourceLedger(
+                owner_app=APP,
+                owner_commit="a" * 40,
+                owner_nonce="c" * 32,
+            ).save(ledger_path)
+            result = cleanup_only(invocation(), transport=transport, ledger_path=ledger_path)
             self.assertEqual(result["status"], "passed")
-            self.assertEqual(ResourceLedger.load(root / "ledger.json"), ResourceLedger())
+            self.assertEqual(ResourceLedger.load(ledger_path), ResourceLedger())
             self.assertIn(
-                ("flyctl", "apps", "destroy", "gf-q958-test", "--yes"),
+                ("flyctl", "apps", "destroy", APP, "--yes"),
                 transport.commands,
             )
-            with self.assertRaisesRegex(AdapterError, "disposable qualification"):
+            with self.assertRaisesRegex(AdapterError, "ownership nonce"):
                 cleanup_only(
                     invocation(app="production-app"),
                     transport=FakeTransport(),
                     ledger_path=root / "other-ledger.json",
                 )
+
+    def test_cleanup_only_absent_app_is_safe_without_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            ledger_path = Path(directory) / "ledger.json"
+            ResourceLedger(
+                owner_app=APP,
+                owner_commit="a" * 40,
+                owner_nonce="c" * 32,
+                app_owned=True,
+                volume_id="vol_fixture123",
+                machine_id="abcdef01234567",
+                image_digest=IMAGE,
+            ).save(ledger_path)
+            result = cleanup_only(
+                invocation(),
+                transport=FakeTransport(),
+                ledger_path=ledger_path,
+            )
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(ResourceLedger.load(ledger_path), ResourceLedger())
+        with tempfile.TemporaryDirectory() as directory:
+            result = cleanup_only(
+                invocation(),
+                transport=FakeTransport(),
+                ledger_path=Path(directory) / "missing-ledger.json",
+            )
+            self.assertEqual(result["status"], "passed")
+
+    def test_cleanup_cli_preserves_teardown_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            result_path = root / "result.json"
+            argv = [
+                "fly_tiny_qualification",
+                "--expected-sha",
+                "a" * 40,
+                "--org",
+                "personal",
+                "--app",
+                APP,
+                "--region",
+                "dfw",
+                "--volume-name",
+                "gf_q958_test",
+                "--machine-name",
+                "gf-q958-machine",
+                "--prerequisite-955",
+                "merged",
+                "--prerequisite-956",
+                "merged",
+                "--prerequisite-957",
+                "merged",
+                "--ledger",
+                str(root / "ledger.json"),
+                "--evidence-out",
+                str(root / "evidence.json"),
+                "--result-out",
+                str(result_path),
+                "--cleanup-only",
+                "--confirm-disposable",
+            ]
+            with (
+                patch("sys.argv", argv),
+                patch(
+                    "graphforge_bench.fly_tiny_qualification.cleanup_only",
+                    side_effect=QualificationError("teardown_failed", "still present"),
+                ),
+            ):
+                self.assertEqual(main(), 1)
+            self.assertEqual(json.loads(result_path.read_text())["failure"], "teardown_failed")
 
     def test_live_capacity_requires_current_region_and_smallest_preset(self) -> None:
         transport = FakeTransport()
@@ -368,7 +462,7 @@ class FlyTinyQualificationTests(unittest.TestCase):
             deploy = next(
                 command for command in transport.commands if command[:2] == ("flyctl", "deploy")
             )
-            self.assertEqual(deploy[deploy.index("--app") + 1], "gf-q958-test")
+            self.assertEqual(deploy[deploy.index("--app") + 1], APP)
             self.assertTrue(Path(deploy[deploy.index("--config") + 1]).is_absolute())
             self.assertTrue(Path(deploy[deploy.index("--dockerfile") + 1]).is_absolute())
             self.assertIn("--build-only", deploy)
@@ -382,7 +476,7 @@ class FlyTinyQualificationTests(unittest.TestCase):
                 )
             )
             self.assertIn(
-                ("flyctl", "apps", "destroy", "gf-q958-test", "--yes"),
+                ("flyctl", "apps", "destroy", APP, "--yes"),
                 transport.commands,
             )
 
@@ -415,7 +509,7 @@ class FlyTinyQualificationTests(unittest.TestCase):
                 "machine",
                 "list",
                 "--app",
-                "gf-q958-test",
+                APP,
                 "--json",
             )
             self.assertEqual(transport.commands[:deploy_index].count(readiness), 3)

--- a/benchmarks/tests/test_fly_tiny_qualification.py
+++ b/benchmarks/tests/test_fly_tiny_qualification.py
@@ -13,7 +13,9 @@ from graphforge_bench.fly_tiny_qualification import (
     QualificationError,
     TinyQualificationInvocation,
     _machine_command,
+    cleanup_only,
     execute,
+    validate_build_environment,
     validate_invocation,
     verify_live_capacity,
 )
@@ -228,6 +230,46 @@ class FlyTinyQualificationTests(unittest.TestCase):
                 invocation(prerequisites={955: "merged", 956: "open", 957: "merged"})
             )
         self.assertFalse(hasattr(invocation(), "rung"))
+
+    def test_hosted_docker_is_linux_github_actions_only(self) -> None:
+        hosted = invocation(build_authority="hosted-docker")
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            self.assertRaisesRegex(QualificationError, "GitHub Actions Linux"),
+        ):
+            validate_build_environment(hosted)
+        with (
+            patch.dict("os.environ", {"CI": "true", "GITHUB_ACTIONS": "true"}, clear=True),
+            patch("graphforge_bench.fly_tiny_qualification.platform.system", return_value="Linux"),
+            patch(
+                "graphforge_bench.fly_tiny_qualification.shutil.which",
+                return_value="/bin/docker",
+            ),
+        ):
+            validate_build_environment(hosted)
+
+    def test_cleanup_only_is_scoped_to_disposable_qualification_app(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transport = FakeTransport()
+            transport.app_created = True
+            result = cleanup_only(
+                invocation(),
+                transport=transport,
+                ledger_path=root / "ledger.json",
+            )
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(ResourceLedger.load(root / "ledger.json"), ResourceLedger())
+            self.assertIn(
+                ("flyctl", "apps", "destroy", "gf-q958-test", "--yes"),
+                transport.commands,
+            )
+            with self.assertRaisesRegex(AdapterError, "disposable qualification"):
+                cleanup_only(
+                    invocation(app="production-app"),
+                    transport=FakeTransport(),
+                    ledger_path=root / "other-ledger.json",
+                )
 
     def test_live_capacity_requires_current_region_and_smallest_preset(self) -> None:
         transport = FakeTransport()

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -99,6 +99,7 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "m6-memory-${{ github.sha }}-blacksmith-4vcpu-ubuntu-2404": 1,
         "g500-certification-${{ inputs.commit_sha }}": 1,
         "native-local-admission-${{ matrix.authority }}-${{ github.sha }}": 1,
+        "fly-tiny-result-${{ inputs.commit_sha }}": 1,
     }
 )
 EXPECTED_ARTIFACT_DOWNLOADS = Counter(
@@ -310,6 +311,12 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
                 "${{ runner.temp }}/g500-certification-phase-journal.json"
             ),
             "benchmarks/outputs/local-admission-evidence.json",
+            (
+                "${{ runner.temp }}/fly-q958-plan.json\n"
+                "${{ runner.temp }}/fly-q958-result.json\n"
+                "${{ runner.temp }}/fly-q958-cleanup-result.json\n"
+                "${{ runner.temp }}/fly-q958-evidence.json"
+            ),
         }, f"artifact upload contains unapproved bytes: {path}"
         uploaded.append(name)
     for step in action_steps(text, "actions/download-artifact@"):

--- a/scripts/ci/test-ci-storage-policy.py
+++ b/scripts/ci/test-ci-storage-policy.py
@@ -99,7 +99,10 @@ EXPECTED_ARTIFACT_UPLOADS = Counter(
         "m6-memory-${{ github.sha }}-blacksmith-4vcpu-ubuntu-2404": 1,
         "g500-certification-${{ inputs.commit_sha }}": 1,
         "native-local-admission-${{ matrix.authority }}-${{ github.sha }}": 1,
-        "fly-tiny-result-${{ inputs.commit_sha }}": 1,
+        "${{ env.PREFLIGHT_ARTIFACT }}": 1,
+        "fly-tiny-execution-${{ inputs.commit_sha }}": 1,
+        "fly-tiny-cleanup-${{ inputs.commit_sha }}": 1,
+        "fly-tiny-manual-cleanup-${{ inputs.source_run_id }}": 1,
     }
 )
 EXPECTED_ARTIFACT_DOWNLOADS = Counter(
@@ -124,6 +127,7 @@ EXPECTED_ARTIFACT_DOWNLOADS = Counter(
         "pr-node-addon-${{ github.sha }}": 1,
         "native-oracle-windows-${{ github.sha }}": 1,
         "native-oracle-macos-${{ github.sha }}": 1,
+        "${{ env.PREFLIGHT_ARTIFACT }}": 3,
     }
 )
 EXPECTED_DEPENDENCY_KEYS = Counter(
@@ -311,12 +315,10 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
                 "${{ runner.temp }}/g500-certification-phase-journal.json"
             ),
             "benchmarks/outputs/local-admission-evidence.json",
-            (
-                "${{ runner.temp }}/fly-q958-plan.json\n"
-                "${{ runner.temp }}/fly-q958-result.json\n"
-                "${{ runner.temp }}/fly-q958-cleanup-result.json\n"
-                "${{ runner.temp }}/fly-q958-evidence.json"
-            ),
+            ("${{ runner.temp }}/fly-q958-ledger.json\n${{ runner.temp }}/fly-q958-plan.json"),
+            ("${{ runner.temp }}/fly-q958-result.json\n${{ runner.temp }}/fly-q958-evidence.json"),
+            "${{ runner.temp }}/fly-q958-cleanup-result.json",
+            "${{ runner.temp }}/fly-q958-manual-cleanup-result.json",
         }, f"artifact upload contains unapproved bytes: {path}"
         uploaded.append(name)
     for step in action_steps(text, "actions/download-artifact@"):
@@ -344,6 +346,7 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             "crates/graphforge-bindings-node",
             "native/windows",
             "native/macos",
+            "${{ runner.temp }}",
         }, f"artifact download path drift: {selector}"
         if pattern is not None:
             assert field(step, "merge-multiple") == "true", (
@@ -356,8 +359,10 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
             assert field(step, "merge-multiple") is None, (
                 f"single artifact unexpectedly merged: {name}"
             )
-            same_run = name == "Release-Load-${{ github.run_id }}" or name.startswith(
-                ("pr-", "native-oracle-")
+            same_run = (
+                name == "Release-Load-${{ github.run_id }}"
+                or name.startswith(("pr-", "native-oracle-"))
+                or (name == "${{ env.PREFLIGHT_ARTIFACT }}" and field(step, "run-id") is None)
             )
             cross_run = not same_run
             if cross_run:
@@ -390,6 +395,7 @@ def artifact_contracts(text: str) -> tuple[list[str], list[str]]:
                         "${{ steps.candidate.outputs.run_id }}",
                         "${{ needs.locate_candidate.outputs.candidate_run_id }}",
                     },
+                    "${{ runner.temp }}": {"${{ inputs.source_run_id }}"},
                 }[path]
                 assert field(step, "run-id") in expected_run_ids, (
                     f"cross-run artifact run ID drift: {name}"


### PR DESCRIPTION
## Summary

- add protected manual workflows for hosted #958 qualification and receipt-bound orphan recovery
- build and push the commit-pinned Fly image with hosted Docker on Blacksmith Linux instead of the failing provider builder
- bind cleanup authority to an exact commit plus a fresh 128-bit app-name nonce
- split execution and recovery into independent jobs with separate timeout budgets
- scope `FLY_API_TOKEN` only to Fly operations and isolate temporary Docker credentials
- preserve immutable registry digest, private Machine, bounded evidence, and typed teardown contracts

## Why

The merged provider-builder path repeatedly failed before image resolution with `provider_build_unknown`; the engine, volume, Machine, and smoke never ran. Fly documents `--local-only --build-only --push` as the supported path for building with a caller-owned Docker daemon and pushing to the same Fly registry. Running that command on the hosted Linux runner removes the opaque provider builder without changing the qualified runtime.

Independent review also identified cleanup hazards in the first revision. The hardened design refuses deletion without the schema-v3 app/commit/nonce receipt, runs manual recovery code from trusted current `main`, shares concurrency with the source workflow, and preserves `teardown_failed` diagnostics.

## Verification

- benchmark controller: 90 passed
- focused controller/recovery suite: 36 passed
- Ruff: passed
- CI storage policy: passed (29 bounded artifact producers, 23 consumers)
- `git diff --check`: passed
- two independent agent reviews: no remaining correctness/security blocker

The live qualification remains manual, environment-protected, exact-current-main only, and requires explicit disposable-resource authorization plus `FLY_API_TOKEN`. This PR creates no Fly resources and does not close #958; one post-merge live tiny qualification and verified teardown are still required.

Related to #958.