### PR TITLE
test(bench): add scale orchestration parity matrix and tiny shadow fixtures

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,6 +16,11 @@ The existing `algorithms/` scripts and benchmark documents predate this
 workspace and remain unchanged. Migration or retirement of that legacy harness
 belongs to issue #959, after parity is proven.
 
+Scale-orchestration parity work lives under `fixtures/parity/` with the
+`graphforge_bench.scale_parity` comparator. The first slice compares tiny/local
+shadow fixtures only; completed #900 ladder bundles are ingested read-only in a
+follow-up.
+
 ## Layout
 
 - `harness/` — Python orchestration and fixture discovery.

--- a/benchmarks/fixtures/parity/accepted-differences.json
+++ b/benchmarks/fixtures/parity/accepted-differences.json
@@ -1,0 +1,42 @@
+{
+  "schema": "graphforge-scale-orchestration-accepted-differences/1",
+  "differences": [
+    {
+      "id": "generator_seed",
+      "summary": "Legacy in-tree ladder uses seed 1; new harness profiles pin seed 13907095936298285200.",
+      "dimensions": ["seed"]
+    },
+    {
+      "id": "generator_identity",
+      "summary": "Legacy ladder embeds Kronecker generation in the Rust reference client; new harness uses graphforge-benchmark-graph500-generator.",
+      "dimensions": ["generator"]
+    },
+    {
+      "id": "execution_surface",
+      "summary": "Legacy scale orchestration exercises the Rust GraphForge API directly; new harness uses gf CLI and public certification runners.",
+      "dimensions": ["execution_surface"]
+    },
+    {
+      "id": "phase_model",
+      "summary": "Legacy certification evidence may include additional CSR, split-query, and negative-drill phases outside the ten-phase public certification contract.",
+      "dimensions": ["phase_coverage"]
+    },
+    {
+      "id": "resource_authority",
+      "summary": "Legacy evidence samples /proc locally; new harness attributes BenchExec process-tree metrics.",
+      "dimensions": ["resource_authority"]
+    }
+  ],
+  "phase_mapping": [
+    { "legacy": "admission", "new": "admission" },
+    { "legacy": "generate", "new": "generate" },
+    { "legacy": "ingest", "new": "ingest" },
+    { "legacy": "reopen", "new": "reopen" },
+    { "legacy": "recount", "new": "recount" },
+    { "legacy": "query", "new": "query" },
+    { "legacy": "export", "new": "export" },
+    { "legacy": "verify", "new": "verify" },
+    { "legacy": "clean_import", "new": "clean_import" },
+    { "legacy": "reopen_proof", "new": "reopen_proof" }
+  ]
+}

--- a/benchmarks/fixtures/parity/legacy/tiny-pass.json
+++ b/benchmarks/fixtures/parity/legacy/tiny-pass.json
@@ -1,0 +1,15 @@
+{
+  "profile": "graph500-tiny-legacy-shadow",
+  "phases": [
+    { "name": "admission", "ok": true, "duration_secs": 0.12, "max_rss_kib": 65536 },
+    { "name": "generate", "ok": true, "duration_secs": 0.45, "max_rss_kib": 98304 },
+    { "name": "ingest", "ok": true, "duration_secs": 1.20, "max_rss_kib": 131072 },
+    { "name": "reopen", "ok": true, "duration_secs": 0.30, "max_rss_kib": 131072 },
+    { "name": "recount", "ok": true, "duration_secs": 0.18, "max_rss_kib": 131072 },
+    { "name": "query", "ok": true, "duration_secs": 0.22, "max_rss_kib": 131072 },
+    { "name": "export", "ok": true, "duration_secs": 0.35, "max_rss_kib": 147456 },
+    { "name": "verify", "ok": true, "duration_secs": 0.28, "max_rss_kib": 147456 },
+    { "name": "clean_import", "ok": true, "duration_secs": 0.40, "max_rss_kib": 147456 },
+    { "name": "reopen_proof", "ok": true, "duration_secs": 0.25, "max_rss_kib": 147456 }
+  ]
+}

--- a/benchmarks/fixtures/parity/new/tiny-pass.json
+++ b/benchmarks/fixtures/parity/new/tiny-pass.json
@@ -1,0 +1,18 @@
+{
+  "schema": "graphforge-public-certification/1",
+  "profile_id": "graph500-tiny-executable",
+  "status": "passed",
+  "failed_phase": null,
+  "phases": [
+    { "phase": "admission", "status": "passed", "duration_ms": 120, "peak_rss_bytes": 67108864, "exit_code": 0, "receipts": [] },
+    { "phase": "generate", "status": "passed", "duration_ms": 450, "peak_rss_bytes": 100663296, "exit_code": 0, "receipts": [] },
+    { "phase": "ingest", "status": "passed", "duration_ms": 1200, "peak_rss_bytes": 134217728, "exit_code": 0, "receipts": [] },
+    { "phase": "reopen", "status": "passed", "duration_ms": 300, "peak_rss_bytes": 134217728, "exit_code": 0, "receipts": [] },
+    { "phase": "recount", "status": "passed", "duration_ms": 180, "peak_rss_bytes": 134217728, "exit_code": 0, "receipts": [] },
+    { "phase": "query", "status": "passed", "duration_ms": 220, "peak_rss_bytes": 134217728, "exit_code": 0, "receipts": [] },
+    { "phase": "export", "status": "passed", "duration_ms": 350, "peak_rss_bytes": 150994944, "exit_code": 0, "receipts": [] },
+    { "phase": "verify", "status": "passed", "duration_ms": 280, "peak_rss_bytes": 150994944, "exit_code": 0, "receipts": [] },
+    { "phase": "clean_import", "status": "passed", "duration_ms": 400, "peak_rss_bytes": 150994944, "exit_code": 0, "receipts": [] },
+    { "phase": "reopen_proof", "status": "passed", "duration_ms": 250, "peak_rss_bytes": 150994944, "exit_code": 0, "receipts": [] }
+  ]
+}

--- a/benchmarks/harness/graphforge_bench/scale_parity.py
+++ b/benchmarks/harness/graphforge_bench/scale_parity.py
@@ -1,0 +1,352 @@
+"""Scale orchestration parity matrix for legacy vs benchmark harness evidence.
+
+Compares normalized lifecycle evidence without rerunning provider-scale ladders.
+Issue #959 uses tiny/local shadow fixtures first; completed #900 ladder bundles
+can be ingested read-only in a follow-up.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from graphforge_bench.progressive_qualification import PHASES
+
+MATRIX_SCHEMA = "graphforge-scale-orchestration-parity-matrix/1"
+ACCEPTED_SCHEMA = "graphforge-scale-orchestration-accepted-differences/1"
+CERT_SCHEMA = "graphforge-public-certification/1"
+
+
+class ParityError(ValueError):
+    """Parity input is missing, malformed, or contradictory."""
+
+
+class Outcome(StrEnum):
+    MATCH = "match"
+    ACCEPTED_DIFFERENCE = "accepted_difference"
+    UNEXPLAINED_GAP = "unexplained_gap"
+
+
+@dataclass(frozen=True)
+class NormalizedPhase:
+    phase: str
+    status: str
+    duration_ms: int | None
+    peak_rss_bytes: int | None
+
+
+@dataclass(frozen=True)
+class NormalizedEvidence:
+    profile_id: str
+    status: str
+    phases: tuple[NormalizedPhase, ...]
+    source: str
+
+
+def workspace_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_schema(name: str) -> Draft202012Validator:
+    document = json.loads((workspace_root() / "schemas" / name).read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(document)
+    return Draft202012Validator(document)
+
+
+def _validate(validator: Draft202012Validator, document: Mapping[str, Any], label: str) -> None:
+    error = next(validator.iter_errors(document), None)
+    if error is not None:
+        raise ParityError(f"{label}: {error.message}")
+
+
+def load_accepted_differences(root: Path | None = None) -> Mapping[str, Any]:
+    path = (root or workspace_root()) / "fixtures" / "parity" / "accepted-differences.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if document.get("schema") != ACCEPTED_SCHEMA:
+        raise ParityError(f"unsupported accepted-differences schema: {document.get('schema')}")
+    return document
+
+
+def normalize_legacy_evidence(document: Mapping[str, Any]) -> NormalizedEvidence:
+    if "profile" not in document or "phases" not in document:
+        raise ParityError("legacy evidence requires profile and phases")
+    phases: list[NormalizedPhase] = []
+    overall = "passed"
+    for entry in document["phases"]:
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise ParityError("legacy phase name is required")
+        ok = bool(entry.get("ok"))
+        if not ok:
+            overall = "failed"
+        duration_ms = None
+        duration_secs = entry.get("duration_secs")
+        if isinstance(duration_secs, (int, float)) and duration_secs >= 0:
+            duration_ms = round(float(duration_secs) * 1_000)
+        peak_rss_bytes = None
+        max_rss_kib = entry.get("max_rss_kib")
+        if isinstance(max_rss_kib, int) and max_rss_kib >= 0:
+            peak_rss_bytes = max_rss_kib * 1_024
+        phases.append(
+            NormalizedPhase(
+                phase=name,
+                status="passed" if ok else "failed",
+                duration_ms=duration_ms,
+                peak_rss_bytes=peak_rss_bytes,
+            )
+        )
+        if not ok:
+            break
+    return NormalizedEvidence(
+        profile_id=str(document["profile"]),
+        status=overall,
+        phases=tuple(phases),
+        source="legacy_profile_phases",
+    )
+
+
+def normalize_new_evidence(document: Mapping[str, Any]) -> NormalizedEvidence:
+    if document.get("schema") != CERT_SCHEMA:
+        raise ParityError(f"unsupported certification schema: {document.get('schema')}")
+    phases: list[NormalizedPhase] = []
+    for entry in document.get("phases", ()):
+        phase = entry.get("phase")
+        status = entry.get("status")
+        if not isinstance(phase, str) or status not in {"passed", "failed"}:
+            raise ParityError("new certification phase requires phase and status")
+        duration_ms = entry.get("duration_ms")
+        if not isinstance(duration_ms, int) or duration_ms < 0:
+            raise ParityError(f"invalid duration_ms for phase {phase}")
+        peak_rss_bytes = entry.get("peak_rss_bytes")
+        if peak_rss_bytes is not None and (
+            not isinstance(peak_rss_bytes, int) or peak_rss_bytes < 0
+        ):
+            raise ParityError(f"invalid peak_rss_bytes for phase {phase}")
+        phases.append(
+            NormalizedPhase(
+                phase=phase,
+                status=status,
+                duration_ms=duration_ms,
+                peak_rss_bytes=peak_rss_bytes,
+            )
+        )
+        if status == "failed":
+            break
+    status = document.get("status")
+    if status not in {"passed", "failed"}:
+        raise ParityError("new certification status must be passed or failed")
+    profile_id = document.get("profile_id")
+    if not isinstance(profile_id, str) or not profile_id:
+        raise ParityError("new certification profile_id is required")
+    return NormalizedEvidence(
+        profile_id=profile_id,
+        status=status,
+        phases=tuple(phases),
+        source=CERT_SCHEMA,
+    )
+
+
+def _phase_mapping(accepted: Mapping[str, Any]) -> dict[str, str | None]:
+    mapping: dict[str, str | None] = {}
+    for row in accepted.get("phase_mapping", ()):
+        legacy = row.get("legacy")
+        new = row.get("new")
+        if isinstance(legacy, str):
+            mapping[legacy] = new if isinstance(new, str) else None
+    return mapping
+
+
+def _accepted_ids(accepted: Mapping[str, Any]) -> dict[str, set[str]]:
+    by_dimension: dict[str, set[str]] = {}
+    for row in accepted.get("differences", ()):
+        diff_id = row.get("id")
+        if not isinstance(diff_id, str):
+            continue
+        for dimension in row.get("dimensions", ()):
+            if isinstance(dimension, str):
+                by_dimension.setdefault(dimension, set()).add(diff_id)
+    return by_dimension
+
+
+def _worst(outcomes: Sequence[Outcome]) -> Outcome:
+    if any(outcome == Outcome.UNEXPLAINED_GAP for outcome in outcomes):
+        return Outcome.UNEXPLAINED_GAP
+    if any(outcome == Outcome.ACCEPTED_DIFFERENCE for outcome in outcomes):
+        return Outcome.ACCEPTED_DIFFERENCE
+    return Outcome.MATCH
+
+
+def compare_evidence(
+    legacy: NormalizedEvidence,
+    new: NormalizedEvidence,
+    *,
+    accepted: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    registry = accepted or load_accepted_differences()
+    mapping = _phase_mapping(registry)
+    accepted_by_dimension = _accepted_ids(registry)
+
+    dimensions: list[dict[str, Any]] = []
+    phase_rows: list[dict[str, Any]] = []
+
+    if legacy.status == new.status:
+        dimensions.append(
+            {
+                "name": "overall_status",
+                "outcome": Outcome.MATCH.value,
+                "accepted_difference_id": None,
+                "detail": f"both {legacy.status}",
+            }
+        )
+    else:
+        dimensions.append(
+            {
+                "name": "overall_status",
+                "outcome": Outcome.UNEXPLAINED_GAP.value,
+                "accepted_difference_id": None,
+                "detail": f"legacy={legacy.status} new={new.status}",
+            }
+        )
+
+    legacy_phases = {phase.phase: phase for phase in legacy.phases}
+    new_phases = {phase.phase: phase for phase in new.phases}
+    expected_new = set(PHASES)
+
+    for legacy_name, legacy_phase in legacy_phases.items():
+        if legacy_name in mapping:
+            new_name = mapping[legacy_name]
+        elif legacy_name in expected_new:
+            new_name = legacy_name
+        else:
+            new_name = None
+
+        if new_name is None:
+            diff_ids = accepted_by_dimension.get("phase_coverage", set())
+            outcome = Outcome.ACCEPTED_DIFFERENCE if diff_ids else Outcome.UNEXPLAINED_GAP
+            phase_rows.append(
+                {
+                    "legacy_phase": legacy_name,
+                    "new_phase": None,
+                    "outcome": outcome.value,
+                    "accepted_difference_id": next(iter(diff_ids), None),
+                    "detail": "legacy-only phase",
+                }
+            )
+            continue
+        new_phase = new_phases.get(new_name)
+        if new_phase is None:
+            phase_rows.append(
+                {
+                    "legacy_phase": legacy_name,
+                    "new_phase": new_name,
+                    "outcome": Outcome.UNEXPLAINED_GAP.value,
+                    "accepted_difference_id": None,
+                    "detail": "mapped new phase missing",
+                }
+            )
+            continue
+        if legacy_phase.status != new_phase.status:
+            phase_rows.append(
+                {
+                    "legacy_phase": legacy_name,
+                    "new_phase": new_name,
+                    "outcome": Outcome.UNEXPLAINED_GAP.value,
+                    "accepted_difference_id": None,
+                    "detail": f"status legacy={legacy_phase.status} new={new_phase.status}",
+                }
+            )
+            continue
+        phase_rows.append(
+            {
+                "legacy_phase": legacy_name,
+                "new_phase": new_name,
+                "outcome": Outcome.MATCH.value,
+                "accepted_difference_id": None,
+                "detail": "status aligned",
+            }
+        )
+
+    extra_new = sorted(set(new_phases) - expected_new)
+    if extra_new:
+        dimensions.append(
+            {
+                "name": "phase_coverage",
+                "outcome": Outcome.UNEXPLAINED_GAP.value,
+                "accepted_difference_id": None,
+                "detail": f"unexpected new phases: {', '.join(extra_new)}",
+            }
+        )
+    else:
+        dimensions.append(
+            {
+                "name": "phase_coverage",
+                "outcome": Outcome.MATCH.value,
+                "accepted_difference_id": None,
+                "detail": "new evidence uses the ten-phase public contract",
+            }
+        )
+
+    for dimension_name, diff_ids in accepted_by_dimension.items():
+        if dimension_name == "phase_coverage" and any(
+            row["outcome"] == Outcome.ACCEPTED_DIFFERENCE.value for row in phase_rows
+        ):
+            dimensions.append(
+                {
+                    "name": dimension_name,
+                    "outcome": Outcome.ACCEPTED_DIFFERENCE.value,
+                    "accepted_difference_id": next(iter(diff_ids), None),
+                    "detail": "documented phase-model delta",
+                }
+            )
+        elif dimension_name not in {row["name"] for row in dimensions}:
+            dimensions.append(
+                {
+                    "name": dimension_name,
+                    "outcome": Outcome.ACCEPTED_DIFFERENCE.value,
+                    "accepted_difference_id": next(iter(diff_ids), None),
+                    "detail": "declared accepted difference; not asserted on tiny shadow fixtures",
+                }
+            )
+
+    overall = _worst([Outcome(row["outcome"]) for row in dimensions + phase_rows])
+    matrix = {
+        "schema": MATRIX_SCHEMA,
+        "legacy_source": legacy.source,
+        "new_source": new.source,
+        "overall": overall.value,
+        "dimensions": dimensions,
+        "phase_rows": phase_rows,
+    }
+    _validate(_load_schema("scale-orchestration-parity-matrix.json"), matrix, "parity matrix")
+    return matrix
+
+
+def assert_no_unexplained_gaps(matrix: Mapping[str, Any]) -> None:
+    if matrix.get("overall") == Outcome.UNEXPLAINED_GAP.value:
+        gaps = [
+            row
+            for row in matrix.get("dimensions", ()) + matrix.get("phase_rows", ())
+            if row.get("outcome") == Outcome.UNEXPLAINED_GAP.value
+        ]
+        raise ParityError(f"unexplained parity gaps: {gaps!r}")
+
+
+def compare_fixture_pair(
+    legacy_path: Path,
+    new_path: Path,
+    *,
+    accepted: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    legacy_doc = json.loads(legacy_path.read_text(encoding="utf-8"))
+    new_doc = json.loads(new_path.read_text(encoding="utf-8"))
+    return compare_evidence(
+        normalize_legacy_evidence(legacy_doc),
+        normalize_new_evidence(new_doc),
+        accepted=accepted,
+    )

--- a/benchmarks/schemas/scale-orchestration-parity-matrix.json
+++ b/benchmarks/schemas/scale-orchestration-parity-matrix.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-scale-orchestration-parity-matrix-schema/1",
+  "type": "object",
+  "properties": {
+    "schema": { "const": "graphforge-scale-orchestration-parity-matrix/1" },
+    "legacy_source": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "new_source": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "overall": { "enum": ["match", "accepted_difference", "unexplained_gap"] },
+    "dimensions": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 64,
+      "items": { "$ref": "#/$defs/dimension" }
+    },
+    "phase_rows": {
+      "type": "array",
+      "maxItems": 32,
+      "items": { "$ref": "#/$defs/phaseRow" }
+    }
+  },
+  "required": ["schema", "legacy_source", "new_source", "overall", "dimensions"],
+  "additionalProperties": false,
+  "$defs": {
+    "outcome": {
+      "enum": ["match", "accepted_difference", "unexplained_gap"]
+    },
+    "dimension": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "outcome": { "$ref": "#/$defs/outcome" },
+        "accepted_difference_id": {
+          "oneOf": [
+            { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+            { "type": "null" }
+          ]
+        },
+        "detail": { "type": "string", "maxLength": 512 }
+      },
+      "required": ["name", "outcome", "accepted_difference_id", "detail"],
+      "additionalProperties": false
+    },
+    "phaseRow": {
+      "type": "object",
+      "properties": {
+        "legacy_phase": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "new_phase": {
+          "oneOf": [
+            { "type": "string", "minLength": 1, "maxLength": 80 },
+            { "type": "null" }
+          ]
+        },
+        "outcome": { "$ref": "#/$defs/outcome" },
+        "accepted_difference_id": {
+          "oneOf": [
+            { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$" },
+            { "type": "null" }
+          ]
+        },
+        "detail": { "type": "string", "maxLength": 512 }
+      },
+      "required": ["legacy_phase", "new_phase", "outcome", "accepted_difference_id", "detail"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/benchmarks/tests/test_scale_parity.py
+++ b/benchmarks/tests/test_scale_parity.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from graphforge_bench.scale_parity import (
+    Outcome,
+    assert_no_unexplained_gaps,
+    compare_evidence,
+    compare_fixture_pair,
+    load_accepted_differences,
+    normalize_legacy_evidence,
+    normalize_new_evidence,
+    workspace_root,
+)
+from jsonschema import Draft202012Validator
+
+ROOT = workspace_root()
+FIXTURES = ROOT / "fixtures" / "parity"
+
+
+class ScaleParityTests(unittest.TestCase):
+    def test_accepted_differences_fixture_loads(self) -> None:
+        document = load_accepted_differences()
+        self.assertEqual(
+            document["schema"], "graphforge-scale-orchestration-accepted-differences/1"
+        )
+        self.assertGreaterEqual(len(document["differences"]), 3)
+        self.assertEqual(len(document["phase_mapping"]), 10)
+
+    def test_tiny_shadow_fixtures_have_no_unexplained_gaps(self) -> None:
+        matrix = compare_fixture_pair(
+            FIXTURES / "legacy" / "tiny-pass.json",
+            FIXTURES / "new" / "tiny-pass.json",
+        )
+        self.assertIn(matrix["overall"], {Outcome.MATCH.value, Outcome.ACCEPTED_DIFFERENCE.value})
+        assert_no_unexplained_gaps(matrix)
+
+    def test_matrix_schema_is_valid(self) -> None:
+        matrix = compare_fixture_pair(
+            FIXTURES / "legacy" / "tiny-pass.json",
+            FIXTURES / "new" / "tiny-pass.json",
+        )
+        schema = json.loads(
+            (ROOT / "schemas" / "scale-orchestration-parity-matrix.json").read_text()
+        )
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(schema).validate(matrix)
+
+    def test_status_mismatch_is_unexplained_gap(self) -> None:
+        legacy = normalize_legacy_evidence(
+            {
+                "profile": "legacy",
+                "phases": [{"name": "admission", "ok": False, "duration_secs": 0.1}],
+            }
+        )
+        new = normalize_new_evidence(
+            {
+                "schema": "graphforge-public-certification/1",
+                "profile_id": "new",
+                "status": "passed",
+                "failed_phase": None,
+                "phases": [
+                    {
+                        "phase": "admission",
+                        "status": "passed",
+                        "duration_ms": 100,
+                        "peak_rss_bytes": 1024,
+                        "exit_code": 0,
+                        "receipts": [],
+                    }
+                ],
+            }
+        )
+        matrix = compare_evidence(legacy, new)
+        self.assertEqual(matrix["overall"], Outcome.UNEXPLAINED_GAP.value)
+        with self.assertRaisesRegex(Exception, "unexplained parity gaps"):
+            assert_no_unexplained_gaps(matrix)
+
+    def test_legacy_only_phase_can_be_accepted_difference(self) -> None:
+        legacy = normalize_legacy_evidence(
+            {
+                "profile": "legacy",
+                "phases": [
+                    {"name": "admission", "ok": True, "duration_secs": 0.1, "max_rss_kib": 64},
+                    {"name": "negative_drill", "ok": True, "duration_secs": 0.1, "max_rss_kib": 64},
+                ],
+            }
+        )
+        new = normalize_new_evidence(json.loads((FIXTURES / "new" / "tiny-pass.json").read_text()))
+        matrix = compare_evidence(legacy, new)
+        drill_rows = [
+            row for row in matrix["phase_rows"] if row["legacy_phase"] == "negative_drill"
+        ]
+        self.assertEqual(len(drill_rows), 1)
+        self.assertEqual(drill_rows[0]["outcome"], Outcome.ACCEPTED_DIFFERENCE.value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First no-cost slice for #959: introduce a scale-orchestration parity matrix, accepted-differences registry, and tiny/local shadow fixtures comparing legacy `{profile, phases}` evidence against new `graphforge-public-certification/1` evidence.

- Add `graphforge_bench.scale_parity` with legacy/new normalizers, phase mapping, and fail-closed gap detection.
- Add JSON schema for parity matrix output and checked-in accepted differences (seed, generator, execution surface, phase model, resource authority).
- Add fixture-only tests; no provider spend and no legacy retirement in this PR.

## Testing

```bash
cd benchmarks
PYTHONPATH=harness uv run --locked python -m unittest tests.test_scale_parity
```

## Issue

Relates to #959 — follow-up PRs will ingest completed #900 ladder bundles read-only and retire duplicated legacy orchestration after the full parity matrix is green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790806007&installation_model_id=20486&pr_number=1052&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1052&signature=dc3e8c793f563783147672dfd995f320b23cf0300fd86e536e02513fddcae02a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `graphforge_bench.scale_parity` comparator and tiny shadow fixtures
> - Introduces `graphforge_bench.scale_parity` with normalization, comparison, and assertion helpers that produce a validated parity matrix comparing legacy and new certification evidence across overall status, phase coverage, and per-phase status.
> - Adds tiny legacy and new pass fixtures under `fixtures/parity/`, an accepted-differences registry with 1:1 phase mapping across ten phases, and a Draft 2020-12 JSON Schema for the matrix output.
> - Adds a test suite covering fixture comparison, schema validation, unexplained-gap detection, and accepted-difference attribution for legacy-only phases.
> - Risk: `normalize_legacy_evidence` truncates at the first failed phase and converts seconds→ms and KiB→bytes; mismatches in unit conversion or phase mapping in `accepted-differences.json` could silently mask gaps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 500e045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->