### PR TITLE
test(bench): add parity gate status tracker for #959

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,9 +1,12 @@
-.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries progressive-provider-plan qualification-operator
+.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries progressive-provider-plan qualification-operator parity-gate
 
 install:
 	uv sync --locked
 
 smoke: smoke-python smoke-rust
+
+parity-gate: install
+	PYTHONPATH=harness uv run --locked python -m graphforge_bench.parity_gate_cli
 
 smoke-python: install
 	PYTHONPATH=harness uv run --locked python -m graphforge_bench.smoke

--- a/benchmarks/harness/graphforge_bench/parity_gate.py
+++ b/benchmarks/harness/graphforge_bench/parity_gate.py
@@ -69,9 +69,7 @@ def parity_gate_status(root: Path | None = None) -> dict[str, Any]:
 
     accepted = load_accepted_differences()
     migration_fixtures = [
-        path.name
-        for path in (fixtures / "legacy").glob("*.json")
-        if path.name != "tiny-pass.json"
+        path.name for path in (fixtures / "legacy").glob("*.json") if path.name != "tiny-pass.json"
     ]
 
     criteria = [

--- a/benchmarks/harness/graphforge_bench/parity_gate.py
+++ b/benchmarks/harness/graphforge_bench/parity_gate.py
@@ -1,0 +1,130 @@
+"""#959 parity gate status — tracks acceptance criteria without fabricating evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from graphforge_bench.scale_parity import (
+    compare_fixture_pair,
+    compare_ladder_bundle,
+    coverage_map,
+    load_accepted_differences,
+    validate_historical_legacy_cert,
+    workspace_root,
+)
+
+GATE_SCHEMA = "graphforge-scale-orchestration-parity-gate/1"
+
+
+def _criterion(
+    name: str,
+    *,
+    met: bool,
+    blocked_by: str | None = None,
+    evidence: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "met": met,
+        "blocked_by": blocked_by,
+        "evidence": evidence,
+    }
+
+
+def ladder_bundle_root(root: Path | None = None) -> Path:
+    return (root or workspace_root()) / "fixtures" / "parity" / "ladder-bundle"
+
+
+def parity_gate_status(root: Path | None = None) -> dict[str, Any]:
+    """Report #959 acceptance-criteria readiness from checked-in fixtures only."""
+    base = root or workspace_root()
+    fixtures = base / "fixtures" / "parity"
+    bundle = ladder_bundle_root(base)
+    rung_files = sorted(bundle.glob("*-rung.json")) if bundle.is_dir() else []
+
+    tiny_matrix = compare_fixture_pair(
+        fixtures / "legacy" / "tiny-pass.json",
+        fixtures / "new" / "tiny-pass.json",
+    )
+    tiny_ok = tiny_matrix["overall"] in {"match", "accepted_difference"}
+
+    historical_path = fixtures / "legacy" / "cert-s20-minimal.json"
+    historical_ok = False
+    if historical_path.is_file():
+        try:
+            validate_historical_legacy_cert(historical_path, expected_sha="a" * 40)
+            historical_ok = True
+        except Exception:
+            historical_ok = False
+
+    ladder_ok = False
+    ladder_detail = "no ingested #900 rung bundles"
+    if rung_files:
+        matrices = compare_ladder_bundle(bundle)
+        ladder_ok = bool(matrices) and all(
+            matrix["overall"] in {"match", "accepted_difference"} for matrix in matrices
+        )
+        ladder_detail = f"{len(rung_files)} rung file(s), {len(matrices)} comparison(s)"
+
+    accepted = load_accepted_differences()
+    migration_fixtures = [
+        path.name
+        for path in (fixtures / "legacy").glob("*.json")
+        if path.name != "tiny-pass.json"
+    ]
+
+    criteria = [
+        _criterion(
+            "parity_matrix_no_unexplained_gaps",
+            met=tiny_ok and (ladder_ok if rung_files else False),
+            blocked_by="#900 ladder bundles" if tiny_ok and not rung_files else None,
+            evidence=f"tiny overall={tiny_matrix['overall']}; ladder {ladder_detail}",
+        ),
+        _criterion(
+            "harness_authoritative_after_ladder_comparison",
+            met=False,
+            blocked_by="#900",
+            evidence=ladder_detail,
+        ),
+        _criterion(
+            "legacy_orchestration_retired_with_coverage",
+            met=False,
+            blocked_by="parity_matrix_no_unexplained_gaps + harness_authoritative",
+            evidence=f"coverage entries={len(coverage_map())}",
+        ),
+        _criterion(
+            "historical_evidence_readable",
+            met=historical_ok,
+            evidence=str(historical_path.relative_to(base)) if historical_ok else None,
+        ),
+        _criterion(
+            "migration_fixtures_preserved",
+            met=bool(migration_fixtures),
+            evidence=", ".join(sorted(migration_fixtures)) or None,
+        ),
+        _criterion(
+            "no_duplicate_s18_s26_ladder_for_parity",
+            met=True,
+            evidence="compare_ladder_bundle ingests #900 output read-only only",
+        ),
+    ]
+
+    ready_for_retirement = all(row["met"] for row in criteria)
+    return {
+        "schema": GATE_SCHEMA,
+        "ready_for_retirement": ready_for_retirement,
+        "accepted_differences_schema": accepted.get("schema"),
+        "criteria": criteria,
+    }
+
+
+def assert_tiny_parity_ready(root: Path | None = None) -> None:
+    """Fail closed when tiny/local shadow parity is not green."""
+    base = root or workspace_root()
+    tiny_only = compare_fixture_pair(
+        base / "fixtures" / "parity" / "legacy" / "tiny-pass.json",
+        base / "fixtures" / "parity" / "new" / "tiny-pass.json",
+    )
+    if tiny_only["overall"] == "unexplained_gap":
+        raise ValueError(f"unexplained tiny parity gaps: {tiny_only}")

--- a/benchmarks/harness/graphforge_bench/parity_gate_cli.py
+++ b/benchmarks/harness/graphforge_bench/parity_gate_cli.py
@@ -1,0 +1,28 @@
+"""CLI entrypoint for the #959 parity gate status report."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from graphforge_bench.parity_gate import assert_tiny_parity_ready, parity_gate_status
+
+
+def main() -> int:
+    status = parity_gate_status()
+    print(json.dumps(status, indent=2, sort_keys=True))
+    try:
+        assert_tiny_parity_ready()
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    if not status["ready_for_retirement"]:
+        print(
+            "parity gate: tiny shadow OK; retirement blocked on #900 ladder bundles",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/harness/graphforge_bench/scale_parity.py
+++ b/benchmarks/harness/graphforge_bench/scale_parity.py
@@ -321,15 +321,25 @@ def compare_ladder_bundle(bundle_root: Path) -> list[dict[str, Any]]:
     """Compare every rung JSON in a completed #900 bundle directory."""
     if not bundle_root.is_dir():
         raise ParityError(f"ladder bundle directory missing: {bundle_root}")
+    rung_paths = sorted(bundle_root.glob("*-rung.json"))
+    if not rung_paths:
+        return []
+    legacy_dir = workspace_root() / "fixtures" / "parity" / "legacy"
     matrices: list[dict[str, Any]] = []
-    for rung_path in sorted(bundle_root.glob("*-rung.json")):
+    for rung_path in rung_paths:
         rung_doc = json.loads(rung_path.read_text(encoding="utf-8"))
         rung = normalize_rung_evidence(rung_doc)
-        legacy_path = workspace_root() / "fixtures" / "parity" / "legacy" / "cert-s20-minimal.json"
-        if legacy_path.exists():
-            legacy_doc = json.loads(legacy_path.read_text(encoding="utf-8"))
-            legacy = normalize_legacy_cert_lifecycle(legacy_doc)
-            matrices.append(compare_evidence(legacy, rung))
+        scale = rung_doc.get("scale")
+        legacy_candidates = []
+        if isinstance(scale, int):
+            legacy_candidates.append(legacy_dir / f"cert-s{scale}-minimal.json")
+        legacy_candidates.append(legacy_dir / "cert-s20-minimal.json")
+        legacy_path = next((path for path in legacy_candidates if path.is_file()), None)
+        if legacy_path is None:
+            raise ParityError(f"no legacy migration fixture for rung {rung_path.name}")
+        legacy_doc = json.loads(legacy_path.read_text(encoding="utf-8"))
+        legacy = normalize_legacy_cert_lifecycle(legacy_doc)
+        matrices.append(compare_evidence(legacy, rung))
     return matrices
 
 

--- a/benchmarks/scale-parity-index.md
+++ b/benchmarks/scale-parity-index.md
@@ -30,9 +30,10 @@ Declared in `fixtures/parity/accepted-differences.json`:
 ## Comparator commands
 
 ```bash
-# Tiny/local shadow fixtures (no provider spend)
+# Parity gate status (#959 criteria tracker; tiny must pass, retirement blocked until #900)
 cd benchmarks
-PYTHONPATH=harness uv run --locked python -m unittest tests.test_scale_parity
+make parity-gate
+PYTHONPATH=harness uv run --locked python -m unittest tests.test_scale_parity tests.test_parity_gate
 
 # Historical legacy certification fixture readability
 PYTHONPATH=harness uv run --locked python -c "

--- a/benchmarks/tests/test_parity_gate.py
+++ b/benchmarks/tests/test_parity_gate.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from graphforge_bench.parity_gate import (
+    assert_tiny_parity_ready,
+    ladder_bundle_root,
+    parity_gate_status,
+)
+from graphforge_bench.scale_parity import compare_ladder_bundle
+
+
+class ParityGateTests(unittest.TestCase):
+    def test_tiny_parity_ready(self) -> None:
+        assert_tiny_parity_ready()
+
+    def test_gate_status_reports_retirement_blocked(self) -> None:
+        status = parity_gate_status()
+        self.assertFalse(status["ready_for_retirement"])
+        blocked = {
+            row["name"]: row["blocked_by"] for row in status["criteria"] if row.get("blocked_by")
+        }
+        self.assertIn("harness_authoritative_after_ladder_comparison", blocked)
+        self.assertEqual(blocked["harness_authoritative_after_ladder_comparison"], "#900")
+
+    def test_historical_evidence_criterion_met(self) -> None:
+        status = parity_gate_status()
+        historical = next(
+            row for row in status["criteria"] if row["name"] == "historical_evidence_readable"
+        )
+        self.assertTrue(historical["met"])
+
+    def test_empty_ladder_bundle_returns_no_comparisons(self) -> None:
+        self.assertEqual(compare_ladder_bundle(ladder_bundle_root()), [])
+
+    def test_gate_status_json_serializable(self) -> None:
+        payload = parity_gate_status()
+        json.dumps(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an explicit #959 parity gate status reporter without fabricating ladder evidence.

- `parity_gate_status()` tracks each #959 acceptance criterion (tiny parity, historical readability, ladder bundle, retirement).
- `make -C benchmarks parity-gate` prints JSON status; exits non-zero only if tiny shadow parity fails.
- Fixes `compare_ladder_bundle` to select legacy migration fixtures by rung scale.
- Tests document that retirement remains blocked on #900.

## Testing

```bash
cd benchmarks
make parity-gate
PYTHONPATH=harness uv run --locked python -m unittest tests.test_parity_gate tests.test_scale_parity
```

## Issue

Relates to #959 — legacy retirement still blocked until #900 Fly ladder bundles are ingested.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790808955&installation_model_id=20486&pr_number=1054&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1054&signature=40501ba6cb18272192033b57b65f0b2e9a504538c377c34ff182f4a8955f029c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->