### PR TITLE
test(bench): add GDC SNB BI suite

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1616,6 +1616,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphforge-benchmark-gdc-snb-bi"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "graphforge-benchmark-graph500-generator"
 version = "0.0.0"
 dependencies = [

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "runners/certify",
     "runners/gdc-graphalytics",
     "runners/gdc-snb-interactive",
+    "runners/gdc-snb-bi",
     "runners/graph500-generator",
     "runners/smoke",
 ]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -63,6 +63,18 @@ PYTHONPATH=harness GRAPHFORGE_GDC_SNB_INTERACTIVE_BIN=target/debug/graphforge-be
   uv run --locked python -m unittest tests.test_gdc_snb_interactive
 ```
 
+Per-suite adapters own workload semantics through their own Rust runner and
+harness module. The SNB BI suite (`gdc_snb_bi`) maps the 20 `BI*` analytical
+reads onto the public Cypher / analyst-verb surface, fails closed on weighted
+shortest-path reads and the `INS*`/`DEL*` batch maintenance stream, validates
+reads against pinned references, and records per-phase resources (load, query,
+spill, RSS, I/O) in a section kept distinct from correctness. Its evidence
+stamps `certification: false`:
+
+```bash
+PYTHONPATH=harness uv run --locked python -m unittest tests.test_gdc_snb_bi
+```
+
 ## Public-interface certification runner
 
 `runners/certify` owns the admission through reopen-proof lifecycle. A profile

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/acquisition.json
@@ -1,0 +1,39 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "snb-bi",
+  "recorded_spec": {
+    "name": "ldbc-snb",
+    "source": "https://ldbcouncil.org/benchmarks/snb/",
+    "release": "engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "ldbc_snb_datagen_spark",
+    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
+    "release": null,
+    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "recorded_driver": {
+    "name": "ldbc_snb_bi_driver",
+    "source": "https://github.com/ldbc/ldbc_snb_bi_opensource",
+    "release": null,
+    "commit": "dddddddddddddddddddddddddddddddddddddddd"
+  },
+  "assets": [
+    {
+      "id": "snb-bi-sf0.003",
+      "path": "snb-bi-sf0.003.graph",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "LDBC-SNB-terms",
+      "acquisition": "fixture"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "snb-bi-sf0.003",
+      "workload_key": "bi-validation",
+      "path": "bi-validation.ref",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db"
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/bi-validation.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/bi-validation.ref
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-reference-v1

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI10.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI10.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI10"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI11.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI11.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI11"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI12.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI12.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI12"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI13.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI13.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI13"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI14.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI14.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI14"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI15.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI15.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI15"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI16.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI16.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI16"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI17.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI17.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI17"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI18.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI18.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI18"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI19.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI19.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI19"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI20.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI20.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI20"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI9.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/BI9.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI9"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/DEL8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/jobs/INS8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI1.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI1.ref
@@ -1,0 +1,2 @@
+BI1-row-1 A
+BI1-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI10.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI10.ref
@@ -1,0 +1,2 @@
+BI10-row-1 A
+BI10-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI11.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI11.ref
@@ -1,0 +1,2 @@
+BI11-row-1 A
+BI11-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI12.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI12.ref
@@ -1,0 +1,2 @@
+BI12-row-1 A
+BI12-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI13.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI13.ref
@@ -1,0 +1,2 @@
+BI13-row-1 A
+BI13-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI14.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI14.ref
@@ -1,0 +1,2 @@
+BI14-row-1 A
+BI14-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI16.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI16.ref
@@ -1,0 +1,2 @@
+BI16-row-1 A
+BI16-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI17.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI17.ref
@@ -1,0 +1,2 @@
+BI17-row-1 A
+BI17-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI18.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI18.ref
@@ -1,0 +1,2 @@
+BI18-row-1 A
+BI18-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI2.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI2.ref
@@ -1,0 +1,2 @@
+BI2-row-1 A
+BI2-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI3.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI3.ref
@@ -1,0 +1,2 @@
+BI3-row-1 A
+BI3-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI4.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI4.ref
@@ -1,0 +1,2 @@
+BI4-row-1 A
+BI4-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI5.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI5.ref
@@ -1,0 +1,2 @@
+BI5-row-1 A
+BI5-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI6.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI6.ref
@@ -1,0 +1,2 @@
+BI6-row-1 A
+BI6-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI7.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI7.ref
@@ -1,0 +1,2 @@
+BI7-row-1 A
+BI7-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI8.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI8.ref
@@ -1,0 +1,2 @@
+BI8-row-1 A
+BI8-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI9.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/references/snb-bi-sf0.003-BI9.ref
@@ -1,0 +1,2 @@
+BI9-row-1 A
+BI9-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/resources.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/resources.json
@@ -1,0 +1,23 @@
+{
+  "schema": "graphforge-gdc-snb-bi-resources/1",
+  "dataset_id": "snb-bi-sf0.003",
+  "load": {
+    "wall_ms": 12,
+    "rows_loaded": 4096
+  },
+  "query": {
+    "wall_ms": 34,
+    "queries_executed": 17
+  },
+  "spill": {
+    "bytes": 0,
+    "events": 0
+  },
+  "rss": {
+    "peak_bytes": 104857600
+  },
+  "io": {
+    "read_bytes": 2048,
+    "write_bytes": 512
+  }
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/snb-bi-sf0.003.graph
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/snb-bi-sf0.003.graph
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-dataset-v1

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI1.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI1.out
@@ -1,0 +1,2 @@
+BI1-row-1 A
+BI1-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI10.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI10.out
@@ -1,0 +1,2 @@
+BI10-row-1 A
+BI10-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI11.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI11.out
@@ -1,0 +1,2 @@
+BI11-row-1 A
+BI11-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI12.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI12.out
@@ -1,0 +1,2 @@
+BI12-row-1 A
+BI12-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI13.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI13.out
@@ -1,0 +1,2 @@
+BI13-row-1 A
+BI13-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI14.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI14.out
@@ -1,0 +1,2 @@
+BI14-row-1 A
+BI14-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI16.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI16.out
@@ -1,0 +1,2 @@
+BI16-row-1 A
+BI16-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI17.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI17.out
@@ -1,0 +1,2 @@
+BI17-row-1 A
+BI17-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI18.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI18.out
@@ -1,0 +1,2 @@
+BI18-row-1 A
+BI18-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI2.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI2.out
@@ -1,0 +1,2 @@
+BI2-row-1 A
+BI2-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI3.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI3.out
@@ -1,0 +1,2 @@
+BI3-row-1 A
+BI3-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI4.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI4.out
@@ -1,0 +1,2 @@
+BI4-row-1 A
+BI4-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI5.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI5.out
@@ -1,0 +1,2 @@
+BI5-row-1 A
+BI5-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI6.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI6.out
@@ -1,0 +1,2 @@
+BI6-row-1 A
+BI6-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI7.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI7.out
@@ -1,0 +1,2 @@
+BI7-row-1 A
+BI7-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI8.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI8.out
@@ -1,0 +1,2 @@
+BI8-row-1 A
+BI8-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI9.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/system-outputs/snb-bi-sf0.003-BI9.out
@@ -1,0 +1,2 @@
+BI9-row-1 A
+BI9-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/acquisition.json
@@ -1,0 +1,39 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "snb-bi",
+  "recorded_spec": {
+    "name": "ldbc-snb",
+    "source": "https://ldbcouncil.org/benchmarks/snb/",
+    "release": "engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "ldbc_snb_datagen_spark",
+    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
+    "release": null,
+    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "recorded_driver": {
+    "name": "ldbc_snb_bi_driver",
+    "source": "https://github.com/ldbc/ldbc_snb_bi_opensource",
+    "release": null,
+    "commit": "dddddddddddddddddddddddddddddddddddddddd"
+  },
+  "assets": [
+    {
+      "id": "snb-bi-sf0.003",
+      "path": "snb-bi-sf0.003.graph",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "LDBC-SNB-terms",
+      "acquisition": "fixture"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "snb-bi-sf0.003",
+      "workload_key": "bi-validation",
+      "path": "bi-validation.ref",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db"
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/bi-validation.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/bi-validation.ref
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-reference-v1

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI10.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI10.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI10"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI11.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI11.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI11"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI12.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI12.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI12"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI13.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI13.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI13"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI14.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI14.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI14"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI15.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI15.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI15"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI16.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI16.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI16"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI17.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI17.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI17"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI18.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI18.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI18"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI19.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI19.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI19"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI20.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI20.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI20"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI9.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/BI9.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI9"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/DEL8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/jobs/INS8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI1.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI1.ref
@@ -1,0 +1,2 @@
+BI1-row-1 A
+BI1-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI10.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI10.ref
@@ -1,0 +1,2 @@
+BI10-row-1 A
+BI10-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI11.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI11.ref
@@ -1,0 +1,2 @@
+BI11-row-1 A
+BI11-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI12.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI12.ref
@@ -1,0 +1,2 @@
+BI12-row-1 A
+BI12-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI13.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI13.ref
@@ -1,0 +1,2 @@
+BI13-row-1 A
+BI13-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI14.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI14.ref
@@ -1,0 +1,2 @@
+BI14-row-1 A
+BI14-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI16.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI16.ref
@@ -1,0 +1,2 @@
+BI16-row-1 A
+BI16-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI17.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI17.ref
@@ -1,0 +1,2 @@
+BI17-row-1 A
+BI17-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI18.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI18.ref
@@ -1,0 +1,2 @@
+BI18-row-1 A
+BI18-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI2.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI2.ref
@@ -1,0 +1,2 @@
+BI2-row-1 A
+BI2-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI3.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI3.ref
@@ -1,0 +1,2 @@
+BI3-row-1 A
+BI3-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI4.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI4.ref
@@ -1,0 +1,2 @@
+BI4-row-1 A
+BI4-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI5.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI5.ref
@@ -1,0 +1,2 @@
+BI5-row-1 A
+BI5-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI6.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI6.ref
@@ -1,0 +1,2 @@
+BI6-row-1 A
+BI6-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI7.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI7.ref
@@ -1,0 +1,2 @@
+BI7-row-1 A
+BI7-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI8.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI8.ref
@@ -1,0 +1,2 @@
+BI8-row-1 A
+BI8-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI9.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/references/snb-bi-sf0.003-BI9.ref
@@ -1,0 +1,2 @@
+BI9-row-1 A
+BI9-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/resources.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/resources.json
@@ -1,0 +1,23 @@
+{
+  "schema": "graphforge-gdc-snb-bi-resources/1",
+  "dataset_id": "snb-bi-sf0.003",
+  "load": {
+    "wall_ms": 12,
+    "rows_loaded": 4096
+  },
+  "query": {
+    "wall_ms": 34,
+    "queries_executed": 17
+  },
+  "spill": {
+    "bytes": 0,
+    "events": 0
+  },
+  "rss": {
+    "peak_bytes": 104857600
+  },
+  "io": {
+    "read_bytes": 2048,
+    "write_bytes": 512
+  }
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/snb-bi-sf0.003.graph
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/snb-bi-sf0.003.graph
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-dataset-v1

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI1.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI1.out
@@ -1,0 +1,2 @@
+BI1-row-1 A
+BI1-row-2 WRONG

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI10.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI10.out
@@ -1,0 +1,2 @@
+BI10-row-1 A
+BI10-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI11.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI11.out
@@ -1,0 +1,2 @@
+BI11-row-1 A
+BI11-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI12.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI12.out
@@ -1,0 +1,2 @@
+BI12-row-1 A
+BI12-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI13.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI13.out
@@ -1,0 +1,2 @@
+BI13-row-1 A
+BI13-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI14.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI14.out
@@ -1,0 +1,2 @@
+BI14-row-1 A
+BI14-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI16.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI16.out
@@ -1,0 +1,2 @@
+BI16-row-1 A
+BI16-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI17.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI17.out
@@ -1,0 +1,2 @@
+BI17-row-1 A
+BI17-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI18.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI18.out
@@ -1,0 +1,2 @@
+BI18-row-1 A
+BI18-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI2.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI2.out
@@ -1,0 +1,2 @@
+BI2-row-1 A
+BI2-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI3.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI3.out
@@ -1,0 +1,2 @@
+BI3-row-1 A
+BI3-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI4.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI4.out
@@ -1,0 +1,2 @@
+BI4-row-1 A
+BI4-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI5.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI5.out
@@ -1,0 +1,2 @@
+BI5-row-1 A
+BI5-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI6.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI6.out
@@ -1,0 +1,2 @@
+BI6-row-1 A
+BI6-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI7.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI7.out
@@ -1,0 +1,2 @@
+BI7-row-1 A
+BI7-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI8.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI8.out
@@ -1,0 +1,2 @@
+BI8-row-1 A
+BI8-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI9.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/system-outputs/snb-bi-sf0.003-BI9.out
@@ -1,0 +1,2 @@
+BI9-row-1 A
+BI9-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/acquisition.json
@@ -1,0 +1,39 @@
+{
+  "schema": "graphforge-gdc-acquisition/1",
+  "suite_id": "snb-bi",
+  "recorded_spec": {
+    "name": "ldbc-snb",
+    "source": "https://ldbcouncil.org/benchmarks/snb/",
+    "release": "engineering-pin",
+    "commit": null
+  },
+  "recorded_generator": {
+    "name": "ldbc_snb_datagen_spark",
+    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
+    "release": null,
+    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "recorded_driver": {
+    "name": "ldbc_snb_bi_driver",
+    "source": "https://github.com/ldbc/ldbc_snb_bi_opensource",
+    "release": null,
+    "commit": "dddddddddddddddddddddddddddddddddddddddd"
+  },
+  "assets": [
+    {
+      "id": "snb-bi-sf0.003",
+      "path": "snb-bi-sf0.003.graph",
+      "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+      "license": "LDBC-SNB-terms",
+      "acquisition": "fixture"
+    }
+  ],
+  "references": [
+    {
+      "dataset_id": "snb-bi-sf0.003",
+      "workload_key": "bi-validation",
+      "path": "bi-validation.ref",
+      "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db"
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/bi-validation.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/bi-validation.ref
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-reference-v1

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI10.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI10.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI10"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI11.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI11.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI11"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI12.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI12.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI12"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI13.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI13.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI13"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI14.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI14.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI14"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI15.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI15.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI15"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI16.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI16.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI16"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI17.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI17.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI17"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI18.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI18.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI18"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI19.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI19.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI19"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI20.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI20.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI20"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI9.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/BI9.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "BI9"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/DEL8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "DEL8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS1.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS1.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS1"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS2.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS2.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS2"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS3.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS3.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS3"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS4.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS4.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS4"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS5.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS5.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS5"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS6.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS6.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS6"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS7.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS7.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS7"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS8.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/jobs/INS8.json
@@ -1,0 +1,6 @@
+{
+  "schema": "graphforge-gdc-snb-bi-job/1",
+  "suite_id": "snb-bi",
+  "dataset_id": "snb-bi-sf0.003",
+  "operation": "INS8"
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI1.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI1.ref
@@ -1,0 +1,2 @@
+BI1-row-1 A
+BI1-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI10.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI10.ref
@@ -1,0 +1,2 @@
+BI10-row-1 A
+BI10-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI11.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI11.ref
@@ -1,0 +1,2 @@
+BI11-row-1 A
+BI11-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI12.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI12.ref
@@ -1,0 +1,2 @@
+BI12-row-1 A
+BI12-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI13.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI13.ref
@@ -1,0 +1,2 @@
+BI13-row-1 A
+BI13-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI14.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI14.ref
@@ -1,0 +1,2 @@
+BI14-row-1 A
+BI14-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI16.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI16.ref
@@ -1,0 +1,2 @@
+BI16-row-1 A
+BI16-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI17.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI17.ref
@@ -1,0 +1,2 @@
+BI17-row-1 A
+BI17-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI18.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI18.ref
@@ -1,0 +1,2 @@
+BI18-row-1 A
+BI18-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI2.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI2.ref
@@ -1,0 +1,2 @@
+BI2-row-1 A
+BI2-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI3.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI3.ref
@@ -1,0 +1,2 @@
+BI3-row-1 A
+BI3-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI4.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI4.ref
@@ -1,0 +1,2 @@
+BI4-row-1 A
+BI4-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI5.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI5.ref
@@ -1,0 +1,2 @@
+BI5-row-1 A
+BI5-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI6.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI6.ref
@@ -1,0 +1,2 @@
+BI6-row-1 A
+BI6-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI7.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI7.ref
@@ -1,0 +1,2 @@
+BI7-row-1 A
+BI7-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI8.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI8.ref
@@ -1,0 +1,2 @@
+BI8-row-1 A
+BI8-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI9.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/references/snb-bi-sf0.003-BI9.ref
@@ -1,0 +1,2 @@
+BI9-row-1 A
+BI9-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/resources.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/resources.json
@@ -1,0 +1,23 @@
+{
+  "schema": "graphforge-gdc-snb-bi-resources/1",
+  "dataset_id": "snb-bi-sf0.003",
+  "load": {
+    "wall_ms": 12,
+    "rows_loaded": 4096
+  },
+  "query": {
+    "wall_ms": 34,
+    "queries_executed": 17
+  },
+  "spill": {
+    "bytes": 0,
+    "events": 0
+  },
+  "rss": {
+    "peak_bytes": 104857600
+  },
+  "io": {
+    "read_bytes": 2048,
+    "write_bytes": 512
+  }
+}

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/snb-bi-sf0.003.graph
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/snb-bi-sf0.003.graph
@@ -1,0 +1,1 @@
+graphforge-gdc-fixture-dataset-v1

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI1.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI1.out
@@ -1,0 +1,2 @@
+BI1-row-1 A
+BI1-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI10.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI10.out
@@ -1,0 +1,2 @@
+BI10-row-1 A
+BI10-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI11.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI11.out
@@ -1,0 +1,2 @@
+BI11-row-1 A
+BI11-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI12.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI12.out
@@ -1,0 +1,2 @@
+BI12-row-1 A
+BI12-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI13.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI13.out
@@ -1,0 +1,2 @@
+BI13-row-1 A
+BI13-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI14.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI14.out
@@ -1,0 +1,2 @@
+BI14-row-1 A
+BI14-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI16.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI16.out
@@ -1,0 +1,2 @@
+BI16-row-1 A
+BI16-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI17.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI17.out
@@ -1,0 +1,2 @@
+BI17-row-1 A
+BI17-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI18.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI18.out
@@ -1,0 +1,2 @@
+BI18-row-1 A
+BI18-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI2.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI2.out
@@ -1,0 +1,2 @@
+BI2-row-1 A
+BI2-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI3.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI3.out
@@ -1,0 +1,2 @@
+BI3-row-1 A
+BI3-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI4.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI4.out
@@ -1,0 +1,2 @@
+BI4-row-1 A
+BI4-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI5.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI5.out
@@ -1,0 +1,2 @@
+BI5-row-1 A
+BI5-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI6.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI6.out
@@ -1,0 +1,2 @@
+BI6-row-1 A
+BI6-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI7.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI7.out
@@ -1,0 +1,2 @@
+BI7-row-1 A
+BI7-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI8.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI8.out
@@ -1,0 +1,2 @@
+BI8-row-1 A
+BI8-row-2 B

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI9.out
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/system-outputs/snb-bi-sf0.003-BI9.out
@@ -1,0 +1,2 @@
+BI9-row-1 A
+BI9-row-2 B

--- a/benchmarks/gdc-suite-index.md
+++ b/benchmarks/gdc-suite-index.md
@@ -130,7 +130,6 @@ declaration or pinned identity.
 CARGO_TARGET_DIR=target cargo build --locked -p graphforge-benchmark-gdc-snb-bi
 PYTHONPATH=harness GRAPHFORGE_GDC_SNB_BI_BIN=target/debug/graphforge-benchmark-gdc-snb-bi \
   uv run --locked python -m unittest tests.test_gdc_snb_bi
->>>>>>> ce976f3 (test(bench): add GDC SNB BI suite (#963))
 ```
 
 ## SPB (Semantic Publishing Benchmark)

--- a/benchmarks/gdc-suite-index.md
+++ b/benchmarks/gdc-suite-index.md
@@ -15,7 +15,7 @@ executable versus inventory-only.
 |---|---|---|---|
 | `graphalytics` | `suites/gdc-graphalytics.json` | executable | Six-algorithm analytics via `gdc-graphalytics` (#961) |
 | `snb-interactive` | `suites/gdc-snb-interactive.json` | executable | SNB Interactive operations via `gdc-snb-interactive` (#962) |
-| `snb-bi` | `suites/gdc-snb-bi.json` | executable | SNB Business Intelligence; blocked on suite issue #963 |
+| `snb-bi` | `suites/gdc-snb-bi.json` | executable | SNB Business Intelligence; runner `gdc-snb-bi` (see [SNB BI](#snb-bi)) |
 | `finbench-transaction` | `suites/gdc-finbench-transaction.json` | executable | FinBench Transaction; blocked on suite issue #964 |
 | `spb` | `suites/gdc-spb.json` | **inventory_only** | Semantic Publishing Benchmark (RDF/SPARQL) |
 
@@ -72,6 +72,65 @@ engineering runs and never masquerade as an audited GDC certification.
 CARGO_TARGET_DIR=target cargo build --locked -p graphforge-benchmark-gdc-snb-interactive
 PYTHONPATH=harness GRAPHFORGE_GDC_SNB_INTERACTIVE_BIN=target/debug/graphforge-benchmark-gdc-snb-interactive \
   uv run --locked python -m unittest tests.test_gdc_snb_interactive
+```
+
+## SNB BI
+
+**Home:** [LDBC Social Network Benchmark](https://ldbcouncil.org/benchmarks/snb/).
+
+| Item | Value |
+|---|---|
+| Official focus | LDBC SNB Business Intelligence: analytical read queries over the social-network graph plus a batch maintenance stream |
+| Queries | 20 analytical reads `BI1`..`BI20` |
+| Maintenance | Batch inserts `INS1`..`INS8` and batch deletes `DEL1`..`DEL8` |
+| Runner | `runners/gdc-snb-bi` (`gdc-snb-bi`), serde-only control plane; no product-crate dependency |
+| GraphForge disposition | `executable` (bounded tiny fixture only) |
+| Certification | **false** — engineering evidence only; never masquerades as an audited GDC certification |
+
+### Query mapping
+
+Analytical reads that are ordinary traversals, aggregations, grouped counts,
+and top-k rankings map to the public GraphForge Cypher / analyst-verb surface.
+The runner records the concrete Cypher/analyst-verb shape for each compatible
+read.
+
+### Unsupported policy (fail closed)
+
+The runner never approximates semantics the public property-graph + Cypher
+surface does not expose. It fails closed with a typed cause instead:
+
+- `weighted_shortest_path_not_exposed` — `BI15`, `BI19`, and `BI20` require a
+  weighted shortest-path search over a dynamically computed edge-weight
+  function; the public surface exposes only unweighted single-path analyst
+  verbs and pattern matching.
+- `bi_batch_update_stream_not_exposed` — the entire `INS*`/`DEL*` maintenance
+  stream requires the official driver's transactional insert/delete semantics,
+  dependency-time ordering, and cascading deletes.
+
+### Validation
+
+Compatible reads are validated against pinned references either exactly
+(row-for-row for a spec-mandated total order) or order-insensitively
+(`normalized`) for grouped/set-shaped aggregations without a total tie-break.
+
+### Resource vs. correctness separation
+
+Evidence records per-phase resource metrics (`load`, `query`, `spill`, `rss`,
+`io`) in a distinct top-level `resources` section, kept separate from the
+per-operation correctness `operations`. Resource evidence is never mixed into a
+correctness verdict.
+
+### Opt-in large scale factors
+
+The default suite runs only the bounded `snb-bi-sf0.003` tiny fixture. Any
+larger scale factor is opt-in / external and never baked into the default
+declaration or pinned identity.
+
+```bash
+CARGO_TARGET_DIR=target cargo build --locked -p graphforge-benchmark-gdc-snb-bi
+PYTHONPATH=harness GRAPHFORGE_GDC_SNB_BI_BIN=target/debug/graphforge-benchmark-gdc-snb-bi \
+  uv run --locked python -m unittest tests.test_gdc_snb_bi
+>>>>>>> ce976f3 (test(bench): add GDC SNB BI suite (#963))
 ```
 
 ## SPB (Semantic Publishing Benchmark)

--- a/benchmarks/harness/graphforge_bench/gdc_snb_bi.py
+++ b/benchmarks/harness/graphforge_bench/gdc_snb_bi.py
@@ -1,0 +1,244 @@
+"""GDC SNB BI suite adapter (workload semantics).
+
+Shares identity/acquisition contracts from ``gdc_contracts`` without embedding
+those contracts' workload-free rules into operation mapping. Rust owns mapping,
+validation modes, phase separation, per-phase resource recording, and reference
+validation via ``graphforge-benchmark-gdc-snb-bi``.
+
+Resource evidence (load/query/spill/rss/io) is kept in a distinct ``resources``
+section, separate from the per-operation correctness ``operations``. Results
+here are engineering evidence only. They never masquerade as an audited GDC
+certification (the runner stamps ``certification: false``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Any
+
+from graphforge_bench.gdc_contracts import (
+    GdcContractError,
+    load_pinned_identity,
+    validate_acquisition,
+    workspace_root,
+)
+
+ANALYTICAL_READS = tuple(f"BI{index}" for index in range(1, 21))
+BATCH_INSERTS = tuple(f"INS{index}" for index in range(1, 9))
+BATCH_DELETES = tuple(f"DEL{index}" for index in range(1, 9))
+OPERATIONS = ANALYTICAL_READS + BATCH_INSERTS + BATCH_DELETES
+
+JOB_SCHEMA = "graphforge-gdc-snb-bi-job/1"
+EVIDENCE_SCHEMA = "graphforge-gdc-snb-bi-evidence/1"
+RESOURCE_SCHEMA = "graphforge-gdc-snb-bi-resources/1"
+
+BATCH_UPDATE_CAUSE = "bi_batch_update_stream_not_exposed"
+WEIGHTED_PATH_CAUSE = "weighted_shortest_path_not_exposed"
+WEIGHTED_PATH_READS = ("BI15", "BI19", "BI20")
+
+BOUNDED_TINY_DATASET = "snb-bi-sf0.003"
+
+
+class SnbBiSuiteError(ValueError):
+    """SNB BI suite mapping or validation failed."""
+
+    def __init__(self, cause: str, message: str) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
+def identity_path(root: Path | None = None) -> Path:
+    return (root or workspace_root()) / "profiles" / "gdc" / "snb-bi-identity.json"
+
+
+def runner_binary(root: Path | None = None) -> Path:
+    base = root or workspace_root()
+    override = os.environ.get("GRAPHFORGE_GDC_SNB_BI_BIN")
+    if override:
+        return Path(override)
+    target = base / "target"
+    for profile in ("debug", "release"):
+        candidate = target / profile / "graphforge-benchmark-gdc-snb-bi"
+        if candidate.is_file():
+            return candidate
+    raise SnbBiSuiteError(
+        "missing_runner",
+        "graphforge-benchmark-gdc-snb-bi binary not built; "
+        "run cargo build -p graphforge-benchmark-gdc-snb-bi",
+    )
+
+
+def _run_runner(args: list[str], root: Path | None = None) -> subprocess.CompletedProcess[str]:
+    binary = runner_binary(root)
+    return subprocess.run(
+        [str(binary), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def list_operation_rules(root: Path | None = None) -> dict[str, dict[str, str]]:
+    completed = _run_runner(["list-operations"], root)
+    if completed.returncode != 0:
+        raise SnbBiSuiteError("invalid_document", completed.stderr.strip())
+    rules: dict[str, dict[str, str]] = {}
+    for line in completed.stdout.splitlines():
+        operation, _, rest = line.partition(" ")
+        fields: dict[str, str] = {}
+        for token in rest.split():
+            key, _, value = token.partition("=")
+            fields[key] = value
+        if "category" not in fields or "validation" not in fields or "mapping" not in fields:
+            raise SnbBiSuiteError("invalid_document", f"bad operation line: {line}")
+        rules[operation] = fields
+    if set(rules) != set(OPERATIONS):
+        raise SnbBiSuiteError(
+            "invalid_document",
+            f"runner must declare all {len(OPERATIONS)} operations, got {sorted(rules)}",
+        )
+    return rules
+
+
+def run_tiny_suite(
+    *,
+    fixture_name: str = "compatible",
+    root: Path | None = None,
+    evidence_path: Path | None = None,
+) -> dict[str, Any]:
+    """Run the bounded snb-bi-sf0.003 SNB BI suite through the Rust runner."""
+    base = root or workspace_root()
+    fixture = base / "fixtures" / "gdc" / "snb-bi-tiny" / fixture_name
+    pin = load_pinned_identity(identity_path(base))
+    acquisition = json.loads((fixture / "acquisition.json").read_text(encoding="utf-8"))
+    # Provenance evidence from shared contracts (checksummed assets only).
+    contract_evidence = validate_acquisition(pin, acquisition, fixture)
+    identities = contract_evidence["identities"]
+    with tempfile.TemporaryDirectory(prefix="gdc-snb-bi-") as tmp:
+        tmp_path = Path(tmp)
+        identities_path = tmp_path / "identities.json"
+        identities_path.write_text(json.dumps(identities, indent=2) + "\n", encoding="utf-8")
+        out_evidence = evidence_path or (tmp_path / "evidence.json")
+        completed = _run_runner(
+            [
+                "run-suite",
+                str(fixture / "jobs"),
+                str(fixture / "references"),
+                str(fixture / "system-outputs"),
+                str(fixture / "resources.json"),
+                str(identities_path),
+                str(out_evidence),
+            ],
+            base,
+        )
+        if not out_evidence.is_file():
+            raise SnbBiSuiteError(
+                "invalid_document",
+                f"runner failed to emit evidence: {completed.stderr.strip()}",
+            )
+        evidence = json.loads(out_evidence.read_text(encoding="utf-8"))
+        if evidence.get("schema") != EVIDENCE_SCHEMA:
+            raise SnbBiSuiteError(
+                "invalid_document",
+                "unexpected snb-bi evidence schema",
+            )
+        if evidence.get("certification") is not False:
+            raise SnbBiSuiteError(
+                "invalid_document",
+                "evidence must never claim GDC certification",
+            )
+        if "resources" not in evidence or "operations" not in evidence:
+            raise SnbBiSuiteError(
+                "invalid_document",
+                "evidence must record resources separately from correctness",
+            )
+        if completed.returncode != 0 and fixture_name == "compatible":
+            raise SnbBiSuiteError(
+                "reference_mismatch",
+                f"compatible fixture must pass: {completed.stderr.strip()}",
+            )
+        return evidence
+
+
+def map_operation_file(path: Path, root: Path | None = None) -> dict[str, Any]:
+    completed = _run_runner(["map-operation", str(path)], root)
+    if completed.returncode == 3:
+        raise SnbBiSuiteError("semantic_incompatibility", completed.stderr.strip())
+    if completed.returncode != 0:
+        raise SnbBiSuiteError("invalid_document", completed.stderr.strip())
+    return json.loads(completed.stdout)
+
+
+def assert_large_scale_factors_are_opt_in(root: Path | None = None) -> None:
+    """Only the bounded tiny fixture is executed by default; larger SFs are opt-in.
+
+    The suite declaration must advertise exactly the bounded ``snb-bi-sf0.003``
+    fixture. Any larger scale factor is external/opt-in and must never be baked
+    into the default declaration.
+    """
+    base = root or workspace_root()
+    suite = json.loads((base / "suites" / "gdc-snb-bi.json").read_text(encoding="utf-8"))
+    datasets = suite.get("datasets", [])
+    if datasets != [BOUNDED_TINY_DATASET]:
+        raise SnbBiSuiteError(
+            "invalid_document",
+            "default SNB BI suite must run only the bounded tiny fixture; "
+            "larger scale factors are opt-in / external",
+        )
+    pin = load_pinned_identity(identity_path(base))
+    pinned_ids = [dataset["id"] for dataset in pin.get("datasets", [])]
+    if pinned_ids != [BOUNDED_TINY_DATASET]:
+        raise SnbBiSuiteError(
+            "invalid_document",
+            "pinned identity must bound the committed fixture to the tiny scale factor",
+        )
+
+
+def assert_separate_from_other_suites(root: Path | None = None) -> None:
+    """SNB BI profiles/validation/evidence stay distinct from siblings."""
+    base = root or workspace_root()
+    suite = json.loads((base / "suites" / "gdc-snb-bi.json").read_text(encoding="utf-8"))
+    if suite.get("family") != "gdc" or suite.get("suite_id") != "snb-bi":
+        raise SnbBiSuiteError(
+            "invalid_document",
+            "suite must remain a GDC SNB BI suite",
+        )
+    rendered = json.dumps(suite)
+    for foreign in ("graph500", "graphalytics", "snb-interactive", "finbench", "spb"):
+        if foreign in rendered:
+            raise SnbBiSuiteError(
+                "invalid_document",
+                f"SNB BI suite must not embed {foreign}",
+            )
+    if suite.get("runner") != "gdc-snb-bi":
+        raise SnbBiSuiteError(
+            "invalid_document",
+            "SNB BI suite must use the gdc-snb-bi runner",
+        )
+
+
+__all__ = [
+    "ANALYTICAL_READS",
+    "BATCH_DELETES",
+    "BATCH_INSERTS",
+    "BATCH_UPDATE_CAUSE",
+    "BOUNDED_TINY_DATASET",
+    "EVIDENCE_SCHEMA",
+    "JOB_SCHEMA",
+    "OPERATIONS",
+    "RESOURCE_SCHEMA",
+    "WEIGHTED_PATH_CAUSE",
+    "WEIGHTED_PATH_READS",
+    "GdcContractError",
+    "SnbBiSuiteError",
+    "assert_large_scale_factors_are_opt_in",
+    "assert_separate_from_other_suites",
+    "identity_path",
+    "list_operation_rules",
+    "map_operation_file",
+    "run_tiny_suite",
+]

--- a/benchmarks/runners/gdc-snb-bi/Cargo.toml
+++ b/benchmarks/runners/gdc-snb-bi/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "graphforge-benchmark-gdc-snb-bi"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[[bin]]
+name = "graphforge-benchmark-gdc-snb-bi"
+path = "src/main.rs"

--- a/benchmarks/runners/gdc-snb-bi/src/lib.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/lib.rs
@@ -1,0 +1,1275 @@
+//! GDC SNB BI suite: operation mapping, reference validation, resources, evidence.
+//!
+//! Workload semantics live here (not in shared `gdc_contracts`). Product graph
+//! behavior remains in GraphForge Rust crates; this runner only maps LDBC SNB
+//! Business Intelligence operations onto the public Cypher / analyst-verb
+//! surface, validates read outputs against pinned references, records per-phase
+//! resource evidence *separately* from correctness, and fails closed on
+//! semantics the public property-graph + Cypher surface does not expose.
+//!
+//! Results here are engineering evidence only. They never masquerade as an
+//! audited GDC certification (`SuiteEvidence::certification` is always `false`).
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs;
+use std::path::Path;
+use std::str::FromStr;
+
+pub const EVIDENCE_SCHEMA: &str = "graphforge-gdc-snb-bi-evidence/1";
+pub const JOB_SCHEMA: &str = "graphforge-gdc-snb-bi-job/1";
+pub const LADDER_SCHEMA: &str = "graphforge-gdc-snb-bi-ladder/1";
+pub const RESOURCE_SCHEMA: &str = "graphforge-gdc-snb-bi-resources/1";
+pub const SUITE_ID: &str = "snb-bi";
+
+/// The bounded engineering fixture dataset every ladder and suite run begins on.
+pub const BOUNDED_TINY_DATASET: &str = "snb-bi-sf0.003";
+
+/// SNB BI workload category.
+///
+/// The 20 BI queries are analytical reads; the maintenance stream applies batch
+/// inserts and batch deletes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Category {
+    AnalyticalRead,
+    BatchInsert,
+    BatchDelete,
+}
+
+impl Category {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::AnalyticalRead => "analytical_read",
+            Self::BatchInsert => "batch_insert",
+            Self::BatchDelete => "batch_delete",
+        }
+    }
+}
+
+/// Reference-validation mode for a compatible read operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ValidationMode {
+    /// Ordered, row-for-row comparison (the operation has a total result order).
+    Exact,
+    /// Order-insensitive multiset comparison with per-row whitespace
+    /// normalization (the operation's result is a grouped set without a
+    /// spec-mandated total tie-break).
+    Normalized,
+}
+
+impl ValidationMode {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Normalized => "normalized",
+        }
+    }
+}
+
+/// LDBC SNB BI operations modeled by this suite.
+///
+/// Analytical reads (`BI1`..`BI20`) plus the batch maintenance stream: inserts
+/// (`INS1`..`INS8`) and deletes (`DEL1`..`DEL8`).
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum Operation {
+    #[serde(rename = "BI1")]
+    Bi1,
+    #[serde(rename = "BI2")]
+    Bi2,
+    #[serde(rename = "BI3")]
+    Bi3,
+    #[serde(rename = "BI4")]
+    Bi4,
+    #[serde(rename = "BI5")]
+    Bi5,
+    #[serde(rename = "BI6")]
+    Bi6,
+    #[serde(rename = "BI7")]
+    Bi7,
+    #[serde(rename = "BI8")]
+    Bi8,
+    #[serde(rename = "BI9")]
+    Bi9,
+    #[serde(rename = "BI10")]
+    Bi10,
+    #[serde(rename = "BI11")]
+    Bi11,
+    #[serde(rename = "BI12")]
+    Bi12,
+    #[serde(rename = "BI13")]
+    Bi13,
+    #[serde(rename = "BI14")]
+    Bi14,
+    #[serde(rename = "BI15")]
+    Bi15,
+    #[serde(rename = "BI16")]
+    Bi16,
+    #[serde(rename = "BI17")]
+    Bi17,
+    #[serde(rename = "BI18")]
+    Bi18,
+    #[serde(rename = "BI19")]
+    Bi19,
+    #[serde(rename = "BI20")]
+    Bi20,
+    #[serde(rename = "INS1")]
+    Ins1,
+    #[serde(rename = "INS2")]
+    Ins2,
+    #[serde(rename = "INS3")]
+    Ins3,
+    #[serde(rename = "INS4")]
+    Ins4,
+    #[serde(rename = "INS5")]
+    Ins5,
+    #[serde(rename = "INS6")]
+    Ins6,
+    #[serde(rename = "INS7")]
+    Ins7,
+    #[serde(rename = "INS8")]
+    Ins8,
+    #[serde(rename = "DEL1")]
+    Del1,
+    #[serde(rename = "DEL2")]
+    Del2,
+    #[serde(rename = "DEL3")]
+    Del3,
+    #[serde(rename = "DEL4")]
+    Del4,
+    #[serde(rename = "DEL5")]
+    Del5,
+    #[serde(rename = "DEL6")]
+    Del6,
+    #[serde(rename = "DEL7")]
+    Del7,
+    #[serde(rename = "DEL8")]
+    Del8,
+}
+
+impl Operation {
+    pub const ALL: [Self; 36] = [
+        Self::Bi1,
+        Self::Bi2,
+        Self::Bi3,
+        Self::Bi4,
+        Self::Bi5,
+        Self::Bi6,
+        Self::Bi7,
+        Self::Bi8,
+        Self::Bi9,
+        Self::Bi10,
+        Self::Bi11,
+        Self::Bi12,
+        Self::Bi13,
+        Self::Bi14,
+        Self::Bi15,
+        Self::Bi16,
+        Self::Bi17,
+        Self::Bi18,
+        Self::Bi19,
+        Self::Bi20,
+        Self::Ins1,
+        Self::Ins2,
+        Self::Ins3,
+        Self::Ins4,
+        Self::Ins5,
+        Self::Ins6,
+        Self::Ins7,
+        Self::Ins8,
+        Self::Del1,
+        Self::Del2,
+        Self::Del3,
+        Self::Del4,
+        Self::Del5,
+        Self::Del6,
+        Self::Del7,
+        Self::Del8,
+    ];
+
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::Bi1 => "BI1",
+            Self::Bi2 => "BI2",
+            Self::Bi3 => "BI3",
+            Self::Bi4 => "BI4",
+            Self::Bi5 => "BI5",
+            Self::Bi6 => "BI6",
+            Self::Bi7 => "BI7",
+            Self::Bi8 => "BI8",
+            Self::Bi9 => "BI9",
+            Self::Bi10 => "BI10",
+            Self::Bi11 => "BI11",
+            Self::Bi12 => "BI12",
+            Self::Bi13 => "BI13",
+            Self::Bi14 => "BI14",
+            Self::Bi15 => "BI15",
+            Self::Bi16 => "BI16",
+            Self::Bi17 => "BI17",
+            Self::Bi18 => "BI18",
+            Self::Bi19 => "BI19",
+            Self::Bi20 => "BI20",
+            Self::Ins1 => "INS1",
+            Self::Ins2 => "INS2",
+            Self::Ins3 => "INS3",
+            Self::Ins4 => "INS4",
+            Self::Ins5 => "INS5",
+            Self::Ins6 => "INS6",
+            Self::Ins7 => "INS7",
+            Self::Ins8 => "INS8",
+            Self::Del1 => "DEL1",
+            Self::Del2 => "DEL2",
+            Self::Del3 => "DEL3",
+            Self::Del4 => "DEL4",
+            Self::Del5 => "DEL5",
+            Self::Del6 => "DEL6",
+            Self::Del7 => "DEL7",
+            Self::Del8 => "DEL8",
+        }
+    }
+
+    pub fn category(self) -> Category {
+        match self {
+            Self::Bi1
+            | Self::Bi2
+            | Self::Bi3
+            | Self::Bi4
+            | Self::Bi5
+            | Self::Bi6
+            | Self::Bi7
+            | Self::Bi8
+            | Self::Bi9
+            | Self::Bi10
+            | Self::Bi11
+            | Self::Bi12
+            | Self::Bi13
+            | Self::Bi14
+            | Self::Bi15
+            | Self::Bi16
+            | Self::Bi17
+            | Self::Bi18
+            | Self::Bi19
+            | Self::Bi20 => Category::AnalyticalRead,
+            Self::Ins1
+            | Self::Ins2
+            | Self::Ins3
+            | Self::Ins4
+            | Self::Ins5
+            | Self::Ins6
+            | Self::Ins7
+            | Self::Ins8 => Category::BatchInsert,
+            Self::Del1
+            | Self::Del2
+            | Self::Del3
+            | Self::Del4
+            | Self::Del5
+            | Self::Del6
+            | Self::Del7
+            | Self::Del8 => Category::BatchDelete,
+        }
+    }
+
+    /// The reference-validation mode for a compatible read, or `None` for an
+    /// operation this suite fails closed on (no reference comparison happens).
+    pub fn validation_mode(self) -> Option<ValidationMode> {
+        match map_operation(self) {
+            MappingOutcome::Compatible(_) => Some(self.intended_validation()),
+            MappingOutcome::SemanticIncompatibility { .. } => None,
+        }
+    }
+
+    /// The validation mode a read *would* use if compatible. Reads with a
+    /// spec-mandated total order use `Exact`; grouped aggregations whose ties
+    /// are not totally ordered use `Normalized`.
+    fn intended_validation(self) -> ValidationMode {
+        match self {
+            // Grouped/set-shaped aggregations without a spec-mandated total
+            // tie-break (tag lists, message-count histogram, related-tag
+            // co-occurrence): compared order-insensitively.
+            Self::Bi2 | Self::Bi12 | Self::Bi16 => ValidationMode::Normalized,
+            _ => ValidationMode::Exact,
+        }
+    }
+}
+
+impl fmt::Display for Operation {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        output.write_str(self.code())
+    }
+}
+
+impl FromStr for Operation {
+    type Err = SuiteError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|operation| operation.code() == value)
+            .ok_or_else(|| {
+                SuiteError::InvalidDocument(format!("unknown SNB BI operation: {value}"))
+            })
+    }
+}
+
+/// Declared public GraphForge contract for a compatible operation mapping.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PublicApiMapping {
+    /// Public surface used: `cypher` or `analyst_verb`.
+    pub interface: String,
+    /// Concrete Cypher / analyst-verb shape that realizes the operation.
+    pub cypher_shape: String,
+    /// Honest engineering note about the mapping decision.
+    pub notes: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MappingOutcome {
+    Compatible(PublicApiMapping),
+    SemanticIncompatibility { cause: &'static str, detail: String },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OperationJob {
+    pub schema: String,
+    pub suite_id: String,
+    pub dataset_id: String,
+    pub operation: Operation,
+}
+
+impl OperationJob {
+    pub fn validate_schema(&self) -> Result<(), SuiteError> {
+        if self.schema != JOB_SCHEMA {
+            return Err(SuiteError::InvalidDocument(format!(
+                "unexpected job schema: {}",
+                self.schema
+            )));
+        }
+        if self.suite_id != SUITE_ID {
+            return Err(SuiteError::InvalidDocument(
+                "job suite_id must be snb-bi".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Ordered load ladder; every ladder must begin on the bounded tiny dataset.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DatasetLadder {
+    pub schema: String,
+    pub suite_id: String,
+    pub datasets: Vec<LadderEntry>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LadderEntry {
+    pub id: String,
+    pub order: u32,
+    pub role: String,
+    /// Anything beyond the bounded tiny fixture is opt-in / external only.
+    #[serde(default)]
+    pub opt_in: bool,
+}
+
+impl DatasetLadder {
+    pub fn validate(&self) -> Result<(), SuiteError> {
+        if self.schema != LADDER_SCHEMA {
+            return Err(SuiteError::InvalidDocument(format!(
+                "unexpected ladder schema: {}",
+                self.schema
+            )));
+        }
+        if self.suite_id != SUITE_ID {
+            return Err(SuiteError::InvalidDocument(
+                "ladder suite_id must be snb-bi".into(),
+            ));
+        }
+        if self.datasets.is_empty() {
+            return Err(SuiteError::InvalidDocument(
+                "dataset ladder must declare at least one dataset".into(),
+            ));
+        }
+        let mut orders = BTreeSet::new();
+        let mut ids = BTreeSet::new();
+        for entry in &self.datasets {
+            if !orders.insert(entry.order) {
+                return Err(SuiteError::InvalidDocument(format!(
+                    "duplicate ladder order: {}",
+                    entry.order
+                )));
+            }
+            if !ids.insert(entry.id.clone()) {
+                return Err(SuiteError::InvalidDocument(format!(
+                    "duplicate ladder dataset: {}",
+                    entry.id
+                )));
+            }
+        }
+        let mut sorted = self.datasets.clone();
+        sorted.sort_by_key(|entry| entry.order);
+        let first = sorted.first().expect("non-empty checked above");
+        if first.id != BOUNDED_TINY_DATASET {
+            return Err(SuiteError::InvalidDocument(format!(
+                "ordered ladder must begin with bounded fixture {BOUNDED_TINY_DATASET}"
+            )));
+        }
+        if first.opt_in {
+            return Err(SuiteError::InvalidDocument(
+                "bounded tiny fixture must not be opt-in".into(),
+            ));
+        }
+        // Everything beyond the bounded tiny fixture is opt-in / external only.
+        for entry in sorted.iter().skip(1) {
+            if !entry.opt_in {
+                return Err(SuiteError::InvalidDocument(format!(
+                    "scale beyond the tiny fixture must be opt-in: {}",
+                    entry.id
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn ordered_ids(&self) -> Vec<String> {
+        let mut sorted = self.datasets.clone();
+        sorted.sort_by_key(|entry| entry.order);
+        sorted.into_iter().map(|entry| entry.id).collect()
+    }
+}
+
+/// Per-phase resource evidence, recorded distinctly from correctness.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceReport {
+    pub schema: String,
+    pub dataset_id: String,
+    pub load: LoadResource,
+    pub query: QueryResource,
+    pub spill: SpillResource,
+    pub rss: RssResource,
+    pub io: IoResource,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LoadResource {
+    pub wall_ms: u64,
+    pub rows_loaded: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct QueryResource {
+    pub wall_ms: u64,
+    pub queries_executed: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SpillResource {
+    pub bytes: u64,
+    pub events: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RssResource {
+    pub peak_bytes: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct IoResource {
+    pub read_bytes: u64,
+    pub write_bytes: u64,
+}
+
+impl ResourceReport {
+    pub fn validate(&self, dataset_id: &str) -> Result<(), SuiteError> {
+        if self.schema != RESOURCE_SCHEMA {
+            return Err(SuiteError::InvalidDocument(format!(
+                "unexpected resource schema: {}",
+                self.schema
+            )));
+        }
+        if self.dataset_id != dataset_id {
+            return Err(SuiteError::InvalidDocument(format!(
+                "resource dataset_id {} does not match suite dataset {dataset_id}",
+                self.dataset_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub fn load_resource_report(path: &Path) -> Result<ResourceReport, SuiteError> {
+    let text = fs::read_to_string(path).map_err(|error| {
+        SuiteError::InvalidDocument(format!("failed to read {}: {error}", path.display()))
+    })?;
+    serde_json::from_str(&text)
+        .map_err(|error| SuiteError::InvalidDocument(format!("invalid resource report: {error}")))
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationStatus {
+    Passed,
+    Failed,
+    SemanticIncompatibility,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct OperationOutcome {
+    pub operation: Operation,
+    pub category: String,
+    pub status: OperationStatus,
+    pub validation_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cause: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_api: Option<PublicApiMapping>,
+}
+
+/// SNB BI lifecycle phases, kept explicitly separate.
+///
+/// The BI workload bulk-loads the graph, applies batch maintenance updates,
+/// runs the analytical query mix, then validates results against references.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Phase {
+    Load,
+    Updates,
+    Query,
+    Validation,
+}
+
+impl Phase {
+    pub const ALL: [Self; 4] = [Self::Load, Self::Updates, Self::Query, Self::Validation];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Load => "load",
+            Self::Updates => "updates",
+            Self::Query => "query",
+            Self::Validation => "validation",
+        }
+    }
+}
+
+pub fn phase_names() -> Vec<String> {
+    Phase::ALL
+        .iter()
+        .map(|phase| phase.name().to_string())
+        .collect()
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct SuiteEvidence {
+    pub schema: String,
+    pub suite_id: String,
+    pub dataset_id: String,
+    pub status: OperationStatus,
+    /// Engineering evidence flag: never an audited GDC certification.
+    pub certification: bool,
+    pub phases: Vec<String>,
+    pub identities: serde_json::Value,
+    /// Per-phase resource evidence, kept distinct from the correctness outcomes.
+    pub resources: ResourceReport,
+    /// Per-operation correctness outcomes.
+    pub operations: Vec<OperationOutcome>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SuiteError {
+    InvalidDocument(String),
+    ReferenceMismatch(String),
+    SemanticIncompatibility { cause: String, detail: String },
+}
+
+impl fmt::Display for SuiteError {
+    fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidDocument(message) => write!(output, "invalid_document: {message}"),
+            Self::ReferenceMismatch(message) => write!(output, "reference_mismatch: {message}"),
+            Self::SemanticIncompatibility { cause, detail } => {
+                write!(output, "semantic_incompatibility:{cause}: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SuiteError {}
+
+/// Map an SNB BI operation onto the public GraphForge surface.
+///
+/// Analytical reads that are ordinary graph traversals, aggregations, grouped
+/// counts, or top-k rankings map to Cypher. Reads that require a weighted
+/// shortest-path computation (BI15/BI19/BI20) and the entire batch maintenance
+/// stream (inserts/deletes) fail closed with a typed cause instead of silently
+/// approximating semantics the public surface does not expose.
+pub fn map_operation(operation: Operation) -> MappingOutcome {
+    match operation {
+        Operation::Bi1 => compatible(
+            "cypher",
+            "MATCH (m:Message) WHERE m.creationDate<$date WITH m, m.creationDate.year AS year, \
+             (m:Comment) AS isComment, CASE ... END AS lengthCategory \
+             RETURN year, isComment, lengthCategory, count(*), sum(m.length) ORDER BY year DESC, isComment, lengthCategory",
+            "posting summary: grouped counts and length aggregation over messages before a date",
+        ),
+        Operation::Bi2 => compatible(
+            "cypher",
+            "MATCH (t:Tag)<-[:HAS_TAG]-(m:Message) WHERE m.creationDate window \
+             RETURN t.name, countWindow1, countWindow2, abs(diff) ORDER BY diff DESC, t.name",
+            "tag evolution: per-tag message counts across two windows; grouped tag set (normalized validation)",
+        ),
+        Operation::Bi3 => compatible(
+            "cypher",
+            "MATCH (co:Country {name:$country})<-[:IS_PART_OF]-(:City)<-[:IS_LOCATED_IN]-(p:Person)<-[:HAS_MODERATOR]-(f:Forum)-[:CONTAINER_OF]->(post)<-[:REPLY_OF*0..]-(msg)-[:HAS_TAG]->(:Tag)-[:HAS_TYPE]->(tc:TagClass {name:$class}) \
+             RETURN f.id, f.title, f.creationDate, p.id, count(DISTINCT msg) ORDER BY count DESC, f.id LIMIT 20",
+            "popular topics in a country: traversal + distinct count top-k",
+        ),
+        Operation::Bi4 => compatible(
+            "cypher",
+            "MATCH (co:Country)<-[:IS_PART_OF]-(:City)<-[:IS_LOCATED_IN]-(p:Person)<-[:HAS_MEMBER]-(f:Forum) \
+             RETURN co.name, top forum by member count, p ORDER BY ... LIMIT 100",
+            "top forum member per country: aggregation with deterministic tie-break",
+        ),
+        Operation::Bi5 => compatible(
+            "cypher",
+            "MATCH (t:Tag {name:$tag})<-[:HAS_TAG]-(msg:Message)-[:HAS_CREATOR]->(p:Person) \
+             OPTIONAL MATCH (msg)<-[l:LIKES]-() OPTIONAL MATCH (msg)<-[:REPLY_OF]-(c) \
+             RETURN p.id, count(DISTINCT l), count(DISTINCT c), count(DISTINCT msg), score ORDER BY score DESC, p.id LIMIT 100",
+            "top posters of a tag: per-person like/reply/message aggregation top-k",
+        ),
+        Operation::Bi6 => compatible(
+            "cypher",
+            "MATCH (t:Tag {name:$tag})<-[:HAS_TAG]-(msg)-[:HAS_CREATOR]->(p:Person)<-[:HAS_CREATOR]-(m2)<-[:LIKES]-(liker) \
+             RETURN p.id, sum(likes) AS authority ORDER BY authority DESC, p.id LIMIT 100",
+            "authoritative users on a topic: summed like counts as authority score",
+        ),
+        Operation::Bi7 => compatible(
+            "cypher",
+            "MATCH (t:Tag {name:$tag})<-[:HAS_TAG]-(msg)<-[:REPLY_OF]-(comment)-[:HAS_TAG]->(related:Tag) \
+             WHERE NOT (comment)-[:HAS_TAG]->(t) RETURN related.name, count(DISTINCT comment) ORDER BY count DESC, related.name LIMIT 100",
+            "related topics: co-occurring tags on replies to a tag's messages",
+        ),
+        Operation::Bi8 => compatible(
+            "cypher",
+            "MATCH (t:Tag {name:$tag}) OPTIONAL MATCH (p:Person)-[:HAS_INTEREST]->(t) \
+             OPTIONAL MATCH (p)<-[:HAS_CREATOR]-(msg)-[:HAS_TAG]->(t) WITH p, interestScore \
+             OPTIONAL MATCH (p)-[:KNOWS]-(f) RETURN p.id, score + friendScore ORDER BY total DESC, p.id LIMIT 100",
+            "central person for a tag: interest + friends' interest scoring top-k",
+        ),
+        Operation::Bi9 => compatible(
+            "cypher",
+            "MATCH (p:Person)<-[:HAS_CREATOR]-(post:Post)<-[:REPLY_OF*0..]-(reply) \
+             WHERE post.creationDate window RETURN p.id, count(DISTINCT post), count(DISTINCT reply), sum(reply.length) ORDER BY threadCount DESC, p.id LIMIT 100",
+            "top thread initiators: variable-length reply-tree traversal with aggregation",
+        ),
+        Operation::Bi10 => compatible(
+            "cypher",
+            "MATCH (p:Person {id:$id})-[:KNOWS*1..2]-(f:Person)-[:IS_LOCATED_IN]->(:City)-[:IS_PART_OF]->(:Country {name:$country}) \
+             OPTIONAL MATCH (f)<-[:HAS_CREATOR]-(msg)-[:HAS_TAG]->(:Tag)-[:HAS_TYPE]->(:TagClass {name:$class}) \
+             RETURN f.id, count(msg) AS score ORDER BY score DESC, f.id LIMIT 100",
+            "experts in a social circle: bounded KNOWS traversal + tag-class filter",
+        ),
+        Operation::Bi11 => compatible(
+            "cypher",
+            "MATCH (a:Person)-[:IS_LOCATED_IN]->(:City)-[:IS_PART_OF]->(:Country {name:$country}) \
+             MATCH (a)-[k1:KNOWS]-(b)-[k2:KNOWS]-(c)-[k3:KNOWS]-(a) WHERE dates within window AND a.id<b.id<c.id \
+             RETURN count(*)",
+            "friend triangles in a country: undirected 3-cycle pattern count",
+        ),
+        Operation::Bi12 => compatible(
+            "cypher",
+            "MATCH (p:Person) OPTIONAL MATCH (p)<-[:HAS_CREATOR]-(msg:Message) \
+             WHERE msg.content IS NOT NULL AND msg.length>$len WITH p, count(msg) AS messageCount \
+             RETURN messageCount, count(p) ORDER BY count(p) DESC, messageCount DESC",
+            "message-count histogram: persons grouped by message count; grouped set (normalized validation)",
+        ),
+        Operation::Bi13 => compatible(
+            "cypher",
+            "MATCH (co:Country {name:$country})<-[:IS_PART_OF]-(:City)<-[:IS_LOCATED_IN]-(zombie:Person) \
+             WHERE zombie.creationDate<$date WITH zombie WHERE messageCount below threshold \
+             WITH collect(zombie) AS zombies MATCH ... RETURN zombie.id, zombieScore ORDER BY zombieScore DESC, zombie.id LIMIT 100",
+            "zombies in a country: two-pass zombie-set membership then like-ratio scoring, expressible with WITH",
+        ),
+        Operation::Bi14 => compatible(
+            "cypher",
+            "MATCH (a:Person)-[:IS_LOCATED_IN]->(:City)-[:IS_PART_OF]->(c1:Country {name:$countryX}) \
+             MATCH (b:Person)-[:IS_LOCATED_IN]->(:City)-[:IS_PART_OF]->(c2:Country {name:$countryY}) \
+             MATCH (a)-[:KNOWS]-(b) RETURN a, b, symmetricInteractionScore ORDER BY score DESC, a.id, b.id LIMIT 100",
+            "international dialog: symmetric interaction scoring over cross-country friend pairs",
+        ),
+        Operation::Bi15 => MappingOutcome::SemanticIncompatibility {
+            cause: "weighted_shortest_path_not_exposed",
+            detail: "BI15 computes the minimum-weight trusted connection path between two persons where each \
+                     KNOWS edge weight is a dynamically computed interaction cost; the public surface exposes \
+                     unweighted single-path analyst verbs and pattern matching but not weighted shortest-path \
+                     search over a computed edge-weight function"
+                .into(),
+        },
+        Operation::Bi16 => compatible(
+            "cypher",
+            "MATCH (p:Person)<-[:HAS_CREATOR]-(msg)-[:HAS_TAG]->(:Tag {name:$tagA}) WHERE msg.creationDate=$dateA \
+             MATCH (p)<-[:HAS_CREATOR]-(msg2)-[:HAS_TAG]->(:Tag {name:$tagB}) WHERE msg2.creationDate=$dateB \
+             RETURN p.id, countA, countB ORDER BY countA+countB DESC, p.id",
+            "fake-news detection: per-person tagged-message counts on two days; grouped set (normalized validation)",
+        ),
+        Operation::Bi17 => compatible(
+            "cypher",
+            "MATCH (t:Tag {name:$tag}) MATCH (p1)<-[:HAS_CREATOR]-(m1)-[:HAS_TAG]->(t) \
+             MATCH (m1)<-[:REPLY_OF]-(m2)-[:HAS_CREATOR]->(p2) ... with temporal and knows constraints \
+             RETURN p1.id, count(DISTINCT structuralMatch) ORDER BY count DESC, p1.id LIMIT 10",
+            "information propagation: multi-hop message/reply pattern with temporal constraints",
+        ),
+        Operation::Bi18 => compatible(
+            "cypher",
+            "MATCH (p:Person {id:$id})-[:KNOWS]-(f)-[:KNOWS]-(fof) WHERE NOT (p)-[:KNOWS]-(fof) AND p<>fof \
+             OPTIONAL MATCH (fof)-[:HAS_INTEREST]->(t:Tag)<-[:HAS_INTEREST]-(p) \
+             RETURN fof.id, count(DISTINCT f) AS mutual, count(DISTINCT t) ORDER BY mutual DESC, fof.id LIMIT 20",
+            "friend recommendation: friends-of-friends by mutual-friend count top-k",
+        ),
+        Operation::Bi19 => MappingOutcome::SemanticIncompatibility {
+            cause: "weighted_shortest_path_not_exposed",
+            detail: "BI19 finds the minimum-cost interaction path between persons located in two cities, where \
+                     each KNOWS edge cost is derived from the reciprocal of the reply/comment interaction count; \
+                     weighted shortest-path search over a computed edge-weight function is not on the public surface"
+                .into(),
+        },
+        Operation::Bi20 => MappingOutcome::SemanticIncompatibility {
+            cause: "weighted_shortest_path_not_exposed",
+            detail: "BI20 (recruitment) computes the minimum-weight path from a person to a company's employees \
+                     over the KNOWS graph with per-person derived edge weights; the public surface exposes \
+                     unweighted path verbs only, not weighted shortest-path search over a computed weight function"
+                .into(),
+        },
+        Operation::Ins1 => batch_update_incompatible("INS1 inserts a Person with dependency-time-ordered edges"),
+        Operation::Ins2 => batch_update_incompatible("INS2 inserts a Person-likes-Post interaction"),
+        Operation::Ins3 => batch_update_incompatible("INS3 inserts a Person-likes-Comment interaction"),
+        Operation::Ins4 => batch_update_incompatible("INS4 inserts a Forum"),
+        Operation::Ins5 => batch_update_incompatible("INS5 inserts a Forum membership"),
+        Operation::Ins6 => batch_update_incompatible("INS6 inserts a Post"),
+        Operation::Ins7 => batch_update_incompatible("INS7 inserts a Comment reply"),
+        Operation::Ins8 => batch_update_incompatible("INS8 inserts a KNOWS friendship"),
+        Operation::Del1 => batch_update_incompatible("DEL1 deletes a Person and its dependent graph"),
+        Operation::Del2 => batch_update_incompatible("DEL2 deletes a Post-likes edge"),
+        Operation::Del3 => batch_update_incompatible("DEL3 deletes a Comment-likes edge"),
+        Operation::Del4 => batch_update_incompatible("DEL4 deletes a Forum and its dependents"),
+        Operation::Del5 => batch_update_incompatible("DEL5 deletes a Forum membership"),
+        Operation::Del6 => batch_update_incompatible("DEL6 deletes a Post and its reply subtree"),
+        Operation::Del7 => batch_update_incompatible("DEL7 deletes a Comment and its reply subtree"),
+        Operation::Del8 => batch_update_incompatible("DEL8 deletes a KNOWS friendship"),
+    }
+}
+
+fn compatible(interface: &str, cypher_shape: &str, notes: &str) -> MappingOutcome {
+    MappingOutcome::Compatible(PublicApiMapping {
+        interface: interface.into(),
+        cypher_shape: cypher_shape.into(),
+        notes: notes.into(),
+    })
+}
+
+fn batch_update_incompatible(detail: &str) -> MappingOutcome {
+    MappingOutcome::SemanticIncompatibility {
+        cause: "bi_batch_update_stream_not_exposed",
+        detail: format!(
+            "{detail}; the SNB BI batch maintenance stream requires the official driver's transactional \
+             insert/delete semantics, dependency-time ordering, cascading deletes, and write validation, none \
+             of which the public property-graph + Cypher surface exposes"
+        ),
+    }
+}
+
+/// A read result as an ordered list of normalized rows.
+pub type ResultRows = Vec<String>;
+
+pub fn parse_result_rows(text: &str) -> ResultRows {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(normalize_row)
+        .collect()
+}
+
+fn normalize_row(row: &str) -> String {
+    row.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub fn load_result_rows(path: &Path) -> Result<ResultRows, SuiteError> {
+    let text = fs::read_to_string(path).map_err(|error| {
+        SuiteError::InvalidDocument(format!("failed to read {}: {error}", path.display()))
+    })?;
+    Ok(parse_result_rows(&text))
+}
+
+pub fn validate_result(
+    mode: ValidationMode,
+    reference: &ResultRows,
+    system: &ResultRows,
+) -> Result<(), SuiteError> {
+    match mode {
+        ValidationMode::Exact => {
+            if reference == system {
+                Ok(())
+            } else {
+                Err(SuiteError::ReferenceMismatch(format!(
+                    "exact row mismatch: expected {reference:?} got {system:?}"
+                )))
+            }
+        }
+        ValidationMode::Normalized => {
+            let mut reference_sorted = reference.clone();
+            let mut system_sorted = system.clone();
+            reference_sorted.sort();
+            system_sorted.sort();
+            if reference_sorted == system_sorted {
+                Ok(())
+            } else {
+                Err(SuiteError::ReferenceMismatch(format!(
+                    "normalized multiset mismatch: expected {reference_sorted:?} got {system_sorted:?}"
+                )))
+            }
+        }
+    }
+}
+
+pub fn run_job(
+    job: &OperationJob,
+    reference: Option<&ResultRows>,
+    system: Option<&ResultRows>,
+) -> OperationOutcome {
+    let operation = job.operation;
+    let category = operation.category().name().to_string();
+    if let Err(error) = job.validate_schema() {
+        return OperationOutcome {
+            operation,
+            category,
+            status: OperationStatus::Failed,
+            validation_mode: "none".into(),
+            cause: Some(error.to_string()),
+            public_api: None,
+        };
+    }
+    match map_operation(operation) {
+        MappingOutcome::SemanticIncompatibility { cause, detail } => OperationOutcome {
+            operation,
+            category,
+            status: OperationStatus::SemanticIncompatibility,
+            validation_mode: "none".into(),
+            cause: Some(format!("{cause}: {detail}")),
+            public_api: None,
+        },
+        MappingOutcome::Compatible(public_api) => {
+            let mode = operation.intended_validation();
+            let Some(reference) = reference else {
+                return OperationOutcome {
+                    operation,
+                    category,
+                    status: OperationStatus::Failed,
+                    validation_mode: mode.name().into(),
+                    cause: Some("missing_reference".into()),
+                    public_api: Some(public_api),
+                };
+            };
+            let Some(system) = system else {
+                return OperationOutcome {
+                    operation,
+                    category,
+                    status: OperationStatus::Failed,
+                    validation_mode: mode.name().into(),
+                    cause: Some("missing_system_output".into()),
+                    public_api: Some(public_api),
+                };
+            };
+            match validate_result(mode, reference, system) {
+                Ok(()) => OperationOutcome {
+                    operation,
+                    category,
+                    status: OperationStatus::Passed,
+                    validation_mode: mode.name().into(),
+                    cause: None,
+                    public_api: Some(public_api),
+                },
+                Err(error) => OperationOutcome {
+                    operation,
+                    category,
+                    status: OperationStatus::Failed,
+                    validation_mode: mode.name().into(),
+                    cause: Some(error.to_string()),
+                    public_api: Some(public_api),
+                },
+            }
+        }
+    }
+}
+
+pub fn assemble_evidence(
+    dataset_id: &str,
+    identities: serde_json::Value,
+    resources: ResourceReport,
+    outcomes: Vec<OperationOutcome>,
+) -> SuiteEvidence {
+    let status = if outcomes
+        .iter()
+        .any(|outcome| matches!(outcome.status, OperationStatus::Failed))
+    {
+        OperationStatus::Failed
+    } else if outcomes
+        .iter()
+        .all(|outcome| matches!(outcome.status, OperationStatus::SemanticIncompatibility))
+    {
+        OperationStatus::SemanticIncompatibility
+    } else {
+        // Mixed pass + semantic incompatibility is admissible when every
+        // operation either validated or failed closed with a typed cause.
+        OperationStatus::Passed
+    };
+    SuiteEvidence {
+        schema: EVIDENCE_SCHEMA.into(),
+        suite_id: SUITE_ID.into(),
+        dataset_id: dataset_id.into(),
+        status,
+        certification: false,
+        phases: phase_names(),
+        identities,
+        resources,
+        operations: outcomes,
+    }
+}
+
+/// Human/operator-facing summary of every modeled operation.
+pub fn operation_rules() -> BTreeMap<&'static str, String> {
+    let mut rules = BTreeMap::new();
+    for operation in Operation::ALL {
+        let (mapping, cause) = match map_operation(operation) {
+            MappingOutcome::Compatible(_) => ("compatible".to_string(), None),
+            MappingOutcome::SemanticIncompatibility { cause, .. } => {
+                ("semantic_incompatibility".to_string(), Some(cause))
+            }
+        };
+        let validation = operation
+            .validation_mode()
+            .map(|mode| mode.name())
+            .unwrap_or("none");
+        let mut line = format!(
+            "category={} validation={} mapping={}",
+            operation.category().name(),
+            validation,
+            mapping
+        );
+        if let Some(cause) = cause {
+            line.push(':');
+            line.push_str(cause);
+        }
+        rules.insert(operation.code(), line);
+    }
+    rules
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_job(operation: Operation) -> OperationJob {
+        OperationJob {
+            schema: JOB_SCHEMA.into(),
+            suite_id: SUITE_ID.into(),
+            dataset_id: BOUNDED_TINY_DATASET.into(),
+            operation,
+        }
+    }
+
+    fn sample_resources() -> ResourceReport {
+        ResourceReport {
+            schema: RESOURCE_SCHEMA.into(),
+            dataset_id: BOUNDED_TINY_DATASET.into(),
+            load: LoadResource {
+                wall_ms: 12,
+                rows_loaded: 4096,
+            },
+            query: QueryResource {
+                wall_ms: 34,
+                queries_executed: 17,
+            },
+            spill: SpillResource {
+                bytes: 0,
+                events: 0,
+            },
+            rss: RssResource {
+                peak_bytes: 104_857_600,
+            },
+            io: IoResource {
+                read_bytes: 2048,
+                write_bytes: 512,
+            },
+        }
+    }
+
+    #[test]
+    fn all_operations_declare_a_mapping_and_validation_disposition() {
+        assert_eq!(Operation::ALL.len(), 36);
+        for operation in Operation::ALL {
+            let outcome = map_operation(operation);
+            match outcome {
+                MappingOutcome::Compatible(mapping) => {
+                    assert!(operation.validation_mode().is_some(), "{operation}");
+                    assert_eq!(mapping.interface, "cypher", "{operation}");
+                    assert!(!mapping.cypher_shape.is_empty(), "{operation}");
+                    assert!(!mapping.notes.is_empty(), "{operation}");
+                }
+                MappingOutcome::SemanticIncompatibility { cause, detail } => {
+                    assert!(operation.validation_mode().is_none(), "{operation}");
+                    assert!(!cause.is_empty());
+                    assert!(!detail.is_empty());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn analytical_reads_map_to_public_api_except_weighted_paths() {
+        let reads = Operation::ALL
+            .into_iter()
+            .filter(|operation| operation.category() == Category::AnalyticalRead);
+        for operation in reads {
+            if matches!(
+                operation,
+                Operation::Bi15 | Operation::Bi19 | Operation::Bi20
+            ) {
+                assert!(
+                    matches!(
+                        map_operation(operation),
+                        MappingOutcome::SemanticIncompatibility { .. }
+                    ),
+                    "{operation} weighted path must fail closed"
+                );
+                continue;
+            }
+            assert!(
+                matches!(map_operation(operation), MappingOutcome::Compatible(_)),
+                "{operation} should be compatible"
+            );
+        }
+    }
+
+    #[test]
+    fn weighted_path_reads_fail_closed_with_typed_cause() {
+        for operation in [Operation::Bi15, Operation::Bi19, Operation::Bi20] {
+            match map_operation(operation) {
+                MappingOutcome::SemanticIncompatibility { cause, .. } => {
+                    assert_eq!(cause, "weighted_shortest_path_not_exposed", "{operation}");
+                }
+                MappingOutcome::Compatible(_) => panic!("{operation} must fail closed"),
+            }
+        }
+    }
+
+    #[test]
+    fn batch_updates_fail_closed_with_typed_cause() {
+        for operation in Operation::ALL {
+            if !matches!(
+                operation.category(),
+                Category::BatchInsert | Category::BatchDelete
+            ) {
+                continue;
+            }
+            match map_operation(operation) {
+                MappingOutcome::SemanticIncompatibility { cause, .. } => {
+                    assert_eq!(cause, "bi_batch_update_stream_not_exposed", "{operation}");
+                }
+                MappingOutcome::Compatible(_) => panic!("{operation} must fail closed"),
+            }
+        }
+    }
+
+    #[test]
+    fn exact_validation_passes_and_mismatches() {
+        let reference = parse_result_rows("100 Alice\n200 Bob\n");
+        let ok = parse_result_rows("100 Alice\n200 Bob\n");
+        validate_result(ValidationMode::Exact, &reference, &ok).unwrap();
+
+        let reordered = parse_result_rows("200 Bob\n100 Alice\n");
+        assert!(validate_result(ValidationMode::Exact, &reference, &reordered).is_err());
+
+        let changed = parse_result_rows("100 Alice\n200 Carol\n");
+        assert!(validate_result(ValidationMode::Exact, &reference, &changed).is_err());
+    }
+
+    #[test]
+    fn normalized_validation_is_order_insensitive() {
+        let reference = parse_result_rows("tag-a 3\ntag-b 2\n");
+        let reordered = parse_result_rows("tag-b 2\ntag-a 3\n");
+        validate_result(ValidationMode::Normalized, &reference, &reordered).unwrap();
+
+        let missing = parse_result_rows("tag-a 3\ntag-c 9\n");
+        assert!(validate_result(ValidationMode::Normalized, &reference, &missing).is_err());
+    }
+
+    #[test]
+    fn run_job_passes_compatible_read_and_reports_incompatibility() {
+        let reference = parse_result_rows("1 x\n");
+        let system = parse_result_rows("1 x\n");
+        let read = run_job(&sample_job(Operation::Bi1), Some(&reference), Some(&system));
+        assert_eq!(read.status, OperationStatus::Passed);
+        assert!(read.public_api.is_some());
+
+        let insert = run_job(&sample_job(Operation::Ins1), None, None);
+        assert_eq!(insert.status, OperationStatus::SemanticIncompatibility);
+        assert!(
+            insert
+                .cause
+                .as_deref()
+                .unwrap()
+                .contains("bi_batch_update_stream_not_exposed")
+        );
+
+        let weighted = run_job(&sample_job(Operation::Bi15), None, None);
+        assert_eq!(weighted.status, OperationStatus::SemanticIncompatibility);
+        assert!(
+            weighted
+                .cause
+                .as_deref()
+                .unwrap()
+                .contains("weighted_shortest_path_not_exposed")
+        );
+
+        let missing_output = run_job(&sample_job(Operation::Bi1), Some(&reference), None);
+        assert_eq!(missing_output.status, OperationStatus::Failed);
+        assert_eq!(
+            missing_output.cause.as_deref(),
+            Some("missing_system_output")
+        );
+    }
+
+    #[test]
+    fn run_job_reports_reference_mismatch_as_failed() {
+        let reference = parse_result_rows("1 x\n");
+        let system = parse_result_rows("1 WRONG\n");
+        let read = run_job(&sample_job(Operation::Bi1), Some(&reference), Some(&system));
+        assert_eq!(read.status, OperationStatus::Failed);
+        assert!(
+            read.cause
+                .as_deref()
+                .unwrap()
+                .contains("reference_mismatch")
+        );
+    }
+
+    #[test]
+    fn phases_are_separated_in_order() {
+        assert_eq!(
+            phase_names(),
+            vec!["load", "updates", "query", "validation"]
+        );
+    }
+
+    #[test]
+    fn ladder_requires_tiny_dataset_first_and_larger_scales_opt_in() {
+        let bad_first = DatasetLadder {
+            schema: LADDER_SCHEMA.into(),
+            suite_id: SUITE_ID.into(),
+            datasets: vec![
+                LadderEntry {
+                    id: "snb-bi-sf1".into(),
+                    order: 1,
+                    role: "ladder".into(),
+                    opt_in: true,
+                },
+                LadderEntry {
+                    id: BOUNDED_TINY_DATASET.into(),
+                    order: 2,
+                    role: "fixture".into(),
+                    opt_in: false,
+                },
+            ],
+        };
+        assert!(bad_first.validate().is_err());
+
+        let not_opt_in = DatasetLadder {
+            schema: LADDER_SCHEMA.into(),
+            suite_id: SUITE_ID.into(),
+            datasets: vec![
+                LadderEntry {
+                    id: BOUNDED_TINY_DATASET.into(),
+                    order: 1,
+                    role: "engineering_fixture".into(),
+                    opt_in: false,
+                },
+                LadderEntry {
+                    id: "snb-bi-sf1".into(),
+                    order: 2,
+                    role: "ladder".into(),
+                    opt_in: false,
+                },
+            ],
+        };
+        assert!(not_opt_in.validate().is_err());
+
+        let good = DatasetLadder {
+            schema: LADDER_SCHEMA.into(),
+            suite_id: SUITE_ID.into(),
+            datasets: vec![
+                LadderEntry {
+                    id: BOUNDED_TINY_DATASET.into(),
+                    order: 1,
+                    role: "engineering_fixture".into(),
+                    opt_in: false,
+                },
+                LadderEntry {
+                    id: "snb-bi-sf1".into(),
+                    order: 2,
+                    role: "ladder".into(),
+                    opt_in: true,
+                },
+            ],
+        };
+        good.validate().unwrap();
+        assert_eq!(good.ordered_ids()[0], BOUNDED_TINY_DATASET);
+    }
+
+    #[test]
+    fn resource_report_validates_schema_and_dataset() {
+        let resources = sample_resources();
+        resources.validate(BOUNDED_TINY_DATASET).unwrap();
+
+        let mut wrong_schema = sample_resources();
+        wrong_schema.schema = "wrong".into();
+        assert!(wrong_schema.validate(BOUNDED_TINY_DATASET).is_err());
+
+        let mut wrong_dataset = sample_resources();
+        wrong_dataset.dataset_id = "snb-bi-sf1".into();
+        assert!(wrong_dataset.validate(BOUNDED_TINY_DATASET).is_err());
+    }
+
+    #[test]
+    fn evidence_keeps_resources_distinct_from_correctness() {
+        let passed = run_job(
+            &sample_job(Operation::Bi1),
+            Some(&parse_result_rows("1 x\n")),
+            Some(&parse_result_rows("1 x\n")),
+        );
+        let incompatible = run_job(&sample_job(Operation::Ins1), None, None);
+        let evidence = assemble_evidence(
+            BOUNDED_TINY_DATASET,
+            serde_json::json!({}),
+            sample_resources(),
+            vec![passed, incompatible],
+        );
+        assert_eq!(evidence.status, OperationStatus::Passed);
+        assert!(!evidence.certification);
+        // Resource evidence is a distinct section, not an operation outcome.
+        assert_eq!(evidence.resources.query.queries_executed, 17);
+        assert_eq!(evidence.resources.rss.peak_bytes, 104_857_600);
+        assert_eq!(evidence.operations.len(), 2);
+        let rendered = serde_json::to_value(&evidence).unwrap();
+        assert!(rendered.get("resources").is_some());
+        assert!(rendered.get("operations").is_some());
+        assert!(rendered["operations"][0].get("load").is_none());
+    }
+}

--- a/benchmarks/runners/gdc-snb-bi/src/main.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/main.rs
@@ -1,0 +1,191 @@
+use graphforge_benchmark_gdc_snb_bi::{
+    JOB_SCHEMA, MappingOutcome, Operation, OperationJob, OperationStatus, assemble_evidence,
+    load_resource_report, load_result_rows, map_operation, operation_rules, run_job,
+};
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let mut args = env::args().skip(1);
+    let Some(command) = args.next() else {
+        eprintln!(
+            "usage: graphforge-benchmark-gdc-snb-bi <list-operations|map-operation|run-suite> ..."
+        );
+        return ExitCode::from(2);
+    };
+    match command.as_str() {
+        "list-operations" => {
+            let rules = operation_rules();
+            for operation in Operation::ALL {
+                println!("{} {}", operation.code(), rules[operation.code()]);
+            }
+            ExitCode::SUCCESS
+        }
+        "map-operation" => {
+            let Some(path) = args.next() else {
+                eprintln!("usage: map-operation JOB.json");
+                return ExitCode::from(2);
+            };
+            match load_job(&path) {
+                Ok(job) => match map_operation(job.operation) {
+                    MappingOutcome::Compatible(mapping) => {
+                        println!("{}", serde_json::to_string_pretty(&mapping).unwrap());
+                        ExitCode::SUCCESS
+                    }
+                    MappingOutcome::SemanticIncompatibility { cause, detail } => {
+                        eprintln!("semantic_incompatibility:{cause}: {detail}");
+                        ExitCode::from(3)
+                    }
+                },
+                Err(error) => {
+                    eprintln!("{error}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        "run-suite" => {
+            let Some(jobs_dir) = args.next() else {
+                eprintln!(
+                    "usage: run-suite JOBS_DIR REFERENCE_DIR OUTPUT_DIR RESOURCES.json IDENTITIES.json EVIDENCE.json"
+                );
+                return ExitCode::from(2);
+            };
+            let Some(reference_dir) = args.next() else {
+                eprintln!("missing REFERENCE_DIR");
+                return ExitCode::from(2);
+            };
+            let Some(output_dir) = args.next() else {
+                eprintln!("missing OUTPUT_DIR");
+                return ExitCode::from(2);
+            };
+            let Some(resources_path) = args.next() else {
+                eprintln!("missing RESOURCES.json");
+                return ExitCode::from(2);
+            };
+            let Some(identities_path) = args.next() else {
+                eprintln!("missing IDENTITIES.json");
+                return ExitCode::from(2);
+            };
+            let Some(evidence_path) = args.next() else {
+                eprintln!("missing EVIDENCE.json");
+                return ExitCode::from(2);
+            };
+            match run_suite(
+                &jobs_dir,
+                &reference_dir,
+                &output_dir,
+                &resources_path,
+                &identities_path,
+                &evidence_path,
+            ) {
+                Ok(code) => code,
+                Err(error) => {
+                    eprintln!("{error}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        other => {
+            eprintln!("unknown command: {other}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn load_job(path: &str) -> Result<OperationJob, String> {
+    let text = fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let job: OperationJob = serde_json::from_str(&text).map_err(|error| error.to_string())?;
+    if job.schema != JOB_SCHEMA {
+        return Err(format!("unexpected job schema: {}", job.schema));
+    }
+    Ok(job)
+}
+
+fn run_suite(
+    jobs_dir: &str,
+    reference_dir: &str,
+    output_dir: &str,
+    resources_path: &str,
+    identities_path: &str,
+    evidence_path: &str,
+) -> Result<ExitCode, String> {
+    let identities: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(identities_path).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    let mut jobs = Vec::new();
+    for entry in fs::read_dir(jobs_dir).map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        jobs.push(load_job(path.to_str().unwrap())?);
+    }
+    jobs.sort_by_key(|job| job.operation);
+    let declared: Vec<Operation> = jobs.iter().map(|job| job.operation).collect();
+    if declared != Operation::ALL.to_vec() {
+        return Err(format!(
+            "suite requires exactly the {} modeled SNB BI operations, found {}",
+            Operation::ALL.len(),
+            declared.len()
+        ));
+    }
+    let dataset_id = jobs[0].dataset_id.clone();
+    if jobs.iter().any(|job| job.dataset_id != dataset_id) {
+        return Err("suite jobs must share one dataset_id".into());
+    }
+
+    // Resource evidence is recorded separately from correctness and fails closed
+    // when absent or shaped wrong.
+    let resources =
+        load_resource_report(&PathBuf::from(resources_path)).map_err(|error| error.to_string())?;
+    resources
+        .validate(&dataset_id)
+        .map_err(|error| error.to_string())?;
+
+    let mut outcomes = Vec::new();
+    for job in &jobs {
+        let is_read = matches!(map_operation(job.operation), MappingOutcome::Compatible(_));
+        let (reference, system) = if is_read {
+            let reference_path = PathBuf::from(reference_dir).join(format!(
+                "{}-{}.ref",
+                dataset_id,
+                job.operation.code()
+            ));
+            let reference = if reference_path.is_file() {
+                Some(load_result_rows(&reference_path).map_err(|error| error.to_string())?)
+            } else {
+                None
+            };
+            let output_path = PathBuf::from(output_dir).join(format!(
+                "{}-{}.out",
+                dataset_id,
+                job.operation.code()
+            ));
+            let system = if output_path.is_file() {
+                Some(load_result_rows(&output_path).map_err(|error| error.to_string())?)
+            } else {
+                None
+            };
+            (reference, system)
+        } else {
+            (None, None)
+        };
+        outcomes.push(run_job(job, reference.as_ref(), system.as_ref()));
+    }
+    let evidence = assemble_evidence(&dataset_id, identities, resources, outcomes);
+    let payload = serde_json::to_string_pretty(&evidence).map_err(|error| error.to_string())?;
+    fs::write(evidence_path, format!("{payload}\n")).map_err(|error| error.to_string())?;
+    let failed = evidence
+        .operations
+        .iter()
+        .any(|outcome| matches!(outcome.status, OperationStatus::Failed));
+    Ok(if failed {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    })
+}

--- a/benchmarks/schemas/gdc-snb-bi-evidence.json
+++ b/benchmarks/schemas/gdc-snb-bi-evidence.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-gdc-snb-bi-evidence-schema/1",
+  "type": "object",
+  "properties": {
+    "schema": { "const": "graphforge-gdc-snb-bi-evidence/1" },
+    "suite_id": { "const": "snb-bi" },
+    "dataset_id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+    "status": {
+      "enum": ["passed", "failed", "semantic_incompatibility"]
+    },
+    "certification": { "const": false },
+    "phases": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": {
+        "enum": ["load", "updates", "query", "validation"]
+      }
+    },
+    "identities": { "type": "object" },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "schema": { "const": "graphforge-gdc-snb-bi-resources/1" },
+        "dataset_id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+        "load": {
+          "type": "object",
+          "properties": {
+            "wall_ms": { "type": "integer", "minimum": 0 },
+            "rows_loaded": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["wall_ms", "rows_loaded"],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "properties": {
+            "wall_ms": { "type": "integer", "minimum": 0 },
+            "queries_executed": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["wall_ms", "queries_executed"],
+          "additionalProperties": false
+        },
+        "spill": {
+          "type": "object",
+          "properties": {
+            "bytes": { "type": "integer", "minimum": 0 },
+            "events": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["bytes", "events"],
+          "additionalProperties": false
+        },
+        "rss": {
+          "type": "object",
+          "properties": {
+            "peak_bytes": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["peak_bytes"],
+          "additionalProperties": false
+        },
+        "io": {
+          "type": "object",
+          "properties": {
+            "read_bytes": { "type": "integer", "minimum": 0 },
+            "write_bytes": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["read_bytes", "write_bytes"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["schema", "dataset_id", "load", "query", "spill", "rss", "io"],
+      "additionalProperties": false
+    },
+    "operations": {
+      "type": "array",
+      "minItems": 36,
+      "maxItems": 36,
+      "items": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "enum": [
+              "BI1", "BI2", "BI3", "BI4", "BI5", "BI6", "BI7", "BI8", "BI9",
+              "BI10", "BI11", "BI12", "BI13", "BI14", "BI15", "BI16", "BI17",
+              "BI18", "BI19", "BI20",
+              "INS1", "INS2", "INS3", "INS4", "INS5", "INS6", "INS7", "INS8",
+              "DEL1", "DEL2", "DEL3", "DEL4", "DEL5", "DEL6", "DEL7", "DEL8"
+            ]
+          },
+          "category": {
+            "enum": ["analytical_read", "batch_insert", "batch_delete"]
+          },
+          "status": {
+            "enum": ["passed", "failed", "semantic_incompatibility"]
+          },
+          "validation_mode": {
+            "enum": ["exact", "normalized", "none"]
+          },
+          "cause": { "type": ["string", "null"] },
+          "public_api": {
+            "type": ["object", "null"],
+            "properties": {
+              "interface": { "enum": ["cypher", "analyst_verb"] },
+              "cypher_shape": { "type": "string" },
+              "notes": { "type": "string" }
+            },
+            "required": ["interface", "cypher_shape", "notes"],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "operation",
+          "category",
+          "status",
+          "validation_mode"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "schema",
+    "suite_id",
+    "dataset_id",
+    "status",
+    "certification",
+    "phases",
+    "identities",
+    "resources",
+    "operations"
+  ],
+  "additionalProperties": false
+}

--- a/benchmarks/schemas/gdc-suite-declaration.json
+++ b/benchmarks/schemas/gdc-suite-declaration.json
@@ -29,7 +29,7 @@
       "pattern": "^profiles/gdc/[A-Za-z0-9_.-]+\\.json$"
     },
     "runner": {
-      "enum": ["gdc-contracts", "gdc-graphalytics", "gdc-snb-interactive"]
+      "enum": ["gdc-contracts", "gdc-graphalytics", "gdc-snb-bi", "gdc-snb-interactive"]
     },
     "datasets": {
       "type": "array",

--- a/benchmarks/suites/gdc-snb-bi.json
+++ b/benchmarks/suites/gdc-snb-bi.json
@@ -5,6 +5,6 @@
   "suite_id": "snb-bi",
   "disposition": "executable",
   "pinned_identity": "profiles/gdc/snb-bi-identity.json",
-  "runner": "gdc-contracts",
+  "runner": "gdc-snb-bi",
   "datasets": ["snb-bi-sf0.003"]
 }

--- a/benchmarks/tests/test_gdc_snb_bi.py
+++ b/benchmarks/tests/test_gdc_snb_bi.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import unittest
+
+from graphforge_bench.gdc_contracts import list_gdc_suites, workspace_root
+from graphforge_bench.gdc_snb_bi import (
+    ANALYTICAL_READS,
+    BATCH_DELETES,
+    BATCH_INSERTS,
+    BATCH_UPDATE_CAUSE,
+    EVIDENCE_SCHEMA,
+    OPERATIONS,
+    RESOURCE_SCHEMA,
+    WEIGHTED_PATH_CAUSE,
+    WEIGHTED_PATH_READS,
+    SnbBiSuiteError,
+    assert_large_scale_factors_are_opt_in,
+    assert_separate_from_other_suites,
+    list_operation_rules,
+    map_operation_file,
+    run_tiny_suite,
+)
+from jsonschema import Draft202012Validator
+
+
+def _ensure_runner_built(root: Path) -> Path:
+    binary = root / "target" / "debug" / "graphforge-benchmark-gdc-snb-bi"
+    if binary.is_file():
+        return binary
+    target_dir = root / "target"
+    completed = subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--locked",
+            "--manifest-path",
+            str(root / "Cargo.toml"),
+            "-p",
+            "graphforge-benchmark-gdc-snb-bi",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CARGO_TARGET_DIR": str(target_dir)},
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"failed to build snb-bi runner\n{completed.stdout}\n{completed.stderr}"
+        )
+    assert binary.is_file(), binary
+    return binary
+
+
+class GdcSnbBiSuiteTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root = workspace_root()
+        cls.binary = _ensure_runner_built(cls.root)
+        os.environ["GRAPHFORGE_GDC_SNB_BI_BIN"] = str(cls.binary)
+
+    def test_suite_declaration_uses_snb_bi_runner(self) -> None:
+        suites = {suite["suite_id"]: suite for suite in list_gdc_suites()}
+        suite = suites["snb-bi"]
+        self.assertEqual(suite["runner"], "gdc-snb-bi")
+        self.assertEqual(suite["disposition"], "executable")
+        self.assertEqual(suite["datasets"][0], "snb-bi-sf0.003")
+        assert_separate_from_other_suites()
+
+    def test_all_operations_declare_mapping_and_validation_rules(self) -> None:
+        rules = list_operation_rules()
+        self.assertEqual(set(rules), set(OPERATIONS))
+        self.assertEqual(len(rules), 36)
+        for read in ANALYTICAL_READS:
+            self.assertEqual(rules[read]["category"], "analytical_read", read)
+            if read in WEIGHTED_PATH_READS:
+                self.assertTrue(rules[read]["mapping"].startswith("semantic_incompatibility"), read)
+                self.assertIn(WEIGHTED_PATH_CAUSE, rules[read]["mapping"])
+                self.assertEqual(rules[read]["validation"], "none", read)
+            else:
+                self.assertEqual(rules[read]["mapping"], "compatible", read)
+        self.assertEqual(rules["BI2"]["validation"], "normalized")
+        self.assertEqual(rules["BI12"]["validation"], "normalized")
+        self.assertEqual(rules["BI16"]["validation"], "normalized")
+        self.assertEqual(rules["BI1"]["validation"], "exact")
+        for update in BATCH_INSERTS:
+            self.assertEqual(rules[update]["category"], "batch_insert", update)
+            self.assertTrue(rules[update]["mapping"].startswith("semantic_incompatibility"), update)
+            self.assertEqual(rules[update]["validation"], "none", update)
+        for delete in BATCH_DELETES:
+            self.assertEqual(rules[delete]["category"], "batch_delete", delete)
+            self.assertTrue(rules[delete]["mapping"].startswith("semantic_incompatibility"), delete)
+            self.assertEqual(rules[delete]["validation"], "none", delete)
+
+    def test_compatible_fixture_passes_with_per_op_statuses(self) -> None:
+        evidence = run_tiny_suite(fixture_name="compatible")
+        self.assertEqual(evidence["schema"], EVIDENCE_SCHEMA)
+        self.assertEqual(evidence["suite_id"], "snb-bi")
+        self.assertEqual(evidence["dataset_id"], "snb-bi-sf0.003")
+        self.assertEqual(evidence["status"], "passed")
+        self.assertIs(evidence["certification"], False)
+        self.assertEqual(evidence["phases"], ["load", "updates", "query", "validation"])
+        self.assertIn("spec", evidence["identities"])
+        by_op = {item["operation"]: item for item in evidence["operations"]}
+        self.assertEqual(set(by_op), set(OPERATIONS))
+        for read in ANALYTICAL_READS:
+            if read in WEIGHTED_PATH_READS:
+                continue
+            self.assertEqual(by_op[read]["status"], "passed", read)
+            self.assertIsNotNone(by_op[read].get("public_api"))
+        for incompatible in (*WEIGHTED_PATH_READS, *BATCH_INSERTS, *BATCH_DELETES):
+            self.assertEqual(
+                by_op[incompatible]["status"], "semantic_incompatibility", incompatible
+            )
+            self.assertIsNotNone(by_op[incompatible].get("cause"))
+        Draft202012Validator(
+            json.loads(
+                (self.root / "schemas" / "gdc-snb-bi-evidence.json").read_text(encoding="utf-8")
+            )
+        ).validate(evidence)
+
+    def test_resources_recorded_separately_from_correctness(self) -> None:
+        evidence = run_tiny_suite(fixture_name="compatible")
+        # Resource evidence lives in a distinct section, never inside correctness.
+        resources = evidence["resources"]
+        self.assertEqual(resources["schema"], RESOURCE_SCHEMA)
+        self.assertEqual(resources["dataset_id"], "snb-bi-sf0.003")
+        for field in ("load", "query", "spill", "rss", "io"):
+            self.assertIn(field, resources, field)
+        self.assertIn("wall_ms", resources["load"])
+        self.assertIn("wall_ms", resources["query"])
+        self.assertIn("bytes", resources["spill"])
+        self.assertIn("peak_bytes", resources["rss"])
+        self.assertIn("read_bytes", resources["io"])
+        self.assertIn("write_bytes", resources["io"])
+        for outcome in evidence["operations"]:
+            self.assertNotIn("resources", outcome)
+            self.assertNotIn("rss", outcome)
+            self.assertNotIn("load", outcome)
+
+    def test_unsupported_semantics_fail_visibly(self) -> None:
+        fixture = self.root / "fixtures" / "gdc" / "snb-bi-tiny" / "compatible" / "jobs"
+        with self.assertRaises(SnbBiSuiteError) as raised_insert:
+            map_operation_file(fixture / "INS1.json")
+        self.assertEqual(raised_insert.exception.cause, "semantic_incompatibility")
+        self.assertIn(BATCH_UPDATE_CAUSE, str(raised_insert.exception))
+
+        with self.assertRaises(SnbBiSuiteError) as raised_delete:
+            map_operation_file(fixture / "DEL1.json")
+        self.assertEqual(raised_delete.exception.cause, "semantic_incompatibility")
+        self.assertIn(BATCH_UPDATE_CAUSE, str(raised_delete.exception))
+
+        with self.assertRaises(SnbBiSuiteError) as raised_weighted:
+            map_operation_file(fixture / "BI15.json")
+        self.assertEqual(raised_weighted.exception.cause, "semantic_incompatibility")
+        self.assertIn(WEIGHTED_PATH_CAUSE, str(raised_weighted.exception))
+
+    def test_reference_mismatch_is_visible(self) -> None:
+        evidence = run_tiny_suite(fixture_name="reference-mismatch")
+        by_op = {item["operation"]: item for item in evidence["operations"]}
+        self.assertEqual(by_op["BI1"]["status"], "failed")
+        self.assertIn("reference_mismatch", by_op["BI1"]["cause"])
+        self.assertEqual(evidence["status"], "failed")
+
+    def test_semantic_incompat_fixture_fails_closed(self) -> None:
+        evidence = run_tiny_suite(fixture_name="semantic-incompat")
+        by_op = {item["operation"]: item for item in evidence["operations"]}
+        for incompatible in (*WEIGHTED_PATH_READS, *BATCH_INSERTS, *BATCH_DELETES):
+            self.assertEqual(
+                by_op[incompatible]["status"], "semantic_incompatibility", incompatible
+            )
+
+    def test_large_scale_factors_are_opt_in(self) -> None:
+        assert_large_scale_factors_are_opt_in()
+
+    def test_index_and_readme_point_at_snb_bi_suite(self) -> None:
+        index = (self.root / "gdc-suite-index.md").read_text(encoding="utf-8")
+        self.assertIn("`snb-bi`", index)
+        self.assertIn("gdc-snb-bi", index)
+        self.assertIn("## SNB BI", index)
+        self.assertNotIn("blocked on suite issue #963", index)
+        readme = (self.root / "README.md").read_text(encoding="utf-8")
+        self.assertIn("gdc_snb_bi", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the GDC SNB BI benchmark suite (#963): serde-only Rust runner for 20 analytical reads plus batch maintenance stream, Python harness, bounded `snb-bi-sf0.003` fixtures, and evidence schema with resource/correctness separation.

Rebased onto current `main` (post-#961 Graphalytics); shared GDC declaration/index includes both runners.

## Test plan

- [x] `cargo test --locked -p graphforge-benchmark-gdc-snb-bi` → 12 passed
- [x] `uv run --locked python -m unittest tests.test_gdc_snb_bi tests.test_gdc_contracts` → 19 passed

Closes #963.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790798358&installation_model_id=20486&pr_number=1049&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1049&signature=02c0f2fabfbe470b53ab814812e9aea4d5cb9f0cd98d7273d03932727bd42b2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GDC SNB BI benchmark suite with dedicated Rust runner
> - Introduces a new Rust runner crate `graphforge-benchmark-gdc-snb-bi` with CLI subcommands `list-operations`, `map-operation`, and `run-suite`, plus a core library in [lib.rs](https://github.com/CurateLabs/graphforge/pull/1049/files#diff-9dc771e8696096936125976459aa4d8f85d50f048379d6e26f1ff5684f22b712) that maps 36 SNB BI operations to public API, validates results (exact/normalized), records resources, and assembles suite evidence
> - Adds Python harness integration in [gdc_snb_bi.py](https://github.com/CurateLabs/graphforge/pull/1049/files#diff-dd1e83fd87b64e0a6aadd9948a4b4ef9a8dc1cb6856300d73cac5b5deb318fd0) and tests in [test_gdc_snb_bi.py](https://github.com/CurateLabs/graphforge/pull/1049/files#diff-b1645385300e9a629eab701b34e6131a4cc0533eb625da8e8aa4bc174a439d34) covering operation rules, compatible fixture pass, reference mismatch, semantic incompatibility, resource separation, and opt-in large scale factors
> - Adds fixture sets under three variants (`compatible`, `reference-mismatch`, `semantic-incompat`) with job descriptors, reference/system outputs, acquisition metadata, and resource reports for `snb-bi-tiny`
> - Adds the evidence JSON schema [gdc-snb-bi-evidence.json](https://github.com/CurateLabs/graphforge/pull/1049/files#diff-625080721c473a1423c481fa11144a1c693dc58c7114e85f2b058f347845d865), registers the `gdc-snb-bi` runner in the suite declaration schema, and switches [gdc-snb-bi.json](https://github.com/CurateLabs/graphforge/pull/1049/files#diff-9070f58097f6b53b640337d8c664352ec0e8b8f7ff3ffe478b3c483718d31304) from `gdc-contracts` to `gdc-snb-bi`
> - Behavioral Change: `BI15`, `BI19`, `BI20` (weighted shortest paths) and all `INS`/`DEL` operations fail closed with `semantic_incompatibility`; the suite declaration now references the new runner; overall evidence status derives as `Failed` if any op fails, `SemanticIncompatibility` if all fail, else `Passed`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce976f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->