### PR TITLE
feat(bench): add ESC readiness check for progressive ladder

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries progressive-provider-plan qualification-operator parity-gate
+.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness parity-gate
 
 install:
 	uv sync --locked
@@ -83,3 +83,9 @@ qualification-operator: install
 	test -n "$(GATE)" && test -n "$(ESC_ENVIRONMENT)"
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python ../scripts/ci/gate-registry.py run "$(GATE)" -- \
 		--environment "$(ESC_ENVIRONMENT)" $(ARGS)
+
+# Validate that Pulumi ESC projects Fly credentials and spend authorization.
+esc-readiness: install
+	test -n "$(ESC_ENVIRONMENT)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.esc_readiness_cli \
+		--environment "$(ESC_ENVIRONMENT)" $(if $(filter 1 true yes,$(ASSERT_READY)),--assert-ready,)

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -88,4 +88,6 @@ qualification-operator: install
 esc-readiness: install
 	test -n "$(ESC_ENVIRONMENT)"
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.esc_readiness_cli \
-		--environment "$(ESC_ENVIRONMENT)" $(if $(filter 1 true yes,$(ASSERT_READY)),--assert-ready,)
+		--environment "$(ESC_ENVIRONMENT)" \
+		--gate "$(or $(GATE),progressive-ladder)" \
+		$(if $(filter 1 true yes,$(ASSERT_READY)),--assert-ready,)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -442,7 +442,8 @@ projections before any live attempt:
 
 ```bash
 make -C benchmarks esc-readiness \
-  ESC_ENVIRONMENT=curatelabs/graphforge/qualification
+  ESC_ENVIRONMENT=curatelabs/graphforge/qualification \
+  GATE=progressive-ladder
 ```
 
 Live operator commands are rendered from

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -436,7 +436,16 @@ environment with fresh credential state. These components remain import-only:
 these tests perform no provider operation.
 
 Provider credentials belong to Pulumi ESC rather than GitHub workflow inputs or
-the caller's ambient shell. Live operator commands are rendered from
+the caller's ambient shell. Populate `curatelabs/graphforge/qualification` from
+`config/pulumi/graphforge-qualification.esc.yaml.example`, then verify the
+projections before any live attempt:
+
+```bash
+make -C benchmarks esc-readiness \
+  ESC_ENVIRONMENT=curatelabs/graphforge/qualification
+```
+
+Live operator commands are rendered from
 `config/gate-registry.json` and run through the Python control plane:
 
 ```bash

--- a/benchmarks/harness/graphforge_bench/esc_readiness.py
+++ b/benchmarks/harness/graphforge_bench/esc_readiness.py
@@ -4,15 +4,22 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import json
+import re
 import subprocess
 from typing import Any
 
 from graphforge_bench.progressive_esc import FLY_TOKEN_ENV, SPEND_AUTHORIZATION_ENV
 from graphforge_bench.progressive_provider_attempt import parse_spend_authorization
-from graphforge_bench.qualification_operator import ESC_ENVIRONMENT
 
 READINESS_SCHEMA = "graphforge-progressive-esc-readiness/1"
-REQUIRED_VARIABLES = (FLY_TOKEN_ENV, SPEND_AUTHORIZATION_ENV)
+ESC_ENVIRONMENT = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.-]*(?:/[A-Za-z0-9][A-Za-z0-9_.-]*){0,2}(?:@[A-Za-z0-9_.-]+)?$"
+)
+REQUIRED_BY_GATE = {
+    "fly-tiny": (FLY_TOKEN_ENV,),
+    "fly-tiny-recovery": (FLY_TOKEN_ENV,),
+    "progressive-ladder": (FLY_TOKEN_ENV, SPEND_AUTHORIZATION_ENV),
+}
 
 
 class EscReadinessError(ValueError):
@@ -54,14 +61,34 @@ def _non_empty_string(value: object) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
-def esc_readiness_status(environment: str) -> dict[str, Any]:
-    """Report whether an ESC environment projects the progressive qualification inputs."""
+def required_projections(gate: str) -> tuple[str, ...]:
+    try:
+        return REQUIRED_BY_GATE[gate]
+    except KeyError as error:
+        raise EscReadinessError("qualification gate is unknown") from error
+
+
+def esc_readiness_status(environment: str, *, gate: str = "progressive-ladder") -> dict[str, Any]:
+    """Report whether an ESC environment projects the inputs required for one live gate."""
+    try:
+        required = required_projections(gate)
+    except EscReadinessError as error:
+        return {
+            "schema": READINESS_SCHEMA,
+            "environment": environment,
+            "gate": gate,
+            "ready": False,
+            "failure": str(error),
+            "projections": [],
+        }
+
     try:
         opened = _open_environment(environment)
     except EscReadinessError as error:
         return {
             "schema": READINESS_SCHEMA,
             "environment": environment,
+            "gate": gate,
             "ready": False,
             "failure": str(error),
             "projections": [],
@@ -70,7 +97,7 @@ def esc_readiness_status(environment: str) -> dict[str, Any]:
     variables = _projected_variables(opened)
     projections: list[dict[str, Any]] = []
     ready = True
-    for name in REQUIRED_VARIABLES:
+    for name in required:
         present = name in variables
         valid = present and _non_empty_string(variables.get(name))
         if not valid:
@@ -78,17 +105,20 @@ def esc_readiness_status(environment: str) -> dict[str, Any]:
         projections.append({"name": name, "present": present, "valid": valid})
 
     spend_valid = False
-    if ready:
+    if SPEND_AUTHORIZATION_ENV in required and ready:
         try:
             parse_spend_authorization(str(variables[SPEND_AUTHORIZATION_ENV]))
             spend_valid = True
         except Exception:
             ready = False
             spend_valid = False
+    elif SPEND_AUTHORIZATION_ENV not in required:
+        spend_valid = True
 
     return {
         "schema": READINESS_SCHEMA,
         "environment": environment,
+        "gate": gate,
         "ready": ready,
         "failure": None if ready else "protected projections are unavailable or invalid",
         "spend_authorization_valid": spend_valid,
@@ -96,8 +126,8 @@ def esc_readiness_status(environment: str) -> dict[str, Any]:
     }
 
 
-def assert_esc_ready(environment: str) -> None:
+def assert_esc_ready(environment: str, *, gate: str = "progressive-ladder") -> None:
     """Fail closed when the ESC environment cannot authorize live qualification."""
-    status = esc_readiness_status(environment)
+    status = esc_readiness_status(environment, gate=gate)
     if not status["ready"]:
         raise EscReadinessError(status.get("failure") or "ESC environment is not ready")

--- a/benchmarks/harness/graphforge_bench/esc_readiness.py
+++ b/benchmarks/harness/graphforge_bench/esc_readiness.py
@@ -1,0 +1,103 @@
+"""Validate Pulumi ESC projections required for live progressive qualification."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import subprocess
+from typing import Any
+
+from graphforge_bench.progressive_esc import FLY_TOKEN_ENV, SPEND_AUTHORIZATION_ENV
+from graphforge_bench.progressive_provider_attempt import parse_spend_authorization
+from graphforge_bench.qualification_operator import ESC_ENVIRONMENT
+
+READINESS_SCHEMA = "graphforge-progressive-esc-readiness/1"
+REQUIRED_VARIABLES = (FLY_TOKEN_ENV, SPEND_AUTHORIZATION_ENV)
+
+
+class EscReadinessError(ValueError):
+    """The protected ESC environment is missing or malformed."""
+
+
+def _open_environment(environment: str) -> Mapping[str, Any]:
+    if ESC_ENVIRONMENT.fullmatch(environment) is None:
+        raise EscReadinessError("Pulumi ESC environment name is invalid")
+    try:
+        completed = subprocess.run(
+            ("pulumi", "env", "open", environment),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except OSError as error:
+        raise EscReadinessError("unable to open Pulumi ESC environment") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise EscReadinessError(f"unable to open Pulumi ESC environment: {detail}")
+    try:
+        value = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise EscReadinessError("Pulumi ESC environment output is malformed") from error
+    if not isinstance(value, Mapping):
+        raise EscReadinessError("Pulumi ESC environment output is malformed")
+    return value
+
+
+def _projected_variables(document: Mapping[str, Any]) -> Mapping[str, Any]:
+    variables = document.get("environmentVariables")
+    if not isinstance(variables, Mapping):
+        return {}
+    return variables
+
+
+def _non_empty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def esc_readiness_status(environment: str) -> dict[str, Any]:
+    """Report whether an ESC environment projects the progressive qualification inputs."""
+    try:
+        opened = _open_environment(environment)
+    except EscReadinessError as error:
+        return {
+            "schema": READINESS_SCHEMA,
+            "environment": environment,
+            "ready": False,
+            "failure": str(error),
+            "projections": [],
+        }
+
+    variables = _projected_variables(opened)
+    projections: list[dict[str, Any]] = []
+    ready = True
+    for name in REQUIRED_VARIABLES:
+        present = name in variables
+        valid = present and _non_empty_string(variables.get(name))
+        if not valid:
+            ready = False
+        projections.append({"name": name, "present": present, "valid": valid})
+
+    spend_valid = False
+    if ready:
+        try:
+            parse_spend_authorization(str(variables[SPEND_AUTHORIZATION_ENV]))
+            spend_valid = True
+        except Exception:
+            ready = False
+            spend_valid = False
+
+    return {
+        "schema": READINESS_SCHEMA,
+        "environment": environment,
+        "ready": ready,
+        "failure": None if ready else "protected projections are unavailable or invalid",
+        "spend_authorization_valid": spend_valid,
+        "projections": projections,
+    }
+
+
+def assert_esc_ready(environment: str) -> None:
+    """Fail closed when the ESC environment cannot authorize live qualification."""
+    status = esc_readiness_status(environment)
+    if not status["ready"]:
+        raise EscReadinessError(status.get("failure") or "ESC environment is not ready")

--- a/benchmarks/harness/graphforge_bench/esc_readiness_cli.py
+++ b/benchmarks/harness/graphforge_bench/esc_readiness_cli.py
@@ -1,0 +1,39 @@
+"""CLI for progressive qualification ESC readiness checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from graphforge_bench.esc_readiness import EscReadinessError, assert_esc_ready, esc_readiness_status
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    result.add_argument("--environment", required=True)
+    result.add_argument(
+        "--assert-ready",
+        action="store_true",
+        help="exit non-zero when required projections are missing or invalid",
+    )
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    if args.assert_ready:
+        try:
+            assert_esc_ready(args.environment)
+        except EscReadinessError as error:
+            print(f"esc readiness refused: {error}", file=sys.stderr)
+            return 2
+        print(json.dumps(esc_readiness_status(args.environment), indent=2, sort_keys=True))
+        return 0
+    status = esc_readiness_status(args.environment)
+    print(json.dumps(status, indent=2, sort_keys=True))
+    return 0 if status["ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/harness/graphforge_bench/esc_readiness_cli.py
+++ b/benchmarks/harness/graphforge_bench/esc_readiness_cli.py
@@ -13,6 +13,11 @@ def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     result.add_argument("--environment", required=True)
     result.add_argument(
+        "--gate",
+        default="progressive-ladder",
+        choices=("fly-tiny", "fly-tiny-recovery", "progressive-ladder"),
+    )
+    result.add_argument(
         "--assert-ready",
         action="store_true",
         help="exit non-zero when required projections are missing or invalid",
@@ -24,13 +29,17 @@ def main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
     if args.assert_ready:
         try:
-            assert_esc_ready(args.environment)
+            assert_esc_ready(args.environment, gate=args.gate)
         except EscReadinessError as error:
             print(f"esc readiness refused: {error}", file=sys.stderr)
             return 2
-        print(json.dumps(esc_readiness_status(args.environment), indent=2, sort_keys=True))
+        print(
+            json.dumps(
+                esc_readiness_status(args.environment, gate=args.gate), indent=2, sort_keys=True
+            )
+        )
         return 0
-    status = esc_readiness_status(args.environment)
+    status = esc_readiness_status(args.environment, gate=args.gate)
     print(json.dumps(status, indent=2, sort_keys=True))
     return 0 if status["ready"] else 1
 

--- a/benchmarks/harness/graphforge_bench/qualification_operator.py
+++ b/benchmarks/harness/graphforge_bench/qualification_operator.py
@@ -16,6 +16,8 @@ import re
 import subprocess
 import sys
 
+from graphforge_bench.esc_readiness import EscReadinessError, assert_esc_ready
+
 ESC_ENVIRONMENT = re.compile(
     r"^[A-Za-z0-9][A-Za-z0-9_.-]*(?:/[A-Za-z0-9][A-Za-z0-9_.-]*){0,2}(?:@[A-Za-z0-9_.-]+)?$"
 )
@@ -145,6 +147,11 @@ def run_under_esc(
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     attestor: Callable[[str | None], None] = attest_current_main,
 ) -> int:
+    if gate in LIVE_GATES:
+        try:
+            assert_esc_ready(environment, gate=gate)
+        except EscReadinessError as error:
+            raise OperatorRefusalError(str(error)) from error
     command = esc_command(environment, gate, argv)
     commit = _single_value(_forwarded(argv), "--expected-sha")
     attestor(commit if gate == "fly-tiny" else None)

--- a/benchmarks/tests/test_esc_readiness.py
+++ b/benchmarks/tests/test_esc_readiness.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+
+from graphforge_bench.esc_readiness import (
+    EscReadinessError,
+    assert_esc_ready,
+    esc_readiness_status,
+)
+from graphforge_bench.progressive_esc import FLY_TOKEN_ENV, SPEND_AUTHORIZATION_ENV
+from tests.test_progressive_provider_attempt import authorization_document
+
+
+class EscReadinessTests(unittest.TestCase):
+    def test_empty_environment_not_ready(self) -> None:
+        with patch(
+            "graphforge_bench.esc_readiness._open_environment",
+            return_value={"environmentVariables": {}},
+        ):
+            status = esc_readiness_status("curatelabs/graphforge/qualification")
+        self.assertFalse(status["ready"])
+        self.assertFalse(status["spend_authorization_valid"])
+        json.dumps(status)
+
+    def test_ready_when_projections_and_authorization_validate(self) -> None:
+        document = authorization_document()
+        with patch(
+            "graphforge_bench.esc_readiness._open_environment",
+            return_value={
+                "environmentVariables": {
+                    FLY_TOKEN_ENV: "fixture-token",
+                    SPEND_AUTHORIZATION_ENV: json.dumps(document),
+                }
+            },
+        ):
+            status = esc_readiness_status("curatelabs/graphforge/qualification")
+        self.assertTrue(status["ready"])
+        self.assertTrue(status["spend_authorization_valid"])
+
+    def test_assert_ready_raises_for_missing_projections(self) -> None:
+        with (
+            patch(
+                "graphforge_bench.esc_readiness._open_environment",
+                return_value={"environmentVariables": {}},
+            ),
+            self.assertRaises(EscReadinessError),
+        ):
+            assert_esc_ready("curatelabs/graphforge/qualification")
+
+    def test_invalid_environment_name(self) -> None:
+        status = esc_readiness_status("../invalid")
+        self.assertFalse(status["ready"])
+        self.assertIn("invalid", status["failure"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_esc_readiness.py
+++ b/benchmarks/tests/test_esc_readiness.py
@@ -35,7 +35,18 @@ class EscReadinessTests(unittest.TestCase):
                 }
             },
         ):
-            status = esc_readiness_status("curatelabs/graphforge/qualification")
+            status = esc_readiness_status(
+                "curatelabs/graphforge/qualification", gate="progressive-ladder"
+            )
+        self.assertTrue(status["ready"])
+        self.assertTrue(status["spend_authorization_valid"])
+
+    def test_fly_tiny_requires_only_token(self) -> None:
+        with patch(
+            "graphforge_bench.esc_readiness._open_environment",
+            return_value={"environmentVariables": {FLY_TOKEN_ENV: "fixture-token"}},
+        ):
+            status = esc_readiness_status("curatelabs/graphforge/qualification", gate="fly-tiny")
         self.assertTrue(status["ready"])
         self.assertTrue(status["spend_authorization_valid"])
 

--- a/benchmarks/tests/test_qualification_operator.py
+++ b/benchmarks/tests/test_qualification_operator.py
@@ -117,10 +117,13 @@ class QualificationOperatorTests(unittest.TestCase):
         self.assertTrue(runner_called)
 
     def test_live_run_refuses_when_esc_is_not_ready(self) -> None:
-        with patch(
-            "graphforge_bench.qualification_operator.assert_esc_ready",
-            side_effect=EscReadinessError("protected projections are unavailable or invalid"),
-        ), self.assertRaisesRegex(OperatorRefusalError, "protected projections"):
+        with (
+            patch(
+                "graphforge_bench.qualification_operator.assert_esc_ready",
+                side_effect=EscReadinessError("protected projections are unavailable or invalid"),
+            ),
+            self.assertRaisesRegex(OperatorRefusalError, "protected projections"),
+        ):
             run_under_esc(
                 "curatelabs/graphforge/qualification",
                 "fly-tiny",
@@ -172,10 +175,13 @@ class QualificationOperatorTests(unittest.TestCase):
             called = True
             return subprocess.CompletedProcess((), 0)
 
-        with patch(
-            "graphforge_bench.qualification_operator.assert_esc_ready",
-            return_value=None,
-        ), self.assertRaisesRegex(OperatorRefusalError, "current origin/main"):
+        with (
+            patch(
+                "graphforge_bench.qualification_operator.assert_esc_ready",
+                return_value=None,
+            ),
+            self.assertRaisesRegex(OperatorRefusalError, "current origin/main"),
+        ):
             run_under_esc(
                 "curatelabs/graphforge/qualification",
                 "fly-tiny",

--- a/benchmarks/tests/test_qualification_operator.py
+++ b/benchmarks/tests/test_qualification_operator.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import subprocess
 import sys
 import unittest
+from unittest.mock import patch
 
+from graphforge_bench.esc_readiness import EscReadinessError
 from graphforge_bench.fly_tiny_qualification import parser as fly_parser
 from graphforge_bench.qualification_operator import (
     OperatorRefusalError,
@@ -98,17 +100,34 @@ class QualificationOperatorTests(unittest.TestCase):
             "--execute",
             "--confirm-disposable",
         ]
-        self.assertEqual(
+        with patch(
+            "graphforge_bench.qualification_operator.assert_esc_ready",
+            return_value=None,
+        ):
+            self.assertEqual(
+                run_under_esc(
+                    "curatelabs/graphforge/qualification",
+                    "progressive-ladder",
+                    progressive_args,
+                    runner=runner,
+                    attestor=lambda _commit: None,
+                ),
+                0,
+            )
+        self.assertTrue(runner_called)
+
+    def test_live_run_refuses_when_esc_is_not_ready(self) -> None:
+        with patch(
+            "graphforge_bench.qualification_operator.assert_esc_ready",
+            side_effect=EscReadinessError("protected projections are unavailable or invalid"),
+        ), self.assertRaisesRegex(OperatorRefusalError, "protected projections"):
             run_under_esc(
                 "curatelabs/graphforge/qualification",
-                "progressive-ladder",
-                progressive_args,
-                runner=runner,
+                "fly-tiny",
+                ARGS,
+                runner=lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0),
                 attestor=lambda _commit: None,
-            ),
-            0,
-        )
-        self.assertTrue(runner_called)
+            )
 
     def test_outer_runner_receives_argv_without_secret_values(self) -> None:
         observed: tuple[str, ...] | None = None
@@ -119,16 +138,20 @@ class QualificationOperatorTests(unittest.TestCase):
             self.assertFalse(check)
             return subprocess.CompletedProcess(argv, 0)
 
-        self.assertEqual(
-            run_under_esc(
-                "curatelabs/graphforge/qualification",
-                "fly-tiny",
-                ARGS,
-                runner=runner,
-                attestor=lambda _commit: None,
-            ),
-            0,
-        )
+        with patch(
+            "graphforge_bench.qualification_operator.assert_esc_ready",
+            return_value=None,
+        ):
+            self.assertEqual(
+                run_under_esc(
+                    "curatelabs/graphforge/qualification",
+                    "fly-tiny",
+                    ARGS,
+                    runner=runner,
+                    attestor=lambda _commit: None,
+                ),
+                0,
+            )
         assert observed is not None
         self.assertNotIn("FLY_API_TOKEN", " ".join(observed))
 
@@ -149,7 +172,10 @@ class QualificationOperatorTests(unittest.TestCase):
             called = True
             return subprocess.CompletedProcess((), 0)
 
-        with self.assertRaisesRegex(OperatorRefusalError, "current origin/main"):
+        with patch(
+            "graphforge_bench.qualification_operator.assert_esc_ready",
+            return_value=None,
+        ), self.assertRaisesRegex(OperatorRefusalError, "current origin/main"):
             run_under_esc(
                 "curatelabs/graphforge/qualification",
                 "fly-tiny",
@@ -169,16 +195,20 @@ class QualificationOperatorTests(unittest.TestCase):
                 return subprocess.CompletedProcess(argv, 0, "", "")
             return subprocess.CompletedProcess(argv, 0, next(responses), "")
 
-        self.assertEqual(
-            run_under_esc(
-                "curatelabs/graphforge/qualification",
-                "fly-tiny",
-                ARGS,
-                runner=lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0),
-                attestor=lambda commit: attest_current_main(commit, runner=git_runner),
-            ),
-            0,
-        )
+        with patch(
+            "graphforge_bench.qualification_operator.assert_esc_ready",
+            return_value=None,
+        ):
+            self.assertEqual(
+                run_under_esc(
+                    "curatelabs/graphforge/qualification",
+                    "fly-tiny",
+                    ARGS,
+                    runner=lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0),
+                    attestor=lambda commit: attest_current_main(commit, runner=git_runner),
+                ),
+                0,
+            )
 
     def test_recovery_attests_current_controller_not_older_receipt_commit(self) -> None:
         observed: list[str | None] = []
@@ -188,16 +218,20 @@ class QualificationOperatorTests(unittest.TestCase):
             "--cleanup-only",
             "--confirm-disposable",
         ]
-        self.assertEqual(
-            run_under_esc(
-                "curatelabs/graphforge/qualification",
-                "fly-tiny-recovery",
-                recovery_args,
-                runner=lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0),
-                attestor=observed.append,
-            ),
-            0,
-        )
+        with patch(
+            "graphforge_bench.qualification_operator.assert_esc_ready",
+            return_value=None,
+        ):
+            self.assertEqual(
+                run_under_esc(
+                    "curatelabs/graphforge/qualification",
+                    "fly-tiny-recovery",
+                    recovery_args,
+                    runner=lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0),
+                    attestor=observed.append,
+                ),
+                0,
+            )
         self.assertEqual(observed, [None])
 
     def test_inner_controller_rejects_abbreviated_expected_sha(self) -> None:

--- a/config/pulumi/graphforge-qualification.esc.yaml.example
+++ b/config/pulumi/graphforge-qualification.esc.yaml.example
@@ -1,0 +1,58 @@
+# Example Pulumi ESC definition for live GraphForge benchmark qualification.
+#
+# Copy into `curatelabs/graphforge/qualification` with real secret values.
+# The progressive ladder controller consumes exactly these projections:
+#   - FLY_API_TOKEN
+#   - GRAPHFORGE_PROGRESSIVE_SPEND_AUTHORIZATION
+#
+# Spend authorization must validate against
+# benchmarks/schemas/progressive-spend-authorization.json and bind the exact
+# merged commit, immutable image digest, and authorized maximum scale.
+
+values:
+  fly:
+    token:
+      fn::secret: "<fly-org-scoped-api-token>"
+
+  spend:
+    authorization:
+      fn::secret: |
+        {
+          "schema": "graphforge-progressive-spend-authorization/1",
+          "status": "authorized",
+          "provider": "fly",
+          "commit": "<40-char-git-sha>",
+          "admitted_plan_sha256": "<64-char-hex>",
+          "image_digest": "registry.fly.io/<app>@sha256:<64-char-hex>",
+          "organization": "<fly-org>",
+          "region": "ord",
+          "machine_class": "performance-2x",
+          "volume_gib": 500,
+          "rung": "S20",
+          "maximum_scale": 26,
+          "attempt_nonce": "<32-char-hex>",
+          "app": "gf-progressive-<32-char-hex>",
+          "issued_at": "2026-01-01T00:00:00Z",
+          "expires_at": "2026-01-01T05:00:00Z",
+          "teardown_owner": "qualification-operator",
+          "maximum_machine_seconds": 18000,
+          "resource_limits": {
+            "apps": 1,
+            "volumes": 1,
+            "machines": 1,
+            "image_builds": 0
+          },
+          "pricing": {
+            "currency": "USD",
+            "machine_microusd_per_hour": 1,
+            "volume_microusd_per_gib_hour": 1,
+            "transfer_allowance_microusd": 1,
+            "estimated_total_microusd": 1,
+            "maximum_total_microusd": 1
+          },
+          "claim": "spend_authorization_only"
+        }
+
+  environmentVariables:
+    FLY_API_TOKEN: ${fly.token}
+    GRAPHFORGE_PROGRESSIVE_SPEND_AUTHORIZATION: ${spend.authorization}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds operator infrastructure to unblock live Fly progressive-ladder execution for #900:

- `graphforge_bench.esc_readiness` validates that Pulumi ESC projects the gate-specific inputs (`FLY_API_TOKEN` for fly-tiny; plus `GRAPHFORGE_PROGRESSIVE_SPEND_AUTHORIZATION` for progressive-ladder).
- `make -C benchmarks esc-readiness ESC_ENVIRONMENT=... GATE=progressive-ladder` reports readiness without spending or calling Fly.
- `qualification_operator` now refuses live runs when ESC projections are missing, before `pulumi env run`.
- `config/pulumi/graphforge-qualification.esc.yaml.example` documents the required ESC definition shape.

## Context

#900 acceptance criteria require executed Fly S18→S26 ladder evidence. Operator wiring merged in #1047; live activation remains blocked on protected ESC configuration. An empty `curatelabs/graphforge/qualification` ESC environment exists and needs secret population per the example template.

## Testing

```bash
cd benchmarks
PYTHONPATH=harness uv run --locked python -m unittest tests.test_esc_readiness tests.test_qualification_operator
make esc-readiness ESC_ENVIRONMENT=curatelabs/graphforge/qualification GATE=progressive-ladder  # exits 1
```

## Related issues

- Supports #900 (Fly ladder execution prerequisites)
- Part of epic #952

**Does not close #900** — readiness tooling only; executed ladder evidence still required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790812798&installation_model_id=20486&pr_number=1055&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1055&signature=483d0fafb3dfc72336290f50e0f3c170ee3cef4c169e6e06f9b879c50bccd662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ESC readiness check CLI for progressive ladder benchmarks
> - Adds [esc_readiness.py](https://github.com/CurateLabs/graphforge/pull/1055/files#diff-83f812a5c423785d3afcb6288174a5b51379eaa860f0134d2f1a645ee0066a5f) to open a Pulumi ESC environment and verify required variables (`FLY_TOKEN_ENV`, `SPEND_AUTHORIZATION_ENV`) and spend authorization.
> - Exposes the check via [esc_readiness_cli.py](https://github.com/CurateLabs/graphforge/pull/1055/files#diff-b248ca7385cc4a414924e8004e83f3189184903d786d3bd6308f6bd2cbfe98c5) and a `make esc-readiness` target with deterministic exit codes (0, 1, 2).
> - Adds an example ESC configuration and README instructions for populating the `curatelabs/graphforge/qualification` environment.
> - Risk: The `esc-readiness` Makefile target requires the `ESC_ENVIRONMENT` variable and the `pulumi env open` command to succeed; failure raises `EscReadinessError` or exits non-zero.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99900e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->