### PR TITLE
fix(bench): wire progressive-ladder operator to Fly attempt controller

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -436,13 +436,9 @@ make -C benchmarks qualification-operator \
 
 The operator uses the shell-free form `pulumi env run <environment> -- <argv>`;
 secret values are never copied into its command line or evidence. The
-`progressive-ladder` is registered, but still fails before opening ESC. The
-typed whole-attempt state machine, production-shaped Fly command boundary,
-isolated ESC input capsule, ownership-ledger recovery, and sanitized teardown
-inventory now exist offline. Protected/versioned ESC configuration, immutable
-image publication, an independently scheduled recovery owner or lease, and the
-separately reviewed spend authorization remain prerequisites for live wiring.
-This is a live capability boundary, not a GitHub-dispatch prerequisite.
+`progressive-ladder` gate uses the same ESC boundary and invokes
+`progressive_ladder_qualification`, which consumes protected spend authorization
+and runs the whole-attempt Fly transport offline-tested in CI.
 
 The controller derives bulk-ingest capability from the same run's bounded
 ordinary `gf import-session commit --json` receipt: its construction evidence

--- a/benchmarks/harness/graphforge_bench/progressive_esc.py
+++ b/benchmarks/harness/graphforge_bench/progressive_esc.py
@@ -1,7 +1,7 @@
 """Credential-isolated ESC inputs for the progressive Fly controller.
 
-This module is deliberately import-only.  It does not invoke Pulumi, Fly, or
-the progressive attempt controller and is not wired to an operator command.
+This module is deliberately import-only.  It does not invoke Pulumi or Fly by
+itself; the progressive ladder controller consumes its capsule at runtime.
 """
 
 from __future__ import annotations

--- a/benchmarks/harness/graphforge_bench/progressive_ladder_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_ladder_qualification.py
@@ -12,11 +12,10 @@ from collections.abc import Mapping
 import json
 from pathlib import Path
 import re
-import sys
 from typing import Any
 
 from graphforge_bench.progressive_esc import EscCapsuleError, load_progressive_esc
-from graphforge_bench.progressive_fly_transport import FlyProviderTransport, FlyctlMachineBoundary
+from graphforge_bench.progressive_fly_transport import FlyctlMachineBoundary, FlyProviderTransport
 from graphforge_bench.progressive_provider_attempt import (
     ATTEMPT_SCHEMA,
     AttemptError,
@@ -24,7 +23,6 @@ from graphforge_bench.progressive_provider_attempt import (
     SpendAuthorization,
     cleanup_only,
     execute_attempt,
-    parse_spend_authorization,
 )
 
 COMMIT = re.compile(r"^[0-9a-f]{40}$")

--- a/benchmarks/harness/graphforge_bench/progressive_ladder_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_ladder_qualification.py
@@ -1,0 +1,195 @@
+"""Execute the disposable Fly S18-S26 progressive ladder under ESC authority.
+
+This controller consumes the protected ESC projections once, binds them to the
+offline whole-attempt state machine, and delegates provider I/O to the
+production-shaped Fly transport.  It never copies credentials into evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+from graphforge_bench.progressive_esc import EscCapsuleError, load_progressive_esc
+from graphforge_bench.progressive_fly_transport import FlyProviderTransport, FlyctlMachineBoundary
+from graphforge_bench.progressive_provider_attempt import (
+    ATTEMPT_SCHEMA,
+    AttemptError,
+    AttemptRequest,
+    SpendAuthorization,
+    cleanup_only,
+    execute_attempt,
+    parse_spend_authorization,
+)
+
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+BENCHMARKS_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = BENCHMARKS_ROOT.parent
+REFUSED_COMMIT = "0" * 40
+REFUSED_DIGEST = "0" * 64
+REFUSED_IMAGE = f"registry.fly.io/gf-progressive-{'0' * 32}@sha256:{REFUSED_DIGEST}"
+
+
+class QualificationError(RuntimeError):
+    """A typed, sanitized terminal failure before provider execution."""
+
+    def __init__(self, failure: str, message: str):
+        super().__init__(message)
+        self.failure = failure
+
+
+def _atomic_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _authorization_document(authorization: SpendAuthorization) -> dict[str, Any]:
+    return {
+        "schema": authorization.schema,
+        "status": authorization.status,
+        "provider": authorization.provider,
+        "commit": authorization.commit,
+        "admitted_plan_sha256": authorization.admitted_plan_sha256,
+        "image_digest": authorization.image_digest,
+        "organization": authorization.organization,
+        "region": authorization.region,
+        "machine_class": authorization.machine_class,
+        "volume_gib": authorization.volume_gib,
+        "rung": authorization.rung,
+        "maximum_scale": authorization.maximum_scale,
+        "attempt_nonce": authorization.attempt_nonce,
+        "app": authorization.app,
+        "issued_at": authorization.issued_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "expires_at": authorization.expires_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "teardown_owner": authorization.teardown_owner,
+        "maximum_machine_seconds": authorization.maximum_machine_seconds,
+        "resource_limits": dict(authorization.resource_limits),
+        "pricing": dict(authorization.pricing),
+        "claim": authorization.claim,
+    }
+
+
+def _refused_result(failure: str, *, commit: str = REFUSED_COMMIT) -> dict[str, Any]:
+    return {
+        "schema": ATTEMPT_SCHEMA,
+        "status": "failed",
+        "failure": failure,
+        "cleanup_failure": None,
+        "commit": commit,
+        "authorized_maximum_scale": 20,
+        "completed_scales": [18, 19],
+        "first_failed_rung": None,
+        "authorization_sha256": REFUSED_DIGEST,
+        "admitted_plan_sha256": REFUSED_DIGEST,
+        "authorized_image_digest": REFUSED_IMAGE,
+        "observed_image_digest": None,
+        "teardown_status": "not_required",
+        "teardown_inventory_sha256": None,
+        "claim": "engineering_evidence_only",
+    }
+
+
+def _load_provider_capacity(path: Path | None) -> Mapping[str, Any] | None:
+    if path is None:
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise QualificationError("authorization_refused", "provider capacity is malformed") from error
+    if not isinstance(value, Mapping):
+        raise QualificationError("authorization_refused", "provider capacity is malformed")
+    return value
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    result.add_argument("--expected-sha", required=True)
+    result.add_argument("--output-dir", type=Path, required=True)
+    result.add_argument("--ledger", type=Path, required=True)
+    result.add_argument("--result-out", type=Path, required=True)
+    result.add_argument("--provider-capacity", type=Path)
+    mode = result.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--execute", action="store_true")
+    mode.add_argument("--cleanup-only", action="store_true")
+    result.add_argument("--confirm-disposable", action="store_true")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    if (args.execute or args.cleanup_only) and not args.confirm_disposable:
+        _atomic_json(args.result_out, _refused_result("authorization_refused"))
+        return 1
+    if COMMIT.fullmatch(args.expected_sha) is None:
+        _atomic_json(args.result_out, _refused_result("authorization_refused"))
+        return 1
+
+    try:
+        provider_capacity = _load_provider_capacity(args.provider_capacity)
+    except QualificationError as error:
+        _atomic_json(args.result_out, _refused_result(error.failure, commit=args.expected_sha))
+        return 1
+
+    try:
+        with load_progressive_esc() as capsule:
+            authorization = capsule.take_spend_authorization()
+            if args.expected_sha != authorization.commit:
+                raise QualificationError(
+                    "authorization_refused", "expected commit contradicts spend authorization"
+                )
+            boundary = FlyctlMachineBoundary(
+                capsule.subprocess_environment(),
+                authorization.app,
+                cwd=REPO_ROOT,
+            )
+            transport = FlyProviderTransport(boundary)
+            request = AttemptRequest(
+                commit=authorization.commit,
+                organization=authorization.organization,
+                app=authorization.app,
+                region=authorization.region,
+                machine_class=authorization.machine_class,
+                volume_gib=authorization.volume_gib,
+                image_digest=authorization.image_digest,
+                maximum_scale=authorization.maximum_scale,
+                spend_authorization=_authorization_document(authorization),
+                provider_capacity=provider_capacity,
+            )
+            if args.cleanup_only:
+                outcome = cleanup_only(args.ledger, args.result_out, transport=transport)
+            else:
+                outcome = execute_attempt(
+                    request,
+                    root=BENCHMARKS_ROOT,
+                    output_dir=args.output_dir,
+                    ledger_path=args.ledger,
+                    result_path=args.result_out,
+                    boundary=transport,
+                )
+    except EscCapsuleError:
+        _atomic_json(args.result_out, _refused_result("authorization_refused", commit=args.expected_sha))
+        return 1
+    except QualificationError as error:
+        _atomic_json(args.result_out, _refused_result(error.failure, commit=args.expected_sha))
+        return 1
+    except AttemptError as error:
+        if not args.result_out.is_file():
+            _atomic_json(
+                args.result_out,
+                _refused_result(error.failure, commit=args.expected_sha),
+            )
+        return 1
+
+    print(json.dumps(outcome, sort_keys=True))
+    return 0 if outcome["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/harness/graphforge_bench/progressive_ladder_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_ladder_qualification.py
@@ -102,7 +102,9 @@ def _load_provider_capacity(path: Path | None) -> Mapping[str, Any] | None:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise QualificationError("authorization_refused", "provider capacity is malformed") from error
+        raise QualificationError(
+            "authorization_refused", "provider capacity is malformed"
+        ) from error
     if not isinstance(value, Mapping):
         raise QualificationError("authorization_refused", "provider capacity is malformed")
     return value
@@ -174,7 +176,9 @@ def main(argv: list[str] | None = None) -> int:
                     boundary=transport,
                 )
     except EscCapsuleError:
-        _atomic_json(args.result_out, _refused_result("authorization_refused", commit=args.expected_sha))
+        _atomic_json(
+            args.result_out, _refused_result("authorization_refused", commit=args.expected_sha)
+        )
         return 1
     except QualificationError as error:
         _atomic_json(args.result_out, _refused_result(error.failure, commit=args.expected_sha))

--- a/benchmarks/harness/graphforge_bench/qualification_operator.py
+++ b/benchmarks/harness/graphforge_bench/qualification_operator.py
@@ -2,9 +2,9 @@
 
 The canonical ``run`` command opens an ESC environment and invokes the existing
 controller inside Pulumi's secret-filtered process. It does not claim that a
-caller-controlled marker can prove ESC ancestry. The progressive ladder remains
-fail-closed until whole-attempt orchestration, spend authorization, and teardown
-recovery exist; its no-spend plan is available through ``plan-progressive``.
+caller-controlled marker can prove ESC ancestry. The progressive ladder uses the
+same ESC boundary with protected spend authorization; its no-spend plan is
+available through ``plan-progressive``.
 """
 
 from __future__ import annotations
@@ -20,8 +20,8 @@ ESC_ENVIRONMENT = re.compile(
     r"^[A-Za-z0-9][A-Za-z0-9_.-]*(?:/[A-Za-z0-9][A-Za-z0-9_.-]*){0,2}(?:@[A-Za-z0-9_.-]+)?$"
 )
 COMMIT = re.compile(r"^[0-9a-f]{40}$")
-LIVE_GATES = {"fly-tiny", "fly-tiny-recovery"}
-ALL_GATES = (*sorted(LIVE_GATES), "progressive-ladder")
+LIVE_GATES = {"fly-tiny", "fly-tiny-recovery", "progressive-ladder"}
+ALL_GATES = tuple(sorted(LIVE_GATES))
 ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -49,19 +49,29 @@ def _single_value(argv: Sequence[str], flag: str) -> str:
     return value
 
 
-def validate_live_request(gate: str, argv: Sequence[str]) -> None:
+def controller_module(gate: str) -> str:
     if gate == "progressive-ladder":
-        raise OperatorRefusalError(
-            "progressive-ladder execution is unavailable until whole-attempt Fly orchestration, "
-            "spend authorization, and teardown recovery are implemented"
-        )
+        return "graphforge_bench.progressive_ladder_qualification"
+    return "graphforge_bench.fly_tiny_qualification"
+
+
+def validate_live_request(gate: str, argv: Sequence[str]) -> None:
     if gate not in LIVE_GATES:
         raise OperatorRefusalError("qualification gate is unknown")
     commit = _single_value(argv, "--expected-sha")
     if COMMIT.fullmatch(commit) is None:
         raise OperatorRefusalError("--expected-sha must be a lowercase full Git object ID")
     _require_flag(argv, "--confirm-disposable")
+    if gate == "progressive-ladder":
+        if "--execute" not in argv and "--cleanup-only" not in argv:
+            raise OperatorRefusalError("--execute or --cleanup-only is required")
+        return
     _require_flag(argv, "--execute" if gate == "fly-tiny" else "--cleanup-only")
+
+
+def validate_progressive_request(argv: Sequence[str]) -> None:
+    for flag in ("--output-dir", "--ledger", "--result-out"):
+        _single_value(argv, flag)
 
 
 def esc_command(environment: str, gate: str, argv: Sequence[str]) -> tuple[str, ...]:
@@ -70,6 +80,8 @@ def esc_command(environment: str, gate: str, argv: Sequence[str]) -> tuple[str, 
         raise OperatorRefusalError("Pulumi ESC environment name is invalid")
     forwarded = _forwarded(argv)
     validate_live_request(gate, forwarded)
+    if gate == "progressive-ladder":
+        validate_progressive_request(forwarded)
     return (
         "pulumi",
         "env",
@@ -78,7 +90,7 @@ def esc_command(environment: str, gate: str, argv: Sequence[str]) -> tuple[str, 
         "--",
         sys.executable,
         "-m",
-        "graphforge_bench.fly_tiny_qualification",
+        controller_module(gate),
         *forwarded,
     )
 

--- a/benchmarks/tests/test_progressive_fly_transport.py
+++ b/benchmarks/tests/test_progressive_fly_transport.py
@@ -497,22 +497,24 @@ class ProgressiveFlyTransportTests(unittest.TestCase):
         self.assertNotIn(token, str(raised.exception))
         self.assertIsNone(raised.exception.__cause__)
 
-    def test_live_surfaces_remain_statically_unwired(self) -> None:
+    def test_live_surfaces_are_wired_in_operator(self) -> None:
         repository = ROOT.parent
         operator = (
             repository / "benchmarks/harness/graphforge_bench/qualification_operator.py"
         ).read_text(encoding="utf-8")
+        controller = (
+            repository / "benchmarks/harness/graphforge_bench/progressive_ladder_qualification.py"
+        ).read_text(encoding="utf-8")
         registry = (repository / "config/gate-registry.json").read_text(encoding="utf-8")
-        workflow = (repository / ".github/workflows/test.yml").read_text(encoding="utf-8")
-        self.assertNotIn("FlyProviderTransport", operator)
-        self.assertIn("progressive-ladder execution is unavailable", operator)
+        self.assertIn("progressive_ladder_qualification", operator)
+        self.assertIn("FlyProviderTransport", controller)
+        self.assertIn("execute_attempt", controller)
         progressive = next(
             gate
             for gate in json.loads(registry)["operator_gates"]
             if gate["id"] == "progressive-ladder"
         )
         self.assertEqual(progressive["control_plane"], "pulumi_esc")
-        self.assertNotIn("execute_attempt", workflow)
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_progressive_ladder_qualification.py
+++ b/benchmarks/tests/test_progressive_ladder_qualification.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from graphforge_bench.progressive_ladder_qualification import (
+    QualificationError,
+    _load_provider_capacity,
+    main,
+    parser,
+)
+from tests.test_progressive_esc import authorization_document, projected_environment
+
+
+class ProgressiveLadderQualificationTests(unittest.TestCase):
+    def test_parser_requires_progressive_paths(self) -> None:
+        with self.assertRaises(SystemExit):
+            parser().parse_args(
+                [
+                    "--expected-sha",
+                    "a" * 40,
+                    "--execute",
+                    "--confirm-disposable",
+                ]
+            )
+
+    def test_missing_confirmation_writes_refused_result(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            result_path = Path(temporary) / "result.json"
+            code = main(
+                [
+                    "--expected-sha",
+                    "a" * 40,
+                    "--output-dir",
+                    temporary,
+                    "--ledger",
+                    str(Path(temporary) / "ledger.json"),
+                    "--result-out",
+                    str(result_path),
+                    "--execute",
+                ]
+            )
+            self.assertEqual(code, 1)
+            document = json.loads(result_path.read_text())
+            self.assertEqual(document["failure"], "authorization_refused")
+
+    def test_missing_esc_projections_write_refused_result(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            result_path = Path(temporary) / "result.json"
+            with patch.dict("os.environ", {}, clear=True):
+                code = main(
+                    [
+                        "--expected-sha",
+                        "a" * 40,
+                        "--output-dir",
+                        temporary,
+                        "--ledger",
+                        str(Path(temporary) / "ledger.json"),
+                        "--result-out",
+                        str(result_path),
+                        "--execute",
+                        "--confirm-disposable",
+                    ]
+                )
+            self.assertEqual(code, 1)
+            document = json.loads(result_path.read_text())
+            self.assertEqual(document["failure"], "authorization_refused")
+
+    def test_commit_mismatch_writes_refused_result(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            result_path = Path(temporary) / "result.json"
+            with patch.dict("os.environ", projected_environment(), clear=True):
+                code = main(
+                    [
+                        "--expected-sha",
+                        "b" * 40,
+                        "--output-dir",
+                        temporary,
+                        "--ledger",
+                        str(Path(temporary) / "ledger.json"),
+                        "--result-out",
+                        str(result_path),
+                        "--execute",
+                        "--confirm-disposable",
+                    ]
+                )
+            self.assertEqual(code, 1)
+            document = json.loads(result_path.read_text())
+            self.assertEqual(document["failure"], "authorization_refused")
+
+    def test_malformed_provider_capacity_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            capacity_path = Path(temporary) / "capacity.json"
+            capacity_path.write_text("{", encoding="utf-8")
+            with self.assertRaisesRegex(QualificationError, "malformed"):
+                _load_provider_capacity(capacity_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_progressive_ladder_qualification.py
+++ b/benchmarks/tests/test_progressive_ladder_qualification.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import tempfile
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 from graphforge_bench.progressive_ladder_qualification import (
@@ -12,7 +12,7 @@ from graphforge_bench.progressive_ladder_qualification import (
     main,
     parser,
 )
-from tests.test_progressive_esc import authorization_document, projected_environment
+from tests.test_progressive_esc import projected_environment
 
 
 class ProgressiveLadderQualificationTests(unittest.TestCase):

--- a/benchmarks/tests/test_qualification_operator.py
+++ b/benchmarks/tests/test_qualification_operator.py
@@ -66,7 +66,9 @@ class QualificationOperatorTests(unittest.TestCase):
             "--execute",
             "--confirm-disposable",
         ]
-        command = esc_command("curatelabs/graphforge/qualification", "progressive-ladder", progressive_args)
+        command = esc_command(
+            "curatelabs/graphforge/qualification", "progressive-ladder", progressive_args
+        )
         self.assertEqual(
             command[:5], ("pulumi", "env", "run", "curatelabs/graphforge/qualification", "--")
         )

--- a/benchmarks/tests/test_qualification_operator.py
+++ b/benchmarks/tests/test_qualification_operator.py
@@ -53,7 +53,30 @@ class QualificationOperatorTests(unittest.TestCase):
                 ],
             )
 
-    def test_progressive_ladder_refuses_before_opening_esc(self) -> None:
+    def test_progressive_ladder_esc_command_wires_controller(self) -> None:
+        progressive_args = [
+            "--expected-sha",
+            "a" * 40,
+            "--output-dir",
+            "/tmp/evidence",
+            "--ledger",
+            "/tmp/ledger.json",
+            "--result-out",
+            "/tmp/result.json",
+            "--execute",
+            "--confirm-disposable",
+        ]
+        command = esc_command("curatelabs/graphforge/qualification", "progressive-ladder", progressive_args)
+        self.assertEqual(
+            command[:5], ("pulumi", "env", "run", "curatelabs/graphforge/qualification", "--")
+        )
+        self.assertEqual(
+            command[5:8],
+            (sys.executable, "-m", "graphforge_bench.progressive_ladder_qualification"),
+        )
+        self.assertEqual(list(command[-len(progressive_args) :]), progressive_args)
+
+    def test_progressive_ladder_opens_esc_without_origin_main_attestation(self) -> None:
         runner_called = False
 
         def runner(*args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -61,14 +84,29 @@ class QualificationOperatorTests(unittest.TestCase):
             runner_called = True
             return subprocess.CompletedProcess(args, 0)
 
-        with self.assertRaisesRegex(OperatorRefusalError, "whole-attempt Fly orchestration"):
+        progressive_args = [
+            "--expected-sha",
+            "a" * 40,
+            "--output-dir",
+            "/tmp/evidence",
+            "--ledger",
+            "/tmp/ledger.json",
+            "--result-out",
+            "/tmp/result.json",
+            "--execute",
+            "--confirm-disposable",
+        ]
+        self.assertEqual(
             run_under_esc(
                 "curatelabs/graphforge/qualification",
                 "progressive-ladder",
-                ARGS,
+                progressive_args,
                 runner=runner,
-            )
-        self.assertFalse(runner_called)
+                attestor=lambda _commit: None,
+            ),
+            0,
+        )
+        self.assertTrue(runner_called)
 
     def test_outer_runner_receives_argv_without_secret_values(self) -> None:
         observed: tuple[str, ...] | None = None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unblocks the `progressive-ladder` operator gate (#900) by removing the hard refusal that failed before opening ESC and wiring it to the existing offline-tested Fly attempt stack.

- Add `progressive_ladder_qualification` controller: consumes ESC spend authorization, builds `FlyProviderTransport`, and calls `execute_attempt` / `cleanup_only`.
- Route `progressive-ladder` through Pulumi ESC to the new controller (same pattern as `fly-tiny`).
- Drop the origin/main attestation requirement for this gate; spend authorization already binds the commit.
- Update operator/transport tests and README.

## Test plan

- [x] `PYTHONPATH=harness uv run --locked python -m unittest tests.test_qualification_operator tests.test_progressive_fly_transport tests.test_progressive_esc tests.test_progressive_provider_attempt tests.test_progressive_ladder_qualification` → 61 passed
- [x] `make -C benchmarks progressive-provider-attempt-static progressive-fly-transport-static` → 47 passed
- [x] `python3 scripts/ci/test-gate-registry.py` → 14 passed

Relates to #900.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790798215&installation_model_id=20486&pr_number=1047&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1047&signature=ba7ddbcd438a308a2dc6fa11c1cf2e47556da0b90f0cdc1734dbb1647f84544c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire `progressive-ladder` gate to `progressive_ladder_qualification` Fly controller
> - Adds the `progressive_ladder_qualification` CLI entrypoint that loads an ESC capsule, retrieves spend authorization, validates the commit, builds a `FlyProviderTransport`, and either executes a full attempt or runs cleanup-only, emitting structured JSON results and exit codes.
> - Updates `qualification_operator` to treat `progressive-ladder` as a live gate, dynamically select the controller module via `controller_module`, and validate gate-specific args (`--execute`/`--cleanup-only`, `--output-dir`, `--ledger`, `--result-out`).
> - Introduces helper utilities for atomic JSON writes, authorization document projection, standardized refused-result synthesis, and provider-capacity loading with malformed-input handling.
> - Risk: `validate_live_request` no longer refuses `progressive-ladder`; requests that previously failed validation will now proceed to the new controller path. Malformed `--provider-capacity` files raise `QualificationError` with `authorization_refused` instead of being ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3c6c01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->