### PR TITLE
fix(exec): count two-hop ordered-LIMIT paths without full expansion (#966)

### DIFF
--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -586,6 +586,7 @@ impl PhysicalOptimizerRule for FixedHopDemandRule {
         } else {
             plan
         };
+        let plan = crate::ordered_two_hop::try_rewrite_ordered_two_hop(plan)?;
         let Some(terminal) = find_terminal_demand(&plan) else {
             if capture_enabled() {
                 let mut rss_ordinal = 0;

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -189,6 +189,7 @@ pub(crate) mod algorithm_similar_knn;
 pub(crate) mod algorithm_weighted_undirected;
 #[doc(hidden)]
 pub mod demand;
+mod ordered_two_hop;
 pub use adjacency::{
     Adjacency, AdjacencyBacking, AdjacencyProvider, AdjacencyStatus, PersistentAdjacencyProvider,
     ScanBuildAdjacencyProvider,
@@ -3199,14 +3200,14 @@ impl V4OrdinalIdentityResolver {
 /// One exact, already-authenticated ordinal authority pinned for the lifetime
 /// of an execution session.
 #[derive(Debug)]
-struct V4OrdinalIdentitySession {
+pub(crate) struct V4OrdinalIdentitySession {
     handle: Arc<Mutex<graphforge_storage::ordinal_identity_v4::V4OrdinalIdentityHandle>>,
     revalidation: graphforge_storage::V4OrdinalRevalidationMetrics,
     attribution_available: AtomicBool,
 }
 
 impl V4OrdinalIdentitySession {
-    fn lookup_node_uuids(
+    pub(crate) fn lookup_node_uuids(
         &self,
         requested: &[u64],
     ) -> Result<graphforge_storage::V4OrdinalLookup, GfError> {
@@ -3361,6 +3362,52 @@ impl ExpandExec {
             ordinal_identities: self.ordinal_identities.clone(),
             ordinal_identity_required: self.ordinal_identity_required,
         })
+    }
+
+    pub(crate) fn rel_type_name(&self) -> &str {
+        &self.rel_type_name
+    }
+
+    pub(crate) fn direction(&self) -> graphforge_ir::Direction {
+        self.direction
+    }
+
+    pub(crate) fn provider(&self) -> &Arc<dyn AdjacencyProvider> {
+        &self.provider
+    }
+
+    pub(crate) fn ordinal_identities(&self) -> Option<Arc<V4OrdinalIdentitySession>> {
+        self.ordinal_identities.clone()
+    }
+
+    pub(crate) fn is_destination_identity_only(&self) -> bool {
+        let Some(required) = self.required_output.as_deref() else {
+            return false;
+        };
+        let dst_width = graphforge_storage::TOPOLOGY_NODES_SCHEMA.fields().len();
+        let edge_end = self.schema.fields().len().saturating_sub(dst_width);
+        let destination_uuid_index = edge_end;
+        let destination_id_index = edge_end + 1;
+        let edge_materialization_unused =
+            required
+                .get(self.input_width..edge_end)
+                .is_some_and(|fields| {
+                    fields.iter().enumerate().all(|(offset, needed)| {
+                        !needed || self.schema.field(self.input_width + offset).name() == "edge_id"
+                    })
+                });
+        edge_materialization_unused
+            && required
+                .iter()
+                .enumerate()
+                .skip(edge_end)
+                .all(|(index, needed)| {
+                    !needed || index == destination_uuid_index || index == destination_id_index
+                })
+            && required
+                .get(destination_uuid_index)
+                .copied()
+                .unwrap_or(false)
     }
 }
 

--- a/crates/graphforge-exec/src/ordered_two_hop.rs
+++ b/crates/graphforge-exec/src/ordered_two_hop.rs
@@ -1,0 +1,325 @@
+//! Order-aware two-hop path counting for `ORDER BY destination_uuid LIMIT K` (#966).
+//!
+//! When the terminal sort is a single ascending key on the destination node UUID
+//! and both hops are fixed, identity-only expansions, materializing every
+//! intermediate candidate before TopK is correct but scales with total path count.
+//! This module replaces the expand chain with destination-order path counting:
+//! iterate destinations in node-id order (equivalent to UUID order for monotonic
+//! ordinal identity), count two-hop paths with optional edge-disjointness, emit
+//! path multiplicity until the limit is satisfied.
+
+use std::fmt;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::array::{ArrayRef, FixedSizeBinaryBuilder};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::ScalarFunctionExpr;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::limit::GlobalLimitExec;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
+    SendableRecordBatchStream,
+};
+use futures::Stream;
+use graphforge_ir::Direction;
+
+use crate::ExpandExec;
+use crate::adjacency::AdjacencyProvider;
+use crate::demand;
+
+/// Rewrite ordered two-hop identity-only plans to path counting when matched.
+pub fn try_rewrite_ordered_two_hop(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    let Some(spec) = detect_ordered_two_hop(&plan) else {
+        return Ok(plan);
+    };
+    let replacement = Arc::new(OrderedTwoHopPathCountExec::new(spec)) as Arc<dyn ExecutionPlan>;
+    replace_peeled_projection(&plan, replacement)
+}
+
+fn replace_peeled_projection(
+    plan: &Arc<dyn ExecutionPlan>,
+    replacement: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    if let Some(limit) = plan.downcast_ref::<GlobalLimitExec>() {
+        return Arc::clone(plan)
+            .with_new_children(vec![replace_peeled_projection(limit.input(), replacement)?]);
+    }
+    if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
+        return Arc::clone(plan).with_new_children(vec![replace_peeled_projection(
+            coalesce.input(),
+            replacement,
+        )?]);
+    }
+    if let Some(repartition) = plan.downcast_ref::<RepartitionExec>() {
+        return Arc::clone(plan).with_new_children(vec![replace_peeled_projection(
+            repartition.input(),
+            replacement,
+        )?]);
+    }
+    Ok(replacement)
+}
+
+struct OrderedTwoHopSpec {
+    schema: SchemaRef,
+    props: Arc<PlanProperties>,
+    fetch: usize,
+    rel_type_name: String,
+    direction: Direction,
+    provider: Arc<dyn AdjacencyProvider>,
+    ordinal_identities: Option<Arc<crate::V4OrdinalIdentitySession>>,
+    require_edge_disjoint: bool,
+}
+
+fn peel_plan(plan: &Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    if let Some(limit) = plan.downcast_ref::<GlobalLimitExec>() {
+        return peel_plan(limit.input());
+    }
+    if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
+        return peel_plan(coalesce.input());
+    }
+    if let Some(repartition) = plan.downcast_ref::<RepartitionExec>() {
+        return peel_plan(repartition.input());
+    }
+    Arc::clone(plan)
+}
+
+fn detect_ordered_two_hop(plan: &Arc<dyn ExecutionPlan>) -> Option<OrderedTwoHopSpec> {
+    let plan = peel_plan(plan);
+    let projection = plan.downcast_ref::<ProjectionExec>()?;
+    if projection.expr().len() != 1 {
+        return None;
+    }
+    let sort = projection.children().first()?.downcast_ref::<SortExec>()?;
+    let fetch = sort.fetch()?;
+    if sort.expr().len() != 1 || sort.expr()[0].options.descending {
+        return None;
+    }
+    let (expand2, require_edge_disjoint) =
+        if let Some(filter) = sort.children().first()?.downcast_ref::<FilterExec>() {
+            let disjoint = filter
+                .predicate()
+                .downcast_ref::<ScalarFunctionExpr>()
+                .is_some_and(|function| function.name() == "cypher_relationship_disjoint");
+            if !disjoint {
+                return None;
+            }
+            let expand2 = filter.children().first()?.downcast_ref::<ExpandExec>()?;
+            (expand2, true)
+        } else {
+            let expand2 = sort.children().first()?.downcast_ref::<ExpandExec>()?;
+            (expand2, false)
+        };
+    let expand1 = expand2.children().first()?.downcast_ref::<ExpandExec>()?;
+    if !expand1.is_destination_identity_only() || !expand2.is_destination_identity_only() {
+        return None;
+    }
+    if expand1.rel_type_name() != expand2.rel_type_name()
+        || expand1.direction() != expand2.direction()
+    {
+        return None;
+    }
+    Some(OrderedTwoHopSpec {
+        schema: plan.schema(),
+        props: Arc::clone(plan.properties()),
+        fetch,
+        rel_type_name: expand2.rel_type_name().to_owned(),
+        direction: expand2.direction(),
+        provider: Arc::clone(expand2.provider()),
+        ordinal_identities: expand2.ordinal_identities(),
+        require_edge_disjoint,
+    })
+}
+
+pub struct OrderedTwoHopPathCountExec {
+    schema: SchemaRef,
+    props: Arc<PlanProperties>,
+    fetch: usize,
+    rel_type_name: String,
+    direction: Direction,
+    provider: Arc<dyn AdjacencyProvider>,
+    ordinal_identities: Option<Arc<crate::V4OrdinalIdentitySession>>,
+    require_edge_disjoint: bool,
+}
+
+impl OrderedTwoHopPathCountExec {
+    fn new(spec: OrderedTwoHopSpec) -> Self {
+        Self {
+            schema: spec.schema,
+            props: spec.props,
+            fetch: spec.fetch,
+            rel_type_name: spec.rel_type_name,
+            direction: spec.direction,
+            provider: spec.provider,
+            ordinal_identities: spec.ordinal_identities,
+            require_edge_disjoint: spec.require_edge_disjoint,
+        }
+    }
+}
+
+impl fmt::Debug for OrderedTwoHopPathCountExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OrderedTwoHopPathCountExec")
+            .field("fetch", &self.fetch)
+            .field("rel", &self.rel_type_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DisplayAs for OrderedTwoHopPathCountExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OrderedTwoHopPathCountExec: rel={}, fetch={}",
+            self.rel_type_name, self.fetch
+        )
+    }
+}
+
+impl ExecutionPlan for OrderedTwoHopPathCountExec {
+    fn name(&self) -> &str {
+        "OrderedTwoHopPathCountExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.props
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return Err(DataFusionError::Internal(
+                "OrderedTwoHopPathCountExec has no children".into(),
+            ));
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "OrderedTwoHopPathCountExec only has partition 0, got {partition}"
+            )));
+        }
+        let outbound = self
+            .provider
+            .adjacency(&self.rel_type_name, self.direction)
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let inbound = self
+            .provider
+            .adjacency(&self.rel_type_name, Direction::In)
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let mut max_node = 0_u64;
+        outbound.for_each_row(|node_id, _| {
+            max_node = max_node.max(node_id);
+        });
+        inbound.for_each_row(|node_id, _| {
+            max_node = max_node.max(node_id);
+        });
+
+        let ordinal = self
+            .ordinal_identities
+            .as_ref()
+            .ok_or_else(|| DataFusionError::Internal("ordinal identity required".into()))?;
+
+        let mut remaining = self.fetch;
+        let mut uuids = Vec::with_capacity(self.fetch);
+        let mut candidates = 0_u64;
+        for destination in 0..=max_node {
+            if remaining == 0 {
+                break;
+            }
+            let path_count =
+                count_two_hop_paths_to(&inbound, destination, self.require_edge_disjoint);
+            if path_count == 0 {
+                continue;
+            }
+            candidates = candidates.saturating_add(path_count);
+            let lookup = ordinal
+                .lookup_node_uuids(&[destination])
+                .map_err(|error| DataFusionError::External(Box::new(error)))?;
+            let uuid = *lookup.values[0]
+                .as_ref()
+                .ok_or_else(|| DataFusionError::Internal("missing destination uuid".into()))?
+                .as_bytes();
+            let emit = usize_from_u64(path_count).min(remaining);
+            uuids.extend(std::iter::repeat_n(uuid, emit));
+            remaining -= emit;
+        }
+
+        demand::record_candidates(1, usize_from_u64(candidates));
+        demand::record_emitted(1, uuids.len());
+
+        let field = Field::new("id", DataType::FixedSizeBinary(16), true);
+        let schema = Arc::new(Schema::new(vec![field]));
+        let mut builder = FixedSizeBinaryBuilder::with_capacity(uuids.len(), 16);
+        for uuid in uuids {
+            builder
+                .append_value(uuid)
+                .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        }
+        let column: ArrayRef = Arc::new(builder.finish());
+        let batch = arrow::record_batch::RecordBatch::try_new(schema, vec![column])
+            .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
+        Ok(Box::pin(OrderedTwoHopStream {
+            schema: Arc::clone(&self.schema),
+            batch: Some(batch),
+        }))
+    }
+}
+
+fn usize_from_u64(value: u64) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}
+
+fn count_two_hop_paths_to(
+    inbound: &crate::Adjacency,
+    destination: u64,
+    require_edge_disjoint: bool,
+) -> u64 {
+    let mut count = 0_u64;
+    for (r2, middle) in inbound.neighbors(destination).iter() {
+        for (r1, _) in inbound.neighbors(middle).iter() {
+            if !require_edge_disjoint || r1 != r2 {
+                count = count.saturating_add(1);
+            }
+        }
+    }
+    count
+}
+
+struct OrderedTwoHopStream {
+    schema: SchemaRef,
+    batch: Option<arrow::record_batch::RecordBatch>,
+}
+
+impl Stream for OrderedTwoHopStream {
+    type Item = Result<arrow::record_batch::RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.batch.take().map(Ok))
+    }
+}
+
+impl RecordBatchStream for OrderedTwoHopStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `OrderedTwoHopPathCountExec` to rewrite fixed-hop plans where both hops are destination-UUID-only and the terminal operator is an ascending TopK on that UUID. Instead of materializing every two-hop candidate before sort (billions of rows at S18+), the executor walks destinations in node-id order, counts two-hop path multiplicity via inbound adjacency (honoring `cypher_relationship_disjoint`), and emits rows until the fetch bound is satisfied.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #966

## Changes Made

- New `crates/graphforge-exec/src/ordered_two_hop.rs` with pattern detection and path-count execution
- Wire rewrite into `FixedHopDemandRule` after projection materialization
- Add `ExpandExec` accessors and `pub(crate)` ordinal session lookup for reuse

## Testing

### Test Commands Run

```bash
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/gf-target cargo clippy -p graphforge-exec -- -D warnings
CARGO_TARGET_DIR=/tmp/gf-target cargo test -p graphforge-exec --lib
```

856 `graphforge-exec` unit tests pass. `fixed_hop_limit` durable-project tests cannot run on the Cloud Agent overlay filesystem (`GF_UNSUPPORTED_FILESYSTEM`); Fly S18 re-qualification will validate the certification query path once this merges and the progressive image is rebuilt.

## Performance Impact

- [x] Performance improved

Two-hop `ORDER BY id LIMIT 1000` on Graph500 should drop from ~89-minute query phases (full candidate materialization) to destination-order path counting with early termination at K rows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790903203&installation_model_id=20486&pr_number=1072&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1072&signature=d8cdc4cb6d153ef26886c021bc73e81ac3a6b3f046e368d538532904bcd1171c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ordered two-hop path-counting rewrite to avoid full expansion in `FixedHopDemandRule`
> - Introduces `ordered_two_hop` module that detects physical plans matching a single-key ascending sort with a finite fetch over a two-hop expand pattern, and replaces the projection/sort/expand subtree with `OrderedTwoHopPathCountExec`.
> - The new operator enumerates destination IDs in ascending order, counts two-hop path multiplicity through inbound adjacency, and emits each destination UUID repeated by its path count up to the fetch limit — avoiding materialization of full path rows.
> - The optimizer in `FixedHopDemandRule.optimize` now runs this rewrite after materialization rewriting and before terminal-demand search; non-matching plans fall through unchanged.
> - Adds crate-visible accessors on `ExpandExec` (rel type, direction, provider, identity session) and an `is_destination_identity_only` predicate so the matcher can reject expansions requiring other materialized fields.
> - Behavioral Change: `detect_ordered_two_hop` matches by structure and function name only — it checks sort-expression count and ascending flag but does not verify the sort key denotes destination UUID, and checks the `cypher_relationship_disjoint` filter by function name without validating arguments. Plans that structurally match but differ semantically may be rewritten incorrectly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 438b051.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->