### PR TITLE
fix(bench): admit hybrid cgroup v2 on Fly Machines (#900)

### DIFF
--- a/benchmarks/harness/graphforge_bench/local_admission.py
+++ b/benchmarks/harness/graphforge_bench/local_admission.py
@@ -29,6 +29,11 @@ REQUIRED_METRICS = (
     "pressure-memory-some",
 )
 REQUIRED_CONTROLLERS = ("cpu", "io", "memory")
+CONTROLLER_INTERFACE_FILES = {
+    "cpu": ("cpu.stat", "cpu.max", "cpu.weight"),
+    "io": ("io.stat", "io.max", "io.pressure"),
+    "memory": ("memory.current", "memory.max", "memory.stat", "memory.pressure"),
+}
 
 
 @dataclass(frozen=True)
@@ -56,17 +61,28 @@ def _resolve_cgroup_v2_root(cgroup_root: Path) -> Path | None:
     return None
 
 
+def _available_controllers(resolved: Path) -> set[str]:
+    """Return cgroup v2 controllers declared or already active in this cgroup."""
+    try:
+        declared = set(resolved.joinpath("cgroup.controllers").read_text(encoding="utf-8").split())
+    except OSError:
+        declared = set()
+    if declared:
+        return declared
+    return {
+        name
+        for name, interface_files in CONTROLLER_INTERFACE_FILES.items()
+        if any(resolved.joinpath(filename).exists() for filename in interface_files)
+    }
+
+
 def _facts(
     system: str,
     cgroup_root: Path = Path("/sys/fs/cgroup"),
 ) -> dict[str, object]:
     linux = system == "Linux"
     resolved = _resolve_cgroup_v2_root(cgroup_root) if linux else None
-    controllers = (
-        set((resolved / "cgroup.controllers").read_text(encoding="utf-8").split())
-        if resolved is not None
-        else set()
-    )
+    controllers = _available_controllers(resolved) if resolved is not None else set()
     release = platform.release() if linux else ""
     try:
         major, minor = (int(part) for part in release.split("-", 1)[0].split(".")[:2])

--- a/benchmarks/harness/graphforge_bench/local_admission.py
+++ b/benchmarks/harness/graphforge_bench/local_admission.py
@@ -46,14 +46,25 @@ def _run(command: Sequence[str]) -> CommandResult:
     return CommandResult(completed.returncode, completed.stdout, completed.stderr)
 
 
+def _resolve_cgroup_v2_root(cgroup_root: Path) -> Path | None:
+    """Return the unified cgroup v2 mount root, including hybrid v1 layouts."""
+    if (cgroup_root / "cgroup.controllers").is_file():
+        return cgroup_root
+    unified = cgroup_root / "unified"
+    if (unified / "cgroup.controllers").is_file():
+        return unified
+    return None
+
+
 def _facts(
     system: str,
     cgroup_root: Path = Path("/sys/fs/cgroup"),
 ) -> dict[str, object]:
     linux = system == "Linux"
+    resolved = _resolve_cgroup_v2_root(cgroup_root) if linux else None
     controllers = (
-        set((cgroup_root / "cgroup.controllers").read_text(encoding="utf-8").split())
-        if linux and (cgroup_root / "cgroup.controllers").is_file()
+        set((resolved / "cgroup.controllers").read_text(encoding="utf-8").split())
+        if resolved is not None
         else set()
     )
     release = platform.release() if linux else ""
@@ -63,7 +74,7 @@ def _facts(
         major, minor = (0, 0)
     return {
         "operating_system": system.lower(),
-        "cgroups_version": 2 if linux and (cgroup_root / "cgroup.controllers").is_file() else None,
+        "cgroups_version": 2 if resolved is not None else None,
         "required_controllers": all(name in controllers for name in REQUIRED_CONTROLLERS),
         "kernel_memory_accounting": linux and (major, minor) >= (5, 19),
         "privileged_execution": linux and os.geteuid() == 0,

--- a/benchmarks/tests/test_local_admission.py
+++ b/benchmarks/tests/test_local_admission.py
@@ -73,16 +73,22 @@ class LocalAdmissionTests(unittest.TestCase):
             hybrid = root / "cgroup"
             unified = hybrid / "unified"
             unified.mkdir(parents=True)
-            (unified / "cgroup.controllers").write_text("cpu io memory", encoding="utf-8")
+            (unified / "cgroup.controllers").write_text("", encoding="utf-8")
+            (unified / "cpu.stat").write_text("", encoding="utf-8")
+            (unified / "io.pressure").write_text("", encoding="utf-8")
+            (unified / "memory.pressure").write_text("", encoding="utf-8")
             proc = root / "proc"
             namespace = proc / "self/ns"
             namespace.mkdir(parents=True)
             for name in ("mnt", "pid", "user"):
                 (namespace / name).touch()
-            with patch("graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"):
+            with patch(
+                "graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"
+            ):
                 result = qualify_local_host(system="Linux", cgroup_root=hybrid, runner=runner)
         self.assertEqual(result["result"], "passed")
         self.assertEqual(result["facts"]["cgroups_version"], 2)
+        self.assertTrue(result["facts"]["required_controllers"])
 
     def test_package_preflight_reports_missing_cpuset_delegation(self) -> None:
         def runner(_command):

--- a/benchmarks/tests/test_local_admission.py
+++ b/benchmarks/tests/test_local_admission.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from graphforge_bench.local_admission import CommandResult, exit_code, qualify_local_host
 from graphforge_bench.local_admission_fixture import _parse_runexec_value
@@ -46,6 +47,42 @@ class LocalAdmissionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             result = qualify_local_host(system="Linux", cgroup_root=Path(directory))
         self.assertEqual(result["cause"], "cgroups_v2_unavailable")
+
+    def test_hybrid_cgroup_layout_uses_unified_v2_root(self) -> None:
+        def runner(command):
+            if "benchexec.check_cgroups" in command:
+                return CommandResult(0, "", "")
+            measurements = {
+                "walltime": 1.0,
+                "cputime": 0.1,
+                "memory": 1048576,
+                "blkio-read": 4096,
+                "blkio-write": 65536,
+                "pressure-cpu-some": 0.0,
+                "pressure-io-some": 0.0,
+                "pressure-memory-some": 0.0,
+                "terminationreason": "walltime",
+                "descendant_stopped": True,
+                "namespace_isolation": True,
+                "overlay_isolation": True,
+            }
+            return CommandResult(0, json.dumps(measurements), "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            hybrid = root / "cgroup"
+            unified = hybrid / "unified"
+            unified.mkdir(parents=True)
+            (unified / "cgroup.controllers").write_text("cpu io memory", encoding="utf-8")
+            proc = root / "proc"
+            namespace = proc / "self/ns"
+            namespace.mkdir(parents=True)
+            for name in ("mnt", "pid", "user"):
+                (namespace / name).touch()
+            with patch("graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"):
+                result = qualify_local_host(system="Linux", cgroup_root=hybrid, runner=runner)
+        self.assertEqual(result["result"], "passed")
+        self.assertEqual(result["facts"]["cgroups_version"], 2)
 
     def test_package_preflight_reports_missing_cpuset_delegation(self) -> None:
         def runner(_command):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Fly Machine local BenchExec admission for issue #900 S18/S19 execution.

Fly Machines use a hybrid cgroup layout: v2 lives under `/sys/fs/cgroup/unified/` rather than the pure-v2 root, and `cgroup.controllers` can be empty even when cpu/io/memory interface files are present.

## Changes

1. **`_resolve_cgroup_v2_root()`** — detect pure v2 or hybrid `unified/` mount (original #1063 scope)
2. **`_available_controllers()`** — when `cgroup.controllers` is empty, infer required controllers from active interface files (`cpu.stat`, `io.pressure`, `memory.pressure`, etc.)
3. **Tests** — hybrid layout test updated to match Fly's empty-controllers behavior

## Verification

- `PYTHONPATH=harness uv run --locked python -m unittest tests.test_local_admission` — 12 passed
- `uv run ruff format --check benchmarks/` — clean
- `uv run ruff check benchmarks/` — clean

Closes #900 (partial — admission blocker for S18/S19 Fly execution).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790833652&installation_model_id=20486&pr_number=1063&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1063&signature=fef0c7fbf9e73c65285465a5b81e8284762438569a558e56aa45d54774bbb69e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cgroup v2 detection in hybrid layouts for `local_admission` benchmark harness
> - Adds `_resolve_cgroup_v2_root` to find the unified cgroup v2 mount root, checking `cgroup_root/unified` when the top-level root lacks `cgroup.controllers`.
> - Adds `_available_controllers` which reads `cgroup.controllers` first, then falls back to checking for known controller interface files (`cpu.stat`, `io.max`, `memory.pressure`, etc.) via the new `CONTROLLER_INTERFACE_FILES` map.
> - Updates `_facts` in [local_admission.py](https://github.com/CurateLabs/graphforge/pull/1063/files#diff-b9b7a01af146bc382daecd56c01eb180dc3d870e1a70a9dd5bf2fcf6954a70ca) to use both helpers, so hybrid v2 layouts on Fly Machines report `cgroups_version=2` and `required_controllers=True` instead of failing qualification.
> - Adds a test in [test_local_admission.py](https://github.com/CurateLabs/graphforge/pull/1063/files#diff-2148f3f4e2bc3a58edaa9815bc4ecfd30bec2988c65bf6d21bedd7618200d175) that constructs a hybrid layout with empty `cgroup.controllers` but present interface files, patched to a 6.x kernel.
> - Risk: `_facts` now infers controller availability from interface file existence when `cgroup.controllers` is empty or unreadable; environments where interface files exist but a controller is not actually enabled may incorrectly report `required_controllers=True`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2562fef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->