### PR TITLE
fix(bench): use commit tag and backoff for flyctl machine run (#900)

### DIFF
--- a/benchmarks/harness/graphforge_bench/fly_adapter.py
+++ b/benchmarks/harness/graphforge_bench/fly_adapter.py
@@ -545,6 +545,15 @@ def pin_remote_image(app: str, digest: str) -> str:
     return image
 
 
+def machine_run_image_ref(pinned_image: str, commit: str) -> str:
+    """Return the flyctl machine-run ref for one commit-pinned build-only push."""
+    _refuse(COMMIT.fullmatch(commit) is None, "build commit is invalid")
+    _refuse(not OCI_DIGEST.fullmatch(pinned_image), "pinned image is invalid")
+    app = pinned_image.removeprefix("registry.fly.io/").rsplit("@", 1)[0]
+    _refuse(not SAFE_NAME.fullmatch(app), "app name is invalid")
+    return f"registry.fly.io/{app}:{commit}"
+
+
 def extract_pushed_image_digest(stdout: str, *, app: str, commit: str) -> str | None:
     """Return the digest flyctl printed for one commit-pinned build-only push."""
     marker = f"registry.fly.io/{app}:{commit}@sha256:"

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -31,6 +31,7 @@ from graphforge_bench.fly_adapter import (
     classify_provider_build_failure,
     extract_pushed_image_digest,
     image_build_command,
+    machine_run_image_ref,
     pin_remote_image,
     sanitized_failure,
 )
@@ -476,11 +477,12 @@ def verify_machine_state(
 def _machine_command(
     invocation: TinyQualificationInvocation, *, image: str, volume_id: str
 ) -> tuple[str, ...]:
+    digest = image.rsplit("@", 1)[1]
     return (
         "flyctl",
         "machine",
         "run",
-        image,
+        machine_run_image_ref(image, invocation.commit),
         "--app",
         invocation.app,
         "--name",
@@ -494,7 +496,7 @@ def _machine_command(
         "--env",
         f"GF_FLY_QUALIFICATION_GIT_SHA={invocation.commit}",
         "--env",
-        f"GF_FLY_QUALIFICATION_IMAGE_DIGEST={image.rsplit('@', 1)[1]}",
+        f"GF_FLY_QUALIFICATION_IMAGE_DIGEST={digest}",
         "--env",
         f"GF_FLY_QUALIFICATION_REGION={invocation.region}",
         "--restart",

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -57,6 +57,9 @@ APP_READINESS_TIMEOUT_SECONDS = 60
 APP_READINESS_PROBE_TIMEOUT_SECONDS = 5
 APP_READINESS_INITIAL_BACKOFF_SECONDS = 0.25
 APP_READINESS_MAX_BACKOFF_SECONDS = 2.0
+IMAGE_LAUNCH_INITIAL_BACKOFF_SECONDS = 2.0
+IMAGE_LAUNCH_MAX_BACKOFF_SECONDS = 15.0
+IMAGE_LAUNCH_ATTEMPTS = 6
 TEARDOWN_POLL_ATTEMPTS = 6
 TEARDOWN_POLL_INTERVAL_SECONDS = 2
 
@@ -512,6 +515,37 @@ def _machine_command(
     )
 
 
+def _image_launch_retryable(error: subprocess.CalledProcessError) -> bool:
+    text = "\n".join(
+        fragment
+        for fragment in (
+            getattr(error, "stdout", None),
+            getattr(error, "stderr", None),
+        )
+        if isinstance(fragment, str)
+    ).lower()
+    return "manifest_unknown" in text or "manifest unknown" in text
+
+
+def _run_machine_with_backoff(
+    transport: Transport,
+    argv: tuple[str, ...],
+    *,
+    timeout: int,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> subprocess.CompletedProcess[str]:
+    backoff = IMAGE_LAUNCH_INITIAL_BACKOFF_SECONDS
+    for attempt in range(IMAGE_LAUNCH_ATTEMPTS):
+        try:
+            return transport.run(argv, timeout=timeout)
+        except subprocess.CalledProcessError as error:
+            if not _image_launch_retryable(error) or attempt + 1 >= IMAGE_LAUNCH_ATTEMPTS:
+                raise
+            sleeper(backoff)
+            backoff = min(backoff * 2, IMAGE_LAUNCH_MAX_BACKOFF_SECONDS)
+    raise QualificationError("provision_failed", "pushed image is not launchable yet")
+
+
 def _validate_evidence(path: Path, invocation: TinyQualificationInvocation, image: str) -> None:
     spec = importlib.util.spec_from_file_location("fly_evidence_validator", VALIDATOR)
     if spec is None or spec.loader is None:
@@ -922,7 +956,8 @@ def execute(
         ledger.volume_id = _single_volume_id(volume)
         _save_ledger(ledger_path, ledger)
 
-        transport.run(
+        _run_machine_with_backoff(
+            transport,
             _machine_command(invocation, image=image, volume_id=ledger.volume_id),
             timeout=CREATE_TIMEOUT_SECONDS,
         )

--- a/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
+++ b/benchmarks/harness/graphforge_bench/fly_tiny_qualification.py
@@ -536,13 +536,19 @@ def _run_machine_with_backoff(
 ) -> subprocess.CompletedProcess[str]:
     backoff = IMAGE_LAUNCH_INITIAL_BACKOFF_SECONDS
     for attempt in range(IMAGE_LAUNCH_ATTEMPTS):
-        try:
-            return transport.run(argv, timeout=timeout)
-        except subprocess.CalledProcessError as error:
-            if not _image_launch_retryable(error) or attempt + 1 >= IMAGE_LAUNCH_ATTEMPTS:
-                raise
-            sleeper(backoff)
-            backoff = min(backoff * 2, IMAGE_LAUNCH_MAX_BACKOFF_SECONDS)
+        completed = transport.run(argv, timeout=timeout, check=False)
+        if completed.returncode == 0:
+            return completed
+        error = subprocess.CalledProcessError(
+            completed.returncode,
+            argv,
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
+        if not _image_launch_retryable(error) or attempt + 1 >= IMAGE_LAUNCH_ATTEMPTS:
+            raise error
+        sleeper(backoff)
+        backoff = min(backoff * 2, IMAGE_LAUNCH_MAX_BACKOFF_SECONDS)
     raise QualificationError("provision_failed", "pushed image is not launchable yet")
 
 

--- a/benchmarks/harness/graphforge_bench/progressive_fly_transport.py
+++ b/benchmarks/harness/graphforge_bench/progressive_fly_transport.py
@@ -20,6 +20,7 @@ from typing import Any, Protocol
 import urllib.error
 import urllib.request
 
+from graphforge_bench.fly_adapter import machine_run_image_ref
 from graphforge_bench.progressive_provider_attempt import (
     AttemptError,
     AttemptInvocation,
@@ -629,7 +630,7 @@ class FlyProviderTransport:
                 "flyctl",
                 "machine",
                 "run",
-                authorization.image_digest,
+                machine_run_image_ref(authorization.image_digest, authorization.commit),
                 lifetime,
                 "--app",
                 authorization.app,

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -19,6 +19,7 @@ from graphforge_bench.fly_adapter import (
     extract_pushed_image_digest,
     image_build_command,
     inventory_commands,
+    machine_run_image_ref,
     pin_remote_image,
     provisioning_commands,
     remote_build_command,
@@ -89,6 +90,11 @@ class FlyAdapterTests(unittest.TestCase):
         self.assertNotIn("--local-only", command.argv)
         self.assertIn("GRAPHFORGE_COMMIT=" + "a" * 40, command.argv)
         self.assertEqual(pin_remote_image("gf-fixture", "sha256:" + "c" * 64), attempt().image)
+        pinned = pin_remote_image("gf-fixture", "sha256:" + "c" * 64)
+        self.assertEqual(
+            machine_run_image_ref(pinned, "a" * 40),
+            "registry.fly.io/gf-fixture:" + "a" * 40,
+        )
         stdout = (
             "#15 pushing manifest for registry.fly.io/gf-fixture:"
             + "a" * 40

--- a/benchmarks/tests/test_progressive_fly_transport.py
+++ b/benchmarks/tests/test_progressive_fly_transport.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+from graphforge_bench.fly_adapter import machine_run_image_ref
 from graphforge_bench.progressive_fly_transport import (
     FlyctlMachineBoundary,
     FlyProviderTransport,
@@ -183,7 +184,7 @@ class ProgressiveFlyTransportTests(unittest.TestCase):
                 "flyctl",
                 "machine",
                 "run",
-                IMAGE,
+                machine_run_image_ref(IMAGE, self.auth.commit),
                 str(self.auth.maximum_machine_seconds),
                 "--app",
                 APP,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes fly-tiny qualification and progressive-ladder machine provisioning after build-only image pushes.

## Root cause

1. **Wrong machine-run ref** — `flyctl machine run` rejects `registry.fly.io/app@sha256:digest` (invalid/doubled identifier). Build-only pushes are launchable via commit tag `registry.fly.io/app:commit`.
2. **Manifest propagation delay** — Immediately after push, machine run can fail with `MANIFEST_UNKNOWN` until the registry manifest is launchable (~15s).

## Changes

- Add `machine_run_image_ref()` to translate pinned `@sha256` identities to commit tags for `flyctl machine run` only; evidence/ledger keep immutable digest form.
- Apply in `fly_tiny_qualification` and `progressive_fly_transport`.
- Retry machine run with bounded exponential backoff on manifest-unknown errors.

## Testing

```bash
cd benchmarks && PYTHONPATH=harness uv run python -m unittest \
  tests.test_fly_adapter tests.test_fly_tiny_qualification tests.test_progressive_fly_transport
# 58 tests OK

# Live fly-tiny under ESC (main + this branch):
pulumi env run curatelabs/graphforge/qualification -- \
  env PYTHONPATH=benchmarks/harness python -m graphforge_bench.fly_tiny_qualification \
  ... --execute --confirm-disposable
# {"status": "passed", "failure": null}
# evidence.result = "qualified"
```

Relates to #900.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790826043&installation_model_id=20486&pr_number=1059&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1059&signature=4d9bb4e3d4e6e003eb507a2232c85966e5d621178fa6d52dd220481e792063f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use commit tag refs and retry backoff for `flyctl machine run`
> - Adds `machine_run_image_ref` helper in [fly_adapter.py](https://github.com/CurateLabs/graphforge/pull/1059/files#diff-df8e52bf2a2ef6f3846ee78480ad2e080703b2c052aed1a64aa9f79f82c67802) that converts a digest-pinned image and commit into a `registry.fly.io/{app}:{commit}` tag ref after validating inputs
> - Updates `flyctl machine run` invocations in [fly_tiny_qualification.py](https://github.com/CurateLabs/graphforge/pull/1059/files#diff-6c552ab18d97786979876e444e100747d22f99925a1d38e18154ee4269921a7b) and [progressive_fly_transport.py](https://github.com/CurateLabs/graphforge/pull/1059/files#diff-0bb5fb9cf7ebc6298dc09d4a8467db0f655688e8cdce0738a025d2a0f4eaa6d7) to pass the tag ref instead of the `@sha256:` digest ref; the digest is still exported via `GF_FLY_QUALIFICATION_IMAGE_DIGEST`
> - Adds `_run_machine_with_backoff` in [fly_tiny_qualification.py](https://github.com/CurateLabs/graphforge/pull/1059/files#diff-6c552ab18d97786979876e444e100747d22f99925a1d38e18154ee4269921a7b) which retries machine launches on `manifest_unknown` errors with exponential backoff (2s–15s, up to 6 attempts) before failing
> - Risk: tag refs are mutable, so a re-pushed tag could resolve to a different digest than the one recorded in `GF_FLY_QUALIFICATION_IMAGE_DIGEST`; reviewers should confirm the commit tag is never overwritten in the registry
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42a40d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->