### PR TITLE
feat(bench): add #900 ladder bundle ingest and fix parity gate (#959)

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness parity-gate
+.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness ingest-ladder-bundle parity-gate
 
 install:
 	uv sync --locked
@@ -91,3 +91,10 @@ esc-readiness: install
 		--environment "$(ESC_ENVIRONMENT)" \
 		--gate "$(or $(GATE),progressive-ladder)" \
 		$(if $(filter 1 true yes,$(ASSERT_READY)),--assert-ready,)
+
+# Copy a validated #900 output bundle into fixtures/parity/ladder-bundle/ for #959 parity.
+ingest-ladder-bundle: install
+	test -n "$(SOURCE)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.ladder_bundle_ingest \
+		--source "$(SOURCE)" $(if $(DESTINATION),--destination "$(DESTINATION)",) \
+		$(if $(filter 1 true yes,$(VALIDATE_ONLY)),--validate-only,)

--- a/benchmarks/fixtures/parity/ladder-bundle/README.md
+++ b/benchmarks/fixtures/parity/ladder-bundle/README.md
@@ -28,3 +28,11 @@ declared accepted differences in `fixtures/parity/accepted-differences.json`.
 
 Until #900 completes, parity work uses only tiny/local shadow fixtures in
 `fixtures/parity/legacy/tiny-pass.json` and `fixtures/parity/new/tiny-pass.json`.
+
+After #900 completes, validate and ingest the sanitized bundle read-only:
+
+```bash
+make -C benchmarks ingest-ladder-bundle SOURCE=/path/to/#900-output VALIDATE_ONLY=1
+make -C benchmarks ingest-ladder-bundle SOURCE=/path/to/#900-output
+make -C benchmarks parity-gate
+```

--- a/benchmarks/harness/graphforge_bench/ladder_bundle_ingest.py
+++ b/benchmarks/harness/graphforge_bench/ladder_bundle_ingest.py
@@ -1,0 +1,151 @@
+"""Validate and ingest completed #900 ladder bundles for #959 parity."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shutil
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from graphforge_bench.parity_gate import ladder_bundle_root
+from graphforge_bench.scale_parity import compare_ladder_bundle
+
+RUNG_NAME = re.compile(r"^s(\d+)-rung\.json$")
+MANIFEST_REQUIRED = (
+    "commit",
+    "image_digest",
+    "generator_identity",
+    "benchexec_version",
+    "maximum_authorized_scale",
+)
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+INGEST_SCHEMA = "graphforge-scale-orchestration-ladder-bundle-ingest/1"
+
+
+class LadderBundleIngestError(ValueError):
+    """The source bundle is missing, malformed, or fails schema validation."""
+
+
+def _schema_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "schemas"
+
+
+def _validator(name: str) -> Draft202012Validator:
+    path = _schema_root() / name
+    return Draft202012Validator(json.loads(path.read_text(encoding="utf-8")))
+
+
+def _read_json(path: Path, message: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise LadderBundleIngestError(message) from error
+
+
+def _validate_manifest(document: Any) -> None:
+    if not isinstance(document, dict):
+        raise LadderBundleIngestError("manifest.json must be a JSON object")
+    missing = [name for name in MANIFEST_REQUIRED if name not in document]
+    if missing:
+        raise LadderBundleIngestError(f"manifest.json missing required keys: {', '.join(missing)}")
+    commit = document.get("commit")
+    if not isinstance(commit, str) or COMMIT.fullmatch(commit) is None:
+        raise LadderBundleIngestError("manifest.json commit must be a lowercase Git object ID")
+
+
+def validate_ladder_bundle(source: Path) -> dict[str, Any]:
+    """Validate a completed #900 bundle directory without copying it."""
+    if not source.is_dir():
+        raise LadderBundleIngestError("source ladder bundle directory is missing")
+
+    manifest_path = source / "manifest.json"
+    teardown_path = source / "teardown-inventory.json"
+    if not manifest_path.is_file():
+        raise LadderBundleIngestError("manifest.json is required")
+    if not teardown_path.is_file():
+        raise LadderBundleIngestError("teardown-inventory.json is required")
+
+    manifest = _read_json(manifest_path, "manifest.json is malformed")
+    _validate_manifest(manifest)
+
+    rung_validator = _validator("progressive-qualification-rung-evidence.json")
+    teardown_validator = _validator("progressive-provider-teardown-inventory.json")
+    teardown = _read_json(teardown_path, "teardown-inventory.json is malformed")
+    teardown_validator.validate(teardown)
+
+    rung_paths = sorted(
+        path for path in source.glob("*-rung.json") if RUNG_NAME.fullmatch(path.name)
+    )
+    if not rung_paths:
+        raise LadderBundleIngestError("at least one sN-rung.json file is required")
+
+    rung_scales: list[int] = []
+    for rung_path in rung_paths:
+        match = RUNG_NAME.fullmatch(rung_path.name)
+        assert match is not None
+        rung_scales.append(int(match.group(1)))
+        document = _read_json(rung_path, f"{rung_path.name} is malformed")
+        rung_validator.validate(document)
+
+    return {
+        "schema": INGEST_SCHEMA,
+        "source": str(source),
+        "manifest_commit": manifest["commit"],
+        "rung_files": [path.name for path in rung_paths],
+        "rung_scales": rung_scales,
+        "teardown_status": teardown.get("status"),
+    }
+
+
+def ingest_ladder_bundle(source: Path, destination: Path | None = None) -> dict[str, Any]:
+    """Validate a #900 bundle and copy it into the parity fixture tree."""
+    report = validate_ladder_bundle(source)
+    target = destination or ladder_bundle_root()
+    if target.exists() and any(target.glob("*-rung.json")):
+        raise LadderBundleIngestError("destination already contains ingested rung bundles")
+
+    target.mkdir(parents=True, exist_ok=True)
+    for name in ("manifest.json", "teardown-inventory.json", *report["rung_files"]):
+        shutil.copy2(source / name, target / name)
+
+    parity = compare_ladder_bundle(target)
+    report["destination"] = str(target)
+    report["parity_comparisons"] = len(parity)
+    report["parity_overall"] = [
+        matrix["overall"] for matrix in parity if isinstance(matrix.get("overall"), str)
+    ]
+    return report
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    result.add_argument("--source", type=Path, required=True)
+    result.add_argument("--destination", type=Path)
+    result.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="validate the source bundle without copying into fixtures/parity/ladder-bundle/",
+    )
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if args.validate_only:
+            report = validate_ladder_bundle(args.source)
+        else:
+            report = ingest_ladder_bundle(args.source, args.destination)
+    except LadderBundleIngestError as error:
+        print(f"ladder bundle ingest refused: {error}")
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/harness/graphforge_bench/parity_gate.py
+++ b/benchmarks/harness/graphforge_bench/parity_gate.py
@@ -72,23 +72,32 @@ def parity_gate_status(root: Path | None = None) -> dict[str, Any]:
         path.name for path in (fixtures / "legacy").glob("*.json") if path.name != "tiny-pass.json"
     ]
 
+    harness_authoritative_met = ladder_ok if rung_files else False
+    parity_matrix_met = tiny_ok and harness_authoritative_met
+
     criteria = [
         _criterion(
             "parity_matrix_no_unexplained_gaps",
-            met=tiny_ok and (ladder_ok if rung_files else False),
+            met=parity_matrix_met,
             blocked_by="#900 ladder bundles" if tiny_ok and not rung_files else None,
             evidence=f"tiny overall={tiny_matrix['overall']}; ladder {ladder_detail}",
         ),
         _criterion(
             "harness_authoritative_after_ladder_comparison",
-            met=False,
-            blocked_by="#900",
+            met=harness_authoritative_met,
+            blocked_by="#900"
+            if not rung_files
+            else ("ladder parity gaps" if not ladder_ok else None),
             evidence=ladder_detail,
         ),
         _criterion(
             "legacy_orchestration_retired_with_coverage",
             met=False,
-            blocked_by="parity_matrix_no_unexplained_gaps + harness_authoritative",
+            blocked_by=(
+                "parity_matrix_no_unexplained_gaps + harness_authoritative"
+                if not parity_matrix_met
+                else "legacy Makefile targets and workflows remain"
+            ),
             evidence=f"coverage entries={len(coverage_map())}",
         ),
         _criterion(

--- a/benchmarks/tests/test_ladder_bundle_ingest.py
+++ b/benchmarks/tests/test_ladder_bundle_ingest.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+from graphforge_bench.ladder_bundle_ingest import (
+    LadderBundleIngestError,
+    ingest_ladder_bundle,
+    validate_ladder_bundle,
+)
+from graphforge_bench.parity_gate import parity_gate_status
+from graphforge_bench.scale_parity import workspace_root
+
+COMMIT = "a" * 40
+DIGEST = "b" * 64
+
+
+def manifest() -> dict[str, object]:
+    return {
+        "commit": COMMIT,
+        "image_digest": f"registry.fly.io/gf-progressive-test@sha256:{'c' * 64}",
+        "generator_identity": "graphforge-benchmark-graph500-generator",
+        "benchexec_version": "2.7.1",
+        "maximum_authorized_scale": 26,
+    }
+
+
+def teardown_inventory() -> dict[str, object]:
+    return {
+        "schema": "graphforge-progressive-provider-teardown-inventory/1",
+        "status": "not_required",
+        "failure": None,
+        "commit": COMMIT,
+        "authorized_maximum_scale": 26,
+        "completed_scales": [18, 19],
+        "authorization_sha256": DIGEST,
+        "admitted_plan_sha256": DIGEST,
+        "checked_at": None,
+        "observed": None,
+        "claim": "control_plane_evidence_only",
+    }
+
+
+class LadderBundleIngestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.source = self.root / "source"
+        self.source.mkdir()
+        rung = json.loads(
+            (workspace_root() / "fixtures" / "parity" / "rung" / "s18-pass.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        (self.source / "manifest.json").write_text(
+            json.dumps(manifest(), indent=2) + "\n", encoding="utf-8"
+        )
+        (self.source / "teardown-inventory.json").write_text(
+            json.dumps(teardown_inventory(), indent=2) + "\n", encoding="utf-8"
+        )
+        (self.source / "s18-rung.json").write_text(
+            json.dumps(rung, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_validate_accepts_complete_bundle(self) -> None:
+        report = validate_ladder_bundle(self.source)
+        self.assertEqual(report["manifest_commit"], COMMIT)
+        self.assertEqual(report["rung_files"], ["s18-rung.json"])
+
+    def test_validate_refuses_missing_manifest(self) -> None:
+        (self.source / "manifest.json").unlink()
+        with self.assertRaises(LadderBundleIngestError):
+            validate_ladder_bundle(self.source)
+
+    def test_ingest_copies_bundle_and_runs_parity(self) -> None:
+        destination = self.root / "dest"
+        report = ingest_ladder_bundle(self.source, destination)
+        self.assertTrue((destination / "s18-rung.json").is_file())
+        self.assertEqual(report["parity_comparisons"], 1)
+
+
+class ParityGateHarnessAuthorityTests(unittest.TestCase):
+    def test_harness_authority_met_after_ingested_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_name:
+            base = Path(temp_name)
+            fixtures = base / "fixtures" / "parity"
+            shutil.copytree(workspace_root() / "fixtures" / "parity", fixtures)
+            source = base / "bundle-source"
+            source.mkdir()
+            rung = json.loads(
+                (workspace_root() / "fixtures" / "parity" / "rung" / "s18-pass.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            bundle = fixtures / "ladder-bundle"
+            (bundle / "manifest.json").write_text(json.dumps(manifest()) + "\n", encoding="utf-8")
+            (bundle / "teardown-inventory.json").write_text(
+                json.dumps(teardown_inventory()) + "\n", encoding="utf-8"
+            )
+            (bundle / "s18-rung.json").write_text(json.dumps(rung) + "\n", encoding="utf-8")
+
+            status = parity_gate_status(base)
+            harness = next(
+                row
+                for row in status["criteria"]
+                if row["name"] == "harness_authoritative_after_ladder_comparison"
+            )
+            self.assertTrue(harness["met"])
+            self.assertIsNone(harness["blocked_by"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_parity_gate.py
+++ b/benchmarks/tests/test_parity_gate.py
@@ -23,6 +23,10 @@ class ParityGateTests(unittest.TestCase):
         }
         self.assertIn("harness_authoritative_after_ladder_comparison", blocked)
         self.assertEqual(blocked["harness_authoritative_after_ladder_comparison"], "#900")
+        self.assertEqual(
+            blocked["legacy_orchestration_retired_with_coverage"],
+            "parity_matrix_no_unexplained_gaps + harness_authoritative",
+        )
 
     def test_historical_evidence_criterion_met(self) -> None:
         status = parity_gate_status()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares the #959 post-#900 workflow:

- `graphforge_bench.ladder_bundle_ingest` validates completed #900 output (manifest, `sN-rung.json`, teardown inventory) against checked-in schemas and optionally copies it into `fixtures/parity/ladder-bundle/`.
- `make -C benchmarks ingest-ladder-bundle SOURCE=...` runs the ingest path; `VALIDATE_ONLY=1` validates without copying.
- Fixes `parity_gate`: `harness_authoritative_after_ladder_comparison` now turns green when ingested ladder bundles pass parity comparison; legacy retirement criterion reports a distinct blocker once ladder parity is green.

## Testing

```bash
cd benchmarks
PYTHONPATH=harness uv run --locked python -m unittest tests.test_ladder_bundle_ingest tests.test_parity_gate
make parity-gate  # still blocked until real #900 bundles ingested
```

## Related issues

- Supports #959 (ingest + parity gate accuracy)
- Blocked on #900 for real bundle content — **does not close #959**

Part of epic #952.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790814920&installation_model_id=20486&pr_number=1056&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1056&signature=1f69ecfb079fe1a9c02ef5974e9afd27b46d14638100db1dfc296e8e1d40c6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->