### PR TITLE
feat(bench): add safe progressive provider ladder planner

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust fly-adapter-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries
+.PHONY: install smoke smoke-python smoke-rust fly-adapter-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries progressive-provider-plan
 
 install:
 	uv sync --locked
@@ -51,3 +51,11 @@ progressive-qualification-project-s20: install
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_run \
 		--project-s20 --output-dir "$(OUTPUT_DIR)" \
 		--provider-capacity "$(PROVIDER_CAPACITY)"
+
+# Safe control-plane admission only; this never provisions a provider.
+progressive-provider-plan: install
+	test -n "$(COMMIT)" && test -n "$(MAXIMUM_SCALE)" && test -n "$(OUTPUT_DIR)" && test -n "$(PLAN_OUT)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_provider_plan \
+		--root "$(CURDIR)" --output-dir "$(OUTPUT_DIR)" --commit "$(COMMIT)" \
+		--maximum-scale "$(MAXIMUM_SCALE)" $(if $(PROVIDER_CAPACITY),--provider-capacity "$(PROVIDER_CAPACITY)",) \
+		--plan-out "$(PLAN_OUT)"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -297,6 +297,24 @@ make -C benchmarks progressive-qualification-project-s20 \
   PROVIDER_CAPACITY=/sanitized/provider-capacity.json
 ```
 
+The sequential provider ladder has a separate no-spend control-plane planner.
+It verifies a contiguous, commit-bound evidence prefix, applies the checked-in
+projection gate, and emits only the next profile and sanitized projection:
+
+```bash
+make -C benchmarks progressive-provider-plan \
+  COMMIT=$(git rev-parse HEAD) MAXIMUM_SCALE=26 \
+  OUTPUT_DIR=/admitted-volume/graphforge-evidence \
+  PLAN_OUT=/admitted-volume/graphforge-evidence/provider-plan.json \
+  PROVIDER_CAPACITY=/sanitized/provider-capacity.json
+```
+
+The planner is deliberately not a provider executor. Provider plans are marked
+refused for execution until a dedicated provider image contains `gf`, the
+Graph500 generator/certifier, Python/BenchExec, and a proven cgroups/I/O
+authority. The canonical order remains S18, S19, S20, S22, S24, S25, S26;
+the first failed or missing gate stops the ladder.
+
 The controller derives bulk-ingest capability from the same run's bounded
 ordinary `gf import-session commit --json` receipt: its construction evidence
 must identify a configuration of at least 65,536 rows, accepted bulk chunks,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -298,7 +298,8 @@ make -C benchmarks progressive-qualification-project-s20 \
 ```
 
 The sequential provider ladder has a separate no-spend control-plane planner.
-It verifies a contiguous, commit-bound evidence prefix, applies the checked-in
+It verifies a contiguous, commit-bound evidence prefix (including the exact
+checked-out repository commit and profile digest), applies the checked-in
 projection gate, and emits only the next profile and sanitized projection:
 
 ```bash

--- a/benchmarks/harness/graphforge_bench/progressive_provider_plan.py
+++ b/benchmarks/harness/graphforge_bench/progressive_provider_plan.py
@@ -1,0 +1,246 @@
+"""No-spend planner for the sequential S18--S26 provider ladder.
+
+The planner is the control-plane boundary for the real provider executor.  It
+does not contact Fly, choose an image, provision a Machine, or execute a
+benchmark.  It only accepts closed rung evidence, applies the checked-in
+projection policy, and emits the next exact profile to execute.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from graphforge_bench.progressive_qualification import (
+    Profile,
+    QualificationError,
+    load_profiles,
+    project,
+    select_next,
+)
+
+SCALES = (18, 19, 20, 22, 24, 25, 26)
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+PLAN_SCHEMA = "graphforge-progressive-provider-plan/1"
+EXECUTION_REFUSAL = "provider_executor_unavailable"
+
+
+class ProviderPlanError(ValueError):
+    """A malformed input or a refused no-spend admission decision."""
+
+
+def _read_json(path: Path, message: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProviderPlanError(message) from error
+
+
+def _profile_path(root: Path, profile: Profile) -> Path:
+    suffix = "local" if profile.scale in (18, 19) else "provider"
+    path = root / "profiles" / "graph500" / f"s{profile.scale}-{suffix}.json"
+    if not path.is_file():
+        raise ProviderPlanError("checked-in progressive profile is unavailable")
+    return path
+
+
+def _sha256(path: Path) -> str:
+    try:
+        value = hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as error:
+        raise ProviderPlanError("checked-in progressive profile is unavailable") from error
+    return value
+
+
+def _validate_rung(root: Path, value: Any, scale: int) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ProviderPlanError("completed rung evidence is malformed")
+    schema = _read_json(
+        root / "schemas" / "progressive-qualification-rung-evidence.json",
+        "rung schema is unavailable",
+    )
+    error = next(Draft202012Validator(schema).iter_errors(value), None)
+    if error is not None:
+        raise ProviderPlanError("completed rung evidence is not schema-valid")
+    expected_source = "progressive_profile" if scale in (18, 19) else None
+    if (
+        value.get("scale") != scale
+        or value.get("status") != "passed"
+        or value.get("live_edges") != 16 * (1 << scale)
+        or value.get("profile_id")
+        != f"graph500-s{scale}-{'local' if scale in (18, 19) else 'provider'}"
+        or (expected_source is not None and value.get("source") != expected_source)
+    ):
+        raise ProviderPlanError("completed rung evidence does not match its canonical profile")
+    return value
+
+
+def _validate_result_identity(
+    output_dir: Path, *, scale: int, commit: str, profile_id: str
+) -> None:
+    """Bind each completed rung to the exact source commit and profile."""
+    value = _read_json(output_dir / f"s{scale}-result.json", "completed rung result is unavailable")
+    if not isinstance(value, Mapping):
+        raise ProviderPlanError("completed rung result is malformed")
+    identities = value.get("identities")
+    if not isinstance(identities, Mapping):
+        raise ProviderPlanError("completed rung result identity is missing")
+    if (
+        value.get("rung") != f"S{scale}"
+        or value.get("status") != "passed"
+        or identities.get("commit") != commit
+        or identities.get("profile_id") != profile_id
+    ):
+        raise ProviderPlanError(
+            "completed rung result is not bound to the requested commit/profile"
+        )
+
+
+def completed_rungs(
+    root: Path, output_dir: Path, *, commit: str | None = None
+) -> list[Mapping[str, Any]]:
+    """Load a contiguous prefix of passed rung evidence and reject gaps."""
+    result: list[Mapping[str, Any]] = []
+    gap = False
+    for scale in SCALES:
+        path = output_dir / f"s{scale}-rung.json"
+        if not path.is_file():
+            gap = True
+            continue
+        if gap:
+            raise ProviderPlanError("rung evidence is out of order")
+        rung = _validate_rung(root, _read_json(path, "completed rung evidence is malformed"), scale)
+        if commit is not None:
+            _validate_result_identity(
+                output_dir,
+                scale=scale,
+                commit=commit,
+                profile_id=str(rung["profile_id"]),
+            )
+        result.append(rung)
+    return result
+
+
+def _profile(profiles: tuple[Profile, ...], scale: int) -> Profile:
+    try:
+        return next(item for item in profiles if item.scale == scale)
+    except StopIteration as error:
+        raise ProviderPlanError("canonical progressive profile is unavailable") from error
+
+
+def plan_provider_ladder(
+    *,
+    root: Path,
+    output_dir: Path,
+    commit: str,
+    maximum_scale: int,
+    provider_capacity: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return one immutable, sanitized next-rung plan without provider calls."""
+    if COMMIT.fullmatch(commit) is None:
+        raise ProviderPlanError("commit must be a lowercase full Git object ID")
+    if maximum_scale not in SCALES:
+        raise ProviderPlanError("maximum scale is not a canonical ladder rung")
+    profiles = load_profiles(root / "profiles" / "graph500")
+    completed = completed_rungs(root, output_dir, commit=commit)
+    if any(int(item["scale"]) > maximum_scale for item in completed):
+        raise ProviderPlanError("completed rung exceeds the authorized maximum scale")
+    try:
+        selected = select_next(profiles, completed, provider_capacity)
+    except QualificationError as error:
+        raise ProviderPlanError("progressive admission policy refused the next rung") from error
+    if selected is None or selected.scale > maximum_scale:
+        raise ProviderPlanError("next rung is not admitted within the authorized maximum scale")
+    profile_path = _profile_path(root, selected)
+    projection: Mapping[str, Any] | None = None
+    if selected.execution == "provider":
+        try:
+            projection = project(selected, completed, provider_capacity)
+        except QualificationError as error:
+            raise ProviderPlanError("provider projection is not admitted") from error
+        if projection["decision"] != "admitted":
+            raise ProviderPlanError("provider projection is not admitted")
+        projection_schema = _read_json(
+            root / "schemas" / "progressive-qualification-evidence.json",
+            "provider projection schema is unavailable",
+        )
+        error = next(Draft202012Validator(projection_schema).iter_errors(projection), None)
+        if error is not None:
+            raise ProviderPlanError("provider projection is not schema-valid")
+    plan = {
+        "schema": PLAN_SCHEMA,
+        "status": "admitted",
+        "commit": commit,
+        "maximum_scale": maximum_scale,
+        "completed_scales": [item["scale"] for item in completed],
+        "next_rung": f"S{selected.scale}",
+        "execution": selected.execution,
+        "profile_id": selected.id,
+        "profile_path": profile_path.relative_to(root).as_posix(),
+        "profile_sha256": "sha256:" + _sha256(profile_path),
+        "projection": projection,
+        "execution_authorized": selected.execution == "local",
+        "execution_refusal": None if selected.execution == "local" else EXECUTION_REFUSAL,
+        "claim": "engineering_evidence_only",
+    }
+    schema_path = root / "schemas" / "progressive-provider-plan.json"
+    schema = _read_json(schema_path, "provider plan schema is unavailable")
+    error = next(Draft202012Validator(schema).iter_errors(plan), None)
+    if error is not None:
+        raise ProviderPlanError("provider plan failed its schema")
+    return plan
+
+
+def require_execution_authority(plan: Mapping[str, Any]) -> None:
+    """Refuse provider execution until its image and resource authority exist."""
+    if plan.get("execution") == "provider":
+        raise ProviderPlanError(
+            "provider execution is refused until a dedicated provider image and BenchExec "
+            "authority exist"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Write one no-spend provider plan for a protected workflow step."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--maximum-scale", type=int, required=True)
+    parser.add_argument("--provider-capacity", type=Path)
+    parser.add_argument("--plan-out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        capacity = None
+        if args.provider_capacity is not None:
+            value = _read_json(args.provider_capacity, "provider capacity evidence is malformed")
+            if not isinstance(value, Mapping):
+                raise ProviderPlanError("provider capacity evidence is malformed")
+            capacity = value
+        plan = plan_provider_ladder(
+            root=args.root,
+            output_dir=args.output_dir,
+            commit=args.commit,
+            maximum_scale=args.maximum_scale,
+            provider_capacity=capacity,
+        )
+        args.plan_out.parent.mkdir(parents=True, exist_ok=True)
+        args.plan_out.write_text(
+            json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except (OSError, ProviderPlanError) as error:
+        print(json.dumps({"schema": PLAN_SCHEMA, "status": "refused", "failure": str(error)}))
+        return 2
+    print(json.dumps(plan, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/harness/graphforge_bench/progressive_provider_plan.py
+++ b/benchmarks/harness/graphforge_bench/progressive_provider_plan.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 from pathlib import Path
 import re
+import subprocess
 from typing import Any
 
 from jsonschema import Draft202012Validator
@@ -59,6 +60,23 @@ def _sha256(path: Path) -> str:
     return value
 
 
+def _repository_commit(root: Path) -> str:
+    """Return the exact commit checked out for the benchmark workspace."""
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(root.parent), "rev-parse", "HEAD"],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError as error:
+        raise ProviderPlanError("repository commit is unavailable") from error
+    value = completed.stdout.strip()
+    if completed.returncode != 0 or COMMIT.fullmatch(value) is None:
+        raise ProviderPlanError("repository commit is unavailable")
+    return value
+
+
 def _validate_rung(root: Path, value: Any, scale: int) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise ProviderPlanError("completed rung evidence is malformed")
@@ -83,20 +101,36 @@ def _validate_rung(root: Path, value: Any, scale: int) -> Mapping[str, Any]:
 
 
 def _validate_result_identity(
-    output_dir: Path, *, scale: int, commit: str, profile_id: str
+    root: Path, output_dir: Path, *, scale: int, commit: str, profile_id: str
 ) -> None:
     """Bind each completed rung to the exact source commit and profile."""
     value = _read_json(output_dir / f"s{scale}-result.json", "completed rung result is unavailable")
     if not isinstance(value, Mapping):
         raise ProviderPlanError("completed rung result is malformed")
+    schema_name = (
+        "progressive-run-result.json"
+        if scale in (18, 19)
+        else "progressive-provider-run-result.json"
+    )
+    schema = _read_json(
+        root / "schemas" / schema_name, "completed rung result schema is unavailable"
+    )
+    error = next(Draft202012Validator(schema).iter_errors(value), None)
+    if error is not None:
+        raise ProviderPlanError("completed rung result is not schema-valid")
     identities = value.get("identities")
     if not isinstance(identities, Mapping):
         raise ProviderPlanError("completed rung result identity is missing")
+    profile_path = _profile_path(
+        root, _profile(load_profiles(root / "profiles" / "graph500"), scale)
+    )
+    expected_profile_sha = _sha256(profile_path)
     if (
         value.get("rung") != f"S{scale}"
         or value.get("status") != "passed"
         or identities.get("commit") != commit
         or identities.get("profile_id") != profile_id
+        or identities.get("profile_sha256") != expected_profile_sha
     ):
         raise ProviderPlanError(
             "completed rung result is not bound to the requested commit/profile"
@@ -119,6 +153,7 @@ def completed_rungs(
         rung = _validate_rung(root, _read_json(path, "completed rung evidence is malformed"), scale)
         if commit is not None:
             _validate_result_identity(
+                root,
                 output_dir,
                 scale=scale,
                 commit=commit,
@@ -146,6 +181,8 @@ def plan_provider_ladder(
     """Return one immutable, sanitized next-rung plan without provider calls."""
     if COMMIT.fullmatch(commit) is None:
         raise ProviderPlanError("commit must be a lowercase full Git object ID")
+    if _repository_commit(root) != commit:
+        raise ProviderPlanError("requested commit is not the checked-out repository commit")
     if maximum_scale not in SCALES:
         raise ProviderPlanError("maximum scale is not a canonical ladder rung")
     profiles = load_profiles(root / "profiles" / "graph500")

--- a/benchmarks/schemas/progressive-provider-plan.json
+++ b/benchmarks/schemas/progressive-provider-plan.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-progressive-provider-plan-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "status", "commit", "maximum_scale", "completed_scales", "next_rung", "execution", "profile_id", "profile_path", "profile_sha256", "projection", "execution_authorized", "execution_refusal", "claim"],
+  "properties": {
+    "schema": {"const": "graphforge-progressive-provider-plan/1"},
+    "status": {"const": "admitted"},
+    "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "maximum_scale": {"enum": [18, 19, 20, 22, 24, 25, 26]},
+    "completed_scales": {"type": "array", "uniqueItems": true, "items": {"enum": [18, 19, 20, 22, 24, 25, 26]}},
+    "next_rung": {"enum": ["S18", "S19", "S20", "S22", "S24", "S25", "S26"]},
+    "execution": {"enum": ["local", "provider"]},
+    "profile_id": {"type": "string", "pattern": "^graph500-s(18|19|20|22|24|25|26)-(local|provider)$"},
+    "profile_path": {"type": "string", "pattern": "^profiles/graph500/s(18|19|20|22|24|25|26)-(local|provider)\\.json$"},
+    "profile_sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "projection": {"oneOf": [{"type": "object"}, {"type": "null"}]},
+    "execution_authorized": {"type": "boolean"},
+    "execution_refusal": {"type": ["string", "null"], "enum": [null, "provider_executor_unavailable"]},
+    "claim": {"const": "engineering_evidence_only"}
+  }
+}

--- a/benchmarks/schemas/progressive-provider-run-result.json
+++ b/benchmarks/schemas/progressive-provider-run-result.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-progressive-provider-run-result-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "rung", "status", "failure", "identities", "claim"],
+  "properties": {
+    "schema": {"const": "graphforge-progressive-provider-run-result/1"},
+    "rung": {"enum": ["S20", "S22", "S24", "S25", "S26"]},
+    "status": {"enum": ["passed", "failed"]},
+    "failure": {"type": ["string", "null"]},
+    "identities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit", "profile_id", "profile_sha256"],
+      "properties": {
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "profile_id": {"enum": ["graph500-s20-provider", "graph500-s22-provider", "graph500-s24-provider", "graph500-s25-provider", "graph500-s26-provider"]},
+        "profile_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "claim": {"const": "engineering_evidence_only"}
+  },
+  "allOf": [
+    {"if": {"properties": {"status": {"const": "passed"}}, "required": ["status"]},
+     "then": {"properties": {"failure": {"type": "null"}}},
+     "else": {"properties": {"failure": {"type": "string"}}}}
+  ]
+}

--- a/benchmarks/tests/test_progressive_provider_plan.py
+++ b/benchmarks/tests/test_progressive_provider_plan.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from graphforge_bench.progressive_provider_plan import (
+    ProviderPlanError,
+    completed_rungs,
+    plan_provider_ladder,
+    require_execution_authority,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMIT = "a" * 40
+
+
+def rung(scale: int, *, source: str | None = None) -> dict:
+    return {
+        "profile_id": f"graph500-s{scale}-{'local' if scale in (18, 19) else 'provider'}",
+        "source": source or ("progressive_profile" if scale in (18, 19) else "canonical_ladder"),
+        "scale": scale,
+        "live_edges": 16 * (1 << scale),
+        "status": "passed",
+        "correctness": True,
+        "phases": [
+            "admission",
+            "generate",
+            "ingest",
+            "reopen",
+            "recount",
+            "query",
+            "export",
+            "verify",
+            "clean_import",
+            "reopen_proof",
+        ],
+        "metrics": {
+            "wall_seconds": 10,
+            "peak_rss_bytes": 100,
+            "retained_storage_bytes": 200,
+            "transient_peak_storage_bytes": 300,
+            "logical_read_bytes": 400,
+            "logical_write_bytes": 500,
+            "physical_read_bytes": 600,
+            "physical_write_bytes": 700,
+            "reader_calls": 8,
+            "publication_work_units": 9,
+        },
+        "metric_sources": {
+            "benchexec": [
+                "wall_seconds",
+                "peak_rss_bytes",
+                "physical_read_bytes",
+                "physical_write_bytes",
+            ],
+            "storage_attribution": [
+                "retained_storage_bytes",
+                "transient_peak_storage_bytes",
+                "logical_read_bytes",
+                "logical_write_bytes",
+                "reader_calls",
+                "publication_work_units",
+            ],
+            "query_qualification": ["live_edges", "correctness"],
+        },
+        "storage_components": {
+            "source_allocated_physical_bytes": 100,
+            "source_retained_logical_eof_bytes": 110,
+            "imported_allocated_physical_bytes": 120,
+            "imported_retained_logical_eof_bytes": 130,
+            "transient_peak_allocated_bytes": 300,
+            "logical_read_bytes": 400,
+            "logical_write_bytes": 500,
+            "reader_calls": 8,
+            "publication_work_units": 9,
+        },
+        "failure": None,
+    }
+
+
+CAPACITY = {
+    "physical_read_bytes_per_second": 100,
+    "physical_write_bytes_per_second": 100,
+    "reader_calls_per_second": 100,
+    "publication_work_per_second": 100,
+}
+PROJECTED_FIELDS = (
+    "wall_seconds",
+    "peak_rss_bytes",
+    "retained_storage_bytes",
+    "transient_peak_storage_bytes",
+    "logical_read_bytes",
+    "logical_write_bytes",
+    "physical_read_bytes",
+    "physical_write_bytes",
+    "reader_calls",
+    "publication_work_units",
+    "storage_peak_bytes",
+)
+RATE_FIELDS = (
+    "physical_read_bytes_per_second",
+    "physical_write_bytes_per_second",
+    "reader_calls_per_second",
+    "publication_work_per_second",
+)
+SLOPE_FIELDS = (
+    "logical_read_bytes",
+    "logical_write_bytes",
+    "physical_read_bytes",
+    "physical_write_bytes",
+    "reader_calls",
+    "publication_work_units",
+)
+CHECK_FIELDS = (
+    "time_headroom",
+    "rss_headroom",
+    "retained_storage_headroom",
+    "transient_storage_headroom",
+    "storage_headroom",
+    "rss_bounded_or_plateaued",
+    "io_reader_publication_capacity_measured",
+    "io_reader_publication_headroom",
+    "correctness",
+)
+
+
+class ProgressiveProviderPlanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.output = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_empty_workspace_admits_only_s18(self) -> None:
+        plan = plan_provider_ladder(
+            root=ROOT, output_dir=self.output, commit=COMMIT, maximum_scale=26
+        )
+        self.assertEqual(plan["next_rung"], "S18")
+        self.assertEqual(plan["execution"], "local")
+        self.assertIsNone(plan["projection"])
+        self.assertEqual(plan["profile_path"], "profiles/graph500/s18-local.json")
+        self.assertNotIn("app", json.dumps(plan))
+        self.assertNotIn("machine", json.dumps(plan))
+        self.assertNotIn("volume", json.dumps(plan))
+
+    def test_evidence_must_be_a_contiguous_passed_prefix(self) -> None:
+        (self.output / "s19-rung.json").write_text(json.dumps(rung(19)), encoding="utf-8")
+        with self.assertRaisesRegex(ProviderPlanError, "out of order"):
+            completed_rungs(ROOT, self.output)
+        (self.output / "s19-rung.json").unlink()
+        bad = rung(18)
+        bad["status"] = "failed"
+        (self.output / "s18-rung.json").write_text(json.dumps(bad), encoding="utf-8")
+        with self.assertRaisesRegex(ProviderPlanError, "schema-valid"):
+            completed_rungs(ROOT, self.output)
+
+    def test_projection_gate_is_required_before_s20(self) -> None:
+        with (
+            patch(
+                "graphforge_bench.progressive_provider_plan.completed_rungs",
+                return_value=[rung(18), rung(19)],
+            ),
+            self.assertRaisesRegex(ProviderPlanError, "not admitted"),
+        ):
+            plan_provider_ladder(root=ROOT, output_dir=self.output, commit=COMMIT, maximum_scale=20)
+
+    def test_provider_plan_contains_only_sanitized_projection(self) -> None:
+        with (
+            patch(
+                "graphforge_bench.progressive_provider_plan.completed_rungs",
+                return_value=[rung(18), rung(19)],
+            ),
+            patch(
+                "graphforge_bench.progressive_provider_plan.project",
+                return_value={
+                    "schema": "graphforge-progressive-qualification-evidence/1",
+                    "target": "S20",
+                    "source_scales": [18, 19],
+                    "decision": "admitted",
+                    "limits": {
+                        "wall_seconds": 14400,
+                        "rss_bytes": 4294967296,
+                        "volume_bytes": 536870912000,
+                    },
+                    "headroom": {
+                        "time_fraction": 0.2,
+                        "rss_fraction": 0.2,
+                        "storage_fraction": 0.15,
+                    },
+                    "projected": dict.fromkeys(PROJECTED_FIELDS, 1),
+                    "required_rates": dict.fromkeys(RATE_FIELDS, 1),
+                    "provider_capacity": CAPACITY,
+                    "slopes_observed": dict.fromkeys(SLOPE_FIELDS, 1),
+                    "rss_growth_fraction": 0,
+                    "checks": dict.fromkeys(CHECK_FIELDS, True),
+                    "claim": "engineering_evidence_only",
+                },
+            ),
+        ):
+            plan = plan_provider_ladder(
+                root=ROOT,
+                output_dir=self.output,
+                commit=COMMIT,
+                maximum_scale=20,
+                provider_capacity=CAPACITY,
+            )
+        self.assertEqual(plan["next_rung"], "S20")
+        self.assertEqual(plan["profile_id"], "graph500-s20-provider")
+        self.assertEqual(plan["projection"]["decision"], "admitted")
+        encoded = json.dumps(plan).lower()
+        for forbidden in ("machine_id", "volume_id", "token", "secret", "provider_id"):
+            self.assertNotIn(forbidden, encoded)
+
+    def test_max_scale_cannot_skip_the_next_rung(self) -> None:
+        with (
+            patch(
+                "graphforge_bench.progressive_provider_plan.completed_rungs",
+                return_value=[rung(18), rung(19)],
+            ),
+            self.assertRaisesRegex(ProviderPlanError, "not admitted"),
+        ):
+            plan_provider_ladder(
+                root=ROOT,
+                output_dir=self.output,
+                commit=COMMIT,
+                maximum_scale=19,
+                provider_capacity=CAPACITY,
+            )
+
+    def test_plan_requires_exact_commit_bound_result_files(self) -> None:
+        for scale in (18, 19):
+            value = rung(scale)
+            (self.output / f"s{scale}-rung.json").write_text(json.dumps(value), encoding="utf-8")
+            result = {
+                "rung": f"S{scale}",
+                "status": "passed",
+                "identities": {"commit": COMMIT, "profile_id": value["profile_id"]},
+            }
+            (self.output / f"s{scale}-result.json").write_text(json.dumps(result), encoding="utf-8")
+        result = json.loads((self.output / "s19-result.json").read_text(encoding="utf-8"))
+        result["identities"]["commit"] = "b" * 40
+        (self.output / "s19-result.json").write_text(json.dumps(result), encoding="utf-8")
+        with self.assertRaisesRegex(ProviderPlanError, "commit/profile"):
+            plan_provider_ladder(
+                root=ROOT,
+                output_dir=self.output,
+                commit=COMMIT,
+                maximum_scale=20,
+                provider_capacity=CAPACITY,
+            )
+
+    def test_provider_execution_is_explicitly_refused(self) -> None:
+        with patch(
+            "graphforge_bench.progressive_provider_plan.completed_rungs",
+            return_value=[rung(18), rung(19)],
+        ):
+            plan = plan_provider_ladder(
+                root=ROOT,
+                output_dir=self.output,
+                commit=COMMIT,
+                maximum_scale=20,
+                provider_capacity=CAPACITY,
+            )
+        with self.assertRaisesRegex(ProviderPlanError, "dedicated provider image"):
+            require_execution_authority(plan)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_progressive_provider_plan.py
+++ b/benchmarks/tests/test_progressive_provider_plan.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -14,7 +16,12 @@ from graphforge_bench.progressive_provider_plan import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-COMMIT = "a" * 40
+COMMIT = subprocess.run(
+    ["git", "-C", str(ROOT.parent), "rev-parse", "HEAD"],
+    capture_output=True,
+    check=True,
+    text=True,
+).stdout.strip()
 
 
 def rung(scale: int, *, source: str | None = None) -> dict:
@@ -78,6 +85,29 @@ def rung(scale: int, *, source: str | None = None) -> dict:
             "publication_work_units": 9,
         },
         "failure": None,
+    }
+
+
+def result(scale: int) -> dict:
+    profile = ROOT / "profiles" / "graph500" / f"s{scale}-local.json"
+    digest = hashlib.sha256(profile.read_bytes()).hexdigest()
+    return {
+        "schema": "graphforge-progressive-run-result/1",
+        "rung": f"S{scale}",
+        "status": "passed",
+        "failure": None,
+        "identities": {
+            "commit": COMMIT,
+            "profile_id": f"graph500-s{scale}-local",
+            "profile_sha256": digest,
+            "generator": "sha256:" + "0" * 64,
+            "generator_executable_sha256": "0" * 64,
+            "gf_sha256": "0" * 64,
+            "certify_sha256": "0" * 64,
+            "benchexec_python_sha256": "0" * 64,
+            "benchexec_version": "1.0",
+        },
+        "claim": "engineering_evidence_only",
     }
 
 
@@ -146,6 +176,15 @@ class ProgressiveProviderPlanTests(unittest.TestCase):
         self.assertNotIn("app", json.dumps(plan))
         self.assertNotIn("machine", json.dumps(plan))
         self.assertNotIn("volume", json.dumps(plan))
+
+    def test_plan_requires_checked_out_commit(self) -> None:
+        with self.assertRaisesRegex(ProviderPlanError, "checked-out repository commit"):
+            plan_provider_ladder(
+                root=ROOT,
+                output_dir=self.output,
+                commit="a" * 40,
+                maximum_scale=26,
+            )
 
     def test_evidence_must_be_a_contiguous_passed_prefix(self) -> None:
         (self.output / "s19-rung.json").write_text(json.dumps(rung(19)), encoding="utf-8")
@@ -235,16 +274,37 @@ class ProgressiveProviderPlanTests(unittest.TestCase):
         for scale in (18, 19):
             value = rung(scale)
             (self.output / f"s{scale}-rung.json").write_text(json.dumps(value), encoding="utf-8")
-            result = {
-                "rung": f"S{scale}",
-                "status": "passed",
-                "identities": {"commit": COMMIT, "profile_id": value["profile_id"]},
-            }
-            (self.output / f"s{scale}-result.json").write_text(json.dumps(result), encoding="utf-8")
-        result = json.loads((self.output / "s19-result.json").read_text(encoding="utf-8"))
-        result["identities"]["commit"] = "b" * 40
-        (self.output / "s19-result.json").write_text(json.dumps(result), encoding="utf-8")
+            result_doc = result(scale)
+            (self.output / f"s{scale}-result.json").write_text(
+                json.dumps(result_doc), encoding="utf-8"
+            )
+        result_doc = json.loads((self.output / "s19-result.json").read_text(encoding="utf-8"))
+        result_doc["identities"]["commit"] = "b" * 40
+        (self.output / "s19-result.json").write_text(json.dumps(result_doc), encoding="utf-8")
         with self.assertRaisesRegex(ProviderPlanError, "commit/profile"):
+            plan_provider_ladder(
+                root=ROOT,
+                output_dir=self.output,
+                commit=COMMIT,
+                maximum_scale=20,
+                provider_capacity=CAPACITY,
+            )
+
+    def test_minimal_result_document_is_rejected(self) -> None:
+        for scale in (18, 19):
+            value = rung(scale)
+            (self.output / f"s{scale}-rung.json").write_text(json.dumps(value), encoding="utf-8")
+            (self.output / f"s{scale}-result.json").write_text(
+                json.dumps(
+                    {
+                        "rung": f"S{scale}",
+                        "status": "passed",
+                        "identities": {"commit": COMMIT, "profile_id": value["profile_id"]},
+                    }
+                ),
+                encoding="utf-8",
+            )
+        with self.assertRaisesRegex(ProviderPlanError, "result is not schema-valid"):
             plan_provider_ladder(
                 root=ROOT,
                 output_dir=self.output,


### PR DESCRIPTION
## Summary
- add a no-spend planner for the canonical S18 → S19 → S20 → S22 → S24 → S25 → S26 ladder
- bind completed evidence to the exact commit and checked-in profile
- emit sanitized next-rung plans and refuse provider execution until dedicated image/BenchExec authority exists
- expose the planner via `make -C benchmarks progressive-provider-plan` and document the boundary

## Validation
- 97 benchmark unit tests passed
- Ruff check and format check passed
- `git diff --check` passed
- no provider resources or credentials touched

This is the first executor increment; it intentionally does not provision or run a provider benchmark.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790711327&installation_model_id=20486&pr_number=1005&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1005&signature=dd31cd7ccccf9ac4d111c3c6fdf34e5181ca53b81fa1545dc92d8fe7fe730099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->