### PR TITLE
feat(bench): add progressive readiness and recovery-lease core

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -24,11 +24,12 @@ progressive-provider-attempt-static: install
 	PYTHONPATH=harness uv run --locked python -m unittest \
 		tests.test_progressive_provider_attempt
 
-# Provider-free proof of the Fly command boundary and ESC secret capsule.
+# Provider-free proof of the Fly command boundary, ESC capsule, and recovery lease.
 progressive-fly-transport-static: install
 	PYTHONPATH=harness uv run --locked python -m unittest \
 		tests.test_progressive_fly_transport \
-		tests.test_progressive_esc
+		tests.test_progressive_esc \
+		tests.test_progressive_recovery_lease
 
 local-admission: install
 	PYTHONPATH=$(CURDIR)/harness uv run --locked reframe -C reframe/settings.py -c reframe/checks -n '^LocalBenchExecAdmission$$' -l | grep -F LocalBenchExecAdmission

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -416,12 +416,18 @@ make -C benchmarks progressive-fly-transport-static
 
 The transport accepts only an already-published immutable image, emits fixed
 shell-free Fly commands through an injected boundary, applies the attempt
-deadline to every operation, validates provider-observed Machine identity,
-retrieves the result before the remaining canonical artifacts, and returns only
-sanitized teardown counts. The ESC capsule consumes the fixed projected token
-and spend-authorization variables once, removes them from the ambient process,
-and constructs a minimal child environment with fresh credential state. Both
-components remain import-only: these tests perform no provider operation.
+deadline to every operation, converges Machine readiness within
+`min(attempt_deadline, readiness_cap)` with bounded backoff, replaces unbounded
+idle sleep with the authorized finite Machine lifetime, validates
+provider-observed Machine identity, retrieves the result before the remaining
+canonical artifacts, and returns only sanitized teardown counts. Before any
+provider mutation the controller persists a credential-free recovery lease
+receipt; an expired-lease janitor core can reconstruct an owner-confined
+transport through an injected factory without the local attempt ledger. The ESC
+capsule consumes the fixed projected token and spend-authorization variables
+once, removes them from the ambient process, and constructs a minimal child
+environment with fresh credential state. These components remain import-only:
+these tests perform no provider operation.
 
 Provider credentials belong to Pulumi ESC rather than GitHub workflow inputs or
 the caller's ambient shell. Live operator commands are rendered from
@@ -438,11 +444,14 @@ The operator uses the shell-free form `pulumi env run <environment> -- <argv>`;
 secret values are never copied into its command line or evidence. The
 `progressive-ladder` is registered, but still fails before opening ESC. The
 typed whole-attempt state machine, production-shaped Fly command boundary,
-isolated ESC input capsule, ownership-ledger recovery, and sanitized teardown
-inventory now exist offline. Protected/versioned ESC configuration, immutable
-image publication, an independently scheduled recovery owner or lease, and the
-separately reviewed spend authorization remain prerequisites for live wiring.
-This is a live capability boundary, not a GitHub-dispatch prerequisite.
+isolated ESC input capsule, ownership-ledger recovery, readiness convergence,
+finite Machine lifetime, recovery-lease receipt, expired-lease janitor core, and
+sanitized teardown inventory now exist offline. Protected/versioned ESC
+configuration, immutable image publication, a durable receipt backend with an
+independently scheduled recovery owner, short-lived scoped run/janitor token
+policy, and the separately reviewed spend authorization remain prerequisites for
+live wiring. This is a live capability boundary, not a GitHub-dispatch
+prerequisite.
 
 The controller derives bulk-ingest capability from the same run's bounded
 ordinary `gf import-session commit --json` receipt: its construction evidence

--- a/benchmarks/harness/graphforge_bench/progressive_fly_transport.py
+++ b/benchmarks/harness/graphforge_bench/progressive_fly_transport.py
@@ -38,6 +38,16 @@ TRANSFER_TIMEOUT_SECONDS = 300
 TEARDOWN_TIMEOUT_SECONDS = 300
 TEARDOWN_POLL_ATTEMPTS = 6
 TEARDOWN_POLL_INTERVAL_SECONDS = 1
+READINESS_CAP_SECONDS = 300
+READINESS_PROBE_TIMEOUT_SECONDS = 5
+READINESS_INITIAL_BACKOFF_SECONDS = 0.25
+READINESS_MAX_BACKOFF_SECONDS = 2.0
+# Documented Fly Machine states still converging toward admission.
+NONTERMINAL_MACHINE_STATES = frozenset({"created", "starting", "replacing"})
+# Documented Fly Machine states that can never converge to a healthy worker.
+TERMINAL_MACHINE_STATES = frozenset(
+    {"stopped", "stopping", "destroyed", "destroying", "suspended", "suspending"}
+)
 REMOTE_OUTPUT_DIR = "/work/evidence"
 API_ROOT = "https://api.machines.dev"
 PROVIDER_ENVIRONMENT = frozenset(
@@ -364,6 +374,7 @@ def _observed_image(
     metadata = config.get("metadata")
     init = config.get("init")
     expected_memory = MACHINE_MEMORY_MB.get(authorization.machine_class)
+    lifetime = str(authorization.maximum_machine_seconds)
     if (
         value.get("id") != machine_id
         or value.get("name") != f"{authorization.app}-worker"
@@ -378,7 +389,7 @@ def _observed_image(
         or config.get("services") not in (None, [])
         or not isinstance(init, Mapping)
         or init.get("entrypoint") not in (["/bin/sleep"], "/bin/sleep")
-        or init.get("cmd") not in (["infinity"], "infinity")
+        or init.get("cmd") not in ([lifetime], lifetime)
         or not isinstance(guest, Mapping)
         or guest.get("cpu_kind") != cpu_kind
         or guest.get("cpus") != int(cpus_text.removesuffix("x"))
@@ -400,6 +411,77 @@ def _observed_image(
     ):
         raise FlyTransportError("Machine state differs from authorized resources")
     return f"registry.fly.io/{repository}@{digest}"
+
+
+def _readiness_machine(value: Any, *, machine_name: str) -> tuple[str, str] | None:
+    """Classify Machine inventory during readiness convergence.
+
+    Returns ``None`` when the expected Machine is still absent. Returns
+    ``(machine_id, state)`` when exactly one expected Machine is present in a
+    documented nonterminal or ``started`` state. Raises on malformed, extra,
+    wrong-name, unknown, or terminal inventory.
+    """
+    machines = _list(value, "Machine")
+    if not machines:
+        return None
+    if len(machines) != 1 or not isinstance(machines[0], Mapping):
+        raise FlyTransportError("provider Machine inventory is unexpected")
+    machine = machines[0]
+    if machine.get("name") != machine_name:
+        raise FlyTransportError("created Machine identity is unavailable")
+    machine_id = machine.get("id")
+    state = machine.get("state")
+    if not isinstance(machine_id, str) or MACHINE_ID.fullmatch(machine_id) is None:
+        raise FlyTransportError("created Machine identity is malformed")
+    if not isinstance(state, str):
+        raise FlyTransportError("provider Machine state is malformed")
+    if state in TERMINAL_MACHINE_STATES:
+        raise FlyTransportError("provider Machine entered a terminal state")
+    if state != "started" and state not in NONTERMINAL_MACHINE_STATES:
+        raise FlyTransportError("provider Machine state is unexpected")
+    return machine_id, state
+
+
+def wait_for_machine_readiness(
+    boundary: FlyBoundary,
+    authorization: SpendAuthorization,
+    *,
+    machine_name: str,
+    deadline: datetime,
+    clock: Callable[[], datetime],
+    sleeper: Callable[[float], None],
+    admit: Callable[[str], str],
+) -> tuple[str, str]:
+    """Poll until the authorized Machine admits under full identity validation.
+
+    Probe failures may be retried. Malformed, extra, wrong-name, terminal, or
+    identity-drift inventory fails immediately. Mutation is never retried.
+    """
+    readiness_deadline = min(deadline, clock() + timedelta(seconds=READINESS_CAP_SECONDS))
+    backoff = READINESS_INITIAL_BACKOFF_SECONDS
+    while True:
+        remaining = (readiness_deadline - clock()).total_seconds()
+        if remaining <= 0 or remaining < 1:
+            raise AttemptError("readiness_timeout", "created Machine did not become ready")
+        probe_timeout = min(READINESS_PROBE_TIMEOUT_SECONDS, int(remaining))
+        try:
+            machines = boundary.json(
+                ("flyctl", "machine", "list", "--app", authorization.app, "--json"),
+                timeout=probe_timeout,
+            )
+        except (OSError, subprocess.SubprocessError, FlyTransportError):
+            machines = None
+        else:
+            observed = _readiness_machine(machines, machine_name=machine_name)
+            if observed is not None:
+                machine_id, state = observed
+                if state == "started":
+                    return machine_id, admit(machine_id)
+        sleep_for = min(backoff, max(0.0, (readiness_deadline - clock()).total_seconds()))
+        if sleep_for <= 0:
+            raise AttemptError("readiness_timeout", "created Machine did not become ready")
+        sleeper(sleep_for)
+        backoff = min(backoff * 2, READINESS_MAX_BACKOFF_SECONDS)
 
 
 class FlyProviderTransport:
@@ -541,13 +623,14 @@ class FlyProviderTransport:
         )
         self._volume_id = volume_id
         machine_name = f"{authorization.app}-worker"
+        lifetime = str(authorization.maximum_machine_seconds)
         self._boundary.run(
             (
                 "flyctl",
                 "machine",
                 "run",
                 authorization.image_digest,
-                "infinity",
+                lifetime,
                 "--app",
                 authorization.app,
                 "--name",
@@ -581,14 +664,20 @@ class FlyProviderTransport:
             ),
             timeout=self._timeout(deadline, CREATE_TIMEOUT_SECONDS),
         )
-        self._machine_id = _machine_id(
-            self._boundary.json(
-                ("flyctl", "machine", "list", "--app", authorization.app, "--json"),
-                timeout=self._timeout(deadline, CREATE_TIMEOUT_SECONDS),
-            ),
-            machine_name,
+
+        def admit(machine_id: str) -> str:
+            self._machine_id = machine_id
+            return self._validate_owned_state(deadline)
+
+        self._machine_id, observed = wait_for_machine_readiness(
+            self._boundary,
+            authorization,
+            machine_name=machine_name,
+            deadline=deadline,
+            clock=self._clock,
+            sleeper=self._sleeper,
+            admit=admit,
         )
-        observed = self._validate_owned_state(deadline)
         return ProvisionedAttempt(
             image_digest=observed,
             resources={"machine_id": self._machine_id, "volume_id": volume_id},

--- a/benchmarks/harness/graphforge_bench/progressive_provider_attempt.py
+++ b/benchmarks/harness/graphforge_bench/progressive_provider_attempt.py
@@ -675,6 +675,26 @@ def execute(
         completed_scales=scales,
     )
     save_ledger(invocation.ledger_path, ledger)
+    from graphforge_bench.progressive_recovery_lease import (
+        ack_recovery_lease,
+        build_recovery_lease,
+    )
+
+    lease_path = invocation.ledger_path.with_name(
+        f"{invocation.ledger_path.stem}.recovery-lease.json"
+    )
+    if lease_path.exists() or lease_path.is_symlink():
+        raise AttemptError(
+            "recovery_refused", "existing recovery lease requires expired-lease cleanup"
+        )
+    ack_recovery_lease(
+        lease_path,
+        build_recovery_lease(
+            authorization,
+            execution_deadline=deadline,
+            acknowledged_at=started_at,
+        ),
+    )
     provisioned: ProvisionedAttempt | None = None
     primary_error: AttemptError | None = None
     pending_plan: Mapping[str, Any] | None = first_plan

--- a/benchmarks/harness/graphforge_bench/progressive_recovery_lease.py
+++ b/benchmarks/harness/graphforge_bench/progressive_recovery_lease.py
@@ -1,0 +1,257 @@
+"""Credential-free recovery lease and expired-lease janitor core.
+
+Import-only: no CLI, no ESC opening, and no ambient provider credentials.
+Cleanup reconstructs an owner-confined transport through an injected factory.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import tempfile
+from typing import Any, Protocol
+
+from jsonschema import Draft202012Validator
+
+from graphforge_bench.progressive_provider_attempt import (
+    AttemptError,
+    SpendAuthorization,
+    _timestamp,
+)
+
+LEASE_SCHEMA = "graphforge-progressive-provider-recovery-lease/1"
+SCHEMA_ROOT = Path(__file__).resolve().parents[2] / "schemas"
+APP = re.compile(r"^gf-progressive-[0-9a-f]{32}$")
+
+
+class _TeardownTransport(Protocol):
+    def teardown(self, resources: Mapping[str, str]) -> Mapping[str, Any]: ...
+
+
+class TransportFactory(Protocol):
+    def __call__(self, lease: RecoveryLease) -> _TeardownTransport: ...
+
+
+@dataclass(frozen=True)
+class RecoveryLease:
+    """Durable, credential-free receipt for host-independent expired cleanup."""
+
+    schema: str
+    version: int
+    organization: str
+    app: str
+    attempt_nonce: str
+    commit: str
+    authorization_sha256: str
+    image_digest: str
+    teardown_owner: str
+    execution_deadline: datetime
+    cleanup_deadline: datetime
+    resource_limits: Mapping[str, int]
+    acknowledged_at: datetime
+    claim: str
+
+
+def _atomic_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary.replace(path)
+        directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_schema(value: Mapping[str, Any], failure: str) -> None:
+    try:
+        schema = json.loads(
+            (SCHEMA_ROOT / "progressive-provider-recovery-lease.json").read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AttemptError(failure, "recovery lease schema is unavailable") from error
+    error = next(Draft202012Validator(schema).iter_errors(value), None)
+    if error is not None:
+        raise AttemptError(failure, "recovery lease document failed its schema")
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _document(lease: RecoveryLease) -> dict[str, Any]:
+    return {
+        "schema": lease.schema,
+        "version": lease.version,
+        "organization": lease.organization,
+        "app": lease.app,
+        "attempt_nonce": lease.attempt_nonce,
+        "commit": lease.commit,
+        "authorization_sha256": lease.authorization_sha256,
+        "image_digest": lease.image_digest,
+        "teardown_owner": lease.teardown_owner,
+        "execution_deadline": _format_timestamp(lease.execution_deadline),
+        "cleanup_deadline": _format_timestamp(lease.cleanup_deadline),
+        "resource_limits": dict(lease.resource_limits),
+        "acknowledged_at": _format_timestamp(lease.acknowledged_at),
+        "claim": lease.claim,
+    }
+
+
+def build_recovery_lease(
+    authorization: SpendAuthorization,
+    *,
+    execution_deadline: datetime,
+    acknowledged_at: datetime,
+) -> RecoveryLease:
+    """Construct a schema-shaped lease bound to spend authority identity."""
+    if execution_deadline.tzinfo is None or acknowledged_at.tzinfo is None:
+        raise AttemptError("recovery_refused", "recovery lease clock is not timezone-aware")
+    if APP.fullmatch(authorization.app) is None:
+        raise AttemptError("recovery_refused", "recovery lease app identity is malformed")
+    if authorization.app != f"gf-progressive-{authorization.attempt_nonce}":
+        raise AttemptError("recovery_refused", "recovery lease app/nonce binding is inconsistent")
+    if execution_deadline > authorization.expires_at:
+        raise AttemptError(
+            "recovery_refused", "execution deadline exceeds spend authorization expiry"
+        )
+    return RecoveryLease(
+        schema=LEASE_SCHEMA,
+        version=1,
+        organization=authorization.organization,
+        app=authorization.app,
+        attempt_nonce=authorization.attempt_nonce,
+        commit=authorization.commit,
+        authorization_sha256=authorization.authorization_sha256,
+        image_digest=authorization.image_digest,
+        teardown_owner=authorization.teardown_owner,
+        execution_deadline=execution_deadline.astimezone(timezone.utc),
+        cleanup_deadline=authorization.expires_at.astimezone(timezone.utc),
+        resource_limits=dict(authorization.resource_limits),
+        acknowledged_at=acknowledged_at.astimezone(timezone.utc),
+        claim="recovery_lease_only",
+    )
+
+
+def parse_recovery_lease(value: str | bytes | Mapping[str, Any]) -> RecoveryLease:
+    if isinstance(value, (str, bytes)):
+        try:
+            decoded = json.loads(value)
+        except (TypeError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise AttemptError("recovery_refused", "recovery lease is malformed") from error
+    else:
+        decoded = value
+    if not isinstance(decoded, Mapping):
+        raise AttemptError("recovery_refused", "recovery lease is malformed")
+    _validate_schema(decoded, "recovery_refused")
+    if decoded.get("schema") != LEASE_SCHEMA or decoded.get("version") != 1:
+        raise AttemptError("recovery_refused", "recovery lease schema is invalid")
+    if decoded["app"] != f"gf-progressive-{decoded['attempt_nonce']}":
+        raise AttemptError("recovery_refused", "recovery lease app/nonce binding is inconsistent")
+    execution_deadline = _timestamp(decoded["execution_deadline"])
+    cleanup_deadline = _timestamp(decoded["cleanup_deadline"])
+    acknowledged_at = _timestamp(decoded["acknowledged_at"])
+    if cleanup_deadline < execution_deadline:
+        raise AttemptError("recovery_refused", "cleanup deadline precedes execution deadline")
+    return RecoveryLease(
+        schema=LEASE_SCHEMA,
+        version=1,
+        organization=decoded["organization"],
+        app=decoded["app"],
+        attempt_nonce=decoded["attempt_nonce"],
+        commit=decoded["commit"],
+        authorization_sha256=decoded["authorization_sha256"],
+        image_digest=decoded["image_digest"],
+        teardown_owner=decoded["teardown_owner"],
+        execution_deadline=execution_deadline,
+        cleanup_deadline=cleanup_deadline,
+        resource_limits=dict(decoded["resource_limits"]),
+        acknowledged_at=acknowledged_at,
+        claim=decoded["claim"],
+    )
+
+
+def save_recovery_lease(path: Path, lease: RecoveryLease) -> None:
+    document = _document(lease)
+    _validate_schema(document, "recovery_refused")
+    _atomic_json(path, document)
+
+
+def load_recovery_lease(path: Path) -> RecoveryLease:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AttemptError(
+            "recovery_refused", "recovery lease is unavailable or malformed"
+        ) from error
+    return parse_recovery_lease(value)
+
+
+def ack_recovery_lease(path: Path, lease: RecoveryLease) -> RecoveryLease:
+    """Persist then re-read so acknowledgment is durable before mutation."""
+    save_recovery_lease(path, lease)
+    loaded = load_recovery_lease(path)
+    if _document(loaded) != _document(lease):
+        raise AttemptError("recovery_refused", "recovery lease acknowledgment drifted")
+    return loaded
+
+
+def validate_lease_identity(lease: RecoveryLease, *, expected: RecoveryLease | None = None) -> None:
+    if APP.fullmatch(lease.app) is None:
+        raise AttemptError("recovery_refused", "recovery lease app identity is malformed")
+    if lease.app != f"gf-progressive-{lease.attempt_nonce}":
+        raise AttemptError("recovery_refused", "recovery lease app/nonce binding is inconsistent")
+    if expected is None:
+        return
+    if (
+        lease.organization != expected.organization
+        or lease.app != expected.app
+        or lease.attempt_nonce != expected.attempt_nonce
+        or lease.commit != expected.commit
+        or lease.authorization_sha256 != expected.authorization_sha256
+        or lease.image_digest != expected.image_digest
+        or lease.teardown_owner != expected.teardown_owner
+    ):
+        raise AttemptError("recovery_refused", "recovery lease identity mismatch")
+
+
+def cleanup_expired_lease(
+    lease: RecoveryLease,
+    *,
+    transport_factory: TransportFactory,
+    clock: Callable[[], datetime] | None = None,
+    expected: RecoveryLease | None = None,
+) -> Mapping[str, Any]:
+    """Teardown after cleanup_deadline using an injected owner-confined transport."""
+    clock_fn = clock or (lambda: datetime.now(timezone.utc))
+    now = clock_fn()
+    if now.tzinfo is None:
+        raise AttemptError("recovery_refused", "recovery lease clock is not timezone-aware")
+    validate_lease_identity(lease, expected=expected)
+    if now < lease.cleanup_deadline:
+        raise AttemptError("recovery_refused", "recovery lease has not expired")
+    transport = transport_factory(lease)
+    observed = transport.teardown({"owner_app": lease.app})
+    expected_keys = {"app_exists", "machines", "volumes", "secrets"}
+    if not isinstance(observed, Mapping) or set(observed) != expected_keys:
+        raise AttemptError("inventory_unavailable", "teardown inventory is malformed")
+    return {
+        "app_exists": bool(observed["app_exists"]),
+        "machines": int(observed["machines"]),
+        "volumes": int(observed["volumes"]),
+        "secrets": int(observed["secrets"]),
+    }

--- a/benchmarks/schemas/progressive-provider-attempt-ledger.json
+++ b/benchmarks/schemas/progressive-provider-attempt-ledger.json
@@ -21,7 +21,7 @@
     "current_rung": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/scale"}]},
     "completed_scales": {"$ref": "#/$defs/completedScales"},
     "first_failed_rung": {"oneOf": [{"type": "null"}, {"$ref": "#/$defs/scale"}]},
-    "failure": {"enum": [null, "authorization_refused", "source_mismatch", "provision_failed", "machine_identity_mismatch", "upload_failed", "rung_failed", "retrieval_failed", "evidence_invalid", "progression_refused"]},
+    "failure": {"enum": [null, "authorization_refused", "source_mismatch", "readiness_timeout", "provision_failed", "machine_identity_mismatch", "upload_failed", "rung_failed", "retrieval_failed", "evidence_invalid", "progression_refused"]},
     "cleanup_failure": {"enum": [null, "evidence_cleanup_failed", "teardown_failed", "inventory_unavailable", "inventory_not_empty"]},
     "resources": {
       "oneOf": [

--- a/benchmarks/schemas/progressive-provider-recovery-lease.json
+++ b/benchmarks/schemas/progressive-provider-recovery-lease.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-progressive-provider-recovery-lease-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "organization",
+    "app",
+    "attempt_nonce",
+    "commit",
+    "authorization_sha256",
+    "image_digest",
+    "teardown_owner",
+    "execution_deadline",
+    "cleanup_deadline",
+    "resource_limits",
+    "acknowledged_at",
+    "claim"
+  ],
+  "properties": {
+    "schema": {"const": "graphforge-progressive-provider-recovery-lease/1"},
+    "version": {"const": 1},
+    "organization": {"$ref": "#/$defs/name"},
+    "app": {"type": "string", "pattern": "^gf-progressive-[0-9a-f]{32}$"},
+    "attempt_nonce": {"$ref": "#/$defs/nonce"},
+    "commit": {"$ref": "#/$defs/commit"},
+    "authorization_sha256": {"$ref": "#/$defs/digest"},
+    "image_digest": {"$ref": "#/$defs/image"},
+    "teardown_owner": {"$ref": "#/$defs/name"},
+    "execution_deadline": {"$ref": "#/$defs/timestamp"},
+    "cleanup_deadline": {"$ref": "#/$defs/timestamp"},
+    "resource_limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["apps", "volumes", "machines", "image_builds"],
+      "properties": {
+        "apps": {"const": 1},
+        "volumes": {"const": 1},
+        "machines": {"const": 1},
+        "image_builds": {"const": 0}
+      }
+    },
+    "acknowledged_at": {"$ref": "#/$defs/timestamp"},
+    "claim": {"const": "recovery_lease_only"}
+  },
+  "$defs": {
+    "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "image": {"type": "string", "pattern": "^registry\\.fly\\.io/[a-z0-9][a-z0-9._/-]*@sha256:[0-9a-f]{64}$"},
+    "name": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{0,62}$"},
+    "nonce": {"type": "string", "pattern": "^[0-9a-f]{32}$"},
+    "timestamp": {"type": "string", "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$"}
+  }
+}

--- a/benchmarks/tests/test_progressive_fly_transport.py
+++ b/benchmarks/tests/test_progressive_fly_transport.py
@@ -32,6 +32,9 @@ class FakeBoundary:
         self.observed_repository = APP
         self.fail_prefix: tuple[str, ...] | None = None
         self.secrets: list[dict[str, str]] = []
+        self.machine_list_responses: list[object] | None = None
+        self.machine_list_state = "started"
+        self.list_fail_remaining = 0
 
     def run(
         self, argv: tuple[str, ...], *, timeout: int, check: bool = True
@@ -61,7 +64,26 @@ class FakeBoundary:
         if argv[:3] == ("flyctl", "volumes", "create"):
             return {"id": VOLUME_ID}
         if argv[:3] == ("flyctl", "machine", "list"):
-            return [{"id": MACHINE_ID, "name": f"{APP}-worker"}]
+            if self.list_fail_remaining > 0:
+                self.list_fail_remaining -= 1
+                raise OSError("transient machine list failure")
+            if self.machine_list_responses is not None:
+                if self.machine_list_responses:
+                    return self.machine_list_responses.pop(0)
+                return [
+                    {
+                        "id": MACHINE_ID,
+                        "name": f"{APP}-worker",
+                        "state": "started",
+                    }
+                ]
+            return [
+                {
+                    "id": MACHINE_ID,
+                    "name": f"{APP}-worker",
+                    "state": self.machine_list_state,
+                }
+            ]
         if argv[:3] == ("flyctl", "volumes", "list"):
             return [{"id": VOLUME_ID}]
         if argv[:3] == ("flyctl", "secrets", "list"):
@@ -79,7 +101,10 @@ class FakeBoundary:
             "config": {
                 "image": IMAGE,
                 "auto_destroy": True,
-                "init": {"entrypoint": ["/bin/sleep"], "cmd": ["infinity"]},
+                "init": {
+                    "entrypoint": ["/bin/sleep"],
+                    "cmd": [str(self.authorization.maximum_machine_seconds)],
+                },
                 "restart": {"policy": "no"},
                 "services": [],
                 "guest": {"cpu_kind": "performance", "cpus": 4, "memory_mb": 8192},
@@ -159,7 +184,7 @@ class ProgressiveFlyTransportTests(unittest.TestCase):
                 "machine",
                 "run",
                 IMAGE,
-                "infinity",
+                str(self.auth.maximum_machine_seconds),
                 "--app",
                 APP,
                 "--name",
@@ -496,6 +521,65 @@ class ProgressiveFlyTransportTests(unittest.TestCase):
             boundary.machine_state(APP, MACHINE_ID, timeout=1)
         self.assertNotIn(token, str(raised.exception))
         self.assertIsNone(raised.exception.__cause__)
+
+    def test_delayed_readiness_converges_without_mutation_retries(self) -> None:
+        worker = {"id": MACHINE_ID, "name": f"{APP}-worker", "state": "starting"}
+        started = {"id": MACHINE_ID, "name": f"{APP}-worker", "state": "started"}
+        self.boundary.machine_list_responses = [[], [worker], [started]]
+        sleeps: list[float] = []
+        self.transport = FlyProviderTransport(
+            self.boundary, clock=lambda: NOW, sleeper=sleeps.append
+        )
+        self.provision()
+        self.assertEqual(len(sleeps), 2)
+        machine_runs = [
+            call[1]
+            for call in self.boundary.calls
+            if call[0] == "run" and call[1][:3] == ("flyctl", "machine", "run")
+        ]
+        self.assertEqual(len(machine_runs), 1)
+
+    def test_terminal_machine_state_fails_immediately(self) -> None:
+        self.boundary.machine_list_responses = [
+            [{"id": MACHINE_ID, "name": f"{APP}-worker", "state": "stopped"}]
+        ]
+        with self.assertRaisesRegex(FlyTransportError, "terminal"):
+            self.transport.provision(self.invocation, self.auth, deadline=self.deadline)
+
+    def test_extra_machine_fails_immediately(self) -> None:
+        self.boundary.machine_list_responses = [
+            [
+                {"id": MACHINE_ID, "name": f"{APP}-worker", "state": "started"},
+                {"id": "1234567890abcd", "name": "other", "state": "started"},
+            ]
+        ]
+        with self.assertRaisesRegex(FlyTransportError, "unexpected"):
+            self.transport.provision(self.invocation, self.auth, deadline=self.deadline)
+
+    def test_readiness_timeout_is_typed_and_stops_polling(self) -> None:
+        self.boundary.machine_list_responses = [[], [], [], [], [], [], [], []]
+        clock = {"now": NOW}
+
+        def advance() -> datetime:
+            return clock["now"]
+
+        def sleep(seconds: float) -> None:
+            clock["now"] = clock["now"] + timedelta(seconds=seconds)
+
+        self.transport = FlyProviderTransport(self.boundary, clock=advance, sleeper=sleep)
+        with self.assertRaises(AttemptError) as raised:
+            self.transport.provision(
+                self.invocation,
+                self.auth,
+                deadline=NOW + timedelta(seconds=2),
+            )
+        self.assertEqual(raised.exception.failure, "readiness_timeout")
+        machine_runs = [
+            call[1]
+            for call in self.boundary.calls
+            if call[0] == "run" and call[1][:3] == ("flyctl", "machine", "run")
+        ]
+        self.assertEqual(len(machine_runs), 1)
 
     def test_live_surfaces_remain_statically_unwired(self) -> None:
         repository = ROOT.parent

--- a/benchmarks/tests/test_progressive_provider_attempt.py
+++ b/benchmarks/tests/test_progressive_provider_attempt.py
@@ -334,6 +334,54 @@ class ProgressiveProviderAttemptTests(unittest.TestCase):
         self.assertEqual(transport.calls, [])
         self.assertFalse(self.ledger.exists())
 
+    def test_recovery_lease_is_acked_before_provision(self) -> None:
+        self.write_prefix(self.output, 18, 19)
+        seen: list[bool] = []
+
+        class TrackingTransport(FakeTransport):
+            def provision(self, invocation, authorization, *, deadline):  # type: ignore[no-untyped-def]
+                lease = invocation.ledger_path.with_name(
+                    f"{invocation.ledger_path.stem}.recovery-lease.json"
+                )
+                seen.append(lease.is_file())
+                return super().provision(invocation, authorization, deadline=deadline)
+
+        tracked = TrackingTransport(self.remote)
+        outcome = execute(
+            self.invocation,
+            authorization(20),
+            transport=tracked,
+            planner=planner,
+            now=NOW,
+            clock=lambda: NOW,
+        )
+        self.assertEqual(outcome.status, "passed")
+        self.assertEqual(seen, [True])
+        self.assertEqual(tracked.calls[0][0], "provision")
+        lease_path = self.ledger.with_name(f"{self.ledger.stem}.recovery-lease.json")
+        self.assertTrue(lease_path.is_file())
+        self.assertNotIn("FLY_API_TOKEN", lease_path.read_text(encoding="utf-8"))
+
+    def test_readiness_timeout_is_preserved_from_transport(self) -> None:
+        self.write_prefix(self.output, 18, 19)
+
+        class ReadyTimeoutTransport(FakeTransport):
+            def provision(self, invocation, authorization, *, deadline):  # type: ignore[no-untyped-def]
+                self.calls.append(("provision", authorization.app, deadline.isoformat()))
+                raise AttemptError("readiness_timeout", "created Machine did not become ready")
+
+        outcome = execute(
+            self.invocation,
+            authorization(20),
+            transport=ReadyTimeoutTransport(self.remote),
+            planner=planner,
+            now=NOW,
+            clock=lambda: NOW,
+        )
+        self.assertEqual(outcome.status, "failed")
+        self.assertEqual(outcome.failure, "readiness_timeout")
+        self.assertEqual(outcome.teardown_status, "empty")
+
     def test_spend_lifetime_and_integer_ceiling_are_closed(self) -> None:
         too_long = authorization_document()
         too_long["expires_at"] = "2026-06-02T00:00:00Z"

--- a/benchmarks/tests/test_progressive_recovery_lease.py
+++ b/benchmarks/tests/test_progressive_recovery_lease.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import tempfile
+import unittest
+
+from graphforge_bench.progressive_provider_attempt import AttemptError
+from graphforge_bench.progressive_recovery_lease import (
+    ack_recovery_lease,
+    build_recovery_lease,
+    cleanup_expired_lease,
+    load_recovery_lease,
+    save_recovery_lease,
+)
+from tests.test_progressive_provider_attempt import APP, authorization
+
+NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+class FakeTeardownTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+        self.inventory = {
+            "app_exists": False,
+            "machines": 0,
+            "volumes": 0,
+            "secrets": 0,
+        }
+
+    def teardown(self, resources: dict[str, str]) -> dict[str, object]:
+        self.calls.append(dict(resources))
+        return dict(self.inventory)
+
+
+class ProgressiveRecoveryLeaseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.base = Path(self.temporary.name)
+        self.auth = authorization(20)
+        self.execution_deadline = NOW + timedelta(seconds=self.auth.maximum_machine_seconds)
+        self.lease = build_recovery_lease(
+            self.auth,
+            execution_deadline=self.execution_deadline,
+            acknowledged_at=NOW,
+        )
+        self.path = self.base / "attempt.recovery-lease.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_ack_persists_schema_valid_credential_free_receipt(self) -> None:
+        loaded = ack_recovery_lease(self.path, self.lease)
+        document = self.path.read_text(encoding="utf-8")
+        self.assertNotIn("FLY_API_TOKEN", document)
+        self.assertNotIn("machine_id", document)
+        self.assertNotIn("volume_id", document)
+        self.assertNotIn(str(self.base), document)
+        self.assertEqual(loaded.app, APP)
+        self.assertEqual(loaded.claim, "recovery_lease_only")
+        again = load_recovery_lease(self.path)
+        self.assertEqual(again.authorization_sha256, self.auth.authorization_sha256)
+        self.assertEqual(again.cleanup_deadline, self.auth.expires_at)
+
+    def test_tampered_lease_is_refused(self) -> None:
+        save_recovery_lease(self.path, self.lease)
+        text = self.path.read_text(encoding="utf-8").replace(APP, "gf-progressive-" + "d" * 32)
+        self.path.write_text(text, encoding="utf-8")
+        with self.assertRaises(AttemptError) as raised:
+            load_recovery_lease(self.path)
+        self.assertEqual(raised.exception.failure, "recovery_refused")
+
+    def test_pre_expiry_cleanup_refuses_without_factory_call(self) -> None:
+        calls: list[object] = []
+
+        def factory(_lease: object) -> FakeTeardownTransport:
+            calls.append(_lease)
+            return FakeTeardownTransport()
+
+        with self.assertRaises(AttemptError) as raised:
+            cleanup_expired_lease(self.lease, transport_factory=factory, clock=lambda: NOW)
+        self.assertEqual(raised.exception.failure, "recovery_refused")
+        self.assertEqual(calls, [])
+
+    def test_expired_cleanup_is_idempotent_and_owner_confined(self) -> None:
+        transport = FakeTeardownTransport()
+        factories = 0
+
+        def factory(lease: object) -> FakeTeardownTransport:
+            nonlocal factories
+            factories += 1
+            self.assertEqual(lease.app, APP)  # type: ignore[attr-defined]
+            return transport
+
+        after = self.auth.expires_at + timedelta(seconds=1)
+        first = cleanup_expired_lease(self.lease, transport_factory=factory, clock=lambda: after)
+        second = cleanup_expired_lease(self.lease, transport_factory=factory, clock=lambda: after)
+        self.assertEqual(first, second)
+        self.assertEqual(factories, 2)
+        self.assertEqual(transport.calls, [{"owner_app": APP}, {"owner_app": APP}])
+
+    def test_identity_mismatch_refuses_cleanup(self) -> None:
+        other = build_recovery_lease(
+            authorization(22),
+            execution_deadline=self.execution_deadline,
+            acknowledged_at=NOW,
+        )
+        with self.assertRaises(AttemptError) as raised:
+            cleanup_expired_lease(
+                self.lease,
+                transport_factory=lambda _lease: FakeTeardownTransport(),
+                clock=lambda: self.auth.expires_at + timedelta(seconds=1),
+                expected=other,
+            )
+        self.assertEqual(raised.exception.failure, "recovery_refused")
+
+    def test_secret_canaries_stay_out_of_diagnostics(self) -> None:
+        token = "FLY_API_TOKEN=super-secret-canary"
+
+        class NoisyTransport(FakeTeardownTransport):
+            def teardown(self, resources: dict[str, str]) -> dict[str, object]:
+                raise RuntimeError(token)
+
+        with self.assertRaises(Exception) as raised:
+            cleanup_expired_lease(
+                self.lease,
+                transport_factory=lambda _lease: NoisyTransport(),
+                clock=lambda: self.auth.expires_at + timedelta(seconds=1),
+            )
+        # Factory errors propagate; callers must not embed them into lease docs.
+        self.assertIn(token, str(raised.exception))
+        document = ack_recovery_lease(self.path, self.lease)
+        self.assertNotIn("super-secret", self.path.read_text(encoding="utf-8"))
+        self.assertEqual(document.app, APP)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Poll Fly Machine readiness within `min(attempt_deadline, readiness_cap)` with bounded backoff; fail closed on terminal/extra/wrong-name inventory; emit typed `readiness_timeout`.
- Replace unbounded `infinity` idle with the authorized finite Machine lifetime while retaining `--rm` / `restart=no`.
- Persist and ack a credential-free recovery lease before provider mutation; add an expired-lease janitor core that reconstructs an owner-confined transport via an injected factory (independent of the local attempt ledger).
- Keep `qualification_operator` / workflows / gate registry live progressive-ladder execution unwired.

## Test plan
- [x] `make -C benchmarks progressive-fly-transport-static` (37 passed)
- [x] `make -C benchmarks progressive-provider-attempt-static` (22 passed)
- [ ] Exact-head CI Gate + CLEAN

Closes #1038


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790804308&installation_model_id=20486&pr_number=1051&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1051&signature=e2bf29e2cd7db65ec4e5bd1eca9bbc1fa07766a662b8104b0ae84facc0b3104b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->