### PR TITLE
feat(bench): expose portable allocation receipt

### DIFF
--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -756,6 +756,31 @@ fn sanitize_receipt(value: &serde_json::Value) -> Option<serde_json::Value> {
                 "equivalent",
             ],
         ),
+        Some("graphforge-portable-export/2") => copy_selected_receipt(
+            object,
+            &[
+                "contract",
+                "package_digest",
+                "transport_digest",
+                "entry_count",
+                "payload_bytes",
+                "representation",
+                "selection_fingerprint",
+                "allocation_logical_bytes",
+                "allocation_allocated_bytes",
+                "allocation_physical_objects",
+            ],
+        )
+        .filter(|receipt| {
+            sanitized_numeric_fields(
+                receipt,
+                &[
+                    "allocation_logical_bytes",
+                    "allocation_allocated_bytes",
+                    "allocation_physical_objects",
+                ],
+            )
+        }),
         Some("graphforge-portable-import/2") => copy_selected_receipt(
             object,
             &[
@@ -1684,6 +1709,52 @@ mod tests {
         let mut leaked = receipt;
         leaked["storage"]["project_path"] = serde_json::json!("/secret");
         let encoded = serde_json::to_vec(&leaked).expect("leaked receipt JSON");
+        assert!(parse_receipts(&encoded, true).is_err());
+    }
+
+    #[test]
+    fn portable_export_receipt_preserves_only_writer_allocation_totals() {
+        let receipt = serde_json::json!({
+            "contract": "graphforge-portable-export/2",
+            "source": "current",
+            "generation_uuid": "00000000-0000-4000-8000-000000000001",
+            "output": "/secret/package.gfpb",
+            "package_digest": format!("sha256:{}", "0".repeat(64)),
+            "transport_digest": format!("sha256:{}", "1".repeat(64)),
+            "entry_count": 4,
+            "payload_bytes": 8_192,
+            "representation": "bundle",
+            "selection_fingerprint": format!("sha256:{}", "2".repeat(64)),
+            "allocation_logical_bytes": 9_000,
+            "allocation_allocated_bytes": 12_288,
+            "allocation_physical_objects": 3,
+            "allocation_identity_allocated_bytes": {"secret-native-id": 12_288}
+        });
+        let encoded = serde_json::to_vec(&receipt).expect("portable export receipt JSON");
+
+        let sanitized = parse_receipts(&encoded, true).expect("closed portable export receipt");
+
+        assert_eq!(sanitized[0]["allocation_logical_bytes"], 9_000);
+        assert_eq!(sanitized[0]["allocation_allocated_bytes"], 12_288);
+        assert_eq!(sanitized[0]["allocation_physical_objects"], 3);
+        let encoded = serde_json::to_string(&sanitized[0]).unwrap();
+        for forbidden in ["/secret", "uuid", "identity", "secret-native-id"] {
+            assert!(!encoded.contains(forbidden));
+        }
+
+        let mut missing_authority = receipt.clone();
+        missing_authority
+            .as_object_mut()
+            .unwrap()
+            .remove("allocation_allocated_bytes");
+        let encoded =
+            serde_json::to_vec(&missing_authority).expect("incomplete portable export receipt");
+        assert!(parse_receipts(&encoded, true).is_err());
+
+        let mut malformed_authority = receipt;
+        malformed_authority["allocation_physical_objects"] = serde_json::json!(-1);
+        let encoded =
+            serde_json::to_vec(&malformed_authority).expect("malformed portable export receipt");
         assert!(parse_receipts(&encoded, true).is_err());
     }
 

--- a/benchmarks/schemas/certification-evidence.json
+++ b/benchmarks/schemas/certification-evidence.json
@@ -63,7 +63,7 @@
           "items": {
             "type": "object",
             "propertyNames": {
-              "enum": ["contract", "outcome", "rows_accepted", "rows_rejected", "bytes_accepted", "construction", "format", "rows", "batches", "bytes", "complete", "result_sha256", "scalar_u64", "query_evidence", "storage", "reopen_agrees", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "transient_peak_allocated_bytes", "logical_read_bytes", "logical_write_bytes", "reader_calls", "publication_work_units", "live_nodes", "live_edges", "one_hop_rows", "two_hop_rows", "source_fingerprint", "imported_fingerprint", "equivalent", "kind", "selected_generation_class", "work_detected", "repaired_journals", "aborted_journals", "removed_generations", "preserved_unknown_entries", "deferred", "elapsed_ms", "package_digest", "transport_digest", "entry_count", "payload_bytes", "representation", "selection_fingerprint", "integrity", "compatibility", "idempotent_replay"]
+              "enum": ["contract", "outcome", "rows_accepted", "rows_rejected", "bytes_accepted", "construction", "format", "rows", "batches", "bytes", "complete", "result_sha256", "scalar_u64", "query_evidence", "storage", "reopen_agrees", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "transient_peak_allocated_bytes", "logical_read_bytes", "logical_write_bytes", "reader_calls", "publication_work_units", "live_nodes", "live_edges", "one_hop_rows", "two_hop_rows", "source_fingerprint", "imported_fingerprint", "equivalent", "kind", "selected_generation_class", "work_detected", "repaired_journals", "aborted_journals", "removed_generations", "preserved_unknown_entries", "deferred", "elapsed_ms", "package_digest", "transport_digest", "entry_count", "payload_bytes", "representation", "selection_fingerprint", "allocation_logical_bytes", "allocation_allocated_bytes", "allocation_physical_objects", "integrity", "compatibility", "idempotent_replay"]
             },
             "allOf": [
               {
@@ -79,6 +79,22 @@
                     "source_project_current_allocated_bytes": { "type": "integer", "minimum": 0 },
                     "retained_storage_bytes": { "type": "integer", "minimum": 0 },
                     "transient_peak_storage_bytes": { "type": "integer", "minimum": 0 }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "contract": { "const": "graphforge-portable-export/2" }
+                  },
+                  "required": ["contract"]
+                },
+                "then": {
+                  "required": ["contract", "allocation_logical_bytes", "allocation_allocated_bytes", "allocation_physical_objects"],
+                  "properties": {
+                    "allocation_logical_bytes": { "type": "integer", "minimum": 0 },
+                    "allocation_allocated_bytes": { "type": "integer", "minimum": 0 },
+                    "allocation_physical_objects": { "type": "integer", "minimum": 0 }
                   }
                 }
               }

--- a/benchmarks/tests/test_smoke.py
+++ b/benchmarks/tests/test_smoke.py
@@ -98,6 +98,60 @@ class WorkspaceSmokeTests(unittest.TestCase):
                 invalid["source_project_current_allocated_bytes"] = malformed
                 self.assertFalse(validator.is_valid(evidence(invalid)))
 
+    def test_portable_export_receipt_schema_requires_writer_allocation(self) -> None:
+        schema = json.loads(
+            (workspace_root() / "schemas" / "certification-evidence.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        validator = Draft202012Validator(schema)
+        receipt = {
+            "contract": "graphforge-portable-export/2",
+            "package_digest": f"sha256:{'0' * 64}",
+            "transport_digest": f"sha256:{'1' * 64}",
+            "entry_count": 4,
+            "payload_bytes": 8192,
+            "representation": "bundle",
+            "selection_fingerprint": f"sha256:{'2' * 64}",
+            "allocation_logical_bytes": 9000,
+            "allocation_allocated_bytes": 12288,
+            "allocation_physical_objects": 3,
+        }
+
+        def evidence(candidate: dict[str, object]) -> dict[str, object]:
+            return {
+                "schema": "graphforge-public-certification/1",
+                "profile_id": "tiny-public-certification",
+                "status": "passed",
+                "phases": [
+                    {
+                        "phase": "export",
+                        "status": "passed",
+                        "duration_ms": 1,
+                        "peak_rss_bytes": 1024,
+                        "exit_code": 0,
+                        "receipts": [candidate],
+                    }
+                ],
+                "failed_phase": None,
+            }
+
+        validator.validate(evidence(receipt))
+        for missing in (
+            "allocation_logical_bytes",
+            "allocation_allocated_bytes",
+            "allocation_physical_objects",
+        ):
+            with self.subTest(missing=missing):
+                invalid = dict(receipt)
+                del invalid[missing]
+                self.assertFalse(validator.is_valid(evidence(invalid)))
+        for malformed in (True, -1, "12288"):
+            with self.subTest(malformed=malformed):
+                invalid = dict(receipt)
+                invalid["allocation_allocated_bytes"] = malformed
+                self.assertFalse(validator.is_valid(evidence(invalid)))
+
     def test_product_manifests_do_not_reference_benchmark_dependencies(self) -> None:
         repository = workspace_root().parent
         manifests = sorted(repository.rglob("Cargo.toml")) + sorted(

--- a/crates/graphforge-cli/src/portable_cli.rs
+++ b/crates/graphforge-cli/src/portable_cli.rs
@@ -13,6 +13,7 @@ use graphforge_api::{
     PortableV2SelectionProfile, PortableV2SelectionRequest, PortableVerifyRequest,
     ResultSinkOptions, publish_portable_v2_oci, pull_portable_v2_oci, verify_portable_v2,
 };
+use serde_json::Value;
 use uuid::Uuid;
 
 use crate::canonical_uuid;
@@ -268,21 +269,7 @@ pub(crate) fn run_portable(
                 )
                 .map_err(map_portable)?;
             if json {
-                write_json(
-                    &serde_json::json!({
-                        "contract": result.contract,
-                        "source": result.source,
-                        "checkpoint": result.checkpoint,
-                        "generation_uuid": result.generation_uuid,
-                        "package_digest": result.package_digest,
-                        "transport_digest": result.transport_digest,
-                        "entry_count": result.entry_count,
-                        "payload_bytes": result.payload_bytes,
-                        "representation": result.representation,
-                        "selection_fingerprint": result.selection_fingerprint,
-                    }),
-                    output,
-                )?;
+                write_json(&portable_export_receipt(&result), output)?;
             } else {
                 writeln!(
                     output,
@@ -305,6 +292,28 @@ pub(crate) fn run_portable(
         }
     }
     Ok(())
+}
+
+fn portable_export_receipt(result: &graphforge_api::PortableV2ExportFacadeResult) -> Value {
+    serde_json::json!({
+        "contract": result.contract,
+        "source": result.source,
+        "checkpoint": result.checkpoint,
+        "generation_uuid": result.generation_uuid,
+        "package_digest": result.package_digest,
+        "transport_digest": result.transport_digest,
+        "entry_count": result.entry_count,
+        "payload_bytes": result.payload_bytes,
+        "representation": result.representation,
+        "selection_fingerprint": result.selection_fingerprint,
+        "allocation_logical_bytes": result.allocation_logical_bytes,
+        "allocation_allocated_bytes": result
+            .allocation_identity_allocated_bytes
+            .values()
+            .copied()
+            .sum::<u64>(),
+        "allocation_physical_objects": result.allocation_physical_objects,
+    })
 }
 
 /// Project-free portable operations that must not hold a live `GraphForge` lock.
@@ -779,6 +788,39 @@ fn write_progress(
 mod lifecycle_storage_tests {
     use super::*;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn portable_export_receipt_exposes_closed_writer_allocation() {
+        let result = graphforge_api::PortableV2ExportFacadeResult {
+            contract: "graphforge-portable-export/2",
+            source: "current",
+            checkpoint: None,
+            generation_uuid: Uuid::nil(),
+            package_digest: format!("sha256:{}", "0".repeat(64)),
+            transport_digest: format!("sha256:{}", "1".repeat(64)),
+            entry_count: 2,
+            payload_bytes: 100,
+            representation: "bundle",
+            selection_fingerprint: format!("sha256:{}", "2".repeat(64)),
+            output: PathBuf::from("/secret/package.gfpb"),
+            allocation_identity_allocated_bytes: BTreeMap::from([
+                ("first-native-identity".to_owned(), 4_096),
+                ("second-native-identity".to_owned(), 8_192),
+            ]),
+            allocation_logical_bytes: 10_000,
+            allocation_physical_objects: 2,
+        };
+
+        let receipt = portable_export_receipt(&result);
+
+        assert_eq!(receipt["allocation_logical_bytes"], 10_000);
+        assert_eq!(receipt["allocation_allocated_bytes"], 12_288);
+        assert_eq!(receipt["allocation_physical_objects"], 2);
+        let encoded = serde_json::to_string(&receipt).unwrap();
+        for forbidden in ["/secret", "native-identity", "output"] {
+            assert!(!encoded.contains(forbidden));
+        }
+    }
 
     fn import_result() -> graphforge_api::PortableV2ImportResult {
         graphforge_api::PortableV2ImportResult {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Expose writer-authoritative portable-package allocation totals through the ordinary `gf portable export --json` receipt, then preserve only those closed numeric totals at the certification sanitizer boundary. This supplies the missing portable-package authority needed by #951 without exposing paths or native identity data.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Tests (adding or updating tests)

## Related Issues

Relates to #951
Relates to #952

## Changes Made

- Add logical bytes, allocated physical bytes, and physical object count to portable export JSON receipts.
- Derive allocation only from the Rust writer-owned identity union.
- Allowlist the closed totals in certification evidence while stripping paths, UUIDs, and identity maps.
- Require those fields with closed numeric types in the certification evidence schema.
- Reject missing or malformed allocation authority in both sanitizer and schema tests.

## Testing

- CLI lifecycle tests: 3 passed.
- Certification runner tests: 18 passed.
- Certification evidence schema tests: 7 passed / 12 subtests.
- Rust formatting, Ruff, and warning-denied `graphforge-cli` Clippy: passed.
- Superseded-head Bazel failure reproduced as missing schema property names; current head includes the root-cause fix and regression test.

### Test Commands Run

```bash
CARGO_TARGET_DIR=/tmp/target-pr1076 cargo test --locked -p graphforge-cli lifecycle_storage_tests
CARGO_TARGET_DIR=/tmp/target-pr1076 cargo test --manifest-path benchmarks/Cargo.toml --locked -p graphforge-benchmark-certify
PYTHONPATH=/tmp/graphforge-951-portable/benchmarks/harness:/workspace/benchmarks/.venv/lib/python3.12/site-packages /workspace/.venv/bin/python -m pytest benchmarks/tests/test_smoke.py -q
cargo fmt --all -- --check
/workspace/.venv/bin/ruff check benchmarks/tests/test_smoke.py
CARGO_TARGET_DIR=/tmp/target-pr1076 cargo clippy --locked -p graphforge-cli -- -D warnings
```

## Checklist

- [x] This PR is small and focused
- [x] This PR addresses one logical change
- [x] No workarounds, skips, ignores, or weakened assertions
- [x] No breaking public API change
- [x] No performance impact
- [x] No breaking changes

## Reviewer Notes

This PR intentionally does not add the progressive-to-v3 adapter. It closes the portable writer-receipt prerequisite so that the subsequent assembly adapter can copy authoritative values without inferring from payload size.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790924910&installation_model_id=20486&pr_number=1076&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1076&signature=dee0d133c145a5fbcb0e4d2829ec61dbc0505d3274794c9f157f9ef43d25f70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose portable allocation receipt in `run_portable` and `sanitize_receipt`
> - `run_portable` builds the portable CLI JSON output via the new `portable_export_receipt` helper, which sums allocated bytes from writer allocation identities and includes logical bytes and physical object count while excluding the output path and identity map.
> - `sanitize_receipt` accepts `graphforge-portable-export/2` receipts, copying only allowlisted allocation totals and rejecting receipts with missing or negative totals.
> - Tests cover receipt generation and sanitization edge cases.
> - Behavioral Change: portable CLI JSON output now includes allocation totals and excludes the output path; `sanitize_receipt` accepts the new `graphforge-portable-export/2` contract.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4e2b72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->