### PR TITLE
docs(bench): inventory GDC SPB without incompatible runner

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,8 +35,12 @@ embedding workload semantics. Each suite remains independently selectable via
 carry tiny checksummed stand-ins. Validation rejects incomplete provenance,
 checksum mismatch, missing assets, reference mismatch, and identity drift.
 
+The harness index is [`gdc-suite-index.md`](gdc-suite-index.md). SPB remains
+`inventory_only` (RDF/SPARQL outside the Cypher product surface); see #965.
+
 ```bash
 PYTHONPATH=harness uv run --locked python -m unittest tests.test_gdc_contracts
+PYTHONPATH=harness uv run --locked python -m unittest tests.test_gdc_spb_inventory
 ```
 
 ## Public-interface certification runner

--- a/benchmarks/gdc-suite-index.md
+++ b/benchmarks/gdc-suite-index.md
@@ -1,0 +1,69 @@
+# GDC / LDBC suite index (benchmark workspace)
+
+This index is owned by the isolated `benchmarks/` workspace. It inventories the
+Graph Data Council (GDC, formerly LDBC) portfolio as independently selectable
+suites. Product crates never embed generators, drivers, or SPARQL approximations.
+
+Authoritative product-facing specification remains
+[`docs/guide/datasets/ldbc.md`](../docs/guide/datasets/ldbc.md). This page is the
+**harness index**: which suites exist, how they are selected, and which are
+executable versus inventory-only.
+
+## Suites
+
+| Suite id | Declaration | Disposition | Notes |
+|---|---|---|---|
+| `graphalytics` | `suites/gdc-graphalytics.json` | executable | Six-algorithm analytics; blocked on suite issue #961 |
+| `snb-interactive` | `suites/gdc-snb-interactive.json` | executable | SNB Interactive; blocked on suite issue #962 |
+| `snb-bi` | `suites/gdc-snb-bi.json` | executable | SNB Business Intelligence; blocked on suite issue #963 |
+| `finbench-transaction` | `suites/gdc-finbench-transaction.json` | executable | FinBench Transaction; blocked on suite issue #964 |
+| `spb` | `suites/gdc-spb.json` | **inventory_only** | Semantic Publishing Benchmark (RDF/SPARQL) |
+
+Shared identity and acquisition contracts live in
+`graphforge_bench.gdc_contracts` (#960). Suite adapters share those contracts
+without sharing workload semantics.
+
+## SPB (Semantic Publishing Benchmark)
+
+**Home:** listed under [GDC Benchmarks](https://ldbcouncil.org/benchmarks/).
+
+| Item | Value |
+|---|---|
+| Official focus | RDF / SPARQL stores over a media-publishing ontology |
+| Protocol | Official SPB driver + SPARQL query/update mix (upstream-owned) |
+| GraphForge disposition | `inventory_only` |
+| Semantic reason | `rdf_sparql_outside_property_graph_cypher_surface` |
+| Harness behavior | Report inventory status only; never advertise an executable SPB profile; never approximate SPARQL with Cypher |
+
+### Inventory-only rationale
+
+GraphForge’s current product surface is property-graph persistence with Cypher
+and analyst verbs. SPB requires RDF storage and SPARQL evaluation. Translating
+SPARQL into Cypher, inventing a fake RDF binding, or shipping a partial
+property-graph “SPB-like” runner would be an incompatible approximation and is
+forbidden.
+
+### Activation criteria (objective)
+
+An executable SPB adapter may be added only when **all** of the following are
+true and recorded in evidence:
+
+1. `product_exposes_supported_rdf_or_sparql_binding` — a supported product
+   binding can evaluate the SPB protocol without Cypher approximation.
+2. `official_spb_spec_and_driver_pins_recorded` — immutable upstream spec and
+   driver identities are pinned through the GDC contracts.
+3. `reference_validation_path_exists_without_cypher_approximation` — official
+   reference validation is available without inventing substitute semantics.
+
+Until then, `suite_status("spb")` returns `disposition=inventory_only`,
+`executable=false`, and the semantic reason above.
+
+## Operator status query
+
+```bash
+PYTHONPATH=harness uv run --locked python - <<'PY'
+from graphforge_bench.gdc_contracts import suite_status, assert_no_executable_spb_profile
+print(suite_status("spb"))
+assert_no_executable_spb_profile()
+PY
+```

--- a/benchmarks/harness/graphforge_bench/gdc_contracts.py
+++ b/benchmarks/harness/graphforge_bench/gdc_contracts.py
@@ -27,6 +27,16 @@ EXECUTABLE_SUITES = (
 )
 INVENTORY_SUITES = ("spb",)
 ALL_SUITES = EXECUTABLE_SUITES + INVENTORY_SUITES
+STATUS_SCHEMA = "graphforge-gdc-suite-status/1"
+
+# SPB is RDF/SPARQL. GraphForge's current product surface is property-graph +
+# Cypher / analyst verbs, so the harness inventories SPB without approximating.
+SPB_INVENTORY_REASON = "rdf_sparql_outside_property_graph_cypher_surface"
+SPB_ACTIVATION_CRITERIA = (
+    "product_exposes_supported_rdf_or_sparql_binding",
+    "official_spb_spec_and_driver_pins_recorded",
+    "reference_validation_path_exists_without_cypher_approximation",
+)
 
 
 class GdcContractError(ValueError):
@@ -316,3 +326,83 @@ def list_gdc_suites(root: Path | None = None) -> tuple[dict[str, Any], ...]:
             "GDC suite index must declare each suite independently exactly once",
         )
     return tuple(by_id[suite_id] for suite_id in ALL_SUITES)
+
+
+def suite_status(suite_id: str, root: Path | None = None) -> dict[str, Any]:
+    """Report a suite disposition without inventing an incompatible runner."""
+    if suite_id not in ALL_SUITES:
+        raise GdcContractError("invalid_document", f"unknown GDC suite: {suite_id}")
+    suites = {suite["suite_id"]: suite for suite in list_gdc_suites(root)}
+    suite = suites[suite_id]
+    pin = load_pinned_identity((root or workspace_root()) / suite["pinned_identity"])
+    if pin["disposition"] != suite["disposition"]:
+        raise GdcContractError(
+            "identity_drift",
+            f"suite disposition drifted from pinned identity: {suite_id}",
+        )
+    if suite["disposition"] == "inventory_only":
+        if suite_id != "spb":
+            raise GdcContractError(
+                "invalid_document",
+                f"unexpected inventory-only suite: {suite_id}",
+            )
+        document = {
+            "schema": STATUS_SCHEMA,
+            "suite_id": suite_id,
+            "disposition": "inventory_only",
+            "executable": False,
+            "reason": SPB_INVENTORY_REASON,
+            "activation_criteria": list(SPB_ACTIVATION_CRITERIA),
+            "pinned_identity": suite["pinned_identity"],
+        }
+    else:
+        document = {
+            "schema": STATUS_SCHEMA,
+            "suite_id": suite_id,
+            "disposition": "executable",
+            "executable": True,
+            "reason": None,
+            "activation_criteria": [],
+            "pinned_identity": suite["pinned_identity"],
+        }
+    _validate(_load_schema("gdc-suite-status.json"), document, "suite status")
+    return document
+
+
+def assert_no_executable_spb_profile(root: Path | None = None) -> None:
+    """Fail closed if an executable SPB profile is advertised."""
+    base = root or workspace_root()
+    status = suite_status("spb", base)
+    if status["executable"] or status["disposition"] != "inventory_only":
+        raise GdcContractError("invalid_document", "SPB must remain inventory-only")
+    for path in (base / "profiles").rglob("*spb*.json"):
+        document = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(document, dict):
+            raise GdcContractError("invalid_document", f"invalid SPB profile: {path.name}")
+        if document.get("schema") != PIN_SCHEMA:
+            raise GdcContractError(
+                "invalid_document",
+                f"executable SPB profile advertised: {path.relative_to(base)}",
+            )
+        if document.get("disposition") != "inventory_only":
+            raise GdcContractError(
+                "invalid_document",
+                f"executable SPB profile advertised: {path.relative_to(base)}",
+            )
+        if document.get("generator") is not None or document.get("driver") is not None:
+            raise GdcContractError(
+                "invalid_document",
+                f"executable SPB tooling advertised: {path.relative_to(base)}",
+            )
+        if document.get("datasets") or document.get("references"):
+            raise GdcContractError(
+                "invalid_document",
+                f"executable SPB assets advertised: {path.relative_to(base)}",
+            )
+    for path in (base / "suites").glob("*spb*.json"):
+        suite = load_suite_declaration(path)
+        if suite["disposition"] != "inventory_only" or suite.get("datasets"):
+            raise GdcContractError(
+                "invalid_document",
+                f"executable SPB suite advertised: {path.name}",
+            )

--- a/benchmarks/schemas/gdc-suite-status.json
+++ b/benchmarks/schemas/gdc-suite-status.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-gdc-suite-status-schema/1",
+  "type": "object",
+  "properties": {
+    "schema": { "const": "graphforge-gdc-suite-status/1" },
+    "suite_id": {
+      "enum": [
+        "graphalytics",
+        "snb-interactive",
+        "snb-bi",
+        "finbench-transaction",
+        "spb"
+      ]
+    },
+    "disposition": { "enum": ["executable", "inventory_only"] },
+    "executable": { "type": "boolean" },
+    "reason": {
+      "type": ["string", "null"],
+      "enum": [
+        null,
+        "rdf_sparql_outside_property_graph_cypher_surface"
+      ]
+    },
+    "activation_criteria": {
+      "type": "array",
+      "maxItems": 16,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_]{0,80}$"
+      }
+    },
+    "pinned_identity": {
+      "type": "string",
+      "pattern": "^profiles/gdc/[A-Za-z0-9_.-]+\\.json$"
+    }
+  },
+  "required": [
+    "schema",
+    "suite_id",
+    "disposition",
+    "executable",
+    "reason",
+    "activation_criteria",
+    "pinned_identity"
+  ],
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": { "disposition": { "const": "inventory_only" } },
+        "required": ["disposition"]
+      },
+      "then": {
+        "properties": {
+          "executable": { "const": false },
+          "reason": { "type": "string" },
+          "activation_criteria": { "minItems": 1 }
+        }
+      },
+      "else": {
+        "properties": {
+          "executable": { "const": true },
+          "reason": { "type": "null" },
+          "activation_criteria": { "maxItems": 0 }
+        }
+      }
+    }
+  ]
+}

--- a/benchmarks/tests/test_gdc_contracts.py
+++ b/benchmarks/tests/test_gdc_contracts.py
@@ -29,6 +29,7 @@ class GdcContractTests(unittest.TestCase):
             "gdc-acquisition.json",
             "gdc-suite-evidence.json",
             "gdc-suite-declaration.json",
+            "gdc-suite-status.json",
         ):
             schema = json.loads((self.root / "schemas" / name).read_text(encoding="utf-8"))
             Draft202012Validator.check_schema(schema)

--- a/benchmarks/tests/test_gdc_spb_inventory.py
+++ b/benchmarks/tests/test_gdc_spb_inventory.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from graphforge_bench.gdc_contracts import (
+    SPB_ACTIVATION_CRITERIA,
+    SPB_INVENTORY_REASON,
+    GdcContractError,
+    assert_no_executable_spb_profile,
+    list_gdc_suites,
+    load_pinned_identity,
+    suite_status,
+    validate_acquisition,
+    workspace_root,
+)
+from jsonschema import Draft202012Validator
+
+
+class GdcSpbInventoryTests(unittest.TestCase):
+    def test_benchmark_index_includes_spb_inventory_disposition(self) -> None:
+        suites = {suite["suite_id"]: suite for suite in list_gdc_suites()}
+        self.assertIn("spb", suites)
+        self.assertEqual(suites["spb"]["disposition"], "inventory_only")
+        index = (workspace_root() / "gdc-suite-index.md").read_text(encoding="utf-8")
+        self.assertIn("`spb`", index)
+        self.assertIn("inventory_only", index)
+        self.assertIn(SPB_INVENTORY_REASON, index)
+        for criterion in SPB_ACTIVATION_CRITERIA:
+            self.assertIn(criterion, index)
+
+    def test_operator_status_reports_inventory_only_with_semantic_reason(self) -> None:
+        status = suite_status("spb")
+        self.assertEqual(status["schema"], "graphforge-gdc-suite-status/1")
+        self.assertEqual(status["disposition"], "inventory_only")
+        self.assertFalse(status["executable"])
+        self.assertEqual(status["reason"], SPB_INVENTORY_REASON)
+        self.assertEqual(status["activation_criteria"], list(SPB_ACTIVATION_CRITERIA))
+        Draft202012Validator(
+            json.loads(
+                (workspace_root() / "schemas" / "gdc-suite-status.json").read_text(encoding="utf-8")
+            )
+        ).validate(status)
+
+    def test_no_executable_spb_profile_is_advertised(self) -> None:
+        assert_no_executable_spb_profile()
+        for suite in list_gdc_suites():
+            if suite["suite_id"] != "spb":
+                continue
+            self.assertEqual(suite["datasets"], [])
+            self.assertEqual(suite["disposition"], "inventory_only")
+
+    def test_activation_criteria_are_objective_and_testable(self) -> None:
+        self.assertGreaterEqual(len(SPB_ACTIVATION_CRITERIA), 3)
+        for criterion in SPB_ACTIVATION_CRITERIA:
+            self.assertRegex(criterion, r"^[a-z][a-z0-9_]{0,80}$")
+        status = suite_status("spb")
+        # Inventory-only means activation criteria are disclosed but not claimed met.
+        self.assertFalse(status["executable"])
+        self.assertEqual(status["activation_criteria"], list(SPB_ACTIVATION_CRITERIA))
+
+    def test_does_not_run_sparql_approximation(self) -> None:
+        module = (workspace_root() / "harness" / "graphforge_bench" / "gdc_contracts.py").read_text(
+            encoding="utf-8"
+        )
+        for forbidden in (
+            "sparql_to_cypher",
+            "approximate_spb",
+            "rdf_literal_as_cypher",
+            "run_spb(",
+        ):
+            self.assertNotIn(forbidden, module)
+        pin = load_pinned_identity(workspace_root() / "profiles" / "gdc" / "spb-identity.json")
+        fake_checksum = "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8"
+        with self.assertRaises(GdcContractError):
+            validate_acquisition(
+                pin,
+                {
+                    "schema": "graphforge-gdc-acquisition/1",
+                    "suite_id": "spb",
+                    "recorded_spec": pin["spec"],
+                    "recorded_generator": None,
+                    "recorded_driver": None,
+                    "assets": [
+                        {
+                            "id": "fake",
+                            "path": "fake.txt",
+                            "checksum_sha256": fake_checksum,
+                            "license": "none",
+                            "acquisition": "fixture",
+                        }
+                    ],
+                    "references": [],
+                },
+                workspace_root(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `benchmarks/gdc-suite-index.md` documenting GDC suite dispositions, including SPB as inventory-only.
- Extend `gdc_contracts` with `suite_status`, SPB semantic reason, and objective activation criteria.
- Reject any executable SPB profile/asset advertisement; never approximate SPARQL with Cypher.

Closes #965

## Test plan
- [x] `PYTHONPATH=harness uv run --locked python -m unittest tests.test_gdc_spb_inventory tests.test_gdc_contracts -v` (15 passed)
- [ ] CI Gate green at exact head SHA