### PR TITLE
fix(make): preserve native wheel during install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -568,6 +568,13 @@ jobs:
           --profile dev
           --out dist
 
+      - name: Prove make install preserves the native wheel
+        shell: bash
+        run: |
+          wheels=(dist/*.whl)
+          test "${#wheels[@]}" -eq 1
+          python3 scripts/ci/test-make-install-preserves-native-wheel.py "${wheels[0]}"
+
       - name: Prove isolated native package
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,10 +121,11 @@ pnpm install
 Standard lint/test/build/run commands are in the `Makefile` and `package.json`;
 prefer those. Non-obvious caveats for this environment:
 
-- **`uv sync` prunes the native wheel.** Plain `uv sync --all-extras` (what
-  `make install` runs) uninstalls the maturin-built `graphforge` package. Use
-  `uv sync --all-extras --inexact` to preserve it, or rebuild afterwards. The
-  editable rebuild is instant when `target/` is warm.
+- **Plain `uv sync` prunes the native wheel.** Direct `uv sync --all-extras`
+  uninstalls the maturin-built `graphforge` package. `make install` and the
+  startup update script use `uv sync --all-extras --inexact` to preserve it;
+  use the same flag for direct syncs, or rebuild afterwards. The editable
+  rebuild is instant when `target/` is warm.
 - **Rebuild native bindings after changing Rust.** The update script does not
   build. After pulling Rust changes, rebuild before Python/Node tests:
   `uv run maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml`

--- a/Makefile
+++ b/Makefile
@@ -458,7 +458,9 @@ check-coverage-node:  ## Validate Node c8 summary meets ≥85% lines (lib/ surfa
 # ================================================================
 
 install:  ## Install all toolchain dependencies (Python + Rust + Node)
-	uv sync --all-extras
+	# The native graphforge wheel is installed outside this deps-only uv project.
+	# Keep it (and other explicitly installed tooling) while syncing workspace deps.
+	uv sync --all-extras --inexact
 	cargo check --workspace
 	pnpm install
 

--- a/scripts/ci/test-make-install-preserves-native-wheel.py
+++ b/scripts/ci/test-make-install-preserves-native-wheel.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Prove ``make install`` preserves an already-installed native wheel."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(*command: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        env=env,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def native_fingerprint(python: Path) -> dict[str, str]:
+    probe = """
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import graphforge
+
+spec = importlib.util.find_spec("graphforge._graphforge_rs")
+assert spec is not None and spec.origin is not None
+extension = Path(spec.origin).resolve()
+print(json.dumps({
+    "extension": str(extension),
+    "sha256": hashlib.sha256(extension.read_bytes()).hexdigest(),
+    "version": graphforge.__version__,
+}, sort_keys=True))
+"""
+    return json.loads(run(str(python), "-I", "-c", probe).stdout)
+
+
+def write_noop(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path, help="same-checkout graphforge wheel to install")
+    args = parser.parse_args()
+    wheel = args.wheel.resolve()
+    if not wheel.is_file() or wheel.suffix != ".whl":
+        raise SystemExit(f"expected one built wheel, got: {wheel}")
+
+    with tempfile.TemporaryDirectory(prefix="graphforge-make-install-") as raw:
+        temporary = Path(raw)
+        environment = temporary / "venv"
+        python = environment / "bin" / "python"
+        shims = temporary / "shims"
+        shims.mkdir()
+        write_noop(shims / "cargo")
+        write_noop(shims / "pnpm")
+
+        run("uv", "venv", str(environment), "--python", sys.executable)
+        clean_probe = subprocess.run(
+            (str(python), "-I", "-c", "import graphforge"),
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if clean_probe.returncode == 0:
+            raise SystemExit("clean test environment unexpectedly imports graphforge")
+
+        run("uv", "pip", "install", "--python", str(python), str(wheel))
+        before = native_fingerprint(python)
+
+        make_environment = dict(os.environ)
+        make_environment["PATH"] = os.pathsep.join((str(shims), make_environment["PATH"]))
+        make_environment["UV_PROJECT_ENVIRONMENT"] = str(environment)
+        completed = run("make", "--no-print-directory", "install", env=make_environment)
+        after = native_fingerprint(python)
+
+        if after != before:
+            raise SystemExit(
+                "make install replaced or removed the native wheel:\n"
+                f"before={json.dumps(before, sort_keys=True)}\n"
+                f"after={json.dumps(after, sort_keys=True)}"
+            )
+
+        evidence = {
+            "installed_native": before,
+            "make_install_output_sha256": hashlib.sha256(completed.stdout.encode()).hexdigest(),
+            "wheel": wheel.name,
+            "wheel_sha256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        }
+        print(json.dumps(evidence, indent=2, sort_keys=True))
+        print("make install preserved the installed native graphforge wheel")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- sync workspace dependencies with `uv --inexact` so `make install` preserves the separately installed native package
- add a clean-environment regression that installs the same-SHA wheel, runs the exact Make target, and compares the native extension path, SHA-256, and version
- run the proof in the existing Python-binding CI lane immediately after wheel construction
- update agent guidance to match the corrected behavior

## Local verification

- Ruff lint and formatting
- Python bytecode compilation
- workflow lint
- changed-path and policy classifier tests
- `make -n install`
- `git diff --check`

The full wheel proof is wired into Python-binding CI; this executor does not have Cargo available for the maturin build.

Closes #1019

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790715824&installation_model_id=20486&pr_number=1029&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1029&signature=e6f8dc3618a0c614e2c032750553bb46fbf2aa8d357bdd875d4ffe6098c72428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->