### PR TITLE
fix(bench): install fuse-overlayfs for BenchExec on Fly (#900)

### DIFF
--- a/containers/graphforge-progressive-qualification/Dockerfile
+++ b/containers/graphforge-progressive-qualification/Dockerfile
@@ -24,6 +24,9 @@ FROM python:3.12.11-slim-bookworm@sha256:519591d6871b7bc437060736b9f7456b8731f14
 
 ENV UV_LINK_MODE=copy
 WORKDIR /opt/graphforge/benchmarks
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends fuse-overlayfs \
+    && rm -rf /var/lib/apt/lists/*
 RUN python -m pip install --no-cache-dir "uv==0.11.33"
 COPY benchmarks/pyproject.toml benchmarks/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
@@ -33,12 +36,12 @@ FROM python:3.12.11-slim-bookworm@sha256:519591d6871b7bc437060736b9f7456b8731f14
 
 ARG GRAPHFORGE_COMMIT
 LABEL org.opencontainers.image.revision="${GRAPHFORGE_COMMIT}"
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends fuse-overlayfs \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /opt/graphforge /work \
+RUN mkdir -p /opt/graphforge /work \
     && chown 10001:10001 /work \
     && chmod 0755 /work
+
+COPY --from=python-deps /usr/bin/fuse-overlayfs /usr/bin/fuse-overlayfs
+COPY --from=python-deps /lib/x86_64-linux-gnu/libfuse3.so.3 /lib/x86_64-linux-gnu/libfuse3.so.3
 
 COPY --from=rust-build /source/target/release/gf /usr/local/bin/gf
 COPY --from=rust-build /source/benchmarks/target/release/graphforge-benchmark-certify \

--- a/containers/graphforge-progressive-qualification/Dockerfile
+++ b/containers/graphforge-progressive-qualification/Dockerfile
@@ -33,7 +33,10 @@ FROM python:3.12.11-slim-bookworm@sha256:519591d6871b7bc437060736b9f7456b8731f14
 
 ARG GRAPHFORGE_COMMIT
 LABEL org.opencontainers.image.revision="${GRAPHFORGE_COMMIT}"
-RUN mkdir -p /opt/graphforge /work \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends fuse-overlayfs \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /opt/graphforge /work \
     && chown 10001:10001 /work \
     && chmod 0755 /work
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

BenchExec `runexec` requires `fuse-overlayfs` to create overlay mounts for container isolation. On Fly Machines the qualification container previously lacked this package, causing:

```
Failed to create overlay mount for '/': Invalid argument.
Please either install version 1.10 or higher of fuse-overlayfs...
```

This blocked local admission and S18/S19 progressive runs after the cgroup fixes in #1063.

## Change

Install `fuse-overlayfs` in the progressive qualification image via `apt-get` in the Dockerfile.

## Verification

Live probe on Fly machine `865116be1d5d08` after manual `apt-get install fuse-overlayfs`:

```
runexec --walltimelimit 1 -- /bin/echo hello
→ returnvalue=0, walltime=0.03s, memory=2666496B, blkio-read=0B, blkio-write=0B
```

Without the package, the same command failed with overlay mount error.

## Related

- #900 S18/S26 ladder execution
- #1063 hybrid cgroup v2 admission (merged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790837322&installation_model_id=20486&pr_number=1064&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1064&signature=d8a5994df62a20a3b56e901fcea836bff060f380850cf40a727fd9e702eb1b53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install `fuse-overlayfs` in BenchExec Fly container image
> Adds `fuse-overlayfs` to the `python-deps` stage via `apt-get` and copies both `/usr/bin/fuse-overlayfs` and `/lib/x86_64-linux-gnu/libfuse3.so.3` into the final qualification stage in [Dockerfile](https://github.com/CurateLabs/graphforge/pull/1064/files#diff-e80e651af7e28051232a5843d31b4eb0c2eb9cf4da8be06fb5286b3900a6b54d). This makes the `fuse-overlayfs` executable available at runtime for BenchExec.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b8944f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->