### PR TITLE
fix(bench): resolve Fly build dockerfile path doubling (#900)

### DIFF
--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -545,6 +545,19 @@ def pin_remote_image(app: str, digest: str) -> str:
     return image
 
 
+def extract_pushed_image_digest(stdout: str, *, app: str, commit: str) -> str | None:
+    """Return the digest flyctl printed for one commit-pinned build-only push."""
+    marker = f"registry.fly.io/{app}:{commit}@sha256:"
+    for line in reversed(stdout.splitlines()):
+        index = line.find(marker)
+        if index == -1:
+            continue
+        digest = line[index + len(marker) : index + len(marker) + 64]
+        if re.fullmatch(r"[0-9a-f]{64}", digest) is not None:
+            return f"sha256:{digest}"
+    return None
+
+
 def accepted_rung_reclamation(
     *,
     accepted_rung: int,

--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -289,6 +289,10 @@ def image_build_command(
         not all(path.is_absolute() for path in (source, config, dockerfile)),
         "build paths must be absolute",
     )
+    _refuse(
+        dockerfile.resolve() != (config.parent / dockerfile.name).resolve(),
+        "dockerfile must live beside the build config",
+    )
     builder_flag = "--remote-only" if authority == "provider" else "--local-only"
     return Command(
         "image_build",
@@ -300,8 +304,6 @@ def image_build_command(
             app,
             "--config",
             str(config),
-            "--dockerfile",
-            str(dockerfile),
             builder_flag,
             "--build-only",
             "--push",

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -883,7 +883,9 @@ def execute(
                 cause=classify_provider_build_failure(error),
             ) from None
         digest = extract_pushed_image_digest(
-            completed.stdout, app=invocation.app, commit=invocation.commit
+            completed.stdout + completed.stderr,
+            app=invocation.app,
+            commit=invocation.commit,
         )
         if digest is None:
             image = transport.resolve_image(

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -29,6 +29,7 @@ from graphforge_bench.fly_adapter import (
     AdapterError,
     ResourceLedger,
     classify_provider_build_failure,
+    extract_pushed_image_digest,
     image_build_command,
     pin_remote_image,
     sanitized_failure,
@@ -874,16 +875,22 @@ def execute(
             authority=invocation.build_authority,
         )
         try:
-            transport.run(build.argv, timeout=BUILD_TIMEOUT_SECONDS)
+            completed = transport.run(build.argv, timeout=BUILD_TIMEOUT_SECONDS)
         except (subprocess.SubprocessError, OSError) as error:
             raise QualificationError(
                 "build_failed",
                 "remote provider build failed",
                 cause=classify_provider_build_failure(error),
             ) from None
-        image = transport.resolve_image(
-            invocation.app, invocation.commit, timeout=CREATE_TIMEOUT_SECONDS
+        digest = extract_pushed_image_digest(
+            completed.stdout, app=invocation.app, commit=invocation.commit
         )
+        if digest is None:
+            image = transport.resolve_image(
+                invocation.app, invocation.commit, timeout=CREATE_TIMEOUT_SECONDS
+            )
+        else:
+            image = pin_remote_image(invocation.app, digest)
         ledger.image_digest = image
         _save_ledger(ledger_path, ledger)
 

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -84,7 +84,7 @@ class FlyAdapterTests(unittest.TestCase):
         self.assertIn("--push", command.argv)
         self.assertEqual(command.argv[command.argv.index("--app") + 1], "gf-fixture")
         self.assertEqual(command.argv[command.argv.index("--config") + 1], "/repo/fly.build.toml")
-        self.assertEqual(command.argv[command.argv.index("--dockerfile") + 1], "/repo/Dockerfile")
+        self.assertNotIn("--dockerfile", command.argv)
         self.assertNotIn("--local-only", command.argv)
         self.assertIn("GRAPHFORGE_COMMIT=" + "a" * 40, command.argv)
         self.assertEqual(pin_remote_image("gf-fixture", "sha256:" + "c" * 64), attempt().image)

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -16,6 +16,7 @@ from graphforge_bench.fly_adapter import (
     accepted_rung_reclamation,
     classify_provider_build_failure,
     cleanup_commands,
+    extract_pushed_image_digest,
     image_build_command,
     inventory_commands,
     pin_remote_image,
@@ -88,6 +89,20 @@ class FlyAdapterTests(unittest.TestCase):
         self.assertNotIn("--local-only", command.argv)
         self.assertIn("GRAPHFORGE_COMMIT=" + "a" * 40, command.argv)
         self.assertEqual(pin_remote_image("gf-fixture", "sha256:" + "c" * 64), attempt().image)
+        stdout = (
+            "#15 pushing manifest for registry.fly.io/gf-fixture:"
+            + "a" * 40
+            + "@sha256:"
+            + "c" * 64
+            + " 0.1s done"
+        )
+        self.assertEqual(
+            extract_pushed_image_digest(stdout, app="gf-fixture", commit="a" * 40),
+            "sha256:" + "c" * 64,
+        )
+        self.assertIsNone(
+            extract_pushed_image_digest("no digest here", app="gf-fixture", commit="a" * 40)
+        )
         with self.assertRaisesRegex(AdapterError, "immutable"):
             pin_remote_image("gf-fixture", "latest")
         with self.assertRaisesRegex(AdapterError, "absolute"):

--- a/benchmarks/tests/test_fly_tiny_qualification.py
+++ b/benchmarks/tests/test_fly_tiny_qualification.py
@@ -395,7 +395,7 @@ class FlyTinyQualificationTests(unittest.TestCase):
         config = tomllib.loads(config_path.read_text(encoding="utf-8"))
         self.assertEqual(
             config,
-            {"build": {"dockerfile": "containers/fly-filesystem-qualification/Dockerfile"}},
+            {"build": {"dockerfile": "Dockerfile"}},
         )
         self.assertNotIn("app", config)
         self.assertNotIn("services", config)
@@ -464,7 +464,7 @@ class FlyTinyQualificationTests(unittest.TestCase):
             )
             self.assertEqual(deploy[deploy.index("--app") + 1], APP)
             self.assertTrue(Path(deploy[deploy.index("--config") + 1]).is_absolute())
-            self.assertTrue(Path(deploy[deploy.index("--dockerfile") + 1]).is_absolute())
+            self.assertNotIn("--dockerfile", deploy)
             self.assertIn("--build-only", deploy)
             self.assertIn("--push", deploy)
             self.assertIn("--no-public-ips", deploy)

--- a/containers/fly-filesystem-qualification/fly.build.toml
+++ b/containers/fly-filesystem-qualification/fly.build.toml
@@ -2,4 +2,4 @@
 # exclusively through `flyctl deploy --app` at runtime.
 
 [build]
-dockerfile = "containers/fly-filesystem-qualification/Dockerfile"
+dockerfile = "Dockerfile"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes Fly remote build and image pinning for fly-tiny qualification and the progressive ladder (#900 control plane).

## Changes

1. **Dockerfile path doubling** — `fly.build.toml` now uses `dockerfile = "Dockerfile"` beside the config; removed redundant `--dockerfile` CLI flag that doubled paths.
2. **Digest extraction** — Parse immutable digest from `flyctl deploy` stderr (build-only pushes are not visible via registry v2 manifest API with `flyctl auth token`).
3. **Validation** — Require Dockerfile to live beside the build config.

## Testing

```bash
cd benchmarks && PYTHONPATH=harness uv run python -m unittest tests.test_fly_adapter tests.test_fly_tiny_qualification
# 36 tests OK

# Manual remote build + live fly-tiny:
# - Remote build succeeds (cached ~3s, uncached ~16min)
# - Live fly-tiny now passes build phase (provision phase reached; further Fly provisioning tracked under #900)
```

Relates to #900. Does not close #900 — ladder execution and spend authorization still required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790819446&installation_model_id=20486&pr_number=1058&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1058&signature=47b92b0ac9dc24d94bd7736e217d2829a01aff9e9e8399ae815bbf602c4eea32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Fly build dockerfile path doubling and pin pushed image digest
> - Removes the `--dockerfile` flag from the `flyctl deploy` command in `image_build_command` and adds a refusal check ensuring the dockerfile sits beside the build config, fixing the path-doubling bug
> - Changes `fly.build.toml` dockerfile value from `containers/fly-filesystem-qualification/Dockerfile` to `Dockerfile`
> - Adds `extract_pushed_image_digest` helper to parse a `sha256` digest from flyctl output; `fly_tiny_qualification.execute` now pins the exact digest when available, falling back to tag resolution otherwise
> - Risk: `image_build_command` now raises `AdapterError` if the dockerfile is not located in the same directory as the build config
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 985e6bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->