### PR TITLE
build(bench): pin GDC identities and evidence contracts

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,6 +26,19 @@ belongs to issue #959, after parity is proven.
 - `tests/` — no-cost workspace and fixture-discovery tests.
 - `runners/` — unpublished Rust benchmark runners.
 
+## GDC identity contracts
+
+`graphforge_bench.gdc_contracts` pins shared GDC/LDBC identities, dataset
+checksum provenance, reference digests, and sanitized suite evidence without
+embedding workload semantics. Each suite remains independently selectable via
+`suites/gdc-*.json`. Bulk datasets are not committed; acquisition fixtures only
+carry tiny checksummed stand-ins. Validation rejects incomplete provenance,
+checksum mismatch, missing assets, reference mismatch, and identity drift.
+
+```bash
+PYTHONPATH=harness uv run --locked python -m unittest tests.test_gdc_contracts
+```
+
 ## Public-interface certification runner
 
 `runners/certify` owns the admission through reopen-proof lifecycle. A profile

--- a/benchmarks/fixtures/gdc/checksum-mismatch/acquisition.json
+++ b/benchmarks/fixtures/gdc/checksum-mismatch/acquisition.json
@@ -1,0 +1,39 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "graphalytics",
+  "recorded_spec": {
+    "name": "ldbc-graphalytics",
+    "source": "https://ldbcouncil.org/benchmarks/graphalytics/",
+    "release": "1.0.0-engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "graphalytics-datasets",
+    "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics",
+    "release": "wiki-Talk-fixture-pin",
+    "commit": null
+  },
+  "recorded_driver": {
+    "name": "ldbc_graphalytics",
+    "source": "https://github.com/ldbc/ldbc_graphalytics",
+    "release": null,
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "assets": [
+    {
+      "id": "wiki-Talk",
+      "path": "wiki-Talk.txt",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "Graphalytics-dataset-terms",
+      "acquisition": "fixture"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "wiki-Talk",
+      "workload_key": "bfs",
+      "path": "wiki-Talk-bfs.ref",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db"
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/checksum-mismatch/wiki-Talk-bfs.ref
+++ b/benchmarks/fixtures/gdc/checksum-mismatch/wiki-Talk-bfs.ref
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-reference-v1

--- a/benchmarks/fixtures/gdc/checksum-mismatch/wiki-Talk.txt
+++ b/benchmarks/fixtures/gdc/checksum-mismatch/wiki-Talk.txt
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-wrong-bytes

--- a/benchmarks/fixtures/gdc/complete/acquisition.json
+++ b/benchmarks/fixtures/gdc/complete/acquisition.json
@@ -1,0 +1,39 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "graphalytics",
+  "recorded_spec": {
+    "name": "ldbc-graphalytics",
+    "source": "https://ldbcouncil.org/benchmarks/graphalytics/",
+    "release": "1.0.0-engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "graphalytics-datasets",
+    "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics",
+    "release": "wiki-Talk-fixture-pin",
+    "commit": null
+  },
+  "recorded_driver": {
+    "name": "ldbc_graphalytics",
+    "source": "https://github.com/ldbc/ldbc_graphalytics",
+    "release": null,
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "assets": [
+    {
+      "id": "wiki-Talk",
+      "path": "wiki-Talk.txt",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "Graphalytics-dataset-terms",
+      "acquisition": "fixture"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "wiki-Talk",
+      "workload_key": "bfs",
+      "path": "wiki-Talk-bfs.ref",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db"
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/complete/wiki-Talk-bfs.ref
+++ b/benchmarks/fixtures/gdc/complete/wiki-Talk-bfs.ref
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-reference-v1

--- a/benchmarks/fixtures/gdc/complete/wiki-Talk.txt
+++ b/benchmarks/fixtures/gdc/complete/wiki-Talk.txt
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-dataset-v1

--- a/benchmarks/fixtures/gdc/identity-drift/acquisition.json
+++ b/benchmarks/fixtures/gdc/identity-drift/acquisition.json
@@ -1,0 +1,39 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "graphalytics",
+  "recorded_spec": {
+    "name": "ldbc-graphalytics",
+    "source": "https://ldbcouncil.org/benchmarks/graphalytics/",
+    "release": "1.0.0-engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "graphalytics-datasets",
+    "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics",
+    "release": "wiki-Talk-fixture-pin",
+    "commit": null
+  },
+  "recorded_driver": {
+    "name": "ldbc_graphalytics",
+    "source": "https://github.com/ldbc/ldbc_graphalytics",
+    "release": null,
+    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "assets": [
+    {
+      "id": "wiki-Talk",
+      "path": "wiki-Talk.txt",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "Graphalytics-dataset-terms",
+      "acquisition": "fixture"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "wiki-Talk",
+      "workload_key": "bfs",
+      "path": "wiki-Talk-bfs.ref",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db"
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/identity-drift/wiki-Talk-bfs.ref
+++ b/benchmarks/fixtures/gdc/identity-drift/wiki-Talk-bfs.ref
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-reference-v1

--- a/benchmarks/fixtures/gdc/identity-drift/wiki-Talk.txt
+++ b/benchmarks/fixtures/gdc/identity-drift/wiki-Talk.txt
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-dataset-v1

--- a/benchmarks/fixtures/gdc/incomplete-provenance/acquisition.json
+++ b/benchmarks/fixtures/gdc/incomplete-provenance/acquisition.json
@@ -1,0 +1,24 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "graphalytics",
+  "recorded_spec": {
+    "name": "ldbc-graphalytics",
+    "source": "https://ldbcouncil.org/benchmarks/graphalytics/",
+    "release": "1.0.0-engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "graphalytics-datasets",
+    "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics",
+    "release": "wiki-Talk-fixture-pin",
+    "commit": null
+  },
+  "recorded_driver": {
+    "name": "ldbc_graphalytics",
+    "source": "https://github.com/ldbc/ldbc_graphalytics",
+    "release": null,
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "assets": [],
+  "references": []
+}

--- a/benchmarks/fixtures/gdc/incomplete-provenance/pinned-identity.json
+++ b/benchmarks/fixtures/gdc/incomplete-provenance/pinned-identity.json
@@ -1,0 +1,34 @@
+{
+  "schema": "graphforge-gdc-pinned-identity/1",
+  "suite_id": "graphalytics",
+  "disposition": "executable",
+  "spec": {
+    "name": "ldbc-graphalytics",
+    "source": "https://ldbcouncil.org/benchmarks/graphalytics/",
+    "release": null,
+    "commit": null
+  },
+  "generator": {
+    "name": "graphalytics-datasets",
+    "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics",
+    "release": "wiki-Talk-fixture-pin",
+    "commit": null
+  },
+  "driver": {
+    "name": "ldbc_graphalytics",
+    "source": "https://github.com/ldbc/ldbc_graphalytics",
+    "release": null,
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "datasets": [
+    {
+      "id": "wiki-Talk",
+      "role": "dataset",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "",
+      "acquisition": "fixture",
+      "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics"
+    }
+  ],
+  "references": []
+}

--- a/benchmarks/fixtures/gdc/missing-assets/acquisition.json
+++ b/benchmarks/fixtures/gdc/missing-assets/acquisition.json
@@ -1,0 +1,39 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "graphalytics",
+  "recorded_spec": {
+    "name": "ldbc-graphalytics",
+    "source": "https://ldbcouncil.org/benchmarks/graphalytics/",
+    "release": "1.0.0-engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "graphalytics-datasets",
+    "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics",
+    "release": "wiki-Talk-fixture-pin",
+    "commit": null
+  },
+  "recorded_driver": {
+    "name": "ldbc_graphalytics",
+    "source": "https://github.com/ldbc/ldbc_graphalytics",
+    "release": null,
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "assets": [
+    {
+      "id": "wiki-Talk",
+      "path": "wiki-Talk.txt",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "Graphalytics-dataset-terms",
+      "acquisition": "fixture"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "wiki-Talk",
+      "workload_key": "bfs",
+      "path": "wiki-Talk-bfs.ref",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db"
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/missing-assets/wiki-Talk.txt
+++ b/benchmarks/fixtures/gdc/missing-assets/wiki-Talk.txt
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-dataset-v1

--- a/benchmarks/fixtures/gdc/reference-mismatch/acquisition.json
+++ b/benchmarks/fixtures/gdc/reference-mismatch/acquisition.json
@@ -1,0 +1,39 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "graphalytics",
+  "recorded_spec": {
+    "name": "ldbc-graphalytics",
+    "source": "https://ldbcouncil.org/benchmarks/graphalytics/",
+    "release": "1.0.0-engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "graphalytics-datasets",
+    "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics",
+    "release": "wiki-Talk-fixture-pin",
+    "commit": null
+  },
+  "recorded_driver": {
+    "name": "ldbc_graphalytics",
+    "source": "https://github.com/ldbc/ldbc_graphalytics",
+    "release": null,
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "assets": [
+    {
+      "id": "wiki-Talk",
+      "path": "wiki-Talk.txt",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "Graphalytics-dataset-terms",
+      "acquisition": "fixture"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "wiki-Talk",
+      "workload_key": "bfs",
+      "path": "wiki-Talk-bfs.ref",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db"
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/reference-mismatch/wiki-Talk-bfs.ref
+++ b/benchmarks/fixtures/gdc/reference-mismatch/wiki-Talk-bfs.ref
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-wrong-bytes

--- a/benchmarks/fixtures/gdc/reference-mismatch/wiki-Talk.txt
+++ b/benchmarks/fixtures/gdc/reference-mismatch/wiki-Talk.txt
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-dataset-v1

--- a/benchmarks/harness/graphforge_bench/gdc_contracts.py
+++ b/benchmarks/harness/graphforge_bench/gdc_contracts.py
@@ -1,0 +1,322 @@
+"""Shared GDC identity, acquisition, and evidence contracts.
+
+Suite adapters share these contracts without sharing workload semantics.
+Bulk datasets are never committed; only checksummed provenance is validated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+PIN_SCHEMA = "graphforge-gdc-pinned-identity/1"
+ACQUISITION_SCHEMA = "graphforge-gdc-acquisition/1"
+EVIDENCE_SCHEMA = "graphforge-gdc-suite-evidence/1"
+SUITE_SCHEMA = "graphforge-benchmark-suite/1"
+
+EXECUTABLE_SUITES = (
+    "graphalytics",
+    "snb-interactive",
+    "snb-bi",
+    "finbench-transaction",
+)
+INVENTORY_SUITES = ("spb",)
+ALL_SUITES = EXECUTABLE_SUITES + INVENTORY_SUITES
+
+
+class GdcContractError(ValueError):
+    """Pinned identity or acquisition evidence is incomplete or contradictory."""
+
+    def __init__(self, cause: str, message: str) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
+def workspace_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_schema(name: str) -> Draft202012Validator:
+    document = json.loads(
+        (workspace_root() / "schemas" / name).read_text(encoding="utf-8")
+    )
+    Draft202012Validator.check_schema(document)
+    return Draft202012Validator(document)
+
+
+def _validate(validator: Draft202012Validator, document: Mapping[str, Any], label: str) -> None:
+    error = next(validator.iter_errors(document), None)
+    if error is not None:
+        raise GdcContractError("invalid_document", f"{label}: {error.message}")
+
+
+def _tool_key(identity: Mapping[str, Any] | None) -> tuple[Any, ...]:
+    if identity is None:
+        return ("null",)
+    return (
+        identity.get("name"),
+        identity.get("source"),
+        identity.get("release"),
+        identity.get("commit"),
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_pinned_identity(path: Path) -> dict[str, Any]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise GdcContractError("invalid_document", "pinned identity must be an object")
+    _validate(_load_schema("gdc-pinned-identity.json"), document, "pinned identity")
+    if document["schema"] != PIN_SCHEMA:
+        raise GdcContractError("invalid_document", "unexpected pinned identity schema")
+    return document
+
+
+def load_acquisition(path: Path) -> dict[str, Any]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise GdcContractError("invalid_document", "acquisition must be an object")
+    _validate(_load_schema("gdc-acquisition.json"), document, "acquisition")
+    if document["schema"] != ACQUISITION_SCHEMA:
+        raise GdcContractError("invalid_document", "unexpected acquisition schema")
+    return document
+
+
+def load_suite_declaration(path: Path) -> dict[str, Any]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise GdcContractError("invalid_document", "suite declaration must be an object")
+    _validate(_load_schema("gdc-suite-declaration.json"), document, "suite declaration")
+    if document["schema"] != SUITE_SCHEMA:
+        raise GdcContractError("invalid_document", "unexpected suite schema")
+    return document
+
+
+def _reject_incomplete_pin(pin: Mapping[str, Any]) -> None:
+    required = ("suite_id", "disposition", "spec", "generator", "driver", "datasets", "references")
+    missing = [name for name in required if name not in pin]
+    if missing:
+        raise GdcContractError(
+            "incomplete_provenance",
+            f"pinned identity missing fields: {', '.join(missing)}",
+        )
+    for tool_name in ("spec", "generator", "driver"):
+        tool = pin[tool_name]
+        if tool is None:
+            continue
+        if not isinstance(tool, Mapping):
+            raise GdcContractError("incomplete_provenance", f"{tool_name} identity is incomplete")
+        if not tool.get("name") or not tool.get("source"):
+            raise GdcContractError("incomplete_provenance", f"{tool_name} identity is incomplete")
+        if tool.get("release") is None and tool.get("commit") is None:
+            raise GdcContractError(
+                "incomplete_provenance",
+                f"{tool_name} requires release or commit",
+            )
+    if pin["disposition"] == "executable":
+        if not pin["datasets"]:
+            raise GdcContractError("incomplete_provenance", "executable suite requires datasets")
+        for dataset in pin["datasets"]:
+            for field in ("id", "checksum_sha256", "license", "acquisition", "source"):
+                if not dataset.get(field):
+                    raise GdcContractError(
+                        "incomplete_provenance",
+                        f"dataset provenance incomplete: {dataset.get('id', '<unknown>')}",
+                    )
+
+
+def _evidence(
+    *,
+    suite_id: str,
+    disposition: str,
+    status: str,
+    cause: str | None,
+    identities: Mapping[str, Any],
+    datasets: list[dict[str, Any]],
+    references: list[dict[str, Any]],
+) -> dict[str, Any]:
+    document = {
+        "schema": EVIDENCE_SCHEMA,
+        "suite_id": suite_id,
+        "disposition": disposition,
+        "status": status,
+        "cause": cause,
+        "identities": {
+            "spec": dict(identities["spec"]),
+            "generator": None
+            if identities["generator"] is None
+            else dict(identities["generator"]),
+            "driver": None if identities["driver"] is None else dict(identities["driver"]),
+        },
+        "datasets": datasets,
+        "references": references,
+    }
+    _validate(_load_schema("gdc-suite-evidence.json"), document, "suite evidence")
+    return document
+
+
+def validate_acquisition(
+    pin: Mapping[str, Any],
+    acquisition: Mapping[str, Any],
+    asset_root: Path,
+) -> dict[str, Any]:
+    """Validate acquired inputs against a pinned identity without workload semantics."""
+    _reject_incomplete_pin(pin)
+    _validate(_load_schema("gdc-pinned-identity.json"), pin, "pinned identity")
+    _validate(_load_schema("gdc-acquisition.json"), acquisition, "acquisition")
+
+    if acquisition.get("suite_id") != pin["suite_id"]:
+        raise GdcContractError("identity_drift", "acquisition suite_id drifted from pin")
+
+    for label, pinned, recorded in (
+        ("spec", pin["spec"], acquisition.get("recorded_spec")),
+        ("generator", pin["generator"], acquisition.get("recorded_generator")),
+        ("driver", pin["driver"], acquisition.get("recorded_driver")),
+    ):
+        if _tool_key(pinned) != _tool_key(recorded if isinstance(recorded, Mapping) or recorded is None else None):
+            raise GdcContractError("identity_drift", f"{label} identity drifted from pin")
+
+    if pin["disposition"] == "inventory_only":
+        if acquisition.get("assets") or acquisition.get("references"):
+            raise GdcContractError(
+                "invalid_document",
+                "inventory-only suites must not acquire executable assets",
+            )
+        return _evidence(
+            suite_id=pin["suite_id"],
+            disposition=pin["disposition"],
+            status="passed",
+            cause=None,
+            identities={
+                "spec": pin["spec"],
+                "generator": None,
+                "driver": None,
+            },
+            datasets=[],
+            references=[],
+        )
+
+    pinned_datasets = {item["id"]: item for item in pin["datasets"]}
+    acquired_assets = {item["id"]: item for item in acquisition.get("assets", [])}
+    missing = sorted(set(pinned_datasets) - set(acquired_assets))
+    if missing:
+        raise GdcContractError(
+            "missing_assets",
+            f"missing acquired datasets: {', '.join(missing)}",
+        )
+    unexpected = sorted(set(acquired_assets) - set(pinned_datasets))
+    if unexpected:
+        raise GdcContractError(
+            "incomplete_provenance",
+            f"acquired datasets not pinned: {', '.join(unexpected)}",
+        )
+
+    datasets_out: list[dict[str, Any]] = []
+    for dataset_id, pinned in pinned_datasets.items():
+        asset = acquired_assets[dataset_id]
+        path = asset_root / asset["path"]
+        if not path.is_file():
+            raise GdcContractError("missing_assets", f"dataset file missing: {asset['path']}")
+        digest = _sha256_file(path)
+        if digest != pinned["checksum_sha256"] or digest != asset["checksum_sha256"]:
+            raise GdcContractError(
+                "checksum_mismatch",
+                f"dataset checksum mismatch: {dataset_id}",
+            )
+        if asset.get("license") != pinned["license"]:
+            raise GdcContractError(
+                "incomplete_provenance",
+                f"dataset license missing or drifted: {dataset_id}",
+            )
+        datasets_out.append(
+            {
+                "id": dataset_id,
+                "checksum_sha256": digest,
+                "license": pinned["license"],
+            }
+        )
+
+    pinned_refs = {
+        (item["dataset_id"], item["workload_key"]): item for item in pin["references"]
+    }
+    acquired_refs = {
+        (item["dataset_id"], item["workload_key"]): item
+        for item in acquisition.get("references", [])
+    }
+    missing_refs = sorted(set(pinned_refs) - set(acquired_refs))
+    if missing_refs:
+        rendered = ", ".join(f"{dataset}:{key}" for dataset, key in missing_refs)
+        raise GdcContractError("reference_mismatch", f"missing references: {rendered}")
+    unexpected_refs = sorted(set(acquired_refs) - set(pinned_refs))
+    if unexpected_refs:
+        rendered = ", ".join(f"{dataset}:{key}" for dataset, key in unexpected_refs)
+        raise GdcContractError("reference_mismatch", f"unexpected references: {rendered}")
+
+    references_out: list[dict[str, Any]] = []
+    for key, pinned in pinned_refs.items():
+        asset = acquired_refs[key]
+        path = asset_root / asset["path"]
+        if not path.is_file():
+            raise GdcContractError("missing_assets", f"reference file missing: {asset['path']}")
+        digest = _sha256_file(path)
+        if digest != pinned["checksum_sha256"] or digest != asset["checksum_sha256"]:
+            raise GdcContractError(
+                "reference_mismatch",
+                f"reference checksum mismatch: {key[0]}:{key[1]}",
+            )
+        references_out.append(
+            {
+                "dataset_id": key[0],
+                "workload_key": key[1],
+                "checksum_sha256": digest,
+            }
+        )
+
+    return _evidence(
+        suite_id=pin["suite_id"],
+        disposition=pin["disposition"],
+        status="passed",
+        cause=None,
+        identities={
+            "spec": pin["spec"],
+            "generator": pin["generator"],
+            "driver": pin["driver"],
+        },
+        datasets=datasets_out,
+        references=references_out,
+    )
+
+
+def list_gdc_suites(root: Path | None = None) -> tuple[dict[str, Any], ...]:
+    base = root or workspace_root()
+    by_id: dict[str, dict[str, Any]] = {}
+    for path in (base / "suites").glob("gdc-*.json"):
+        suite = load_suite_declaration(path)
+        suite_id = suite["suite_id"]
+        if suite_id in by_id:
+            raise GdcContractError(
+                "incomplete_provenance",
+                f"duplicate GDC suite declaration: {suite_id}",
+            )
+        by_id[suite_id] = suite
+    if set(by_id) != set(ALL_SUITES):
+        raise GdcContractError(
+            "incomplete_provenance",
+            "GDC suite index must declare each suite independently exactly once",
+        )
+    return tuple(by_id[suite_id] for suite_id in ALL_SUITES)

--- a/benchmarks/harness/graphforge_bench/gdc_contracts.py
+++ b/benchmarks/harness/graphforge_bench/gdc_contracts.py
@@ -42,9 +42,7 @@ def workspace_root() -> Path:
 
 
 def _load_schema(name: str) -> Draft202012Validator:
-    document = json.loads(
-        (workspace_root() / "schemas" / name).read_text(encoding="utf-8")
-    )
+    document = json.loads((workspace_root() / "schemas" / name).read_text(encoding="utf-8"))
     Draft202012Validator.check_schema(document)
     return Draft202012Validator(document)
 
@@ -158,9 +156,7 @@ def _evidence(
         "cause": cause,
         "identities": {
             "spec": dict(identities["spec"]),
-            "generator": None
-            if identities["generator"] is None
-            else dict(identities["generator"]),
+            "generator": None if identities["generator"] is None else dict(identities["generator"]),
             "driver": None if identities["driver"] is None else dict(identities["driver"]),
         },
         "datasets": datasets,
@@ -188,7 +184,9 @@ def validate_acquisition(
         ("generator", pin["generator"], acquisition.get("recorded_generator")),
         ("driver", pin["driver"], acquisition.get("recorded_driver")),
     ):
-        if _tool_key(pinned) != _tool_key(recorded if isinstance(recorded, Mapping) or recorded is None else None):
+        if _tool_key(pinned) != _tool_key(
+            recorded if isinstance(recorded, Mapping) or recorded is None else None
+        ):
             raise GdcContractError("identity_drift", f"{label} identity drifted from pin")
 
     if pin["disposition"] == "inventory_only":
@@ -251,9 +249,7 @@ def validate_acquisition(
             }
         )
 
-    pinned_refs = {
-        (item["dataset_id"], item["workload_key"]): item for item in pin["references"]
-    }
+    pinned_refs = {(item["dataset_id"], item["workload_key"]): item for item in pin["references"]}
     acquired_refs = {
         (item["dataset_id"], item["workload_key"]): item
         for item in acquisition.get("references", [])

--- a/benchmarks/profiles/gdc/finbench-transaction-identity.json
+++ b/benchmarks/profiles/gdc/finbench-transaction-identity.json
@@ -1,0 +1,41 @@
+{
+  "schema": "graphforge-gdc-pinned-identity/1",
+  "suite_id": "finbench-transaction",
+  "disposition": "executable",
+  "spec": {
+    "name": "ldbc-finbench",
+    "source": "https://ldbcouncil.org/benchmarks/finbench/",
+    "release": "0.2.0-alpha-engineering-pin",
+    "commit": null
+  },
+  "generator": {
+    "name": "finbench-datagen",
+    "source": "https://github.com/ldbc/ldbc_finbench_datagen",
+    "release": null,
+    "commit": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "driver": {
+    "name": "finbench-transaction-driver",
+    "source": "https://github.com/ldbc/ldbc_finbench_transaction",
+    "release": null,
+    "commit": "ffffffffffffffffffffffffffffffffffffffff"
+  },
+  "datasets": [
+    {
+      "id": "finbench-sf0.01",
+      "role": "dataset",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "LDBC-FinBench-terms",
+      "acquisition": "fixture",
+      "source": "https://ldbcouncil.org/benchmarks/finbench/datasets/"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "finbench-sf0.01",
+      "workload_key": "transaction-validation",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db",
+      "source": "https://github.com/ldbc/ldbc_finbench_transaction"
+    }
+  ]
+}

--- a/benchmarks/profiles/gdc/graphalytics-identity.json
+++ b/benchmarks/profiles/gdc/graphalytics-identity.json
@@ -1,0 +1,41 @@
+{
+  "schema": "graphforge-gdc-pinned-identity/1",
+  "suite_id": "graphalytics",
+  "disposition": "executable",
+  "spec": {
+    "name": "ldbc-graphalytics",
+    "source": "https://ldbcouncil.org/benchmarks/graphalytics/",
+    "release": "1.0.0-engineering-pin",
+    "commit": null
+  },
+  "generator": {
+    "name": "graphalytics-datasets",
+    "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics",
+    "release": "wiki-Talk-fixture-pin",
+    "commit": null
+  },
+  "driver": {
+    "name": "ldbc_graphalytics",
+    "source": "https://github.com/ldbc/ldbc_graphalytics",
+    "release": null,
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "datasets": [
+    {
+      "id": "wiki-Talk",
+      "role": "dataset",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "Graphalytics-dataset-terms",
+      "acquisition": "fixture",
+      "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "wiki-Talk",
+      "workload_key": "bfs",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db",
+      "source": "https://repository.surfsara.nl/datasets/cwi/graphalytics"
+    }
+  ]
+}

--- a/benchmarks/profiles/gdc/snb-bi-identity.json
+++ b/benchmarks/profiles/gdc/snb-bi-identity.json
@@ -1,0 +1,41 @@
+{
+  "schema": "graphforge-gdc-pinned-identity/1",
+  "suite_id": "snb-bi",
+  "disposition": "executable",
+  "spec": {
+    "name": "ldbc-snb",
+    "source": "https://ldbcouncil.org/benchmarks/snb/",
+    "release": "engineering-pin",
+    "commit": null
+  },
+  "generator": {
+    "name": "ldbc_snb_datagen_spark",
+    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
+    "release": null,
+    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "driver": {
+    "name": "ldbc_snb_bi_driver",
+    "source": "https://github.com/ldbc/ldbc_snb_bi_opensource",
+    "release": null,
+    "commit": "dddddddddddddddddddddddddddddddddddddddd"
+  },
+  "datasets": [
+    {
+      "id": "snb-bi-sf0.003",
+      "role": "dataset",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "LDBC-SNB-terms",
+      "acquisition": "fixture",
+      "source": "https://github.com/ldbc/ldbc_snb_datagen_spark"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "snb-bi-sf0.003",
+      "workload_key": "bi-validation",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db",
+      "source": "https://github.com/ldbc/ldbc_snb_bi_opensource"
+    }
+  ]
+}

--- a/benchmarks/profiles/gdc/snb-interactive-identity.json
+++ b/benchmarks/profiles/gdc/snb-interactive-identity.json
@@ -1,0 +1,41 @@
+{
+  "schema": "graphforge-gdc-pinned-identity/1",
+  "suite_id": "snb-interactive",
+  "disposition": "executable",
+  "spec": {
+    "name": "ldbc-snb",
+    "source": "https://ldbcouncil.org/benchmarks/snb/",
+    "release": "engineering-pin",
+    "commit": null
+  },
+  "generator": {
+    "name": "ldbc_snb_datagen_spark",
+    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
+    "release": null,
+    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "driver": {
+    "name": "ldbc_snb_interactive_driver",
+    "source": "https://github.com/ldbc/ldbc_snb_interactive_v1_impls",
+    "release": null,
+    "commit": "cccccccccccccccccccccccccccccccccccccccc"
+  },
+  "datasets": [
+    {
+      "id": "snb-sf0.003",
+      "role": "dataset",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "LDBC-SNB-terms",
+      "acquisition": "fixture",
+      "source": "https://github.com/ldbc/ldbc_snb_datagen_spark"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "snb-sf0.003",
+      "workload_key": "interactive-validation",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db",
+      "source": "https://github.com/ldbc/ldbc_snb_interactive_v1_impls"
+    }
+  ]
+}

--- a/benchmarks/profiles/gdc/spb-identity.json
+++ b/benchmarks/profiles/gdc/spb-identity.json
@@ -1,0 +1,15 @@
+{
+  "schema": "graphforge-gdc-pinned-identity/1",
+  "suite_id": "spb",
+  "disposition": "inventory_only",
+  "spec": {
+    "name": "ldbc-spb",
+    "source": "https://ldbcouncil.org/benchmarks/",
+    "release": "inventory-only",
+    "commit": null
+  },
+  "generator": null,
+  "driver": null,
+  "datasets": [],
+  "references": []
+}

--- a/benchmarks/schemas/gdc-acquisition.json
+++ b/benchmarks/schemas/gdc-acquisition.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-gdc-acquisition-schema/1",
+  "type": "object",
+  "properties": {
+    "schema": { "const": "graphforge-gdc-acquisition/1" },
+    "suite_id": {
+      "enum": [
+        "graphalytics",
+        "snb-interactive",
+        "snb-bi",
+        "finbench-transaction",
+        "spb"
+      ]
+    },
+    "recorded_spec": { "$ref": "#/$defs/toolIdentity" },
+    "recorded_generator": {
+      "oneOf": [
+        { "$ref": "#/$defs/toolIdentity" },
+        { "type": "null" }
+      ]
+    },
+    "recorded_driver": {
+      "oneOf": [
+        { "$ref": "#/$defs/toolIdentity" },
+        { "type": "null" }
+      ]
+    },
+    "assets": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 64,
+      "items": { "$ref": "#/$defs/asset" }
+    },
+    "references": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 256,
+      "items": { "$ref": "#/$defs/referenceAsset" }
+    }
+  },
+  "required": [
+    "schema",
+    "suite_id",
+    "recorded_spec",
+    "recorded_generator",
+    "recorded_driver",
+    "assets",
+    "references"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "relativePath": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-][A-Za-z0-9._/-]{0,200}$"
+    },
+    "toolIdentity": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "source": {
+          "type": "string",
+          "pattern": "^https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+        },
+        "release": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "commit": {
+          "type": ["string", "null"],
+          "pattern": "^[a-f0-9]{40}$"
+        }
+      },
+      "required": ["name", "source", "release", "commit"],
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "properties": { "release": { "type": "string" } },
+          "required": ["release"]
+        },
+        {
+          "properties": { "commit": { "type": "string" } },
+          "required": ["commit"]
+        }
+      ]
+    },
+    "asset": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+        "path": { "$ref": "#/$defs/relativePath" },
+        "checksum_sha256": { "$ref": "#/$defs/sha256" },
+        "license": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "acquisition": {
+          "type": "string",
+          "enum": ["download", "generate", "mirror", "fixture"]
+        }
+      },
+      "required": ["id", "path", "checksum_sha256", "license", "acquisition"],
+      "additionalProperties": false
+    },
+    "referenceAsset": {
+      "type": "object",
+      "properties": {
+        "dataset_id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+        "workload_key": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]{1,80}$"
+        },
+        "path": { "$ref": "#/$defs/relativePath" },
+        "checksum_sha256": { "$ref": "#/$defs/sha256" }
+      },
+      "required": ["dataset_id", "workload_key", "path", "checksum_sha256"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/benchmarks/schemas/gdc-pinned-identity.json
+++ b/benchmarks/schemas/gdc-pinned-identity.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-gdc-pinned-identity-schema/1",
+  "type": "object",
+  "properties": {
+    "schema": { "const": "graphforge-gdc-pinned-identity/1" },
+    "suite_id": {
+      "enum": [
+        "graphalytics",
+        "snb-interactive",
+        "snb-bi",
+        "finbench-transaction",
+        "spb"
+      ]
+    },
+    "disposition": { "enum": ["executable", "inventory_only"] },
+    "spec": { "$ref": "#/$defs/toolIdentity" },
+    "generator": {
+      "oneOf": [
+        { "$ref": "#/$defs/toolIdentity" },
+        { "type": "null" }
+      ]
+    },
+    "driver": {
+      "oneOf": [
+        { "$ref": "#/$defs/toolIdentity" },
+        { "type": "null" }
+      ]
+    },
+    "datasets": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 64,
+      "items": { "$ref": "#/$defs/datasetPin" }
+    },
+    "references": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 256,
+      "items": { "$ref": "#/$defs/referencePin" }
+    }
+  },
+  "required": [
+    "schema",
+    "suite_id",
+    "disposition",
+    "spec",
+    "generator",
+    "driver",
+    "datasets",
+    "references"
+  ],
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": { "disposition": { "const": "inventory_only" } },
+        "required": ["disposition"]
+      },
+      "then": {
+        "properties": {
+          "generator": { "type": "null" },
+          "driver": { "type": "null" },
+          "datasets": { "maxItems": 0 },
+          "references": { "maxItems": 0 }
+        }
+      },
+      "else": {
+        "properties": {
+          "generator": { "$ref": "#/$defs/toolIdentity" },
+          "driver": { "$ref": "#/$defs/toolIdentity" },
+          "datasets": { "minItems": 1 }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "toolIdentity": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "source": {
+          "type": "string",
+          "pattern": "^https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+        },
+        "release": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "commit": {
+          "type": ["string", "null"],
+          "pattern": "^[a-f0-9]{40}$"
+        }
+      },
+      "required": ["name", "source", "release", "commit"],
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "properties": { "release": { "type": "string" } },
+          "required": ["release"]
+        },
+        {
+          "properties": { "commit": { "type": "string" } },
+          "required": ["commit"]
+        }
+      ]
+    },
+    "datasetPin": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+        "role": { "enum": ["dataset", "parameter", "other"] },
+        "checksum_sha256": { "$ref": "#/$defs/sha256" },
+        "license": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "acquisition": {
+          "type": "string",
+          "enum": ["download", "generate", "mirror", "fixture"]
+        },
+        "source": {
+          "type": "string",
+          "pattern": "^https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+        }
+      },
+      "required": [
+        "id",
+        "role",
+        "checksum_sha256",
+        "license",
+        "acquisition",
+        "source"
+      ],
+      "additionalProperties": false
+    },
+    "referencePin": {
+      "type": "object",
+      "properties": {
+        "dataset_id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+        "workload_key": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]{1,80}$"
+        },
+        "checksum_sha256": { "$ref": "#/$defs/sha256" },
+        "source": {
+          "type": "string",
+          "pattern": "^https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+        }
+      },
+      "required": ["dataset_id", "workload_key", "checksum_sha256", "source"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/benchmarks/schemas/gdc-suite-declaration.json
+++ b/benchmarks/schemas/gdc-suite-declaration.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-gdc-suite-declaration-schema/1",
+  "type": "object",
+  "properties": {
+    "schema": { "const": "graphforge-benchmark-suite/1" },
+    "id": {
+      "enum": [
+        "gdc-graphalytics",
+        "gdc-snb-interactive",
+        "gdc-snb-bi",
+        "gdc-finbench-transaction",
+        "gdc-spb"
+      ]
+    },
+    "family": { "const": "gdc" },
+    "suite_id": {
+      "enum": [
+        "graphalytics",
+        "snb-interactive",
+        "snb-bi",
+        "finbench-transaction",
+        "spb"
+      ]
+    },
+    "disposition": { "enum": ["executable", "inventory_only"] },
+    "pinned_identity": {
+      "type": "string",
+      "pattern": "^profiles/gdc/[A-Za-z0-9_.-]+\\.json$"
+    },
+    "runner": { "const": "gdc-contracts" },
+    "datasets": {
+      "type": "array",
+      "maxItems": 64,
+      "items": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" }
+    }
+  },
+  "required": [
+    "schema",
+    "id",
+    "family",
+    "suite_id",
+    "disposition",
+    "pinned_identity",
+    "runner",
+    "datasets"
+  ],
+  "additionalProperties": false
+}

--- a/benchmarks/schemas/gdc-suite-evidence.json
+++ b/benchmarks/schemas/gdc-suite-evidence.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-gdc-suite-evidence-schema/1",
+  "type": "object",
+  "properties": {
+    "schema": { "const": "graphforge-gdc-suite-evidence/1" },
+    "suite_id": {
+      "enum": [
+        "graphalytics",
+        "snb-interactive",
+        "snb-bi",
+        "finbench-transaction",
+        "spb"
+      ]
+    },
+    "disposition": { "enum": ["executable", "inventory_only"] },
+    "status": { "enum": ["passed", "failed"] },
+    "cause": {
+      "type": ["string", "null"],
+      "enum": [
+        null,
+        "incomplete_provenance",
+        "checksum_mismatch",
+        "missing_assets",
+        "reference_mismatch",
+        "identity_drift",
+        "invalid_document"
+      ]
+    },
+    "identities": {
+      "type": "object",
+      "properties": {
+        "spec": { "$ref": "#/$defs/toolIdentity" },
+        "generator": {
+          "oneOf": [
+            { "$ref": "#/$defs/toolIdentity" },
+            { "type": "null" }
+          ]
+        },
+        "driver": {
+          "oneOf": [
+            { "$ref": "#/$defs/toolIdentity" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "required": ["spec", "generator", "driver"],
+      "additionalProperties": false
+    },
+    "datasets": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+          "checksum_sha256": { "$ref": "#/$defs/sha256" },
+          "license": { "type": "string", "minLength": 1, "maxLength": 120 }
+        },
+        "required": ["id", "checksum_sha256", "license"],
+        "additionalProperties": false
+      }
+    },
+    "references": {
+      "type": "array",
+      "maxItems": 256,
+      "items": {
+        "type": "object",
+        "properties": {
+          "dataset_id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+          "workload_key": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_.-]{1,80}$"
+          },
+          "checksum_sha256": { "$ref": "#/$defs/sha256" }
+        },
+        "required": ["dataset_id", "workload_key", "checksum_sha256"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "schema",
+    "suite_id",
+    "disposition",
+    "status",
+    "cause",
+    "identities",
+    "datasets",
+    "references"
+  ],
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": { "status": { "const": "passed" } },
+        "required": ["status"]
+      },
+      "then": { "properties": { "cause": { "type": "null" } } },
+      "else": { "properties": { "cause": { "type": "string" } } }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "toolIdentity": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "source": {
+          "type": "string",
+          "pattern": "^https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+        },
+        "release": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "commit": {
+          "type": ["string", "null"],
+          "pattern": "^[a-f0-9]{40}$"
+        }
+      },
+      "required": ["name", "source", "release", "commit"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/benchmarks/suites/gdc-finbench-transaction.json
+++ b/benchmarks/suites/gdc-finbench-transaction.json
@@ -1,0 +1,10 @@
+{
+  "schema": "graphforge-benchmark-suite/1",
+  "id": "gdc-finbench-transaction",
+  "family": "gdc",
+  "suite_id": "finbench-transaction",
+  "disposition": "executable",
+  "pinned_identity": "profiles/gdc/finbench-transaction-identity.json",
+  "runner": "gdc-contracts",
+  "datasets": ["finbench-sf0.01"]
+}

--- a/benchmarks/suites/gdc-graphalytics.json
+++ b/benchmarks/suites/gdc-graphalytics.json
@@ -1,0 +1,10 @@
+{
+  "schema": "graphforge-benchmark-suite/1",
+  "id": "gdc-graphalytics",
+  "family": "gdc",
+  "suite_id": "graphalytics",
+  "disposition": "executable",
+  "pinned_identity": "profiles/gdc/graphalytics-identity.json",
+  "runner": "gdc-contracts",
+  "datasets": ["wiki-Talk"]
+}

--- a/benchmarks/suites/gdc-snb-bi.json
+++ b/benchmarks/suites/gdc-snb-bi.json
@@ -1,0 +1,10 @@
+{
+  "schema": "graphforge-benchmark-suite/1",
+  "id": "gdc-snb-bi",
+  "family": "gdc",
+  "suite_id": "snb-bi",
+  "disposition": "executable",
+  "pinned_identity": "profiles/gdc/snb-bi-identity.json",
+  "runner": "gdc-contracts",
+  "datasets": ["snb-bi-sf0.003"]
+}

--- a/benchmarks/suites/gdc-snb-interactive.json
+++ b/benchmarks/suites/gdc-snb-interactive.json
@@ -1,0 +1,10 @@
+{
+  "schema": "graphforge-benchmark-suite/1",
+  "id": "gdc-snb-interactive",
+  "family": "gdc",
+  "suite_id": "snb-interactive",
+  "disposition": "executable",
+  "pinned_identity": "profiles/gdc/snb-interactive-identity.json",
+  "runner": "gdc-contracts",
+  "datasets": ["snb-sf0.003"]
+}

--- a/benchmarks/suites/gdc-spb.json
+++ b/benchmarks/suites/gdc-spb.json
@@ -1,0 +1,10 @@
+{
+  "schema": "graphforge-benchmark-suite/1",
+  "id": "gdc-spb",
+  "family": "gdc",
+  "suite_id": "spb",
+  "disposition": "inventory_only",
+  "pinned_identity": "profiles/gdc/spb-identity.json",
+  "runner": "gdc-contracts",
+  "datasets": []
+}

--- a/benchmarks/tests/test_gdc_contracts.py
+++ b/benchmarks/tests/test_gdc_contracts.py
@@ -20,9 +20,7 @@ class GdcContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.root = workspace_root()
-        cls.pin = load_pinned_identity(
-            cls.root / "profiles" / "gdc" / "graphalytics-identity.json"
-        )
+        cls.pin = load_pinned_identity(cls.root / "profiles" / "gdc" / "graphalytics-identity.json")
         cls.fixtures = cls.root / "fixtures" / "gdc"
 
     def test_schemas_are_draft2020_valid(self) -> None:
@@ -54,9 +52,7 @@ class GdcContractTests(unittest.TestCase):
 
     def test_complete_acquisition_records_immutable_identities(self) -> None:
         acquisition = load_acquisition(self.fixtures / "complete" / "acquisition.json")
-        evidence = validate_acquisition(
-            self.pin, acquisition, self.fixtures / "complete"
-        )
+        evidence = validate_acquisition(self.pin, acquisition, self.fixtures / "complete")
         self.assertEqual(evidence["status"], "passed")
         self.assertIsNone(evidence["cause"])
         self.assertEqual(evidence["identities"]["spec"]["release"], "1.0.0-engineering-pin")
@@ -79,13 +75,9 @@ class GdcContractTests(unittest.TestCase):
                 encoding="utf-8"
             )
         )
-        acquisition = load_acquisition(
-            self.fixtures / "incomplete-provenance" / "acquisition.json"
-        )
+        acquisition = load_acquisition(self.fixtures / "incomplete-provenance" / "acquisition.json")
         with self.assertRaises(GdcContractError) as raised:
-            validate_acquisition(
-                incomplete, acquisition, self.fixtures / "incomplete-provenance"
-            )
+            validate_acquisition(incomplete, acquisition, self.fixtures / "incomplete-provenance")
         self.assertEqual(raised.exception.cause, "incomplete_provenance")
 
         stripped = copy.deepcopy(self.pin)
@@ -99,37 +91,25 @@ class GdcContractTests(unittest.TestCase):
         self.assertEqual(raised_license.exception.cause, "incomplete_provenance")
 
     def test_checksum_mismatch_fixture(self) -> None:
-        acquisition = load_acquisition(
-            self.fixtures / "checksum-mismatch" / "acquisition.json"
-        )
+        acquisition = load_acquisition(self.fixtures / "checksum-mismatch" / "acquisition.json")
         with self.assertRaises(GdcContractError) as raised:
-            validate_acquisition(
-                self.pin, acquisition, self.fixtures / "checksum-mismatch"
-            )
+            validate_acquisition(self.pin, acquisition, self.fixtures / "checksum-mismatch")
         self.assertEqual(raised.exception.cause, "checksum_mismatch")
 
     def test_missing_assets_fixture(self) -> None:
-        acquisition = load_acquisition(
-            self.fixtures / "missing-assets" / "acquisition.json"
-        )
+        acquisition = load_acquisition(self.fixtures / "missing-assets" / "acquisition.json")
         with self.assertRaises(GdcContractError) as raised:
             validate_acquisition(self.pin, acquisition, self.fixtures / "missing-assets")
         self.assertEqual(raised.exception.cause, "missing_assets")
 
     def test_reference_mismatch_fixture(self) -> None:
-        acquisition = load_acquisition(
-            self.fixtures / "reference-mismatch" / "acquisition.json"
-        )
+        acquisition = load_acquisition(self.fixtures / "reference-mismatch" / "acquisition.json")
         with self.assertRaises(GdcContractError) as raised:
-            validate_acquisition(
-                self.pin, acquisition, self.fixtures / "reference-mismatch"
-            )
+            validate_acquisition(self.pin, acquisition, self.fixtures / "reference-mismatch")
         self.assertEqual(raised.exception.cause, "reference_mismatch")
 
     def test_identity_drift_fixture(self) -> None:
-        acquisition = load_acquisition(
-            self.fixtures / "identity-drift" / "acquisition.json"
-        )
+        acquisition = load_acquisition(self.fixtures / "identity-drift" / "acquisition.json")
         with self.assertRaises(GdcContractError) as raised:
             validate_acquisition(self.pin, acquisition, self.fixtures / "identity-drift")
         self.assertEqual(raised.exception.cause, "identity_drift")
@@ -145,7 +125,7 @@ class GdcContractTests(unittest.TestCase):
             "assets": [],
             "references": [],
         }
-        evidence = validate_acquisition(pin, acquisition, Path("."))
+        evidence = validate_acquisition(pin, acquisition, Path())
         self.assertEqual(evidence["status"], "passed")
         self.assertEqual(evidence["disposition"], "inventory_only")
         self.assertEqual(evidence["datasets"], [])

--- a/benchmarks/tests/test_gdc_contracts.py
+++ b/benchmarks/tests/test_gdc_contracts.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+import unittest
+
+from graphforge_bench.gdc_contracts import (
+    GdcContractError,
+    list_gdc_suites,
+    load_acquisition,
+    load_pinned_identity,
+    validate_acquisition,
+    workspace_root,
+)
+from jsonschema import Draft202012Validator
+
+
+class GdcContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root = workspace_root()
+        cls.pin = load_pinned_identity(
+            cls.root / "profiles" / "gdc" / "graphalytics-identity.json"
+        )
+        cls.fixtures = cls.root / "fixtures" / "gdc"
+
+    def test_schemas_are_draft2020_valid(self) -> None:
+        for name in (
+            "gdc-pinned-identity.json",
+            "gdc-acquisition.json",
+            "gdc-suite-evidence.json",
+            "gdc-suite-declaration.json",
+        ):
+            schema = json.loads((self.root / "schemas" / name).read_text(encoding="utf-8"))
+            Draft202012Validator.check_schema(schema)
+
+    def test_suites_are_independently_selectable(self) -> None:
+        suites = list_gdc_suites()
+        self.assertEqual(
+            [suite["suite_id"] for suite in suites],
+            [
+                "graphalytics",
+                "snb-interactive",
+                "snb-bi",
+                "finbench-transaction",
+                "spb",
+            ],
+        )
+        for suite in suites:
+            pin = load_pinned_identity(self.root / suite["pinned_identity"])
+            self.assertEqual(pin["suite_id"], suite["suite_id"])
+            self.assertEqual(pin["disposition"], suite["disposition"])
+
+    def test_complete_acquisition_records_immutable_identities(self) -> None:
+        acquisition = load_acquisition(self.fixtures / "complete" / "acquisition.json")
+        evidence = validate_acquisition(
+            self.pin, acquisition, self.fixtures / "complete"
+        )
+        self.assertEqual(evidence["status"], "passed")
+        self.assertIsNone(evidence["cause"])
+        self.assertEqual(evidence["identities"]["spec"]["release"], "1.0.0-engineering-pin")
+        self.assertEqual(
+            evidence["identities"]["driver"]["commit"],
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        self.assertEqual(
+            evidence["datasets"][0]["checksum_sha256"],
+            "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+        )
+        self.assertEqual(
+            evidence["references"][0]["checksum_sha256"],
+            "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db",
+        )
+
+    def test_incomplete_provenance_is_rejected(self) -> None:
+        incomplete = json.loads(
+            (self.fixtures / "incomplete-provenance" / "pinned-identity.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        acquisition = load_acquisition(
+            self.fixtures / "incomplete-provenance" / "acquisition.json"
+        )
+        with self.assertRaises(GdcContractError) as raised:
+            validate_acquisition(
+                incomplete, acquisition, self.fixtures / "incomplete-provenance"
+            )
+        self.assertEqual(raised.exception.cause, "incomplete_provenance")
+
+        stripped = copy.deepcopy(self.pin)
+        stripped["datasets"][0]["license"] = ""
+        with self.assertRaises(GdcContractError) as raised_license:
+            validate_acquisition(
+                stripped,
+                load_acquisition(self.fixtures / "complete" / "acquisition.json"),
+                self.fixtures / "complete",
+            )
+        self.assertEqual(raised_license.exception.cause, "incomplete_provenance")
+
+    def test_checksum_mismatch_fixture(self) -> None:
+        acquisition = load_acquisition(
+            self.fixtures / "checksum-mismatch" / "acquisition.json"
+        )
+        with self.assertRaises(GdcContractError) as raised:
+            validate_acquisition(
+                self.pin, acquisition, self.fixtures / "checksum-mismatch"
+            )
+        self.assertEqual(raised.exception.cause, "checksum_mismatch")
+
+    def test_missing_assets_fixture(self) -> None:
+        acquisition = load_acquisition(
+            self.fixtures / "missing-assets" / "acquisition.json"
+        )
+        with self.assertRaises(GdcContractError) as raised:
+            validate_acquisition(self.pin, acquisition, self.fixtures / "missing-assets")
+        self.assertEqual(raised.exception.cause, "missing_assets")
+
+    def test_reference_mismatch_fixture(self) -> None:
+        acquisition = load_acquisition(
+            self.fixtures / "reference-mismatch" / "acquisition.json"
+        )
+        with self.assertRaises(GdcContractError) as raised:
+            validate_acquisition(
+                self.pin, acquisition, self.fixtures / "reference-mismatch"
+            )
+        self.assertEqual(raised.exception.cause, "reference_mismatch")
+
+    def test_identity_drift_fixture(self) -> None:
+        acquisition = load_acquisition(
+            self.fixtures / "identity-drift" / "acquisition.json"
+        )
+        with self.assertRaises(GdcContractError) as raised:
+            validate_acquisition(self.pin, acquisition, self.fixtures / "identity-drift")
+        self.assertEqual(raised.exception.cause, "identity_drift")
+
+    def test_inventory_only_spb_shares_contracts_without_workload_assets(self) -> None:
+        pin = load_pinned_identity(self.root / "profiles" / "gdc" / "spb-identity.json")
+        acquisition = {
+            "schema": "graphforge-gdc-acquisition/1",
+            "suite_id": "spb",
+            "recorded_spec": pin["spec"],
+            "recorded_generator": None,
+            "recorded_driver": None,
+            "assets": [],
+            "references": [],
+        }
+        evidence = validate_acquisition(pin, acquisition, Path("."))
+        self.assertEqual(evidence["status"], "passed")
+        self.assertEqual(evidence["disposition"], "inventory_only")
+        self.assertEqual(evidence["datasets"], [])
+        self.assertEqual(evidence["references"], [])
+
+    def test_adapters_do_not_embed_shared_workload_semantics(self) -> None:
+        module = (self.root / "harness" / "graphforge_bench" / "gdc_contracts.py").read_text(
+            encoding="utf-8"
+        )
+        for forbidden in ("PageRank", "bfs_params", "interactive_query", "finbench_tcr"):
+            self.assertNotIn(forbidden, module)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add shared GDC pinned-identity, acquisition, suite-declaration, and sanitized evidence schemas under `benchmarks/`.
- Implement `graphforge_bench.gdc_contracts` validation that rejects incomplete provenance, checksum mismatch, missing assets, reference mismatch, and identity drift.
- Declare independently selectable GDC suites (Graphalytics, SNB Interactive/BI, FinBench Transaction, SPB inventory-only) with fixture-only checksummed stand-ins—no bulk datasets.

Closes #960

## Test plan
- [x] `PYTHONPATH=harness uv run --locked python -m unittest tests.test_gdc_contracts -v` (10 passed)
- [x] `PYTHONPATH=harness uv run --locked python -m graphforge_bench.smoke`
- [x] `PYTHONPATH=harness uv run --locked python -m unittest discover -s tests -p 'test_*.py'` (186 passed)
- [ ] CI Gate green at exact head SHA


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790792062&installation_model_id=20486&pr_number=1043&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1043&signature=388f7a8af52b5886dd06247aa5f63a85f81cdba7e46561cd2bbbfc057c018858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->