### PR TITLE
test(bench): update parity gate tests for post-retirement state (#959)

### DIFF
--- a/benchmarks/tests/test_parity_gate.py
+++ b/benchmarks/tests/test_parity_gate.py
@@ -15,23 +15,22 @@ class ParityGateTests(unittest.TestCase):
     def test_tiny_parity_ready(self) -> None:
         assert_tiny_parity_ready()
 
-    def test_gate_status_reports_retirement_blocked(self) -> None:
+    def test_gate_status_reports_retirement_ready(self) -> None:
         status = parity_gate_status()
-        self.assertFalse(status["ready_for_retirement"])
-        blocked = {
-            row["name"]: row["blocked_by"] for row in status["criteria"] if row.get("blocked_by")
-        }
-        self.assertIn("harness_authoritative_after_ladder_comparison", blocked)
-        self.assertEqual(blocked["harness_authoritative_after_ladder_comparison"], "#900")
-        self.assertEqual(
-            blocked["legacy_orchestration_retired_with_coverage"],
-            "parity_matrix_no_unexplained_gaps + harness_authoritative",
+        self.assertTrue(status["ready_for_retirement"])
+        harness = next(
+            row
+            for row in status["criteria"]
+            if row["name"] == "harness_authoritative_after_ladder_comparison"
         )
+        self.assertTrue(harness["met"])
+        self.assertIsNone(harness["blocked_by"])
         legacy = next(
             row
             for row in status["criteria"]
             if row["name"] == "legacy_orchestration_retired_with_coverage"
         )
+        self.assertTrue(legacy["met"])
         self.assertIn("legacy_present=False", legacy["evidence"])
 
     def test_historical_evidence_criterion_met(self) -> None:
@@ -41,8 +40,10 @@ class ParityGateTests(unittest.TestCase):
         )
         self.assertTrue(historical["met"])
 
-    def test_empty_ladder_bundle_returns_no_comparisons(self) -> None:
-        self.assertEqual(compare_ladder_bundle(ladder_bundle_root()), [])
+    def test_ingested_ladder_bundle_runs_comparisons(self) -> None:
+        comparisons = compare_ladder_bundle(ladder_bundle_root())
+        self.assertEqual(len(comparisons), 2)
+        self.assertTrue(all(matrix.get("overall") for matrix in comparisons))
 
     def test_gate_status_json_serializable(self) -> None:
         payload = parity_gate_status()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes smoke-python failure on `main` after #1061 merged ingested S18/S19 ladder bundles.

- `test_gate_status_reports_retirement_ready`: expects `ready_for_retirement: true` now that legacy orchestration is retired and ladder evidence is ingested.
- `test_ingested_ladder_bundle_runs_comparisons`: ladder bundle now contains two rung files.

```bash
cd benchmarks && PYTHONPATH=harness uv run --locked python -m unittest tests.test_parity_gate -q
make -C benchmarks smoke-python
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855617&installation_model_id=20486&pr_number=1068&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1068&signature=95486bb2c9b8cc677481f890f784a0416d29805cabe22d1686a715fcbbcc5215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update parity gate tests to expect retirement-ready state and non-empty comparisons
> - `test_gate_status_reports_retirement_ready` (renamed from `test_gate_status_reports_retirement_blocked`) now asserts `ready_for_retirement` is `True`, with `harness_authoritative_after_ladder_comparison` met and no `blocked_by`, and `legacy_orchestration_retired_with_coverage` met with `legacy_present=False` evidence.
> - `test_ingested_ladder_bundle_runs_comparisons` (renamed from `test_empty_ladder_bundle_returns_no_comparisons`) now expects `compare_ladder_bundle` to return two comparison matrices, each with a truthy `overall` field, instead of an empty list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf8b2ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->