### PR TITLE
fix(bench): use canonical ordered-LIMIT queries in Graph500 profiles (#952)

### DIFF
--- a/benchmarks/fixtures/progressive/tiny-executable.json
+++ b/benchmarks/fixtures/progressive/tiny-executable.json
@@ -148,7 +148,7 @@
             "workspace/tiny/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/tiny/one-hop.arrow"
           ],
@@ -158,7 +158,7 @@
             "workspace/tiny/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/tiny/two-hop.arrow"
           ]
@@ -242,7 +242,7 @@
             "workspace/tiny/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/tiny/imported-one-hop.arrow"
           ],
@@ -252,7 +252,7 @@
             "workspace/tiny/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/tiny/imported-two-hop.arrow"
           ],

--- a/benchmarks/harness/graphforge_bench/progressive_queries.py
+++ b/benchmarks/harness/graphforge_bench/progressive_queries.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-ONE_HOP_ORDERED_LIMIT = (
-    "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000"
-)
+ONE_HOP_ORDERED_LIMIT = "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000"
 TWO_HOP_ORDERED_LIMIT = (
     "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000"
 )

--- a/benchmarks/harness/graphforge_bench/progressive_queries.py
+++ b/benchmarks/harness/graphforge_bench/progressive_queries.py
@@ -1,0 +1,15 @@
+"""Canonical Graph500 progressive qualification query shapes (#900, #904)."""
+
+from __future__ import annotations
+
+ONE_HOP_ORDERED_LIMIT = (
+    "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000"
+)
+TWO_HOP_ORDERED_LIMIT = (
+    "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000"
+)
+
+CANONICAL_QUERY_PHASES = (
+    ("query", ONE_HOP_ORDERED_LIMIT, TWO_HOP_ORDERED_LIMIT),
+    ("reopen_proof", ONE_HOP_ORDERED_LIMIT, TWO_HOP_ORDERED_LIMIT),
+)

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -378,14 +378,10 @@ def _stage_benchmark_xml(root: Path, stage: Path) -> None:
     text = (root / "definitions/graphforge-progressive-qualification-v1.xml").read_text(
         encoding="utf-8"
     )
-    if _provider_volume_mounted():
-        text = text.replace('memlimit="4 GB"', 'memlimit="16 GB"')
     (stage / "benchmark.xml").write_text(text, encoding="utf-8")
 
 
 def _benchexec_memory_limit() -> list[str]:
-    if _provider_volume_mounted():
-        return ["--memorylimit", "16 GB"]
     return []
 
 

--- a/benchmarks/profiles/graph500/s18-local.json
+++ b/benchmarks/profiles/graph500/s18-local.json
@@ -154,7 +154,7 @@
             "workspace/s18/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s18/one-hop.arrow"
           ],
@@ -164,7 +164,7 @@
             "workspace/s18/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s18/two-hop.arrow"
           ]
@@ -248,7 +248,7 @@
             "workspace/s18/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s18/imported-one-hop.arrow"
           ],
@@ -258,7 +258,7 @@
             "workspace/s18/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s18/imported-two-hop.arrow"
           ],

--- a/benchmarks/profiles/graph500/s19-local.json
+++ b/benchmarks/profiles/graph500/s19-local.json
@@ -154,7 +154,7 @@
             "workspace/s19/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s19/one-hop.arrow"
           ],
@@ -164,7 +164,7 @@
             "workspace/s19/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s19/two-hop.arrow"
           ]
@@ -248,7 +248,7 @@
             "workspace/s19/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s19/imported-one-hop.arrow"
           ],
@@ -258,7 +258,7 @@
             "workspace/s19/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s19/imported-two-hop.arrow"
           ],

--- a/benchmarks/profiles/graph500/s20-provider.json
+++ b/benchmarks/profiles/graph500/s20-provider.json
@@ -154,7 +154,7 @@
             "workspace/s20/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s20/one-hop.arrow"
           ],
@@ -164,7 +164,7 @@
             "workspace/s20/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s20/two-hop.arrow"
           ]
@@ -248,7 +248,7 @@
             "workspace/s20/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s20/imported-one-hop.arrow"
           ],
@@ -258,7 +258,7 @@
             "workspace/s20/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s20/imported-two-hop.arrow"
           ],

--- a/benchmarks/profiles/graph500/s22-provider.json
+++ b/benchmarks/profiles/graph500/s22-provider.json
@@ -154,7 +154,7 @@
             "workspace/s22/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s22/one-hop.arrow"
           ],
@@ -164,7 +164,7 @@
             "workspace/s22/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s22/two-hop.arrow"
           ]
@@ -248,7 +248,7 @@
             "workspace/s22/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s22/imported-one-hop.arrow"
           ],
@@ -258,7 +258,7 @@
             "workspace/s22/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s22/imported-two-hop.arrow"
           ],

--- a/benchmarks/profiles/graph500/s24-provider.json
+++ b/benchmarks/profiles/graph500/s24-provider.json
@@ -154,7 +154,7 @@
             "workspace/s24/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s24/one-hop.arrow"
           ],
@@ -164,7 +164,7 @@
             "workspace/s24/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s24/two-hop.arrow"
           ]
@@ -248,7 +248,7 @@
             "workspace/s24/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s24/imported-one-hop.arrow"
           ],
@@ -258,7 +258,7 @@
             "workspace/s24/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s24/imported-two-hop.arrow"
           ],

--- a/benchmarks/profiles/graph500/s25-provider.json
+++ b/benchmarks/profiles/graph500/s25-provider.json
@@ -154,7 +154,7 @@
             "workspace/s25/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s25/one-hop.arrow"
           ],
@@ -164,7 +164,7 @@
             "workspace/s25/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s25/two-hop.arrow"
           ]
@@ -248,7 +248,7 @@
             "workspace/s25/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s25/imported-one-hop.arrow"
           ],
@@ -258,7 +258,7 @@
             "workspace/s25/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s25/imported-two-hop.arrow"
           ],

--- a/benchmarks/profiles/graph500/s26-provider.json
+++ b/benchmarks/profiles/graph500/s26-provider.json
@@ -154,7 +154,7 @@
             "workspace/s26/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s26/one-hop.arrow"
           ],
@@ -164,7 +164,7 @@
             "workspace/s26/source",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s26/two-hop.arrow"
           ]
@@ -248,7 +248,7 @@
             "workspace/s26/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r]->(b) RETURN a, r, b LIMIT 1024",
+            "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s26/imported-one-hop.arrow"
           ],
@@ -258,7 +258,7 @@
             "workspace/s26/imported",
             "query",
             "--cypher",
-            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN a, r1, b, r2, c LIMIT 1024",
+            "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000",
             "--output",
             "workspace/s26/imported-two-hop.arrow"
           ],

--- a/benchmarks/tests/test_progressive_profile_queries.py
+++ b/benchmarks/tests/test_progressive_profile_queries.py
@@ -1,0 +1,56 @@
+"""Graph500 progressive profiles must use canonical ordered-LIMIT query shapes."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from graphforge_bench.progressive_queries import (
+    CANONICAL_QUERY_PHASES,
+    ONE_HOP_ORDERED_LIMIT,
+    TWO_HOP_ORDERED_LIMIT,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILES = ROOT / "profiles" / "graph500"
+
+
+def _phase_cyphers(phase: dict) -> list[str]:
+    values: list[str] = []
+    for command in phase["action"]["commands"]:
+        if "query" not in command:
+            continue
+        index = command.index("--cypher")
+        values.append(command[index + 1])
+    return values
+
+
+def _canonical_hop_cyphers(phase_name: str, phase: dict) -> list[str]:
+    cyphers = _phase_cyphers(phase)
+    if phase_name == "reopen_proof":
+        return cyphers[-2:]
+    return cyphers
+
+
+class ProgressiveProfileQueryTests(unittest.TestCase):
+    def test_graph500_profiles_use_canonical_ordered_limit_queries(self) -> None:
+        for path in sorted(PROFILES.glob("*.json")):
+            with self.subTest(profile=path.name):
+                profile = json.loads(path.read_text(encoding="utf-8"))
+                phases = {entry["phase"]: entry for entry in profile["phases"]}
+                for phase_name, one_hop, two_hop in CANONICAL_QUERY_PHASES:
+                    cyphers = _canonical_hop_cyphers(phase_name, phases[phase_name])
+                    self.assertEqual(cyphers, [one_hop, two_hop])
+
+    def test_tiny_executable_fixture_matches_canonical_queries(self) -> None:
+        profile = json.loads(
+            (ROOT / "fixtures/progressive/tiny-executable.json").read_text(encoding="utf-8")
+        )
+        query = next(entry for entry in profile["phases"] if entry["phase"] == "query")
+        cyphers = _phase_cyphers(query)
+        self.assertEqual(cyphers, [ONE_HOP_ORDERED_LIMIT, TWO_HOP_ORDERED_LIMIT])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_progressive_profile_queries.py
+++ b/benchmarks/tests/test_progressive_profile_queries.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-import unittest
 from pathlib import Path
+import unittest
 
 from graphforge_bench.progressive_queries import (
     CANONICAL_QUERY_PHASES,

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -675,7 +675,7 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         with patch("graphforge_bench.progressive_run._provider_volume_mounted", return_value=True):
             self.assertEqual(_benchexec_tool_directory(stage), stage / "bin")
 
-    def test_provider_volume_stages_higher_benchexec_memory(self) -> None:
+    def test_provider_volume_keeps_four_gib_benchexec_memory(self) -> None:
         stage = self.base / "stage"
         stage.mkdir()
         with patch("graphforge_bench.progressive_run._provider_volume_mounted", return_value=True):
@@ -683,8 +683,8 @@ class ProgressiveRunControllerTests(unittest.TestCase):
 
             _stage_benchmark_xml(ROOT, stage)
             xml = (stage / "benchmark.xml").read_text(encoding="utf-8")
-            self.assertIn('memlimit="16 GB"', xml)
-            self.assertNotIn('memlimit="4 GB"', xml)
+            self.assertIn('memlimit="4 GB"', xml)
+            self.assertNotIn('memlimit="16 GB"', xml)
             plan = build_plan(
                 root=ROOT,
                 output_dir=self.output,
@@ -701,8 +701,7 @@ class ProgressiveRunControllerTests(unittest.TestCase):
                 execute.return_value.returncode = 0
                 _run_benchexec(stage, self.executables, plan["identities"])
             command = execute.call_args.args[0]
-            self.assertIn("--memorylimit", command)
-            self.assertIn("16 GB", command)
+            self.assertNotIn("--memorylimit", command)
 
     def test_failed_result_schema_requires_closed_exact_identities(self) -> None:
         plan = build_plan(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Progressive Graph500 profiles were running full-entity `RETURN a, r, b LIMIT 1024` queries instead of the canonical one-hop/two-hop ordered-LIMIT shapes required by #900 and implemented for #904/#966 in `scale_g500_ladder.rs`. That mismatch drove 7–15 GB BenchExec peaks on Fly S18/S19 and blocked S20 admission even after the engine RSS fixes landed on `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Tests (adding or updating tests)

## Related Issues

Relates to #952, #900, #904

## Changes Made

- Replace entity-materialization query phases across S18–S26 profiles and the tiny executable fixture with `RETURN b.node_uuid/c.node_uuid AS id ORDER BY id LIMIT 1000`
- Revert the Fly-only 16 GB BenchExec memlimit override so provider runs are measured against the declared 4 GiB qualification ceiling
- Add `progressive_queries` constants and regression tests locking profile query shapes

## Testing

```bash
cd benchmarks && PYTHONPATH=harness uv run --locked python -m unittest tests.test_progressive_profile_queries tests.test_progressive_run
make -C benchmarks smoke-python  # 279 tests OK
```

Existing ingested Fly S18/S19 ladder-bundle evidence (collected with the old query shapes) still correctly refuses S20 admission until re-qualification with these profiles completes.

## Checklist

- [x] This PR addresses one logical change
- [x] Unit tests added/updated
- [x] All existing tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790864217&installation_model_id=20486&pr_number=1070&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1070&signature=ade57eda7e8d9f0f369f5c51b87dcdf7e90e5a3e23cb77265fa8f0f8f12f951e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use canonical ordered-LIMIT Cypher queries in Graph500 benchmark profiles
> - Replaces one-hop and two-hop queries across all Graph500 profiles and [tiny-executable.json](https://github.com/CurateLabs/graphforge/pull/1070/files#diff-cdbc9c48499168213be0af5fe2fbb35ef893825da55a5c53be7bb435548381a3) to return ordered, limited IDs (`ORDER BY id LIMIT 1000`) instead of full triples
> - Adds canonical constants in [progressive_queries.py](https://github.com/CurateLabs/graphforge/pull/1070/files#diff-b8a49d9d08c3208cd93c5da19de689a427e2b02252b840014fb3c9bb4efb6951) and tests in [test_progressive_profile_queries.py](https://github.com/CurateLabs/graphforge/pull/1070/files#diff-b542d612e8a055298f5a53782201f8899400de2eaf9414839bac0f5e9513a920) that enforce profiles match them
> - Removes provider-volume `16 GB` memlimit override in `_stage_benchmark_xml` and `_benchexec_memory_limit` in [progressive_run.py](https://github.com/CurateLabs/graphforge/pull/1070/files#diff-0c7e145e0e3608068b322307c08079a6a1dc695792664b94487ad556d8bff04d); `benchmark.xml` now always keeps `memlimit="4 GB"`
> - Behavioral Change: provider-volume benchmarks now run with a 4 GB memory limit instead of 16 GB, and benchexec no longer passes `--memorylimit` on those runs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fad73a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->