### PR TITLE
test(bench): assert Fly S18/S19 evidence refuses S20 until RSS plateaus (#952)

### DIFF
--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -522,6 +522,29 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         self.assertEqual(evidence["source_scales"], [18, 19])
         self.assertNotIn("secret", path.read_text())
 
+    def test_fly_s18_s19_ladder_bundle_refuses_s20_until_rss_plateaus(self) -> None:
+        """Real #900 Fly evidence must not authorize S20 while RSS grows across rungs."""
+        bundle = ROOT / "fixtures" / "parity" / "ladder-bundle"
+        for scale in (18, 19):
+            source = bundle / f"s{scale}-rung.json"
+            (self.output / source.name).write_text(source.read_text(encoding="utf-8"))
+        capacity = self.base / "capacity.json"
+        capacity.write_text(
+            json.dumps(
+                {
+                    "physical_read_bytes_per_second": 1_000_000_000,
+                    "physical_write_bytes_per_second": 500_000_000,
+                    "reader_calls_per_second": 1_000_000,
+                    "publication_work_per_second": 500_000,
+                }
+            )
+        )
+        path = write_s20_projection(ROOT, self.output, capacity)
+        evidence = json.loads(path.read_text())
+        self.assertEqual(evidence["decision"], "refused")
+        self.assertFalse(evidence["checks"]["rss_bounded_or_plateaued"])
+        self.assertFalse(evidence["checks"]["rss_headroom"])
+
     def test_staged_executables_are_verified_private_copies(self) -> None:
         plan = build_plan(
             root=ROOT,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a regression test that documents the current epic #952 blocker: real Fly S18/S19 rung evidence in `fixtures/parity/ladder-bundle/` produces `decision: refused` on S20 projection because adjacent RSS growth exceeds the 10% plateau gate.

This prevents treating ingested prefix evidence as S20-ready and encodes the admission policy in CI.

```bash
cd benchmarks && PYTHONPATH=harness uv run --locked python -m unittest \
  tests.test_progressive_run.ProgressiveRunControllerTests.test_fly_s18_s19_ladder_bundle_refuses_s20_until_rss_plateaus -q
```

Relates to #952 — epic remains open until full S18–S26 ladder passes with bounded RSS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790857748&installation_model_id=20486&pr_number=1069&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1069&signature=aafe3297219b823d6e9446345f06cd9994abd32258c1162129b366611df16409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test asserting `write_s20_projection` refuses S20 for S18/S19 ladder evidence until RSS plateaus
> Adds `ProgressiveRunControllerTests.test_fly_s18_s19_ladder_bundle_refuses_s20_until_rss_plateaus` in [test_progressive_run.py](https://github.com/CurateLabs/graphforge/pull/1069/files#diff-5e9a27caeaa2704f89fdf519fb8dc0fd2ce0840480f34afa5e5c4371ea6c407d). The test writes S18/S19 rung evidence files and a `capacity.json`, calls `write_s20_projection`, and asserts the decision is `refused` with `rss_bounded_or_plateaued` and `rss_headroom` both `False`. This locks in the gating behavior that prevents S20 authorization when RSS growth remains unbounded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6790d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->