### PR TITLE
build(bench): preserve Cargo cache across Fly images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,17 @@
 .git
 .venv
 target
+**/.venv
+**/target
+**/__pycache__
+**/.mypy_cache
+**/.pytest_cache
+**/.ruff_cache
 bazel-*
 build
 dist
 node_modules
+**/node_modules
 *.env
 .env*
 *.pem

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -72,6 +72,24 @@ def attempt(**changes: object) -> FlyAttempt:
 
 
 class FlyAdapterTests(unittest.TestCase):
+    def test_progressive_image_build_preserves_incremental_cargo_cache(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        dockerfile = (
+            root / "containers" / "graphforge-progressive-qualification" / "Dockerfile"
+        ).read_text(encoding="utf-8")
+        dockerignore = (root / ".dockerignore").read_text(encoding="utf-8").splitlines()
+
+        self.assertIn("**/target", dockerignore)
+        self.assertIn("**/.venv", dockerignore)
+        self.assertIn("target=/usr/local/cargo/registry", dockerfile)
+        self.assertIn("target=/source/target", dockerfile)
+        self.assertIn("target=/source/benchmarks/target", dockerfile)
+        self.assertLess(
+            dockerfile.index("cargo build --locked"),
+            dockerfile.index("ARG GRAPHFORGE_COMMIT"),
+        )
+        self.assertIn("COPY --from=rust-build /artifacts/gf", dockerfile)
+
     def test_remote_build_is_remote_only_pushed_and_commit_pinned(self) -> None:
         command = remote_build_command(
             app="gf-fixture",

--- a/benchmarks/tests/test_fly_adapter.py
+++ b/benchmarks/tests/test_fly_adapter.py
@@ -82,8 +82,8 @@ class FlyAdapterTests(unittest.TestCase):
         self.assertIn("**/target", dockerignore)
         self.assertIn("**/.venv", dockerignore)
         self.assertIn("target=/usr/local/cargo/registry", dockerfile)
-        self.assertIn("target=/source/target", dockerfile)
-        self.assertIn("target=/source/benchmarks/target", dockerfile)
+        self.assertEqual(dockerfile.count("target=/cargo-target"), 1)
+        self.assertEqual(dockerfile.count("CARGO_TARGET_DIR=/cargo-target cargo build"), 2)
         self.assertLess(
             dockerfile.index("cargo build --locked"),
             dockerfile.index("ARG GRAPHFORGE_COMMIT"),

--- a/containers/graphforge-progressive-qualification/Dockerfile
+++ b/containers/graphforge-progressive-qualification/Dockerfile
@@ -14,16 +14,15 @@ RUN test "${TARGETOS}/${TARGETARCH}" = linux/amd64 \
     && chmod 0444 /source-tree-sha256
 RUN --mount=type=cache,id=graphforge-progressive-cargo-registry-v1,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=graphforge-progressive-cargo-git-v1,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,id=graphforge-progressive-target-v1,target=/source/target,sharing=locked \
-    --mount=type=cache,id=graphforge-progressive-benchmark-target-v1,target=/source/benchmarks/target,sharing=locked \
-    cargo build --locked --release --package graphforge-cli --bin gf \
-    && cargo build --manifest-path benchmarks/Cargo.toml --locked --release \
+    --mount=type=cache,id=graphforge-progressive-target-v1,target=/cargo-target,sharing=locked \
+    CARGO_TARGET_DIR=/cargo-target cargo build --locked --release --package graphforge-cli --bin gf \
+    && CARGO_TARGET_DIR=/cargo-target cargo build --manifest-path benchmarks/Cargo.toml --locked --release \
         --package graphforge-benchmark-certify \
         --package graphforge-benchmark-graph500-generator \
-    && install -D -m 0555 target/release/gf /artifacts/gf \
-    && install -D -m 0555 benchmarks/target/release/graphforge-benchmark-certify \
+    && install -D -m 0555 /cargo-target/release/gf /artifacts/gf \
+    && install -D -m 0555 /cargo-target/release/graphforge-benchmark-certify \
         /artifacts/graphforge-benchmark-certify \
-    && install -D -m 0555 benchmarks/target/release/graphforge-benchmark-graph500-generator \
+    && install -D -m 0555 /cargo-target/release/graphforge-benchmark-graph500-generator \
         /artifacts/graphforge-benchmark-graph500-generator
 ARG GRAPHFORGE_COMMIT
 RUN printf '%s\n' "${GRAPHFORGE_COMMIT}" | grep -Eq '^[0-9a-f]{40}$' \

--- a/containers/graphforge-progressive-qualification/Dockerfile
+++ b/containers/graphforge-progressive-qualification/Dockerfile
@@ -1,23 +1,34 @@
+# syntax=docker/dockerfile:1.7
+
 FROM rust:1.96-bookworm@sha256:a339861ae23e9abb272cea45dfafde21760d2ce6577a70f8a926153677902663 AS rust-build
 
-ARG GRAPHFORGE_COMMIT
 ARG TARGETARCH
 ARG TARGETOS
 WORKDIR /source
 COPY . .
 RUN test "${TARGETOS}/${TARGETARCH}" = linux/amd64 \
-    && printf '%s\n' "${GRAPHFORGE_COMMIT}" | grep -Eq '^[0-9a-f]{40}$' \
-    && printf '%s\n' "${GRAPHFORGE_COMMIT}" > /graphforge-commit \
-    && chmod 0444 /graphforge-commit \
     && tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
         -cf /tmp/source-tree.tar . \
     && sha256sum /tmp/source-tree.tar | cut -d ' ' -f 1 > /source-tree-sha256 \
     && rm /tmp/source-tree.tar \
-    && chmod 0444 /source-tree-sha256 \
-    && cargo build --locked --release --package graphforge-cli --bin gf \
+    && chmod 0444 /source-tree-sha256
+RUN --mount=type=cache,id=graphforge-progressive-cargo-registry-v1,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=graphforge-progressive-cargo-git-v1,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=graphforge-progressive-target-v1,target=/source/target,sharing=locked \
+    --mount=type=cache,id=graphforge-progressive-benchmark-target-v1,target=/source/benchmarks/target,sharing=locked \
+    cargo build --locked --release --package graphforge-cli --bin gf \
     && cargo build --manifest-path benchmarks/Cargo.toml --locked --release \
         --package graphforge-benchmark-certify \
-        --package graphforge-benchmark-graph500-generator
+        --package graphforge-benchmark-graph500-generator \
+    && install -D -m 0555 target/release/gf /artifacts/gf \
+    && install -D -m 0555 benchmarks/target/release/graphforge-benchmark-certify \
+        /artifacts/graphforge-benchmark-certify \
+    && install -D -m 0555 benchmarks/target/release/graphforge-benchmark-graph500-generator \
+        /artifacts/graphforge-benchmark-graph500-generator
+ARG GRAPHFORGE_COMMIT
+RUN printf '%s\n' "${GRAPHFORGE_COMMIT}" | grep -Eq '^[0-9a-f]{40}$' \
+    && printf '%s\n' "${GRAPHFORGE_COMMIT}" > /graphforge-commit \
+    && chmod 0444 /graphforge-commit
 
 
 FROM python:3.12.11-slim-bookworm@sha256:519591d6871b7bc437060736b9f7456b8731f1499a57e22e6c285135ae657bf7 AS python-deps
@@ -43,10 +54,10 @@ RUN mkdir -p /opt/graphforge /work \
 COPY --from=python-deps /usr/bin/fuse-overlayfs /usr/bin/fuse-overlayfs
 COPY --from=python-deps /lib/x86_64-linux-gnu/libfuse3.so.3 /lib/x86_64-linux-gnu/libfuse3.so.3
 
-COPY --from=rust-build /source/target/release/gf /usr/local/bin/gf
-COPY --from=rust-build /source/benchmarks/target/release/graphforge-benchmark-certify \
+COPY --from=rust-build /artifacts/gf /usr/local/bin/gf
+COPY --from=rust-build /artifacts/graphforge-benchmark-certify \
     /usr/local/bin/graphforge-benchmark-certify
-COPY --from=rust-build /source/benchmarks/target/release/graphforge-benchmark-graph500-generator \
+COPY --from=rust-build /artifacts/graphforge-benchmark-graph500-generator \
     /usr/local/bin/graphforge-benchmark-graph500-generator
 COPY --from=rust-build --chmod=0444 /graphforge-commit /opt/graphforge/commit
 COPY --from=python-deps /opt/graphforge/benchmarks/.venv /opt/graphforge/benchmarks/.venv

--- a/scripts/ci/test-progressive-qualification-image.py
+++ b/scripts/ci/test-progressive-qualification-image.py
@@ -174,14 +174,14 @@ def validate_contract(root: Path) -> None:
         raise ContractError("benchmark lock must resolve exactly one pinned BenchExec package")
 
     ignored = (root / DOCKERIGNORE).read_text(encoding="utf-8").splitlines()
-    for pattern in (".git", "*.env", ".env*", "*.pem", "*.key"):
+    for pattern in (".git", "**/.venv", "**/target", "*.env", ".env*", "*.pem", "*.key"):
         if pattern not in ignored:
             raise ContractError(f"container build context must exclude {pattern}")
 
     for binary in (
-        "/source/target/release/gf",
-        "/source/benchmarks/target/release/graphforge-benchmark-certify",
-        "/source/benchmarks/target/release/graphforge-benchmark-graph500-generator",
+        "/artifacts/gf",
+        "/artifacts/graphforge-benchmark-certify",
+        "/artifacts/graphforge-benchmark-graph500-generator",
     ):
         require(dockerfile, binary, f"runtime must copy built binary {Path(binary).name}")
     require(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Make progressive qualification image builds incremental. The previous Dockerfile copied the entire repository and combined commit attestation with `cargo build`, while nested build outputs inflated the remote context. It also compiled shared dependencies twice because the root and benchmark workspaces used separate target directories.

## Type of Change

- [x] 🔧 Configuration/infrastructure change
- [x] ✅ Tests (adding or updating tests)

## Related Issues

Relates to #952

## Changes Made

- Exclude nested Cargo targets, virtual environments, package trees, and tool caches from the Docker context.
- Add persistent BuildKit cache mounts for Cargo registries and one shared Rust target directory.
- Point both root and benchmark workspace builds at the shared target cache, avoiding duplicate dependency compilation.
- Copy final binaries out of the cache mount into an immutable artifact directory.
- Move commit attestation after compilation so changing the image revision does not invalidate compilation.
- Update the authoritative progressive image contract and add a focused cache-boundary regression test.

## Testing

```bash
python3 scripts/ci/test-progressive-qualification-image.py
# Ran 2 tests — OK

cd benchmarks && PYTHONPATH=harness uv run python -m unittest tests.test_fly_adapter -q
# Ran 16 tests — OK

uv run ruff check scripts/ci/test-progressive-qualification-image.py benchmarks/tests/test_fly_adapter.py
uv run ruff format --check scripts/ci/test-progressive-qualification-image.py benchmarks/tests/test_fly_adapter.py
# All checks passed

flyctl config validate --app gf-s18-7606e467d50dd396cffb8700b1c78510 \
  --config containers/graphforge-progressive-qualification/fly.build.toml
# Configuration is valid
```

Remote validation reduced the uploaded build context from 7.3 GB to 417 MB. The first optimized build seeds the persistent target cache; the exact-head build validates reuse and the resulting image.

## Checklist

- [x] This PR is small and focused
- [x] This PR addresses one logical change
- [x] No skips, retries, or weakened assertions
- [x] Unit and repository-policy tests updated
- [x] No breaking API changes
- [x] No runtime performance impact; build performance improves

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790919108&installation_model_id=20486&pr_number=1074&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1074&signature=b88e792558ac0411977314880af35fbc365bfcb69ad3b37cbc216473aad92397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add BuildKit Cargo cache mounts and artifact directory to Fly progressive qualification image
> - Adds locked BuildKit cache mounts for the Cargo registry, Git data, and a shared target directory in the `rust-build` stage of [Dockerfile](https://github.com/CurateLabs/graphforge/pull/1074/files#diff-e80e651af7e28051232a5843d31b4eb0c2eb9cf4da8be06fb5286b3900a6b54d); both release builds now share one target directory.
> - Installs the three Rust executables into a stable artifact directory and copies them from there in the qualification stage instead of from source-tree target paths.
> - Moves commit-argument validation and commit-file creation to a later layer, so source-tree hashing runs in the build layer and the commit check runs after compilation.
> - Adds recursive exclusions for nested virtual environments, Rust target directories, Python bytecode, and Node dependencies to [.dockerignore](https://github.com/CurateLabs/graphforge/pull/1074/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5) to keep build contexts small.
> - Adds a contract test in [test_fly_adapter.py](https://github.com/CurateLabs/graphforge/pull/1074/files#diff-2ec8cd5a99b1e44a459f3ab07f2fe37e6872f836b0a2f3c518d4e33420b9f10d) and updates the validator in [test-progressive-qualification-image.py](https://github.com/CurateLabs/graphforge/pull/1074/files#diff-f5ac9681ddd2f1b2be2e6069b883db23a6303a977aa8469897c6b46df90c51d2) to enforce the new ignore patterns, cache mounts, shared target config, build ordering, and artifact-copy layout.
> - Behavioral Change: the qualification stage now sources executables from the artifact directory (`/artifacts`) rather than source-tree `target/` paths; out-of-tree Dockerfiles relying on the old copy paths will fail contract validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56ebf06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->