### PR TITLE
fix(bench): align progressive ingest row count with LIMIT 1000 queries

### DIFF
--- a/benchmarks/harness/graphforge_bench/progressive_queries.py
+++ b/benchmarks/harness/graphforge_bench/progressive_queries.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-ONE_HOP_ORDERED_LIMIT = "MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT 1000"
+ORDERED_LIMIT_ROW_COUNT = 1000
+
+ONE_HOP_ORDERED_LIMIT = (
+    f"MATCH (a)-[r]->(b) RETURN b.node_uuid AS id ORDER BY id LIMIT {ORDERED_LIMIT_ROW_COUNT}"
+)
 TWO_HOP_ORDERED_LIMIT = (
-    "MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id LIMIT 1000"
+    f"MATCH (a)-[r1]->(b)-[r2]->(c) RETURN c.node_uuid AS id ORDER BY id "
+    f"LIMIT {ORDERED_LIMIT_ROW_COUNT}"
 )
 
 CANONICAL_QUERY_PHASES = (

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -31,6 +31,7 @@ from graphforge_bench.benchexec_authority import Limits, normalize_run
 from graphforge_bench.hybrid_cgroup_v2 import measure_hybrid_pressure
 from graphforge_bench.local_admission import qualify_local_host
 from graphforge_bench.progressive_qualification import QualificationError, load_profiles, project
+from graphforge_bench.progressive_queries import ORDERED_LIMIT_ROW_COUNT
 
 PLAN_SCHEMA = "graphforge-progressive-run-plan/1"
 RESULT_SCHEMA = "graphforge-progressive-run-result/1"
@@ -675,8 +676,8 @@ def assemble_rung_evidence(
         if source_counts[index]["result_sha256"] != imported_counts[index]["result_sha256"]:
             raise ControllerError("source/imported recount evidence disagrees")
     if any(
-        source.get("rows") != 1024
-        or imported_receipt.get("rows") != 1024
+        source.get("rows") != ORDERED_LIMIT_ROW_COUNT
+        or imported_receipt.get("rows") != ORDERED_LIMIT_ROW_COUNT
         or source["result_sha256"] != imported_receipt["result_sha256"]
         for source, imported_receipt in zip(source_hops, imported_hops, strict=True)
     ):

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -195,8 +195,8 @@ def authoritative_receipts(scale: int) -> dict[str, list[dict]]:
     nodes, edges = 1 << scale, 16 * (1 << scale)
     node_count = sink("a" * 64, rows=1, scalar=nodes)
     edge_count = sink("b" * 64, rows=1, scalar=edges)
-    one_hop = sink("c" * 64, rows=1024)
-    two_hop = sink("d" * 64, rows=1024)
+    one_hop = sink("c" * 64, rows=1000)
+    two_hop = sink("d" * 64, rows=1000)
     return {
         "ingest": construction,
         "reopen": [source_storage],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a mismatch between canonical progressive qualification queries (`ORDER BY … LIMIT 1000`, merged in #1070) and `assemble_rung_evidence`, which still required 1024-row query receipts.

On Fly S18 run #3, every certification phase passed (including `reopen_proof`, peak RSS ~570 MB, no OOM), but `progressive_run` ingest failed with `ordinary_receipt_missing` because hop query receipts reported `rows: 1000`.

## Changes

- Introduce `ORDERED_LIMIT_ROW_COUNT = 1000` in `progressive_queries.py`
- Use that constant in `assemble_rung_evidence` row validation
- Update unit test fixtures to match

## Verification

```bash
cd benchmarks && PYTHONPATH=harness uv run python -m unittest tests.test_progressive_run -q
# Ran 23 tests in 0.083s — OK
```

## Issue

Unblocks Fly ladder re-qualification for epic #952 after S18 run #3 false-negative ingest failure.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790911636&installation_model_id=20486&pr_number=1073&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1073&signature=86c675c03df5b768e04ef034017de5a089ed792c94ede67bb49baa6b3ce46b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix progressive ingest row-count validation to match `LIMIT 1000` queries
> The ordered-hop query strings use `LIMIT 1000`, but `assemble_rung_evidence` in [progressive_run.py](https://github.com/CurateLabs/graphforge/pull/1073/files#diff-0c7e145e0e3608068b322307c08079a6a1dc695792664b94487ad556d8bff04d) validated receipts against a hard-coded `1024`-row value, causing valid receipts to be rejected.
>
> - Introduces a shared module-level row-count constant in [progressive_queries.py](https://github.com/CurateLabs/graphforge/pull/1073/files#diff-b8a49d9d08c3208cd93c5da19de689a427e2b02252b840014fb3c9bb4efb6951) and interpolates it into the one-hop and two-hop ordered-limit query strings instead of duplicating the literal.
> - `assemble_rung_evidence` now imports and checks against that same constant, so query and validation agree at `1000` rows.
> - Updates the `authoritative_receipts` test fixtures in [test_progressive_run.py](https://github.com/CurateLabs/graphforge/pull/1073/files#diff-5e9a27caeaa2704f89fdf519fb8dc0fd2ce0840480f34afa5e5c4371ea6c407d) to report `1000` rows.
> - Behavioral Change: receipts reporting `1024` rows are now rejected; any out-of-tree code relying on the old `1024`-row threshold will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9d9be5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->