### PR TITLE
fix(bench): hybrid PSI pressure and BenchExec CLI for Fly S18 (#900)

### DIFF
--- a/benchmarks/harness/graphforge_bench/hybrid_cgroup_v2.py
+++ b/benchmarks/harness/graphforge_bench/hybrid_cgroup_v2.py
@@ -9,10 +9,10 @@ unified PSI files around a BenchExec invocation.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, TypeVar
+from typing import TypeVar
 
 T = TypeVar("T")
 
@@ -107,10 +107,7 @@ def read_unified_pressure_totals(*, unified_root: Path) -> dict[str, float]:
 def hybrid_pressure_deltas(
     before: Mapping[str, float], after: Mapping[str, float]
 ) -> dict[str, float]:
-    return {
-        key: max(0.0, after.get(key, 0.0) - before.get(key, 0.0))
-        for key in PRESSURE_KEYS
-    }
+    return {key: max(0.0, after.get(key, 0.0) - before.get(key, 0.0)) for key in PRESSURE_KEYS}
 
 
 @contextmanager
@@ -122,7 +119,7 @@ def measure_hybrid_pressure(
 
     unified_root = unified_v2_root(cgroup_root=cgroup_root)
     before = read_unified_pressure_totals(unified_root=unified_root)
-    deltas: dict[str, float] = {key: 0.0 for key in PRESSURE_KEYS}
+    deltas: dict[str, float] = dict.fromkeys(PRESSURE_KEYS, 0.0)
 
     def _result() -> dict[str, float]:
         return dict(deltas)

--- a/benchmarks/harness/graphforge_bench/hybrid_cgroup_v2.py
+++ b/benchmarks/harness/graphforge_bench/hybrid_cgroup_v2.py
@@ -1,0 +1,154 @@
+"""Hybrid cgroup accommodations for Fly Machines and similar hosts.
+
+Fly exposes cgroup v2 at ``/sys/fs/cgroup/unified`` while legacy v1 hierarchies
+remain mounted. BenchExec treats that as hybrid mode, executes with v1, and
+does not emit PSI pressure metrics even though the unified hierarchy exposes
+them. These helpers detect that layout and derive pressure totals from the
+unified PSI files around a BenchExec invocation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, TypeVar
+
+T = TypeVar("T")
+
+PRESSURE_KEYS = (
+    "pressure-cpu-some",
+    "pressure-io-some",
+    "pressure-memory-some",
+)
+_PSI_SUBSYSTEMS = {
+    "pressure-cpu-some": "cpu",
+    "pressure-io-some": "io",
+    "pressure-memory-some": "memory",
+}
+
+
+def cgroup_v1_mountpoints(*, mounts_path: Path = Path("/proc/mounts")) -> tuple[Path, ...]:
+    """Return mountpoints for legacy cgroup v1 hierarchies."""
+
+    mountpoints: list[Path] = []
+    for line in mounts_path.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == "cgroup":
+            mountpoints.append(Path(parts[1]))
+    return tuple(mountpoints)
+
+
+def has_cgroup_v2_mount(*, mounts_path: Path = Path("/proc/mounts")) -> bool:
+    for line in mounts_path.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == "cgroup2":
+            return True
+    return False
+
+
+def is_hybrid_cgroup_layout(
+    *,
+    cgroup_root: Path = Path("/sys/fs/cgroup"),
+    mounts_path: Path = Path("/proc/mounts"),
+) -> bool:
+    """Return whether the host exposes both v1 mounts and a unified v2 root."""
+
+    unified = cgroup_root / "unified"
+    return (
+        has_cgroup_v2_mount(mounts_path=mounts_path)
+        and bool(cgroup_v1_mountpoints(mounts_path=mounts_path))
+        and (unified / "cgroup.controllers").is_file()
+    )
+
+
+def benchexec_cgroup_version(*, mounts_path: Path = Path("/proc/mounts")) -> int | None:
+    """Mirror BenchExec's cgroup version selection from ``/proc/mounts``."""
+
+    version: int | None = None
+    for line in mounts_path.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        if parts[2] == "cgroup":
+            return 1
+        if parts[2] == "cgroup2" and version != 1:
+            version = 2
+    return version
+
+
+def unified_v2_root(*, cgroup_root: Path = Path("/sys/fs/cgroup")) -> Path:
+    return cgroup_root / "unified"
+
+
+def read_psi_total_seconds(pressure_file: Path) -> float:
+    """Return the ``some`` line ``total`` stall seconds from one PSI file."""
+
+    try:
+        contents = pressure_file.read_text(encoding="utf-8")
+    except OSError:
+        return 0.0
+    for line in contents.splitlines():
+        if not line.startswith("some "):
+            continue
+        for token in line.split():
+            if token.startswith("total="):
+                return int(token.split("=", 1)[1]) / 1_000_000_000
+    return 0.0
+
+
+def read_unified_pressure_totals(*, unified_root: Path) -> dict[str, float]:
+    return {
+        key: read_psi_total_seconds(unified_root / f"{subsystem}.pressure")
+        for key, subsystem in _PSI_SUBSYSTEMS.items()
+    }
+
+
+def hybrid_pressure_deltas(
+    before: Mapping[str, float], after: Mapping[str, float]
+) -> dict[str, float]:
+    return {
+        key: max(0.0, after.get(key, 0.0) - before.get(key, 0.0))
+        for key in PRESSURE_KEYS
+    }
+
+
+@contextmanager
+def measure_hybrid_pressure(
+    *,
+    cgroup_root: Path = Path("/sys/fs/cgroup"),
+) -> Iterator[Callable[[], dict[str, float]]]:
+    """Capture unified PSI totals around a BenchExec invocation on hybrid hosts."""
+
+    unified_root = unified_v2_root(cgroup_root=cgroup_root)
+    before = read_unified_pressure_totals(unified_root=unified_root)
+    deltas: dict[str, float] = {key: 0.0 for key in PRESSURE_KEYS}
+
+    def _result() -> dict[str, float]:
+        return dict(deltas)
+
+    try:
+        yield _result
+    finally:
+        after = read_unified_pressure_totals(unified_root=unified_root)
+        deltas.update(hybrid_pressure_deltas(before, after))
+
+
+def supplement_missing_pressure(
+    measurements: dict[str, object],
+    *,
+    cgroup_root: Path = Path("/sys/fs/cgroup"),
+) -> dict[str, object]:
+    """Fill hybrid PSI metrics when BenchExec v1 omitted optional pressure keys."""
+
+    if not is_hybrid_cgroup_layout(cgroup_root=cgroup_root):
+        return measurements
+    if benchexec_cgroup_version() != 1:
+        return measurements
+    missing = [key for key in PRESSURE_KEYS if key not in measurements]
+    if not missing:
+        return measurements
+    totals = read_unified_pressure_totals(unified_root=unified_v2_root(cgroup_root=cgroup_root))
+    for key in missing:
+        measurements[key] = totals.get(key, 0.0)
+    return measurements

--- a/benchmarks/harness/graphforge_bench/local_admission.py
+++ b/benchmarks/harness/graphforge_bench/local_admission.py
@@ -17,6 +17,8 @@ import platform
 import subprocess
 import sys
 
+from graphforge_bench.hybrid_cgroup_v2 import benchexec_cgroup_version, is_hybrid_cgroup_layout
+
 SCHEMA = "graphforge-local-admission-evidence/1"
 REQUIRED_METRICS = (
     "walltime",
@@ -88,6 +90,8 @@ def _facts(
         major, minor = (int(part) for part in release.split("-", 1)[0].split(".")[:2])
     except (TypeError, ValueError):
         major, minor = (0, 0)
+    benchexec_version = benchexec_cgroup_version() if linux else None
+    hybrid_layout = is_hybrid_cgroup_layout(cgroup_root=cgroup_root) if linux else False
     return {
         "operating_system": system.lower(),
         "cgroups_version": 2 if resolved is not None else None,
@@ -97,6 +101,8 @@ def _facts(
         "benchexec_cgroup_delegation": False,
         "namespace_isolation": False,
         "overlay_isolation": False,
+        "_benchexec_cgroups_version": benchexec_version,
+        "_hybrid_cgroup_layout": hybrid_layout,
     }
 
 
@@ -110,7 +116,11 @@ def _evidence(
         "schema": SCHEMA,
         "result": result,
         "cause": cause,
-        "facts": dict(facts),
+        "facts": {
+            key: value
+            for key, value in facts.items()
+            if not str(key).startswith("_")
+        },
     }
     if measurements is not None:
         document["measurements"] = dict(measurements)

--- a/benchmarks/harness/graphforge_bench/local_admission.py
+++ b/benchmarks/harness/graphforge_bench/local_admission.py
@@ -116,11 +116,7 @@ def _evidence(
         "schema": SCHEMA,
         "result": result,
         "cause": cause,
-        "facts": {
-            key: value
-            for key, value in facts.items()
-            if not str(key).startswith("_")
-        },
+        "facts": {key: value for key, value in facts.items() if not str(key).startswith("_")},
     }
     if measurements is not None:
         document["measurements"] = dict(measurements)

--- a/benchmarks/harness/graphforge_bench/local_admission_fixture.py
+++ b/benchmarks/harness/graphforge_bench/local_admission_fixture.py
@@ -9,6 +9,12 @@ import sys
 import tempfile
 import time
 
+from graphforge_bench.hybrid_cgroup_v2 import (
+    benchexec_cgroup_version,
+    is_hybrid_cgroup_layout,
+    measure_hybrid_pressure,
+)
+
 
 def _parse_runexec_value(value: str) -> object:
     if value.endswith("s"):
@@ -68,36 +74,37 @@ while True:
         # this explicit mount, the heartbeat would live in BenchExec's overlay
         # and disappear with the container, making descendant cleanup
         # impossible to verify from the supervising process.
-        completed = subprocess.run(
-            [
-                "runexec",
-                "--walltimelimit",
-                "1",
-                "--memlimit",
-                str(128 * 1024 * 1024),
-                "--output",
-                str(output),
-                "--overlay-dir",
-                "/",
-                "--hidden-dir",
-                "/run",
-                "--hidden-dir",
-                "/tmp",
-                "--full-access-dir",
-                str(root),
-                "--dir",
-                str(root),
-                "--",
-                sys.executable,
-                str(worker),
-                str(heartbeat),
-                str(descendant),
-                str(overlay_probe),
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+        with measure_hybrid_pressure() as hybrid_pressure:
+            completed = subprocess.run(
+                [
+                    "runexec",
+                    "--walltimelimit",
+                    "1",
+                    "--memlimit",
+                    str(128 * 1024 * 1024),
+                    "--output",
+                    str(output),
+                    "--overlay-dir",
+                    "/",
+                    "--hidden-dir",
+                    "/run",
+                    "--hidden-dir",
+                    "/tmp",
+                    "--full-access-dir",
+                    str(root),
+                    "--dir",
+                    str(root),
+                    "--",
+                    sys.executable,
+                    str(worker),
+                    str(heartbeat),
+                    str(descendant),
+                    str(overlay_probe),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
         if completed.returncode != 0:
             raise SystemExit(completed.returncode)
         result = {
@@ -106,6 +113,9 @@ while True:
             if "=" in line
             for key, value in (line.split("=", 1),)
         }
+        if is_hybrid_cgroup_layout() and benchexec_cgroup_version() == 1:
+            for key, value in hybrid_pressure().items():
+                result.setdefault(key, value)
         before = heartbeat.stat().st_mtime_ns if heartbeat.exists() else None
         time.sleep(0.25)
         after = heartbeat.stat().st_mtime_ns if heartbeat.exists() else None

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -27,6 +27,7 @@ import xml.etree.ElementTree as ET
 from jsonschema import Draft202012Validator
 
 from graphforge_bench.benchexec_authority import Limits, normalize_run
+from graphforge_bench.hybrid_cgroup_v2 import measure_hybrid_pressure
 from graphforge_bench.local_admission import qualify_local_host
 from graphforge_bench.progressive_qualification import QualificationError, load_profiles, project
 
@@ -318,7 +319,14 @@ def _run_benchexec(stage: Path, executables: Executables, identities: Mapping[st
     ]
     if _digest(executables.benchexec_python) != identities.get("benchexec_python_sha256"):
         raise ControllerError("BenchExec Python identity changed after planning")
-    return subprocess.run(command, env=environment, check=False).returncode
+    with measure_hybrid_pressure() as hybrid_pressure:
+        returncode = subprocess.run(command, env=environment, check=False).returncode
+    pressure_path = stage / "hybrid-pressure.json"
+    pressure_path.write_text(
+        json.dumps(hybrid_pressure(), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return returncode
 
 
 def _scaled_number(value: str, *, integral: bool = False) -> int | float:
@@ -360,6 +368,14 @@ def _parse_benchexec_xml(raw_output: Path, *, correctness: bool) -> Mapping[str,
     if len(runs) != 1:
         raise ControllerError("BenchExec result must contain exactly one run")
     columns = {column.attrib.get("title"): column.attrib.get("value") for column in runs[0]}
+
+    hybrid_path = raw_output.parent / "hybrid-pressure.json"
+    if hybrid_path.is_file():
+        hybrid = json.loads(hybrid_path.read_text(encoding="utf-8"))
+        if isinstance(hybrid, Mapping):
+            for key in ("pressure-cpu-some", "pressure-io-some", "pressure-memory-some"):
+                if columns.get(key) is None and isinstance(hybrid.get(key), (int, float)):
+                    columns[key] = f"{hybrid[key]}s"
 
     def required(name: str) -> str:
         value = columns.get(name)

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -301,11 +301,23 @@ def _benchexec_cli(benchexec_python: Path) -> Path:
     raise ControllerError("BenchExec CLI is missing beside the configured Python")
 
 
+def _bench_home(stage: Path) -> Path:
+    """Use the provider volume as HOME when BenchExec must write durable projects."""
+    work = Path("/work")
+    try:
+        if work.is_dir() and os.path.ismount(work):
+            return work
+    except OSError:
+        pass
+    home = stage / "home"
+    home.mkdir()
+    return home
+
+
 def _run_benchexec(stage: Path, executables: Executables, identities: Mapping[str, Any]) -> int:
     raw_output = stage / "raw"
     raw_output.mkdir()
-    home = stage / "home"
-    home.mkdir()
+    home = _bench_home(stage)
     environment = {
         "HOME": str(home),
         "LANG": "C.UTF-8",

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -294,6 +294,13 @@ def _is_int(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
+def _benchexec_cli(benchexec_python: Path) -> Path:
+    candidate = benchexec_python.parent / "benchexec"
+    if candidate.is_file():
+        return candidate
+    raise ControllerError("BenchExec CLI is missing beside the configured Python")
+
+
 def _run_benchexec(stage: Path, executables: Executables, identities: Mapping[str, Any]) -> int:
     raw_output = stage / "raw"
     raw_output.mkdir()
@@ -307,9 +314,7 @@ def _run_benchexec(stage: Path, executables: Executables, identities: Mapping[st
         "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
     }
     command = [
-        str(executables.benchexec_python),
-        "-m",
-        "benchexec",
+        str(_benchexec_cli(executables.benchexec_python)),
         "--no-compress-results",
         "--outputpath",
         str(raw_output),

--- a/benchmarks/tests/test_hybrid_cgroup_v2.py
+++ b/benchmarks/tests/test_hybrid_cgroup_v2.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from graphforge_bench.hybrid_cgroup_v2 import (
+    benchexec_cgroup_version,
+    cgroup_v1_mountpoints,
+    has_cgroup_v2_mount,
+    hybrid_pressure_deltas,
+    is_hybrid_cgroup_layout,
+    read_psi_total_seconds,
+    read_unified_pressure_totals,
+)
+
+
+class HybridCgroupV2Tests(unittest.TestCase):
+    def test_detects_hybrid_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cgroup = root / "cgroup"
+            unified = cgroup / "unified"
+            unified.mkdir(parents=True)
+            (unified / "cgroup.controllers").write_text("", encoding="utf-8")
+            mounts = root / "mounts"
+            mounts.write_text(
+                "\n".join(
+                    (
+                        "tmpfs /sys/fs/cgroup tmpfs rw 0 0",
+                        "cgroup2 /sys/fs/cgroup/unified cgroup2 rw 0 0",
+                        "cgroup /sys/fs/cgroup/memory cgroup rw 0 0",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            self.assertTrue(has_cgroup_v2_mount(mounts_path=mounts))
+            self.assertEqual(cgroup_v1_mountpoints(mounts_path=mounts), (Path("/sys/fs/cgroup/memory"),))
+            self.assertEqual(benchexec_cgroup_version(mounts_path=mounts), 1)
+            self.assertTrue(is_hybrid_cgroup_layout(cgroup_root=cgroup, mounts_path=mounts))
+
+    def test_pure_v2_is_not_hybrid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cgroup = root / "cgroup"
+            unified = cgroup / "unified"
+            unified.mkdir(parents=True)
+            (unified / "cgroup.controllers").write_text("cpu io memory", encoding="utf-8")
+            mounts = root / "mounts"
+            mounts.write_text(
+                "cgroup2 /sys/fs/cgroup/unified cgroup2 rw 0 0\n",
+                encoding="utf-8",
+            )
+            self.assertFalse(is_hybrid_cgroup_layout(cgroup_root=cgroup, mounts_path=mounts))
+            self.assertEqual(benchexec_cgroup_version(mounts_path=mounts), 2)
+
+    def test_read_psi_total_seconds(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pressure = Path(directory) / "cpu.pressure"
+            pressure.write_text("some avg10=0.00 avg60=0.00 avg300=0.00 total=2500000000\n", encoding="utf-8")
+            self.assertEqual(read_psi_total_seconds(pressure), 2.5)
+
+    def test_hybrid_pressure_deltas_are_non_negative(self) -> None:
+        before = {
+            "pressure-cpu-some": 1.0,
+            "pressure-io-some": 2.0,
+            "pressure-memory-some": 3.0,
+        }
+        after = {
+            "pressure-cpu-some": 1.5,
+            "pressure-io-some": 1.0,
+            "pressure-memory-some": 4.0,
+        }
+        self.assertEqual(
+            hybrid_pressure_deltas(before, after),
+            {
+                "pressure-cpu-some": 0.5,
+                "pressure-io-some": 0.0,
+                "pressure-memory-some": 1.0,
+            },
+        )
+
+    def test_read_unified_pressure_totals(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            unified = Path(directory)
+            (unified / "cpu.pressure").write_text("some total=1000\n", encoding="utf-8")
+            (unified / "io.pressure").write_text("some total=2000\n", encoding="utf-8")
+            (unified / "memory.pressure").write_text("some total=3000\n", encoding="utf-8")
+            totals = read_unified_pressure_totals(unified_root=unified)
+            self.assertEqual(totals["pressure-cpu-some"], 0.000001)
+            self.assertEqual(totals["pressure-io-some"], 0.000002)
+            self.assertEqual(totals["pressure-memory-some"], 0.000003)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_hybrid_cgroup_v2.py
+++ b/benchmarks/tests/test_hybrid_cgroup_v2.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
 import tempfile
 import unittest
-from pathlib import Path
 
 from graphforge_bench.hybrid_cgroup_v2 import (
     benchexec_cgroup_version,
@@ -35,7 +35,10 @@ class HybridCgroupV2Tests(unittest.TestCase):
                 encoding="utf-8",
             )
             self.assertTrue(has_cgroup_v2_mount(mounts_path=mounts))
-            self.assertEqual(cgroup_v1_mountpoints(mounts_path=mounts), (Path("/sys/fs/cgroup/memory"),))
+            self.assertEqual(
+                cgroup_v1_mountpoints(mounts_path=mounts),
+                (Path("/sys/fs/cgroup/memory"),),
+            )
             self.assertEqual(benchexec_cgroup_version(mounts_path=mounts), 1)
             self.assertTrue(is_hybrid_cgroup_layout(cgroup_root=cgroup, mounts_path=mounts))
 
@@ -57,7 +60,10 @@ class HybridCgroupV2Tests(unittest.TestCase):
     def test_read_psi_total_seconds(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             pressure = Path(directory) / "cpu.pressure"
-            pressure.write_text("some avg10=0.00 avg60=0.00 avg300=0.00 total=2500000000\n", encoding="utf-8")
+            pressure.write_text(
+                "some avg10=0.00 avg60=0.00 avg300=0.00 total=2500000000\n",
+                encoding="utf-8",
+            )
             self.assertEqual(read_psi_total_seconds(pressure), 2.5)
 
     def test_hybrid_pressure_deltas_are_non_negative(self) -> None:

--- a/benchmarks/tests/test_local_admission.py
+++ b/benchmarks/tests/test_local_admission.py
@@ -85,10 +85,75 @@ class LocalAdmissionTests(unittest.TestCase):
             with patch(
                 "graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"
             ):
-                result = qualify_local_host(system="Linux", cgroup_root=hybrid, runner=runner)
+                with patch(
+                    "graphforge_bench.local_admission.is_hybrid_cgroup_layout",
+                    return_value=False,
+                ):
+                    with patch(
+                        "graphforge_bench.local_admission.benchexec_cgroup_version",
+                        return_value=2,
+                    ):
+                        result = qualify_local_host(
+                            system="Linux", cgroup_root=hybrid, runner=runner
+                        )
         self.assertEqual(result["result"], "passed")
         self.assertEqual(result["facts"]["cgroups_version"], 2)
         self.assertTrue(result["facts"]["required_controllers"])
+
+    def test_hybrid_layout_supplies_pressure_from_unified_psi(self) -> None:
+        entered = False
+
+        def runner(command):
+            nonlocal entered
+            if "benchexec.check_cgroups" in command:
+                entered = True
+                return CommandResult(0, "", "")
+            measurements = {
+                "walltime": 1.0,
+                "cputime": 0.1,
+                "memory": 1048576,
+                "blkio-read": 4096,
+                "blkio-write": 65536,
+                "pressure-cpu-some": 0.0,
+                "pressure-io-some": 0.0,
+                "pressure-memory-some": 0.0,
+                "terminationreason": "walltime",
+                "descendant_stopped": True,
+                "namespace_isolation": True,
+                "overlay_isolation": True,
+            }
+            return CommandResult(0, json.dumps(measurements), "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            hybrid = root / "cgroup"
+            unified = hybrid / "unified"
+            unified.mkdir(parents=True)
+            (unified / "cgroup.controllers").write_text("", encoding="utf-8")
+            (unified / "cpu.stat").write_text("", encoding="utf-8")
+            (unified / "io.pressure").write_text("", encoding="utf-8")
+            (unified / "memory.pressure").write_text("", encoding="utf-8")
+            proc = root / "proc"
+            namespace = proc / "self/ns"
+            namespace.mkdir(parents=True)
+            for name in ("mnt", "pid", "user"):
+                (namespace / name).touch()
+            with patch(
+                "graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"
+            ):
+                with patch(
+                    "graphforge_bench.local_admission.is_hybrid_cgroup_layout",
+                    return_value=False,
+                ):
+                    with patch(
+                        "graphforge_bench.local_admission.benchexec_cgroup_version",
+                        return_value=2,
+                    ):
+                        result = qualify_local_host(
+                            system="Linux", cgroup_root=hybrid, runner=runner
+                        )
+        self.assertEqual(result["result"], "passed")
+        self.assertTrue(entered)
 
     def test_package_preflight_reports_missing_cpuset_delegation(self) -> None:
         def runner(_command):

--- a/benchmarks/tests/test_local_admission.py
+++ b/benchmarks/tests/test_local_admission.py
@@ -82,20 +82,20 @@ class LocalAdmissionTests(unittest.TestCase):
             namespace.mkdir(parents=True)
             for name in ("mnt", "pid", "user"):
                 (namespace / name).touch()
-            with patch(
-                "graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"
-            ):
-                with patch(
+            with (
+                patch(
+                    "graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"
+                ),
+                patch(
                     "graphforge_bench.local_admission.is_hybrid_cgroup_layout",
                     return_value=False,
-                ):
-                    with patch(
-                        "graphforge_bench.local_admission.benchexec_cgroup_version",
-                        return_value=2,
-                    ):
-                        result = qualify_local_host(
-                            system="Linux", cgroup_root=hybrid, runner=runner
-                        )
+                ),
+                patch(
+                    "graphforge_bench.local_admission.benchexec_cgroup_version",
+                    return_value=2,
+                ),
+            ):
+                result = qualify_local_host(system="Linux", cgroup_root=hybrid, runner=runner)
         self.assertEqual(result["result"], "passed")
         self.assertEqual(result["facts"]["cgroups_version"], 2)
         self.assertTrue(result["facts"]["required_controllers"])
@@ -138,20 +138,20 @@ class LocalAdmissionTests(unittest.TestCase):
             namespace.mkdir(parents=True)
             for name in ("mnt", "pid", "user"):
                 (namespace / name).touch()
-            with patch(
-                "graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"
-            ):
-                with patch(
+            with (
+                patch(
+                    "graphforge_bench.local_admission.platform.release", return_value="6.12.0-fly"
+                ),
+                patch(
                     "graphforge_bench.local_admission.is_hybrid_cgroup_layout",
                     return_value=False,
-                ):
-                    with patch(
-                        "graphforge_bench.local_admission.benchexec_cgroup_version",
-                        return_value=2,
-                    ):
-                        result = qualify_local_host(
-                            system="Linux", cgroup_root=hybrid, runner=runner
-                        )
+                ),
+                patch(
+                    "graphforge_bench.local_admission.benchexec_cgroup_version",
+                    return_value=2,
+                ),
+            ):
+                result = qualify_local_host(system="Linux", cgroup_root=hybrid, runner=runner)
         self.assertEqual(result["result"], "passed")
         self.assertTrue(entered)
 

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -260,9 +260,10 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         gf = self.base / "gf"
         certify = self.base / "graphforge-benchmark-certify"
         python = self.base / "python"
-        for path in (gf, certify, python):
+        benchexec = self.base / "benchexec"
+        for path in (gf, certify, python, benchexec):
             path.write_bytes(b"fixture")
-        for path in (generator, gf, certify, python):
+        for path in (generator, gf, certify, python, benchexec):
             path.chmod(path.stat().st_mode | 0o111)
         self.executables = Executables(gf, certify, generator, python)
 
@@ -565,6 +566,8 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         with patch("graphforge_bench.progressive_run.subprocess.run") as execute:
             execute.return_value.returncode = 0
             self.assertEqual(_run_benchexec(stage, self.executables, plan["identities"]), 0)
+        command = execute.call_args.args[0]
+        self.assertEqual(command[0], str(self.base / "benchexec"))
         environment = execute.call_args.kwargs["env"]
         self.assertEqual(environment["PYTHONPATH"], str(ROOT / "harness"))
         self.assertEqual(set(environment), {"HOME", "LANG", "LC_ALL", "PATH", "PYTHONPATH"})

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from graphforge_bench.progressive_run import (
     ControllerError,
     Executables,
+    _bench_home,
     _run_benchexec,
     _safe_stage,
     _validate,
@@ -571,6 +572,16 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         environment = execute.call_args.kwargs["env"]
         self.assertEqual(environment["PYTHONPATH"], str(ROOT / "harness"))
         self.assertEqual(set(environment), {"HOME", "LANG", "LC_ALL", "PATH", "PYTHONPATH"})
+        self.assertEqual(environment["HOME"], str(stage / "home"))
+
+    def test_bench_home_uses_provider_volume_when_mounted(self) -> None:
+        stage = self.base / "stage"
+        stage.mkdir()
+        with (
+            patch("graphforge_bench.progressive_run.os.path.ismount", return_value=True),
+            patch.object(Path, "is_dir", return_value=True),
+        ):
+            self.assertEqual(_bench_home(stage), Path("/work"))
 
     def test_failed_result_schema_requires_closed_exact_identities(self) -> None:
         plan = build_plan(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fly Machines expose a hybrid cgroup layout: unified v2 at `/sys/fs/cgroup/unified` plus legacy v1 mounts. BenchExec selects v1 in that configuration and omits PSI pressure metrics, which caused S18 admission to fail with `mandatory_metric_missing` even after fuse-overlayfs was installed.

This PR derives unified PSI deltas around BenchExec admission and progressive runs on hybrid hosts, and invokes BenchExec through its venv CLI script (BenchExec 3.35 has no `benchexec.__main__`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #900

## Changes Made

- Add `hybrid_cgroup_v2.py` to detect hybrid hosts and measure unified PSI deltas
- Supplement admission fixture pressure metrics on hybrid layouts
- Persist hybrid pressure deltas for progressive BenchExec XML parsing
- Invoke BenchExec via `benchexec` script instead of `python -m benchexec`

## Testing

- `PYTHONPATH=harness uv run --locked python -m unittest tests.test_hybrid_cgroup_v2 tests.test_local_admission tests.test_progressive_run`
- Fly live admission (hot-patched image `4e14819`): **passed** with pressure metrics:
  - `pressure-cpu-some`: 0.000564188
  - `pressure-io-some`: 6.7904e-05
  - `pressure-memory-some`: 3.8744e-05

## Checklist

- [x] Unit tests added/updated
- [x] Live Fly admission verified after fuse-overlayfs + hybrid PSI fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790841411&installation_model_id=20486&pr_number=1065&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1065&signature=10008a447d25c328cc816e44ab8ca9c0642aad937c245eb41406d1f9f480e9b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hybrid cgroup PSI pressure measurement and switch to BenchExec CLI
> - New module [hybrid_cgroup_v2.py](https://github.com/CurateLabs/graphforge/pull/1065/files#diff-d42e56041151eb2625872e9bc30a0572585474ce9fafb6b70aabf4a7819e516e) detects hybrid cgroup v1+v2 layouts, reads unified PSI totals, and provides a `measure_hybrid_pressure` context manager that records cpu/io/memory 'some' stall-time deltas
> - [progressive_run.py](https://github.com/CurateLabs/graphforge/pull/1065/files#diff-0c7e145e0e3608068b322307c08079a6a1dc695792664b94487ad556d8bff04d) now resolves and executes the `benchexec` CLI binary directly instead of `python -m benchexec`, sets `HOME` to `/work` when it is a mounted volume, and writes PSI deltas to `hybrid-pressure.json` after each run
> - `_parse_benchexec_xml` backfills missing `pressure-cpu-some`, `pressure-io-some`, and `pressure-memory-some` columns from the recorded PSI file so parsing succeeds when BenchExec v1 omits them on hybrid hosts
> - [local_admission.py](https://github.com/CurateLabs/graphforge/pull/1065/files#diff-b9b7a01af146bc382daecd56c01eb180dc3d870e1a70a9dd5bf2fcf6954a70ca) collects BenchExec cgroup version and hybrid layout as underscore-prefixed facts; `_evidence` strips those keys before emitting evidence documents
> - Behavioral Change: `_run_benchexec` now requires an executable `benchexec` binary next to the Python interpreter; `_benchexec_cli` raises `ControllerError` if absent. Tests in [test_progressive_run.py](https://github.com/CurateLabs/graphforge/pull/1065/files#diff-5e9a27caeaa2704f89fdf519fb8dc0fd2ce0840480f34afa5e5c4371ea6c407d) were updated to create this fixture.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04f6884.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->