### PR TITLE
fix(bench): drop cgroup page cache between certify subprocesses (#904)

### DIFF
--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -595,6 +595,7 @@ fn execute_process(executable: &str, args: &[String]) -> Result<Execution, Strin
             ) {
                 Ok(receipts) => receipts,
                 Err(_) if status.success() => {
+                    release_cgroup_page_cache();
                     return Ok(Execution {
                         exit_code: status.code(),
                         duration_ms: millis(started.elapsed()),
@@ -603,8 +604,12 @@ fn execute_process(executable: &str, args: &[String]) -> Result<Execution, Strin
                         receipts: Vec::new(),
                     });
                 }
-                Err(error) => return Err(error),
+                Err(error) => {
+                    release_cgroup_page_cache();
+                    return Err(error);
+                }
             };
+            release_cgroup_page_cache();
             return Ok(Execution {
                 exit_code: status.code(),
                 duration_ms: millis(started.elapsed()),
@@ -616,6 +621,23 @@ fn execute_process(executable: &str, args: &[String]) -> Result<Execution, Strin
         thread::sleep(Duration::from_millis(10));
     }
 }
+
+/// Drop Linux page-cache pressure attributed to the BenchExec cgroup between
+/// sequential public-command invocations. Without this, file-backed cache from
+/// prior `gf` subprocesses accumulates until the 4 GiB memlimit even though
+/// each invocation's anonymous RSS stays bounded (#904).
+#[cfg(target_os = "linux")]
+fn release_cgroup_page_cache() {
+    use std::io::Write;
+
+    let _ = std::process::Command::new("sync").status();
+    if let Ok(mut drop_caches) = fs::File::create("/proc/sys/vm/drop_caches") {
+        let _ = drop_caches.write_all(b"3");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn release_cgroup_page_cache() {}
 
 fn read_bounded(mut input: impl Read, limit: usize) -> Result<Vec<u8>, String> {
     let mut kept = Vec::new();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fly S18 re-qualification with canonical ordered-LIMIT queries completed every GraphForge certification phase (`status: passed`, max per-phase anonymous RSS **555 MiB**), yet BenchExec terminated the run with **OUT OF MEMORY** at cgroup memory **4000067584 B** after ~3.5 h.

Root cause: BenchExec's 4 GiB cgroup memlimit counts **file-backed page cache** from sequential `gf` subprocess invocations. Each phase stays bounded in anonymous RSS, but cache from multi-TB logical reads accumulates across the full S18 lifecycle (ingest → query → export → reopen_proof).

## Fix

After each public-command child completes in `graphforge-benchmark-certify`, call `sync` and write `3` to `/proc/sys/vm/drop_caches` on Linux to release page-cache pressure before the next subprocess starts.

## Evidence

Downloaded from Fly machine `89122db6197348` run #2 (commit `c640c49`):

- `graphforge-certify-evidence.json`: all 10 phases `passed`, max `peak_rss_bytes` = 555175936
- BenchExec XML: `terminationreason=memory`, `memory=4000067584B`, `returnvalue=0`

## Testing

- `cargo test -p graphforge-benchmark-certify` (16 passed)
- `cargo clippy -p graphforge-benchmark-certify -- -D warnings`

Closes #904 (partial — Fly S18 re-run required after merge to confirm full lifecycle under 4 GiB).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790894521&installation_model_id=20486&pr_number=1071&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1071&signature=8d2d56b085e5393b182c892d4ac9c2c269ed0efde68a11594f9eb4000d600e64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop cgroup page cache between certify subprocesses in `execute_process`
> - Adds a Linux-only `release_cgroup_page_cache` helper that runs `sync` and writes `"3"` to `/proc/sys/vm/drop_caches`, best-effort with all errors ignored; non-Linux gets a no-op stub.
> - Calls the helper on every return path in `execute_process` in [lib.rs](https://github.com/CurateLabs/graphforge/pull/1071/files#diff-4ae9ef5a9e6c6b00bc7c84a8c7f695535a298d12b789f775490b8d813df49085) after the child process exits, so page cache is evicted between subprocess runs.
> - Behavioral Change: benchmarks now evict page cache after each subprocess, which may reduce cross-run cache interference and slow down individual runs that previously benefited from warm cache.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 720a140.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->