### PR TITLE
feat(bench): adapt progressive storage qualification evidence

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -69,10 +69,12 @@ progressive-qualification-project-s20: install
 
 progressive-storage-qualification: install
 	test -n "$(LOW_RUNG)" && test -n "$(HIGH_RUNG)" && test -n "$(EVIDENCE)"
+	test -n "$(COMMIT)" && test -n "$(IMAGE_DIGEST)"
 	test -n "$(VOLUME_BYTES)" && test -n "$(RESERVED_HEADROOM_BYTES)"
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m \
 		graphforge_bench.progressive_storage_qualification \
 		"$(LOW_RUNG)" "$(HIGH_RUNG)" "$(EVIDENCE)" \
+		--commit "$(COMMIT)" --image-digest "$(IMAGE_DIGEST)" \
 		--volume-bytes "$(VOLUME_BYTES)" \
 		--reserved-headroom-bytes "$(RESERVED_HEADROOM_BYTES)"
 

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -70,11 +70,14 @@ progressive-qualification-project-s20: install
 progressive-storage-qualification: install
 	test -n "$(LOW_RUNG)" && test -n "$(HIGH_RUNG)" && test -n "$(EVIDENCE)"
 	test -n "$(COMMIT)" && test -n "$(IMAGE_DIGEST)"
+	test -n "$(LOW_RESULT_SHA256)" && test -n "$(HIGH_RESULT_SHA256)"
 	test -n "$(VOLUME_BYTES)" && test -n "$(RESERVED_HEADROOM_BYTES)"
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m \
 		graphforge_bench.progressive_storage_qualification \
 		"$(LOW_RUNG)" "$(HIGH_RUNG)" "$(EVIDENCE)" \
 		--commit "$(COMMIT)" --image-digest "$(IMAGE_DIGEST)" \
+		--low-result-sha256 "$(LOW_RESULT_SHA256)" \
+		--high-result-sha256 "$(HIGH_RESULT_SHA256)" \
 		--volume-bytes "$(VOLUME_BYTES)" \
 		--reserved-headroom-bytes "$(RESERVED_HEADROOM_BYTES)"
 

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness ingest-ladder-bundle parity-gate
+.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-storage-qualification progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness ingest-ladder-bundle parity-gate
 
 install:
 	uv sync --locked
@@ -66,6 +66,15 @@ progressive-qualification-project-s20: install
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_run \
 		--project-s20 --output-dir "$(OUTPUT_DIR)" \
 		--provider-capacity "$(PROVIDER_CAPACITY)"
+
+progressive-storage-qualification: install
+	test -n "$(LOW_RUNG)" && test -n "$(HIGH_RUNG)" && test -n "$(EVIDENCE)"
+	test -n "$(VOLUME_BYTES)" && test -n "$(RESERVED_HEADROOM_BYTES)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m \
+		graphforge_bench.progressive_storage_qualification \
+		"$(LOW_RUNG)" "$(HIGH_RUNG)" "$(EVIDENCE)" \
+		--volume-bytes "$(VOLUME_BYTES)" \
+		--reserved-headroom-bytes "$(RESERVED_HEADROOM_BYTES)"
 
 # Safe control-plane admission only; this never provisions a provider.
 progressive-provider-plan: install

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -515,15 +515,20 @@ make -C benchmarks progressive-storage-qualification \
   EVIDENCE=/evidence/g500-ladder-qualification.json \
   COMMIT=$(git rev-parse HEAD) \
   IMAGE_DIGEST=registry.fly.io/graphforge-bench@sha256:<64-hex-digest> \
+  LOW_RESULT_SHA256=<independently-recorded-s20-result-sha256> \
+  HIGH_RESULT_SHA256=<independently-recorded-s22-result-sha256> \
   VOLUME_BYTES=536870912000 RESERVED_HEADROOM_BYTES=53687091200
 ```
 
 Each rung path must be accompanied by its canonical provider plan, BenchExec,
 GraphForge, and passed result files in the same evidence directory. The adapter
-verifies the result-owned artifact digests and exact commit/profile/image
-identities, preserves integer numerators and denominators, recomputes all
-reconciliations, and emits `refuse` when the projected S26 lifecycle peak lacks
-the requested storage headroom.
+first verifies each result against its independently supplied SHA-256 trust
+anchor, then verifies the result-owned artifact digests and exact
+commit/profile/image identities. The anchors must come from trusted transport
+metadata or an immutable manifest outside the evidence directory, never from
+the bundle being qualified. The adapter preserves integer numerators and
+denominators, recomputes all reconciliations, and emits `refuse` when the
+projected S26 lifecycle peak lacks the requested storage headroom.
 
 ## Native local admission deployment
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -513,10 +513,15 @@ orchestration:
 make -C benchmarks progressive-storage-qualification \
   LOW_RUNG=/evidence/s20-rung.json HIGH_RUNG=/evidence/s22-rung.json \
   EVIDENCE=/evidence/g500-ladder-qualification.json \
+  COMMIT=$(git rev-parse HEAD) \
+  IMAGE_DIGEST=registry.fly.io/graphforge-bench@sha256:<64-hex-digest> \
   VOLUME_BYTES=536870912000 RESERVED_HEADROOM_BYTES=53687091200
 ```
 
-The adapter preserves integer numerators and denominators, recomputes all
+Each rung path must be accompanied by its canonical provider plan, BenchExec,
+GraphForge, and passed result files in the same evidence directory. The adapter
+verifies the result-owned artifact digests and exact commit/profile/image
+identities, preserves integer numerators and denominators, recomputes all
 reconciliations, and emits `refuse` when the projected S26 lifecycle peak lacks
 the requested storage headroom.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -484,11 +484,13 @@ fails closed while that ordinary receipt is absent rather than summing project
 owners or treating portable logical payload bytes as allocated storage.
 Newly assembled rungs identify `graphforge-progressive-rung-assembly/2`; for
 that provenance the rung schema requires the lifecycle receipt's authoritative
-`source_project_current_allocated_bytes`. Historical version-1 S18/S19 rungs
-lack both the assembly marker and this previously unavailable measurement, so
-they remain schema-readable but cannot supply #951 adapter evidence. The
-controller rejects a missing or malformed value before emitting any new passed
-rung; consumers producing #951 evidence must apply the same refusal.
+`source_project_current_allocated_bytes` and the complete closed
+`storage_attribution` payload. That payload copies the source and imported
+ten-category snapshots, committed construction application-I/O phases,
+portable-writer allocation, lifecycle unions, and reopened counts from the
+ordinary sanitized receipts. Historical version-1 rungs remain schema-readable
+but cannot supply #951 adapter evidence. The controller rejects any missing,
+malformed, or non-reconciling authority before emitting a new passed rung.
 The Rust certification runner owns that allocation session: it deduplicates
 stable native identities for the generated inputs, source project, result
 sinks, portable package, and clean-imported project; consumes writer-owned
@@ -502,6 +504,21 @@ cardinality, query evidence, and source/import logical-result digests. Missing
 or contradictory storage, construction, or query receipts cause a typed first
 failure; the controller never manufactures values from command counts,
 recursive file scans, portable payload size, or synthetic labels.
+
+Two complete adjacent S20/S22 or S22/S24 `/2` rungs can be adapted to the
+versioned `/3` storage qualification without restoring retired root
+orchestration:
+
+```bash
+make -C benchmarks progressive-storage-qualification \
+  LOW_RUNG=/evidence/s20-rung.json HIGH_RUNG=/evidence/s22-rung.json \
+  EVIDENCE=/evidence/g500-ladder-qualification.json \
+  VOLUME_BYTES=536870912000 RESERVED_HEADROOM_BYTES=53687091200
+```
+
+The adapter preserves integer numerators and denominators, recomputes all
+reconciliations, and emits `refuse` when the projected S26 lifecycle peak lacks
+the requested storage headroom.
 
 ## Native local admission deployment
 

--- a/benchmarks/harness/graphforge_bench/progressive_provider_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_provider_run.py
@@ -27,8 +27,8 @@ from graphforge_bench.progressive_run import (
     _native_authority,
     _run_benchexec,
     _safe_stage,
-    _write_json,
     ingest_benchexec_result,
+    publish_json_no_clobber,
     repository_commit,
     resolve_executables,
 )
@@ -367,12 +367,12 @@ def run(
     except (ControllerError, OSError) as error:
         failed = _result(plan, "failed", "native_authority_unavailable")
         _schema(root, "progressive-provider-run-result.json", failed)
-        _write_json(result_path, failed)
+        publish_json_no_clobber(result_path, failed)
         raise ProviderRunError("native BenchExec authority is unavailable") from error
     if not isinstance(authority, Mapping) or authority.get("result") != "passed":
         failed = _result(plan, "failed", "native_authority_unavailable")
         _schema(root, "progressive-provider-run-result.json", failed)
-        _write_json(result_path, failed)
+        publish_json_no_clobber(result_path, failed)
         raise ProviderRunError("native BenchExec authority is unavailable")
     try:
         temporary_context = tempfile.TemporaryDirectory(
@@ -381,7 +381,7 @@ def run(
     except OSError as error:
         failed = _result(plan, "failed", "staging_failed")
         _schema(root, "progressive-provider-run-result.json", failed)
-        _write_json(result_path, failed)
+        publish_json_no_clobber(result_path, failed)
         raise ProviderRunError("staging_failed") from error
     with temporary_context as temporary:
         try:
@@ -391,19 +391,19 @@ def run(
         except (ControllerError, OSError) as error:
             failed = _result(plan, "failed", "staging_failed")
             _schema(root, "progressive-provider-run-result.json", failed)
-            _write_json(result_path, failed)
+            publish_json_no_clobber(result_path, failed)
             raise ProviderRunError("staging_failed") from error
         try:
             execution_status = execution_boundary(stage, executables, identities)
         except Exception as error:
             failed = _result(plan, "failed", "execution_boundary_failed")
             _schema(root, "progressive-provider-run-result.json", failed)
-            _write_json(result_path, failed)
+            publish_json_no_clobber(result_path, failed)
             raise ProviderRunError("execution_boundary_failed") from error
         if execution_status != 0:
             failed = _result(plan, "failed", "benchexec_failed")
             _schema(root, "progressive-provider-run-result.json", failed)
-            _write_json(result_path, failed)
+            publish_json_no_clobber(result_path, failed)
             raise ProviderRunError("benchexec_failed")
         try:
             benchexec, graphforge, rung = ingest_benchexec_result(
@@ -417,7 +417,7 @@ def run(
         except (ControllerError, ValueError) as error:
             failed = _result(plan, "failed", "ordinary_receipt_missing")
             _schema(root, "progressive-provider-run-result.json", failed)
-            _write_json(result_path, failed)
+            publish_json_no_clobber(result_path, failed)
             raise ProviderRunError("ordinary_receipt_missing") from error
         try:
             _schema(root, "benchexec-run-evidence.json", benchexec)
@@ -426,7 +426,7 @@ def run(
         except ProviderRunError as error:
             failed = _result(plan, "failed", "ordinary_receipt_missing")
             _schema(root, "progressive-provider-run-result.json", failed)
-            _write_json(result_path, failed)
+            publish_json_no_clobber(result_path, failed)
             raise ProviderRunError("ordinary_receipt_missing") from error
         try:
             stored_plan, _ = _read_document(output_dir / f"s{scale}-plan.json")
@@ -435,7 +435,7 @@ def run(
         except ProviderRunError as error:
             failed = _result(plan, "failed", "stored_plan_mismatch")
             _schema(root, "progressive-provider-run-result.json", failed)
-            _write_json(result_path, failed)
+            publish_json_no_clobber(result_path, failed)
             raise ProviderRunError("stored_plan_mismatch") from error
         artifact_paths = {
             "benchexec_sha256": output_dir / f"s{scale}-benchexec.json",
@@ -443,13 +443,13 @@ def run(
             "rung_sha256": output_dir / f"s{scale}-rung.json",
             "plan_sha256": output_dir / f"s{scale}-plan.json",
         }
-        _write_json(artifact_paths["benchexec_sha256"], benchexec)
-        _write_json(artifact_paths["graphforge_sha256"], graphforge)
-        _write_json(artifact_paths["rung_sha256"], rung)
+        publish_json_no_clobber(artifact_paths["benchexec_sha256"], benchexec)
+        publish_json_no_clobber(artifact_paths["graphforge_sha256"], graphforge)
+        publish_json_no_clobber(artifact_paths["rung_sha256"], rung)
         artifacts = {name: _digest(path) for name, path in artifact_paths.items()}
         passed = _result(plan, "passed", None, artifacts)
         _schema(root, "progressive-provider-run-result.json", passed)
-        _write_json(result_path, passed)
+        publish_json_no_clobber(result_path, passed)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -477,7 +477,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         output_dir.mkdir(parents=True, exist_ok=True)
         _require_fresh_outputs(output_dir, plan)
-        _write_json(output_dir / f"{str(plan['rung']).lower()}-plan.json", plan)
+        publish_json_no_clobber(output_dir / f"{str(plan['rung']).lower()}-plan.json", plan)
         run(
             root=root,
             output_dir=output_dir,

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -614,11 +614,30 @@ def _query_receipts(
     return receipts
 
 
-def _one_receipt(graphforge: Mapping[str, Any], contract: str) -> Mapping[str, Any]:
-    matching = [receipt for receipt in _receipts(graphforge) if receipt.get("contract") == contract]
-    if len(matching) != 1:
-        raise ControllerError(f"required ordinary receipt is missing or ambiguous: {contract}")
-    return matching[0]
+def _phase_bound_receipt(
+    graphforge: Mapping[str, Any],
+    phase: str,
+    contract: str,
+    *,
+    outcome: str | None = None,
+) -> Mapping[str, Any]:
+    matching: list[tuple[str, Mapping[str, Any]]] = []
+    phases = graphforge.get("phases")
+    if not isinstance(phases, list):
+        raise ControllerError("GraphForge phases are missing")
+    for phase_value in phases:
+        if not isinstance(phase_value, Mapping) or not isinstance(phase_value.get("phase"), str):
+            raise ControllerError("GraphForge phase is malformed")
+        for receipt in _phase_receipts(graphforge, str(phase_value["phase"])):
+            if receipt.get("contract") == contract and (
+                outcome is None or receipt.get("outcome") == outcome
+            ):
+                matching.append((str(phase_value["phase"]), receipt))
+    if len(matching) != 1 or matching[0][0] != phase:
+        raise ControllerError(
+            f"required ordinary receipt is missing, moved, or ambiguous: {contract}"
+        )
+    return matching[0][1]
 
 
 def _storage_receipt(graphforge: Mapping[str, Any], phase: str) -> Mapping[str, Any]:
@@ -664,7 +683,7 @@ def _storage_receipt(graphforge: Mapping[str, Any], phase: str) -> Mapping[str, 
         if storage[name] != value:
             raise ControllerError(f"ordinary storage receipt does not reconcile: {name}")
     other = categories["other"]
-    if other["logical_references"] != 0 or other["physical_objects"] != 0:
+    if any(other[name] != 0 for name in STORAGE_CATEGORY_FIELDS):
         raise ControllerError("ordinary storage receipt contains unclassified artifacts")
     return storage
 
@@ -703,11 +722,22 @@ def _application_io(construction: Mapping[str, Any]) -> Mapping[str, Any]:
 
 def _construction_metrics(
     import_receipt: Mapping[str, Any],
-) -> tuple[dict[str, int], Mapping[str, Any]]:
+) -> tuple[dict[str, int], Mapping[str, Any], Mapping[str, Any], int]:
     construction = import_receipt.get("construction")
     if not isinstance(construction, Mapping):
         raise ControllerError("ordinary import construction evidence is absent")
     application_io = _application_io(construction)
+    staging = construction.get("construction_staging")
+    staging_peak = construction.get("construction_staging_transient_peak_allocated_bytes")
+    if (
+        not isinstance(staging, Mapping)
+        or set(staging) != set(STORAGE_CATEGORY_FIELDS)
+        or any(not _is_int(staging.get(name)) or staging[name] < 0 for name in staging)
+        or not _is_int(staging_peak)
+        or staging_peak < staging["allocated_bytes"]
+        or staging["physical_objects"] > staging["logical_references"]
+    ):
+        raise ControllerError("ordinary import construction staging authority is incomplete")
     totals = application_io["totals"]
     publication = construction.get("publication_work")
     values = {
@@ -725,11 +755,16 @@ def _construction_metrics(
         for value in values.values()
     ):
         raise ControllerError("ordinary import construction metrics are incomplete")
-    return {name: int(value) for name, value in values.items()}, application_io
+    return (
+        {name: int(value) for name, value in values.items()},
+        application_io,
+        staging,
+        staging_peak,
+    )
 
 
 def _portable_allocation(graphforge: Mapping[str, Any]) -> Mapping[str, Any]:
-    receipt = _one_receipt(graphforge, "graphforge-portable-export/2")
+    receipt = _phase_bound_receipt(graphforge, "export", "graphforge-portable-export/2")
     names = (
         "allocation_logical_bytes",
         "allocation_allocated_bytes",
@@ -751,19 +786,21 @@ def assemble_rung_evidence(
 ) -> dict[str, Any]:
     if graphforge.get("status") != "passed" or benchexec.get("outcome") != "passed":
         raise ControllerError("a failed execution cannot produce passed rung evidence")
-    imports = [
-        receipt
-        for receipt in _receipts(graphforge)
-        if receipt.get("contract") == "graphforge-import-session/1"
-        and receipt.get("outcome") == "committed"
-    ]
-    if len(imports) != 1:
-        raise ControllerError("ordinary import commit receipt is missing or ambiguous")
-    require_bulk_ingest_capability(imports[0])
+    committed_import = _phase_bound_receipt(
+        graphforge,
+        "ingest",
+        "graphforge-import-session/1",
+        outcome="committed",
+    )
+    require_bulk_ingest_capability(committed_import)
     source_storage = _storage_receipt(graphforge, "reopen")
     imported_storage = _storage_receipt(graphforge, "reopen_proof")
-    lifecycle_storage = _one_receipt(graphforge, "graphforge-lifecycle-storage/1")
-    construction, application_io = _construction_metrics(imports[0])
+    lifecycle_storage = _phase_bound_receipt(
+        graphforge, "reopen_proof", "graphforge-lifecycle-storage/1"
+    )
+    construction, application_io, construction_staging, staging_peak = _construction_metrics(
+        committed_import
+    )
     portable_allocation = _portable_allocation(graphforge)
     expected_edges = 16 * (1 << scale)
     source_counts = _query_receipts(graphforge, "recount", 2)
@@ -858,6 +895,8 @@ def assemble_rung_evidence(
             "imported": imported_storage,
             "construction": {
                 "application_io": application_io,
+                "staging": construction_staging,
+                "staging_transient_peak_allocated_bytes": staging_peak,
                 "transient_peak_allocated_bytes": construction["transient_peak_allocated_bytes"],
             },
             "portable_package": portable_allocation,

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -17,6 +17,7 @@ import os
 from pathlib import Path
 import platform
 import re
+import secrets
 import shutil
 import stat
 import subprocess
@@ -242,29 +243,78 @@ def build_plan(
     return plan
 
 
-def _write_json(path: Path, value: Mapping[str, Any]) -> None:
-    encoded = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
-    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    temporary = Path(temporary_name)
+def _open_durable_directory(path: Path) -> int:
+    absolute = path.absolute()
+    flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0)
+    directory = os.open(absolute.anchor, flags)
     try:
-        with os.fdopen(descriptor, "wb") as stream:
-            stream.write(encoded)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.link(temporary, path)
-        temporary.unlink()
-        directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
-        try:
-            os.fsync(directory)
-        finally:
+        for part in absolute.parts[1:]:
+            created = False
+            try:
+                child = os.open(part, flags, dir_fd=directory)
+            except FileNotFoundError:
+                try:
+                    os.mkdir(part, mode=0o755, dir_fd=directory)
+                    created = True
+                    os.fsync(directory)
+                except FileExistsError:
+                    pass
+                child = os.open(part, flags, dir_fd=directory)
+            if created:
+                os.fsync(child)
             os.close(directory)
+            directory = child
+        os.fsync(directory)
+        return directory
     except BaseException:
-        temporary.unlink(missing_ok=True)
+        os.close(directory)
         raise
 
 
+def publish_json_no_clobber(path: Path, value: Mapping[str, Any]) -> None:
+    """Durably publish JSON once without trusting symlinked directory components."""
+    encoded = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    directory = _open_durable_directory(path.parent)
+    temporary_name = f".{path.name}.{secrets.token_hex(8)}"
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=directory,
+        )
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = -1
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(
+            temporary_name,
+            path.name,
+            src_dir_fd=directory,
+            dst_dir_fd=directory,
+            follow_symlinks=False,
+        )
+        os.unlink(temporary_name, dir_fd=directory)
+        os.fsync(directory)
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary_name, dir_fd=directory)
+            os.fsync(directory)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        os.close(directory)
+
+
+_write_json = publish_json_no_clobber
+
+
 def write_plan(output_dir: Path, plan: Mapping[str, Any]) -> Path:
-    output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / f"{str(plan['rung']).lower()}-plan.json"
     _write_json(path, plan)
     return path
@@ -591,16 +641,44 @@ def _phase_receipts(graphforge: Mapping[str, Any], name: str) -> list[Mapping[st
     return receipts
 
 
+def _closed_receipt_inventory(
+    graphforge: Mapping[str, Any],
+    contract: str,
+    expected_counts: Mapping[str, int],
+) -> dict[str, list[Mapping[str, Any]]]:
+    phases = graphforge.get("phases")
+    if not isinstance(phases, list):
+        raise ControllerError("GraphForge phases are missing")
+    inventory: dict[str, list[Mapping[str, Any]]] = {}
+    for phase in phases:
+        if not isinstance(phase, Mapping) or not isinstance(phase.get("phase"), str):
+            raise ControllerError("GraphForge phase is malformed")
+        name = str(phase["phase"])
+        receipts = phase.get("receipts", [])
+        if not isinstance(receipts, list) or any(
+            not isinstance(receipt, Mapping) for receipt in receipts
+        ):
+            raise ControllerError(f"GraphForge phase receipts are malformed: {name}")
+        matching = [receipt for receipt in receipts if receipt.get("contract") == contract]
+        if matching:
+            inventory.setdefault(name, []).extend(matching)
+    actual_counts = {name: len(receipts) for name, receipts in inventory.items()}
+    if actual_counts != dict(expected_counts):
+        raise ControllerError(
+            f"ordinary receipt inventory is incomplete, moved, or ambiguous: {contract}"
+        )
+    return inventory
+
+
 def _query_receipts(
     graphforge: Mapping[str, Any], phase: str, expected: int
 ) -> list[Mapping[str, Any]]:
-    receipts = [
-        receipt
-        for receipt in _phase_receipts(graphforge, phase)
-        if receipt.get("contract") == "graphforge-result-sink/2"
-    ]
-    if len(receipts) != expected:
+    expected_inventory = {"recount": 2, "query": 2, "reopen_proof": 4}
+    if expected_inventory.get(phase) != expected:
         raise ControllerError(f"ordinary query receipts are missing or ambiguous: {phase}")
+    receipts = _closed_receipt_inventory(
+        graphforge, "graphforge-result-sink/2", expected_inventory
+    )[phase]
     for receipt in receipts:
         digest = receipt.get("result_sha256")
         if (
@@ -641,13 +719,15 @@ def _phase_bound_receipt(
 
 
 def _storage_receipt(graphforge: Mapping[str, Any], phase: str) -> Mapping[str, Any]:
-    receipts = _phase_receipts(graphforge, phase)
-    matching = [
-        receipt
-        for receipt in receipts
-        if receipt.get("contract") == "graphforge-storage-attribution-command/1"
-    ]
-    if len(matching) != 1 or matching[0].get("reopen_agrees") is not True:
+    expected_inventory = {"reopen": 1, "reopen_proof": 1}
+    if phase not in expected_inventory:
+        raise ControllerError(f"ordinary storage receipt phase is not authoritative: {phase}")
+    matching = _closed_receipt_inventory(
+        graphforge,
+        "graphforge-storage-attribution-command/1",
+        expected_inventory,
+    )[phase]
+    if matching[0].get("reopen_agrees") is not True:
         raise ControllerError(f"ordinary storage receipt is missing or ambiguous: {phase}")
     storage = matching[0].get("storage")
     if (

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -37,6 +37,45 @@ PLAN_SCHEMA = "graphforge-progressive-run-plan/1"
 RESULT_SCHEMA = "graphforge-progressive-run-result/1"
 GIT_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 LOCAL_RUNGS = (18, 19)
+STORAGE_CATEGORIES = (
+    "topology_nodes",
+    "topology_edges",
+    "properties",
+    "uuid_and_surrogates",
+    "adjacency",
+    "catalog_and_manifests",
+    "construction_staging",
+    "portable_package",
+    "clean_imported_project",
+    "other",
+)
+STORAGE_CATEGORY_FIELDS = (
+    "logical_references",
+    "logical_bytes",
+    "physical_objects",
+    "physical_logical_bytes",
+    "allocated_bytes",
+)
+APPLICATION_IO_PHASES = (
+    "append_merge",
+    "seal_authentication",
+    "shape_consume_reauthentication",
+    "encode_write_postwrite_authentication",
+    "publication_preauthentication",
+    "cas_install_read_write",
+    "hydration_verification",
+    "fsync_synchronization",
+    "recovery_reauthentication",
+)
+APPLICATION_IO_FIELDS = (
+    "read_bytes",
+    "write_bytes",
+    "read_calls",
+    "write_calls",
+    "object_count",
+    "block_count",
+    "fsync_calls",
+)
 
 
 class ControllerError(ValueError):
@@ -597,34 +636,85 @@ def _storage_receipt(graphforge: Mapping[str, Any], phase: str) -> Mapping[str, 
         or storage.get("contract") != "graphforge-storage-attribution/1"
     ):
         raise ControllerError("ordinary storage receipt is incomplete")
-    for name in (
-        "logical_references",
-        "logical_bytes",
-        "retained_logical_eof_bytes",
-        "allocated_physical_bytes",
-        "physical_objects",
-    ):
-        if (
-            isinstance(storage.get(name), bool)
-            or not isinstance(storage.get(name), int)
-            or storage[name] < 0
-        ):
+    categories = storage.get("categories")
+    if not isinstance(categories, Mapping) or set(categories) != set(STORAGE_CATEGORIES):
+        raise ControllerError("ordinary storage receipt categories are incomplete")
+    sums = dict.fromkeys(STORAGE_CATEGORY_FIELDS, 0)
+    for category in STORAGE_CATEGORIES:
+        values = categories.get(category)
+        if not isinstance(values, Mapping) or set(values) != set(STORAGE_CATEGORY_FIELDS):
+            raise ControllerError(f"ordinary storage category is malformed: {category}")
+        for name in STORAGE_CATEGORY_FIELDS:
+            value = values.get(name)
+            if not _is_int(value) or value < 0:
+                raise ControllerError(f"ordinary storage category omitted {name}: {category}")
+            sums[name] += value
+        if values["physical_objects"] > values["logical_references"]:
+            raise ControllerError("ordinary storage category physical identities contradict")
+    expected = {
+        "logical_references": sums["logical_references"],
+        "logical_bytes": sums["logical_bytes"],
+        "retained_logical_eof_bytes": sums["physical_logical_bytes"],
+        "allocated_physical_bytes": sums["allocated_bytes"],
+        "physical_objects": sums["physical_objects"],
+    }
+    for name, value in expected.items():
+        if not _is_int(storage.get(name)) or storage[name] < 0:
             raise ControllerError(f"ordinary storage receipt omitted {name}")
+        if storage[name] != value:
+            raise ControllerError(f"ordinary storage receipt does not reconcile: {name}")
+    other = categories["other"]
+    if other["logical_references"] != 0 or other["physical_objects"] != 0:
+        raise ControllerError("ordinary storage receipt contains unclassified artifacts")
     return storage
 
 
-def _construction_metrics(import_receipt: Mapping[str, Any]) -> dict[str, int]:
+def _application_io(construction: Mapping[str, Any]) -> Mapping[str, Any]:
+    application_io = construction.get("application_io")
+    if not isinstance(application_io, Mapping) or set(application_io) != {"phases", "totals"}:
+        raise ControllerError("ordinary import application I/O evidence is absent")
+    phases = application_io.get("phases")
+    totals = application_io.get("totals")
+    if (
+        not isinstance(phases, Mapping)
+        or set(phases) != set(APPLICATION_IO_PHASES)
+        or not isinstance(totals, Mapping)
+        or set(totals) != set(APPLICATION_IO_FIELDS)
+    ):
+        raise ControllerError("ordinary import application I/O inventory is incomplete")
+    sums = dict.fromkeys(APPLICATION_IO_FIELDS, 0)
+    for phase in APPLICATION_IO_PHASES:
+        values = phases.get(phase)
+        if not isinstance(values, Mapping) or set(values) != set(APPLICATION_IO_FIELDS):
+            raise ControllerError(f"ordinary import application I/O phase is malformed: {phase}")
+        for name in APPLICATION_IO_FIELDS:
+            value = values.get(name)
+            if not _is_int(value) or value < 0:
+                raise ControllerError(f"ordinary import application I/O omitted {name}: {phase}")
+            sums[name] += value
+        if (values["read_bytes"] == 0) != (values["read_calls"] == 0):
+            raise ControllerError("ordinary import application I/O read counters disagree")
+        if (values["write_bytes"] == 0) != (values["write_calls"] == 0):
+            raise ControllerError("ordinary import application I/O write counters disagree")
+    if totals != sums:
+        raise ControllerError("ordinary import application I/O totals do not reconcile")
+    return application_io
+
+
+def _construction_metrics(
+    import_receipt: Mapping[str, Any],
+) -> tuple[dict[str, int], Mapping[str, Any]]:
     construction = import_receipt.get("construction")
     if not isinstance(construction, Mapping):
         raise ControllerError("ordinary import construction evidence is absent")
-    application_io = construction.get("application_io")
-    totals = application_io.get("totals") if isinstance(application_io, Mapping) else None
+    application_io = _application_io(construction)
+    totals = application_io["totals"]
     publication = construction.get("publication_work")
     values = {
         "transient_peak_allocated_bytes": construction.get("transient_peak_allocated_bytes"),
-        "logical_read_bytes": totals.get("read_bytes") if isinstance(totals, Mapping) else None,
-        "logical_write_bytes": totals.get("write_bytes") if isinstance(totals, Mapping) else None,
-        "reader_calls": totals.get("read_calls") if isinstance(totals, Mapping) else None,
+        "logical_read_bytes": totals["read_bytes"],
+        "logical_write_bytes": totals["write_bytes"],
+        "reader_calls": totals["read_calls"],
         "publication_work_units": publication.get("semantic_total_operations")
         if isinstance(publication, Mapping)
         and publication.get("contract") == "graphforge-publication-work/1"
@@ -635,7 +725,19 @@ def _construction_metrics(import_receipt: Mapping[str, Any]) -> dict[str, int]:
         for value in values.values()
     ):
         raise ControllerError("ordinary import construction metrics are incomplete")
-    return {name: int(value) for name, value in values.items()}
+    return {name: int(value) for name, value in values.items()}, application_io
+
+
+def _portable_allocation(graphforge: Mapping[str, Any]) -> Mapping[str, Any]:
+    receipt = _one_receipt(graphforge, "graphforge-portable-export/2")
+    names = (
+        "allocation_logical_bytes",
+        "allocation_allocated_bytes",
+        "allocation_physical_objects",
+    )
+    if any(not _is_int(receipt.get(name)) or receipt[name] < 0 for name in names):
+        raise ControllerError("ordinary portable allocation authority is incomplete")
+    return {"contract": receipt["contract"], **{name: receipt[name] for name in names}}
 
 
 def assemble_rung_evidence(
@@ -661,13 +763,15 @@ def assemble_rung_evidence(
     source_storage = _storage_receipt(graphforge, "reopen")
     imported_storage = _storage_receipt(graphforge, "reopen_proof")
     lifecycle_storage = _one_receipt(graphforge, "graphforge-lifecycle-storage/1")
-    construction = _construction_metrics(imports[0])
+    construction, application_io = _construction_metrics(imports[0])
+    portable_allocation = _portable_allocation(graphforge)
     expected_edges = 16 * (1 << scale)
     source_counts = _query_receipts(graphforge, "recount", 2)
     source_hops = _query_receipts(graphforge, "query", 2)
     imported = _query_receipts(graphforge, "reopen_proof", 4)
     imported_counts, imported_hops = imported[:2], imported[2:]
     expected_counts = (1 << scale, expected_edges)
+    authoritative_counts: dict[str, int] = {}
     for index, expected in enumerate(expected_counts):
         source_value = source_counts[index].get("scalar_u64")
         imported_value = imported_counts[index].get("scalar_u64")
@@ -675,6 +779,9 @@ def assemble_rung_evidence(
             raise ControllerError("recount evidence contradicts the selected rung")
         if source_counts[index]["result_sha256"] != imported_counts[index]["result_sha256"]:
             raise ControllerError("source/imported recount evidence disagrees")
+        name = ("nodes", "edges")[index]
+        authoritative_counts[f"source_{name}"] = source_value
+        authoritative_counts[f"imported_{name}"] = imported_value
     if any(
         source.get("rows") != ORDERED_LIMIT_ROW_COUNT
         or imported_receipt.get("rows") != ORDERED_LIMIT_ROW_COUNT
@@ -745,6 +852,17 @@ def assemble_rung_evidence(
             "imported_allocated_physical_bytes": imported_storage["allocated_physical_bytes"],
             "imported_retained_logical_eof_bytes": imported_storage["retained_logical_eof_bytes"],
             **construction,
+        },
+        "storage_attribution": {
+            "source": source_storage,
+            "imported": imported_storage,
+            "construction": {
+                "application_io": application_io,
+                "transient_peak_allocated_bytes": construction["transient_peak_allocated_bytes"],
+            },
+            "portable_package": portable_allocation,
+            "lifecycle": lifecycle_storage,
+            "counts": authoritative_counts,
         },
         "failure": None,
     }

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -272,7 +272,13 @@ def _open_durable_directory(path: Path) -> int:
 
 
 def publish_json_no_clobber(path: Path, value: Mapping[str, Any]) -> None:
-    """Durably publish JSON once without trusting symlinked directory components."""
+    """Durably publish JSON once without trusting symlinked directory components.
+
+    If the final directory fsync fails after linking the complete target, this
+    function raises but leaves that target in place. It never rolls back,
+    removes, or replaces a complete linked target; a retry therefore fails
+    closed with ``FileExistsError``.
+    """
     encoded = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
     directory = _open_durable_directory(path.parent)
     temporary_name = f".{path.name}.{secrets.token_hex(8)}"

--- a/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
@@ -14,7 +14,7 @@ from typing import Any
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
-from graphforge_bench.progressive_run import _write_json
+from graphforge_bench.progressive_run import publish_json_no_clobber
 
 BENCHMARK_ROOT = Path(__file__).resolve().parents[2]
 REPOSITORY_ROOT = BENCHMARK_ROOT.parent
@@ -77,6 +77,7 @@ APPLICATION_IO_FIELDS = (
 )
 ADJACENT_SOURCES = ((20, 22), (22, 24))
 COMMIT = re.compile(r"^[0-9a-f]{40}$")
+HEX_DIGEST = re.compile(r"^[0-9a-f]{64}$")
 IMAGE_DIGEST = re.compile(r"^registry\.fly\.io/[a-z0-9][a-z0-9._/-]*@sha256:[0-9a-f]{64}$")
 FORBIDDEN_KEY = re.compile(
     r"(?:secret|credential|token|password|host_path|absolute_path|machine[_-]?id|"
@@ -372,14 +373,36 @@ def _read_digest(path: Path) -> tuple[Mapping[str, Any], str]:
     return value, hashlib.sha256(encoded).hexdigest()
 
 
+def _read_anchored_result(path: Path, expected_sha256: str) -> Mapping[str, Any]:
+    if HEX_DIGEST.fullmatch(expected_sha256) is None:
+        raise StorageQualificationError("provider result anchor must be a SHA-256 digest")
+    try:
+        encoded = path.read_bytes()
+    except OSError as error:
+        raise StorageQualificationError("anchored provider result is unavailable") from error
+    if hashlib.sha256(encoded).hexdigest() != expected_sha256:
+        raise StorageQualificationError("provider result does not match its external anchor")
+    try:
+        value = json.loads(encoded)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise StorageQualificationError("anchored provider result is malformed") from error
+    if not isinstance(value, Mapping):
+        raise StorageQualificationError("anchored provider result must be an object")
+    return value
+
+
 def _bound_provider_rung(
-    path: Path, *, expected_commit: str, expected_image_digest: str
+    path: Path,
+    *,
+    provider_result_sha256: str,
+    expected_commit: str,
+    expected_image_digest: str,
 ) -> Mapping[str, Any]:
     rung, rung_digest = _read_digest(path)
     validate_source_rung(rung)
     scale = int(rung["scale"])
     base = path.parent
-    result, _ = _read_digest(base / f"s{scale}-result.json")
+    result = _read_anchored_result(base / f"s{scale}-result.json", provider_result_sha256)
     plan, plan_digest = _read_digest(base / f"s{scale}-plan.json")
     _schema(PROVIDER_RESULT_SCHEMA, result, "provider result")
     _schema(PROVIDER_PLAN_SCHEMA, plan, "provider execution plan")
@@ -432,6 +455,7 @@ def _bound_provider_rung(
 def build(
     source_paths: Sequence[Path],
     *,
+    provider_result_sha256: Sequence[str],
     expected_commit: str,
     expected_image_digest: str,
     volume_bytes: int,
@@ -444,13 +468,18 @@ def build(
         raise StorageQualificationError("expected image must be an immutable Fly OCI digest")
     if len(source_paths) != 2:
         raise StorageQualificationError("exactly two adjacent observations are required")
+    if len(provider_result_sha256) != 2:
+        raise StorageQualificationError("exactly two ordered provider result anchors are required")
+    if any(HEX_DIGEST.fullmatch(digest) is None for digest in provider_result_sha256):
+        raise StorageQualificationError("provider result anchor must be a SHA-256 digest")
     source_rungs = [
         _bound_provider_rung(
             path,
+            provider_result_sha256=digest,
             expected_commit=expected_commit,
             expected_image_digest=expected_image_digest,
         )
-        for path in source_paths
+        for path, digest in zip(source_paths, provider_result_sha256, strict=True)
     ]
     return _build_qualification(
         source_rungs,
@@ -681,19 +710,24 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("output", type=Path)
     parser.add_argument("--commit", required=True)
     parser.add_argument("--image-digest", required=True)
+    parser.add_argument("--low-result-sha256", required=True)
+    parser.add_argument("--high-result-sha256", required=True)
     parser.add_argument("--volume-bytes", type=int, required=True)
     parser.add_argument("--reserved-headroom-bytes", type=int, required=True)
     args = parser.parse_args(argv)
     try:
         qualification = build(
             [args.low, args.high],
+            provider_result_sha256=[
+                args.low_result_sha256,
+                args.high_result_sha256,
+            ],
             expected_commit=args.commit,
             expected_image_digest=args.image_digest,
             volume_bytes=args.volume_bytes,
             reserved_headroom_bytes=args.reserved_headroom_bytes,
         )
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        _write_json(args.output, qualification)
+        publish_json_no_clobber(args.output, qualification)
         return 0
     except (OSError, StorageQualificationError) as error:
         parser.error(str(error))

--- a/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping, Sequence
+import hashlib
 from itertools import pairwise
 import json
 from pathlib import Path
@@ -13,12 +14,16 @@ from typing import Any
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
+from graphforge_bench.progressive_run import _write_json
+
 BENCHMARK_ROOT = Path(__file__).resolve().parents[2]
 REPOSITORY_ROOT = BENCHMARK_ROOT.parent
 RUNG_SCHEMA = BENCHMARK_ROOT / "schemas/progressive-qualification-rung-evidence.json"
 QUALIFICATION_SCHEMA = (
     REPOSITORY_ROOT / "docs/development/evidence/g500-ladder-qualification.schema.json"
 )
+PROVIDER_RESULT_SCHEMA = BENCHMARK_ROOT / "schemas/progressive-provider-run-result.json"
+PROVIDER_PLAN_SCHEMA = BENCHMARK_ROOT / "schemas/progressive-provider-run-plan.json"
 ASSEMBLY_CONTRACT = "graphforge-progressive-rung-assembly/2"
 QUALIFICATION_CONTRACT = "graphforge-g500-ladder-qualification/3"
 S26_EDGES = 1 << 30
@@ -71,6 +76,8 @@ APPLICATION_IO_FIELDS = (
     "fsync_calls",
 )
 ADJACENT_SOURCES = ((20, 22), (22, 24))
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+IMAGE_DIGEST = re.compile(r"^registry\.fly\.io/[a-z0-9][a-z0-9._/-]*@sha256:[0-9a-f]{64}$")
 FORBIDDEN_KEY = re.compile(
     r"(?:secret|credential|token|password|host_path|absolute_path|machine[_-]?id|"
     r"volume[_-]?id|provider_resource_id)",
@@ -149,7 +156,7 @@ def _validate_snapshot(snapshot: Mapping[str, Any], label: str) -> None:
     if any(snapshot[name] != value for name, value in expected.items()):
         raise StorageQualificationError(f"{label} category totals do not reconcile")
     other = categories["other"]
-    if other["logical_references"] != 0 or other["physical_objects"] != 0:
+    if any(other[field] != 0 for field in STORAGE_FIELDS):
         raise StorageQualificationError(f"{label} contains unclassified storage")
 
 
@@ -187,6 +194,14 @@ def validate_source_rung(value: Mapping[str, Any]) -> None:
     _validate_application_io(storage["construction"]["application_io"])
     counts = storage["counts"]
     scale = _integer(value["scale"], "scale", positive=True)
+    if (
+        scale not in {20, 22, 24}
+        or value.get("source") != "canonical_ladder"
+        or value.get("profile_id") != f"graph500-s{scale}-provider"
+    ):
+        raise StorageQualificationError(
+            "storage qualification requires the canonical provider source/profile"
+        )
     nodes = 1 << scale
     edges = 16 * nodes
     if (
@@ -236,9 +251,9 @@ def adapt_rung(value: Mapping[str, Any]) -> dict[str, Any]:
     artifacts.append(
         _artifact(
             "construction_staging_spill",
-            source["categories"]["construction_staging"],
+            construction["staging"],
             "construction_receipts",
-            transient_peak=construction["transient_peak_allocated_bytes"],
+            transient_peak=construction["staging_transient_peak_allocated_bytes"],
         )
     )
     artifacts.append(
@@ -328,7 +343,105 @@ def ceil_ratio(numerator: int, denominator: int) -> int:
     return (numerator + denominator - 1) // denominator
 
 
+def _read_digest(path: Path) -> tuple[Mapping[str, Any], str]:
+    try:
+        encoded = path.read_bytes()
+        value = json.loads(encoded)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise StorageQualificationError(f"invalid evidence document: {path.name}") from error
+    if not isinstance(value, Mapping):
+        raise StorageQualificationError(f"evidence root must be an object: {path.name}")
+    return value, hashlib.sha256(encoded).hexdigest()
+
+
+def _bound_provider_rung(
+    path: Path, *, expected_commit: str, expected_image_digest: str
+) -> Mapping[str, Any]:
+    rung, rung_digest = _read_digest(path)
+    validate_source_rung(rung)
+    scale = int(rung["scale"])
+    base = path.parent
+    result, _ = _read_digest(base / f"s{scale}-result.json")
+    plan, plan_digest = _read_digest(base / f"s{scale}-plan.json")
+    _schema(PROVIDER_RESULT_SCHEMA, result, "provider result")
+    _schema(PROVIDER_PLAN_SCHEMA, plan, "provider execution plan")
+    profile_path = BENCHMARK_ROOT / "profiles" / "graph500" / f"s{scale}-provider.json"
+    try:
+        profile_digest = hashlib.sha256(profile_path.read_bytes()).hexdigest()
+    except OSError as error:
+        raise StorageQualificationError("canonical provider profile is unavailable") from error
+    identities = result.get("identities")
+    if (
+        result.get("status") != "passed"
+        or result.get("rung") != f"S{scale}"
+        or not isinstance(identities, Mapping)
+        or identities.get("commit") != expected_commit
+        or identities.get("profile_id") != f"graph500-s{scale}-provider"
+        or identities.get("profile_sha256") != profile_digest
+        or identities.get("image_digest") != expected_image_digest
+        or plan.get("rung") != f"S{scale}"
+        or plan.get("identities") != identities
+    ):
+        raise StorageQualificationError(
+            "provider rung is not bound to the expected commit/profile/image"
+        )
+    artifacts = result.get("artifacts")
+    artifact_paths = {
+        "plan_sha256": base / f"s{scale}-plan.json",
+        "benchexec_sha256": base / f"s{scale}-benchexec.json",
+        "graphforge_sha256": base / f"s{scale}-graphforge.json",
+        "rung_sha256": path,
+    }
+    try:
+        expected_artifacts = {
+            name: hashlib.sha256(artifact.read_bytes()).hexdigest()
+            for name, artifact in artifact_paths.items()
+        }
+    except OSError as error:
+        raise StorageQualificationError("provider rung bundle is incomplete") from error
+    if (
+        not isinstance(artifacts, Mapping)
+        or dict(artifacts) != expected_artifacts
+        or plan_digest != expected_artifacts["plan_sha256"]
+        or rung_digest != expected_artifacts["rung_sha256"]
+    ):
+        raise StorageQualificationError(
+            "provider rung bundle artifacts do not match the provider result"
+        )
+    return rung
+
+
 def build(
+    source_paths: Sequence[Path],
+    *,
+    expected_commit: str,
+    expected_image_digest: str,
+    volume_bytes: int,
+    reserved_headroom_bytes: int,
+) -> dict[str, Any]:
+    """Build from two provider-result-bound rung bundle paths."""
+    if COMMIT.fullmatch(expected_commit) is None:
+        raise StorageQualificationError("expected commit must be a full Git object ID")
+    if IMAGE_DIGEST.fullmatch(expected_image_digest) is None:
+        raise StorageQualificationError("expected image must be an immutable Fly OCI digest")
+    if len(source_paths) != 2:
+        raise StorageQualificationError("exactly two adjacent observations are required")
+    source_rungs = [
+        _bound_provider_rung(
+            path,
+            expected_commit=expected_commit,
+            expected_image_digest=expected_image_digest,
+        )
+        for path in source_paths
+    ]
+    return _build_qualification(
+        source_rungs,
+        volume_bytes=volume_bytes,
+        reserved_headroom_bytes=reserved_headroom_bytes,
+    )
+
+
+def _build_qualification(
     source_rungs: Sequence[Mapping[str, Any]],
     *,
     volume_bytes: int,
@@ -543,37 +656,28 @@ def validate(evidence: Mapping[str, Any]) -> None:
         raise StorageQualificationError("S26 admission decision contradicts projected headroom")
 
 
-def _read(path: Path) -> Mapping[str, Any]:
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise StorageQualificationError(f"invalid evidence document: {path.name}") from error
-    if not isinstance(value, Mapping):
-        raise StorageQualificationError(f"evidence root must be an object: {path.name}")
-    return value
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("low", type=Path)
     parser.add_argument("high", type=Path)
     parser.add_argument("output", type=Path)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--image-digest", required=True)
     parser.add_argument("--volume-bytes", type=int, required=True)
     parser.add_argument("--reserved-headroom-bytes", type=int, required=True)
     args = parser.parse_args(argv)
     try:
         qualification = build(
-            [_read(args.low), _read(args.high)],
+            [args.low, args.high],
+            expected_commit=args.commit,
+            expected_image_digest=args.image_digest,
             volume_bytes=args.volume_bytes,
             reserved_headroom_bytes=args.reserved_headroom_bytes,
         )
         args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(
-            json.dumps(qualification, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
+        _write_json(args.output, qualification)
         return 0
-    except StorageQualificationError as error:
+    except (OSError, StorageQualificationError) as error:
         parser.error(str(error))
 
 

--- a/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
@@ -461,7 +461,12 @@ def build(
     volume_bytes: int,
     reserved_headroom_bytes: int,
 ) -> dict[str, Any]:
-    """Build from two provider-result-bound rung bundle paths."""
+    """Build from ordered low/high bundles using externally trusted result digests.
+
+    ``provider_result_sha256`` must contain the low-result digest followed by
+    the high-result digest. Each digest must come from trusted transport or an
+    immutable manifest outside the evidence bundle.
+    """
     if COMMIT.fullmatch(expected_commit) is None:
         raise StorageQualificationError("expected commit must be a full Git object ID")
     if IMAGE_DIGEST.fullmatch(expected_image_digest) is None:
@@ -705,13 +710,27 @@ def validate(evidence: Mapping[str, Any]) -> None:
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("low", type=Path)
-    parser.add_argument("high", type=Path)
+    parser.add_argument("low", type=Path, help="lower-scale provider rung path")
+    parser.add_argument("high", type=Path, help="higher-scale provider rung path")
     parser.add_argument("output", type=Path)
     parser.add_argument("--commit", required=True)
     parser.add_argument("--image-digest", required=True)
-    parser.add_argument("--low-result-sha256", required=True)
-    parser.add_argument("--high-result-sha256", required=True)
+    parser.add_argument(
+        "--low-result-sha256",
+        required=True,
+        help=(
+            "SHA-256 of the low provider result from trusted transport or an immutable "
+            "manifest outside the evidence bundle"
+        ),
+    )
+    parser.add_argument(
+        "--high-result-sha256",
+        required=True,
+        help=(
+            "SHA-256 of the high provider result from trusted transport or an immutable "
+            "manifest outside the evidence bundle"
+        ),
+    )
     parser.add_argument("--volume-bytes", type=int, required=True)
     parser.add_argument("--reserved-headroom-bytes", type=int, required=True)
     args = parser.parse_args(argv)

--- a/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
@@ -1,0 +1,581 @@
+"""Adapt two complete progressive rungs into closed #951 storage qualification."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from itertools import pairwise
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
+
+BENCHMARK_ROOT = Path(__file__).resolve().parents[2]
+REPOSITORY_ROOT = BENCHMARK_ROOT.parent
+RUNG_SCHEMA = BENCHMARK_ROOT / "schemas/progressive-qualification-rung-evidence.json"
+QUALIFICATION_SCHEMA = (
+    REPOSITORY_ROOT / "docs/development/evidence/g500-ladder-qualification.schema.json"
+)
+ASSEMBLY_CONTRACT = "graphforge-progressive-rung-assembly/2"
+QUALIFICATION_CONTRACT = "graphforge-g500-ladder-qualification/3"
+S26_EDGES = 1 << 30
+S26_NODES = 1 << 26
+SOURCE_CATEGORIES = (
+    ("canonical_node_topology", "topology_nodes", "storage_owned_snapshot"),
+    ("canonical_edge_topology", "topology_edges", "storage_owned_snapshot"),
+    ("properties", "properties", "storage_owned_snapshot"),
+    ("uuid_surrogate_indexes", "uuid_and_surrogates", "storage_owned_snapshot"),
+    ("adjacency_csr", "adjacency", "storage_owned_snapshot"),
+    ("catalog_manifests", "catalog_and_manifests", "storage_owned_snapshot"),
+)
+STORAGE_CATEGORIES = (
+    "topology_nodes",
+    "topology_edges",
+    "properties",
+    "uuid_and_surrogates",
+    "adjacency",
+    "catalog_and_manifests",
+    "construction_staging",
+    "portable_package",
+    "clean_imported_project",
+    "other",
+)
+STORAGE_FIELDS = (
+    "logical_references",
+    "logical_bytes",
+    "physical_objects",
+    "physical_logical_bytes",
+    "allocated_bytes",
+)
+APPLICATION_IO_PHASES = (
+    "append_merge",
+    "seal_authentication",
+    "shape_consume_reauthentication",
+    "encode_write_postwrite_authentication",
+    "publication_preauthentication",
+    "cas_install_read_write",
+    "hydration_verification",
+    "fsync_synchronization",
+    "recovery_reauthentication",
+)
+APPLICATION_IO_FIELDS = (
+    "read_bytes",
+    "write_bytes",
+    "read_calls",
+    "write_calls",
+    "object_count",
+    "block_count",
+    "fsync_calls",
+)
+ADJACENT_SOURCES = ((20, 22), (22, 24))
+FORBIDDEN_KEY = re.compile(
+    r"(?:secret|credential|token|password|host_path|absolute_path|machine[_-]?id|"
+    r"volume[_-]?id|provider_resource_id)",
+    re.I,
+)
+ABSOLUTE_PATH = re.compile(r"(?:^|[\s=:])(?:/|[A-Za-z]:[\\/])")
+RAW_UUID = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.I,
+)
+
+
+class StorageQualificationError(ValueError):
+    """Input evidence or a derived qualification is incomplete or contradictory."""
+
+
+def reject_unsanitized(value: Any, trail: str = "$") -> None:
+    """Reject path, identity, and credential material recursively."""
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if not isinstance(key, str) or FORBIDDEN_KEY.search(key):
+                raise StorageQualificationError(f"sensitive evidence key at {trail}.{key}")
+            reject_unsanitized(child, f"{trail}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_unsanitized(child, f"{trail}[{index}]")
+    elif isinstance(value, str):
+        if ABSOLUTE_PATH.search(value):
+            raise StorageQualificationError(f"absolute host path at {trail}")
+        if RAW_UUID.fullmatch(value):
+            raise StorageQualificationError(f"raw UUID at {trail}")
+
+
+def _schema(path: Path, value: Mapping[str, Any], label: str) -> None:
+    try:
+        contract = json.loads(path.read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(contract)
+        Draft202012Validator(contract).validate(value)
+    except (OSError, json.JSONDecodeError, SchemaError) as error:
+        raise StorageQualificationError(f"committed {label} schema is invalid: {error}") from error
+    except ValidationError as error:
+        location = ".".join(str(part) for part in error.absolute_path) or "$"
+        raise StorageQualificationError(
+            f"{label} schema violation at {location}: {error.message}"
+        ) from error
+
+
+def _integer(value: Any, label: str, *, positive: bool = False) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < (1 if positive else 0):
+        raise StorageQualificationError(f"{label} must be an exact nonnegative integer")
+    return value
+
+
+def _validate_snapshot(snapshot: Mapping[str, Any], label: str) -> None:
+    categories = snapshot["categories"]
+    if set(categories) != set(STORAGE_CATEGORIES):
+        raise StorageQualificationError(f"{label} categories must be complete and unique")
+    sums = dict.fromkeys(STORAGE_FIELDS, 0)
+    for name in STORAGE_CATEGORIES:
+        row = categories[name]
+        if set(row) != set(STORAGE_FIELDS):
+            raise StorageQualificationError(f"{label} category is malformed: {name}")
+        for field in STORAGE_FIELDS:
+            sums[field] += _integer(row[field], f"{label}.{name}.{field}")
+        if row["physical_objects"] > row["logical_references"]:
+            raise StorageQualificationError(
+                f"{label} physical identities exceed logical references"
+            )
+    expected = {
+        "logical_references": sums["logical_references"],
+        "logical_bytes": sums["logical_bytes"],
+        "retained_logical_eof_bytes": sums["physical_logical_bytes"],
+        "allocated_physical_bytes": sums["allocated_bytes"],
+        "physical_objects": sums["physical_objects"],
+    }
+    if any(snapshot[name] != value for name, value in expected.items()):
+        raise StorageQualificationError(f"{label} category totals do not reconcile")
+    other = categories["other"]
+    if other["logical_references"] != 0 or other["physical_objects"] != 0:
+        raise StorageQualificationError(f"{label} contains unclassified storage")
+
+
+def _validate_application_io(application_io: Mapping[str, Any]) -> None:
+    phases = application_io["phases"]
+    totals = application_io["totals"]
+    if set(phases) != set(APPLICATION_IO_PHASES):
+        raise StorageQualificationError("application I/O phases must be complete and unique")
+    sums = dict.fromkeys(APPLICATION_IO_FIELDS, 0)
+    for name in APPLICATION_IO_PHASES:
+        phase = phases[name]
+        if set(phase) != set(APPLICATION_IO_FIELDS):
+            raise StorageQualificationError(f"application I/O phase is malformed: {name}")
+        for field in APPLICATION_IO_FIELDS:
+            sums[field] += _integer(phase[field], f"application_io.{name}.{field}")
+        if (phase["read_bytes"] == 0) != (phase["read_calls"] == 0):
+            raise StorageQualificationError("application I/O read bytes and calls disagree")
+        if (phase["write_bytes"] == 0) != (phase["write_calls"] == 0):
+            raise StorageQualificationError("application I/O write bytes and calls disagree")
+    if totals != sums:
+        raise StorageQualificationError("application I/O totals do not reconcile")
+
+
+def validate_source_rung(value: Mapping[str, Any]) -> None:
+    """Validate one current, complete controller-produced rung."""
+    reject_unsanitized(value)
+    _schema(RUNG_SCHEMA, value, "progressive rung")
+    if value.get("assembly_contract") != ASSEMBLY_CONTRACT:
+        raise StorageQualificationError("historical rung assembly is not adapter authority")
+    if value.get("status") != "passed" or value.get("correctness") is not True:
+        raise StorageQualificationError("storage qualification requires passed correct rungs")
+    storage = value["storage_attribution"]
+    _validate_snapshot(storage["source"], "source")
+    _validate_snapshot(storage["imported"], "imported")
+    _validate_application_io(storage["construction"]["application_io"])
+    counts = storage["counts"]
+    scale = _integer(value["scale"], "scale", positive=True)
+    nodes = 1 << scale
+    edges = 16 * nodes
+    if (
+        counts["source_nodes"] != nodes
+        or counts["source_edges"] != edges
+        or counts["imported_nodes"] != nodes
+        or counts["imported_edges"] != edges
+        or value["live_edges"] != edges
+    ):
+        raise StorageQualificationError("authoritative counts contradict rung scale")
+
+
+def _artifact(
+    category: str,
+    totals: Mapping[str, Any],
+    source: str,
+    *,
+    transient_peak: int | None = None,
+) -> dict[str, Any]:
+    allocated = totals["allocated_bytes"]
+    return {
+        "category": category,
+        "logical_bytes": totals["logical_bytes"],
+        "allocated_bytes": allocated,
+        "current_retained_bytes": allocated,
+        "transient_peak_allocated_bytes": (allocated if transient_peak is None else transient_peak),
+        "logical_references": totals["logical_references"],
+        "physical_objects": totals["physical_objects"],
+        "source": source,
+    }
+
+
+def adapt_rung(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert one validated progressive rung without rounding any observation."""
+    validate_source_rung(value)
+    storage = value["storage_attribution"]
+    source = storage["source"]
+    imported = storage["imported"]
+    construction = storage["construction"]
+    portable = storage["portable_package"]
+    lifecycle = storage["lifecycle"]
+    counts = storage["counts"]
+    artifacts = [
+        _artifact(name, source["categories"][category], owner)
+        for name, category, owner in SOURCE_CATEGORIES
+    ]
+    artifacts.append(
+        _artifact(
+            "construction_staging_spill",
+            source["categories"]["construction_staging"],
+            "construction_receipts",
+            transient_peak=construction["transient_peak_allocated_bytes"],
+        )
+    )
+    artifacts.append(
+        {
+            "category": "portable_package",
+            "logical_bytes": portable["allocation_logical_bytes"],
+            "allocated_bytes": portable["allocation_allocated_bytes"],
+            "current_retained_bytes": portable["allocation_allocated_bytes"],
+            "transient_peak_allocated_bytes": portable["allocation_allocated_bytes"],
+            # Each writer-owned package object is one retained package reference.
+            "logical_references": portable["allocation_physical_objects"],
+            "physical_objects": portable["allocation_physical_objects"],
+            "source": "exact_descriptor",
+        }
+    )
+    artifacts.append(
+        {
+            "category": "clean_imported_project",
+            "logical_bytes": imported["logical_bytes"],
+            "allocated_bytes": imported["allocated_physical_bytes"],
+            "current_retained_bytes": imported["allocated_physical_bytes"],
+            "transient_peak_allocated_bytes": imported["allocated_physical_bytes"],
+            "logical_references": imported["logical_references"],
+            "physical_objects": imported["physical_objects"],
+            "source": "clean_import_snapshot",
+        }
+    )
+    phases = []
+    for name in APPLICATION_IO_PHASES:
+        counters = construction["application_io"]["phases"][name]
+        phases.append(
+            {
+                "phase": name,
+                "applicable": any(counters[field] != 0 for field in APPLICATION_IO_FIELDS),
+                **counters,
+            }
+        )
+    totals = {
+        "logical_bytes": sum(item["logical_bytes"] for item in artifacts),
+        "allocated_bytes": sum(item["allocated_bytes"] for item in artifacts),
+        "current_retained_bytes": lifecycle["retained_storage_bytes"],
+        "transient_peak_allocated_bytes": lifecycle["transient_peak_storage_bytes"],
+        **{
+            f"phase_{field}": sum(phase[field] for phase in phases)
+            for field in APPLICATION_IO_FIELDS
+        },
+    }
+    by_category = {item["category"]: item for item in artifacts}
+    live_nodes = counts["source_nodes"]
+    live_edges = counts["source_edges"]
+    return {
+        "id": f"S{value['scale']}",
+        "scale": value["scale"],
+        "live_nodes": live_nodes,
+        "live_edges": live_edges,
+        "source_project_current_allocated_bytes": lifecycle[
+            "source_project_current_allocated_bytes"
+        ],
+        "workspace_current_allocated_bytes": lifecycle["retained_storage_bytes"],
+        "artifacts": artifacts,
+        "phases": phases,
+        "totals": totals,
+        "ratios": {
+            "canonical_node_bytes_per_live_node": {
+                "numerator_bytes": by_category["canonical_node_topology"]["logical_bytes"],
+                "denominator_count": live_nodes,
+            },
+            "canonical_edge_bytes_per_live_edge": {
+                "numerator_bytes": by_category["canonical_edge_topology"]["logical_bytes"],
+                "denominator_count": live_edges,
+            },
+            "authoritative_project_bytes_per_live_edge": {
+                "numerator_bytes": lifecycle["source_project_current_allocated_bytes"],
+                "denominator_count": live_edges,
+            },
+            "full_lifecycle_peak_bytes_per_live_edge": {
+                "numerator_bytes": lifecycle["transient_peak_storage_bytes"],
+                "denominator_count": live_edges,
+            },
+        },
+    }
+
+
+def ceil_ratio(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise StorageQualificationError("projection denominator must be positive")
+    return (numerator + denominator - 1) // denominator
+
+
+def build(
+    source_rungs: Sequence[Mapping[str, Any]],
+    *,
+    volume_bytes: int,
+    reserved_headroom_bytes: int,
+) -> dict[str, Any]:
+    """Build and semantically validate one exact `/3` qualification."""
+    if len(source_rungs) != 2:
+        raise StorageQualificationError("exactly two adjacent observations are required")
+    volume = _integer(volume_bytes, "volume_bytes", positive=True)
+    reserved = _integer(reserved_headroom_bytes, "reserved_headroom_bytes")
+    rungs = [adapt_rung(value) for value in source_rungs]
+    scales = tuple(item["scale"] for item in rungs)
+    if scales not in ADJACENT_SOURCES:
+        raise StorageQualificationError("rungs must be ordered adjacent S20/S22 or S22/S24")
+    low, high = rungs
+    delta_bytes = (
+        high["totals"]["transient_peak_allocated_bytes"]
+        - low["totals"]["transient_peak_allocated_bytes"]
+    )
+    delta_edges = high["live_edges"] - low["live_edges"]
+    ratio_num = high["totals"]["transient_peak_allocated_bytes"]
+    ratio_den = high["live_edges"]
+    if delta_bytes > 0 and delta_bytes * ratio_den > ratio_num * delta_edges:
+        ratio_num, ratio_den = delta_bytes, delta_edges
+    projected_peak = ceil_ratio(ratio_num * S26_EDGES, ratio_den)
+    latest = {item["category"]: item for item in high["artifacts"]}
+    projected_nodes = ceil_ratio(
+        latest["canonical_node_topology"]["current_retained_bytes"] * S26_NODES,
+        high["live_nodes"],
+    )
+    projected_edges = ceil_ratio(
+        latest["canonical_edge_topology"]["current_retained_bytes"] * S26_EDGES,
+        high["live_edges"],
+    )
+    headroom = max(0, volume - projected_peak)
+    qualification = {
+        "schema": QUALIFICATION_CONTRACT,
+        "rungs": rungs,
+        "projection": {
+            "target": "S26",
+            "source_rungs": [low["id"], high["id"]],
+            "rate": {
+                "numerator_bytes": ratio_num,
+                "denominator_count": ratio_den,
+            },
+            "projected_canonical_node_bytes": projected_nodes,
+            "projected_canonical_edge_bytes": projected_edges,
+            "projected_lifecycle_peak_bytes": projected_peak,
+            "volume_bytes": volume,
+            "reserved_headroom_bytes": reserved,
+            "headroom_bytes": headroom,
+            "decision": (
+                "admit" if projected_peak <= volume and headroom >= reserved else "refuse"
+            ),
+        },
+    }
+    validate(qualification)
+    return qualification
+
+
+def validate(evidence: Mapping[str, Any]) -> None:
+    """Apply the committed schema and the retired semantic reconciliation rules."""
+    reject_unsanitized(evidence)
+    _schema(QUALIFICATION_SCHEMA, evidence, "ladder qualification")
+    rungs = evidence["rungs"]
+    if len(rungs) != 2:
+        raise StorageQualificationError("exactly two adjacent observations are required")
+    scales = tuple(rung["scale"] for rung in rungs)
+    if scales not in ADJACENT_SOURCES:
+        raise StorageQualificationError("rungs must be ordered adjacent S20/S22 or S22/S24")
+    for rung in rungs:
+        if rung["id"] != f"S{rung['scale']}":
+            raise StorageQualificationError("rung id and scale disagree")
+        categories = [artifact["category"] for artifact in rung["artifacts"]]
+        if len(categories) != len(set(categories)):
+            raise StorageQualificationError("artifact categories must be complete and unique")
+        phase_names = [phase["phase"] for phase in rung["phases"]]
+        if set(phase_names) != set(APPLICATION_IO_PHASES) or len(phase_names) != len(
+            set(phase_names)
+        ):
+            raise StorageQualificationError("application I/O phases must be complete and unique")
+        for phase in rung["phases"]:
+            observed = any(phase[field] != 0 for field in APPLICATION_IO_FIELDS)
+            if phase["applicable"] != observed:
+                raise StorageQualificationError(
+                    "phase applicability contradicts source-owned counters"
+                )
+            if (phase["read_bytes"] == 0) != (phase["read_calls"] == 0):
+                raise StorageQualificationError("phase read bytes and calls disagree")
+            if (phase["write_bytes"] == 0) != (phase["write_calls"] == 0):
+                raise StorageQualificationError("phase write bytes and calls disagree")
+        if any(
+            artifact["physical_objects"] > artifact["logical_references"]
+            for artifact in rung["artifacts"]
+        ):
+            raise StorageQualificationError(
+                "physical identities must be deduplicated from logical references"
+            )
+        expected_totals = {
+            "logical_bytes": sum(item["logical_bytes"] for item in rung["artifacts"]),
+            "allocated_bytes": sum(item["allocated_bytes"] for item in rung["artifacts"]),
+            **{
+                f"phase_{field}": sum(phase[field] for phase in rung["phases"])
+                for field in APPLICATION_IO_FIELDS
+            },
+        }
+        if any(rung["totals"][name] != value for name, value in expected_totals.items()):
+            raise StorageQualificationError("artifact or phase totals do not reconcile")
+        retained = rung["totals"]["current_retained_bytes"]
+        transient = rung["totals"]["transient_peak_allocated_bytes"]
+        retained_views = sum(item["current_retained_bytes"] for item in rung["artifacts"])
+        if retained != rung["workspace_current_allocated_bytes"]:
+            raise StorageQualificationError(
+                "workspace numerator disagrees with retained identity union"
+            )
+        if transient < max(item["transient_peak_allocated_bytes"] for item in rung["artifacts"]):
+            raise StorageQualificationError("lifecycle peak is below a category peak")
+        if retained > retained_views or retained < max(
+            item["current_retained_bytes"] for item in rung["artifacts"]
+        ):
+            raise StorageQualificationError(
+                "native retained union is inconsistent with owner views"
+            )
+        if any(
+            item["current_retained_bytes"] > item["allocated_bytes"] for item in rung["artifacts"]
+        ):
+            raise StorageQualificationError("retained allocation exceeds category allocation")
+        if transient < retained:
+            raise StorageQualificationError("lifecycle peak is below current retained allocation")
+        source_project = rung["source_project_current_allocated_bytes"]
+        selected_source = sum(
+            item["allocated_bytes"]
+            for item in rung["artifacts"]
+            if item["source"] == "storage_owned_snapshot"
+        )
+        if source_project < selected_source or source_project > retained:
+            raise StorageQualificationError("source project union is inconsistent")
+        nodes = rung["live_nodes"]
+        edges = rung["live_edges"]
+        if nodes != 1 << rung["scale"] or not 0 < edges <= nodes * 16:
+            raise StorageQualificationError("live denominators contradict the Graph500 envelope")
+        by_category = {item["category"]: item for item in rung["artifacts"]}
+        ratios = {
+            "canonical_node_bytes_per_live_node": {
+                "numerator_bytes": by_category["canonical_node_topology"]["logical_bytes"],
+                "denominator_count": nodes,
+            },
+            "canonical_edge_bytes_per_live_edge": {
+                "numerator_bytes": by_category["canonical_edge_topology"]["logical_bytes"],
+                "denominator_count": edges,
+            },
+            "authoritative_project_bytes_per_live_edge": {
+                "numerator_bytes": source_project,
+                "denominator_count": edges,
+            },
+            "full_lifecycle_peak_bytes_per_live_edge": {
+                "numerator_bytes": transient,
+                "denominator_count": edges,
+            },
+        }
+        if rung["ratios"] != ratios:
+            raise StorageQualificationError("ratios must preserve exact reproducible denominators")
+    rate = evidence["projection"]["rate"]
+    numerator = rate["numerator_bytes"]
+    denominator = rate["denominator_count"]
+    for low, high in pairwise(rungs):
+        delta_edges = high["live_edges"] - low["live_edges"]
+        delta_bytes = (
+            high["totals"]["transient_peak_allocated_bytes"]
+            - low["totals"]["transient_peak_allocated_bytes"]
+        )
+        if delta_edges <= 0:
+            raise StorageQualificationError("live-edge denominator must increase")
+        if delta_bytes > 0 and numerator * delta_edges < delta_bytes * denominator:
+            raise StorageQualificationError(
+                "projection rate is below the observed adjacent-rung slope"
+            )
+        if (
+            numerator * high["live_edges"]
+            < high["totals"]["transient_peak_allocated_bytes"] * denominator
+        ):
+            raise StorageQualificationError(
+                "projection rate is below the latest observed peak ratio"
+            )
+    projection = evidence["projection"]
+    projected = ceil_ratio(numerator * S26_EDGES, denominator)
+    if projection["source_rungs"] != [rungs[0]["id"], rungs[1]["id"]]:
+        raise StorageQualificationError("projection must cite both adjacent source rungs")
+    if projection["projected_lifecycle_peak_bytes"] != projected:
+        raise StorageQualificationError("S26 projected peak is not reproducible")
+    latest = {item["category"]: item for item in rungs[-1]["artifacts"]}
+    if projection["projected_canonical_node_bytes"] != ceil_ratio(
+        latest["canonical_node_topology"]["current_retained_bytes"] * S26_NODES,
+        rungs[-1]["live_nodes"],
+    ):
+        raise StorageQualificationError("S26 canonical node projection is not reproducible")
+    if projection["projected_canonical_edge_bytes"] != ceil_ratio(
+        latest["canonical_edge_topology"]["current_retained_bytes"] * S26_EDGES,
+        rungs[-1]["live_edges"],
+    ):
+        raise StorageQualificationError("S26 canonical edge projection is not reproducible")
+    expected_headroom = max(0, projection["volume_bytes"] - projected)
+    if projection["headroom_bytes"] != expected_headroom:
+        raise StorageQualificationError("headroom does not reconcile")
+    expected_decision = (
+        "admit"
+        if projected <= projection["volume_bytes"]
+        and expected_headroom >= projection["reserved_headroom_bytes"]
+        else "refuse"
+    )
+    if projection["decision"] != expected_decision:
+        raise StorageQualificationError("S26 admission decision contradicts projected headroom")
+
+
+def _read(path: Path) -> Mapping[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise StorageQualificationError(f"invalid evidence document: {path.name}") from error
+    if not isinstance(value, Mapping):
+        raise StorageQualificationError(f"evidence root must be an object: {path.name}")
+    return value
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("low", type=Path)
+    parser.add_argument("high", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--volume-bytes", type=int, required=True)
+    parser.add_argument("--reserved-headroom-bytes", type=int, required=True)
+    args = parser.parse_args(argv)
+    try:
+        qualification = build(
+            [_read(args.low), _read(args.high)],
+            volume_bytes=args.volume_bytes,
+            reserved_headroom_bytes=args.reserved_headroom_bytes,
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(qualification, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+    except StorageQualificationError as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
@@ -191,7 +191,25 @@ def validate_source_rung(value: Mapping[str, Any]) -> None:
     storage = value["storage_attribution"]
     _validate_snapshot(storage["source"], "source")
     _validate_snapshot(storage["imported"], "imported")
-    _validate_application_io(storage["construction"]["application_io"])
+    construction = storage["construction"]
+    _validate_application_io(construction["application_io"])
+    staging = construction["staging"]
+    for field in STORAGE_FIELDS:
+        _integer(staging[field], f"construction.staging.{field}")
+    staging_peak = _integer(
+        construction["staging_transient_peak_allocated_bytes"],
+        "construction.staging_transient_peak_allocated_bytes",
+    )
+    total_peak = _integer(
+        construction["transient_peak_allocated_bytes"],
+        "construction.transient_peak_allocated_bytes",
+    )
+    if (
+        staging["physical_objects"] > staging["logical_references"]
+        or staging_peak < staging["allocated_bytes"]
+        or total_peak < staging_peak
+    ):
+        raise StorageQualificationError("construction staging authority contradicts its peak")
     counts = storage["counts"]
     scale = _integer(value["scale"], "scale", positive=True)
     if (

--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -1623,8 +1623,17 @@ mod tests {
         assert!(parse_receipts(br#"{"contract":"unknown/1"}"#, true).is_err());
         assert!(parse_receipts(&[], true).is_err());
         assert!(parse_receipts(b"human output\n", false).unwrap().is_empty());
-        let import = br#"{"contract":"graphforge-import-session/1","outcome":"committed","construction":{"configured_batch_rows":65536,"publication_work":{"contract":"graphforge-publication-work/1","semantic_total_operations":9}}}"#;
-        assert_eq!(parse_receipts(import, true).unwrap().len(), 1);
+        let import = br#"{"contract":"graphforge-import-session/1","outcome":"committed","construction":{"configured_batch_rows":65536,"construction_staging":{"logical_references":3,"logical_bytes":4096,"physical_objects":3,"physical_logical_bytes":4096,"allocated_bytes":8192},"construction_staging_transient_peak_allocated_bytes":12288,"publication_work":{"contract":"graphforge-publication-work/1","semantic_total_operations":9}}}"#;
+        let sanitized = parse_receipts(import, true).unwrap();
+        assert_eq!(sanitized.len(), 1);
+        assert_eq!(
+            sanitized[0]["construction"]["construction_staging"]["allocated_bytes"],
+            8192
+        );
+        assert_eq!(
+            sanitized[0]["construction"]["construction_staging_transient_peak_allocated_bytes"],
+            12288
+        );
         let leaked = br#"{"contract":"graphforge-import-session/1","outcome":"committed","construction":{"project_path":"/secret"}}"#;
         assert!(parse_receipts(leaked, true).is_err());
         let query = serde_json::json!({

--- a/benchmarks/schemas/progressive-qualification-rung-evidence.json
+++ b/benchmarks/schemas/progressive-qualification-rung-evidence.json
@@ -59,9 +59,11 @@
         "imported": {"$ref": "#/$defs/storageSnapshot"},
         "construction": {
           "type": "object", "additionalProperties": false,
-          "required": ["application_io", "transient_peak_allocated_bytes"],
+          "required": ["application_io", "staging", "staging_transient_peak_allocated_bytes", "transient_peak_allocated_bytes"],
           "properties": {
             "application_io": {"$ref": "#/$defs/applicationIo"},
+            "staging": {"$ref": "#/$defs/categoryTotals"},
+            "staging_transient_peak_allocated_bytes": {"$ref": "#/$defs/nonnegative"},
             "transient_peak_allocated_bytes": {"$ref": "#/$defs/nonnegative"}
           }
         },

--- a/benchmarks/schemas/progressive-qualification-rung-evidence.json
+++ b/benchmarks/schemas/progressive-qualification-rung-evidence.json
@@ -51,6 +51,52 @@
         "publication_work_units": {"$ref": "#/$defs/nonnegative"}
       }
     },
+    "storage_attribution": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "imported", "construction", "portable_package", "lifecycle", "counts"],
+      "properties": {
+        "source": {"$ref": "#/$defs/storageSnapshot"},
+        "imported": {"$ref": "#/$defs/storageSnapshot"},
+        "construction": {
+          "type": "object", "additionalProperties": false,
+          "required": ["application_io", "transient_peak_allocated_bytes"],
+          "properties": {
+            "application_io": {"$ref": "#/$defs/applicationIo"},
+            "transient_peak_allocated_bytes": {"$ref": "#/$defs/nonnegative"}
+          }
+        },
+        "portable_package": {
+          "type": "object", "additionalProperties": false,
+          "required": ["contract", "allocation_logical_bytes", "allocation_allocated_bytes", "allocation_physical_objects"],
+          "properties": {
+            "contract": {"const": "graphforge-portable-export/2"},
+            "allocation_logical_bytes": {"$ref": "#/$defs/nonnegative"},
+            "allocation_allocated_bytes": {"$ref": "#/$defs/nonnegative"},
+            "allocation_physical_objects": {"$ref": "#/$defs/nonnegative"}
+          }
+        },
+        "lifecycle": {
+          "type": "object", "additionalProperties": false,
+          "required": ["contract", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes"],
+          "properties": {
+            "contract": {"const": "graphforge-lifecycle-storage/1"},
+            "source_project_current_allocated_bytes": {"$ref": "#/$defs/nonnegative"},
+            "retained_storage_bytes": {"$ref": "#/$defs/nonnegative"},
+            "transient_peak_storage_bytes": {"$ref": "#/$defs/nonnegative"}
+          }
+        },
+        "counts": {
+          "type": "object", "additionalProperties": false,
+          "required": ["source_nodes", "source_edges", "imported_nodes", "imported_edges"],
+          "properties": {
+            "source_nodes": {"$ref": "#/$defs/positive"},
+            "source_edges": {"$ref": "#/$defs/positive"},
+            "imported_nodes": {"$ref": "#/$defs/positive"},
+            "imported_edges": {"$ref": "#/$defs/positive"}
+          }
+        }
+      }
+    },
     "failure": {"type": ["string", "null"], "enum": [null, "admission", "generate", "ingest", "reopen", "recount", "query", "export", "verify", "clean_import", "reopen_proof", "timeout", "oom", "storage", "correctness", "harness"]}
   },
   "allOf": [
@@ -76,6 +122,7 @@
         "required": ["status", "assembly_contract"]
       },
       "then": {
+        "required": ["storage_attribution"],
         "properties": {
           "storage_components": {
             "required": ["source_project_current_allocated_bytes"]
@@ -84,5 +131,84 @@
       }
     }
   ],
-  "$defs": {"nonnegative": {"type": "integer", "minimum": 0}}
+  "$defs": {
+    "nonnegative": {"type": "integer", "minimum": 0},
+    "positive": {"type": "integer", "minimum": 1},
+    "categoryTotals": {
+      "type": "object", "additionalProperties": false,
+      "required": ["logical_references", "logical_bytes", "physical_objects", "physical_logical_bytes", "allocated_bytes"],
+      "properties": {
+        "logical_references": {"$ref": "#/$defs/nonnegative"},
+        "logical_bytes": {"$ref": "#/$defs/nonnegative"},
+        "physical_objects": {"$ref": "#/$defs/nonnegative"},
+        "physical_logical_bytes": {"$ref": "#/$defs/nonnegative"},
+        "allocated_bytes": {"$ref": "#/$defs/nonnegative"}
+      }
+    },
+    "categories": {
+      "type": "object", "additionalProperties": false,
+      "required": ["topology_nodes", "topology_edges", "properties", "uuid_and_surrogates", "adjacency", "catalog_and_manifests", "construction_staging", "portable_package", "clean_imported_project", "other"],
+      "properties": {
+        "topology_nodes": {"$ref": "#/$defs/categoryTotals"},
+        "topology_edges": {"$ref": "#/$defs/categoryTotals"},
+        "properties": {"$ref": "#/$defs/categoryTotals"},
+        "uuid_and_surrogates": {"$ref": "#/$defs/categoryTotals"},
+        "adjacency": {"$ref": "#/$defs/categoryTotals"},
+        "catalog_and_manifests": {"$ref": "#/$defs/categoryTotals"},
+        "construction_staging": {"$ref": "#/$defs/categoryTotals"},
+        "portable_package": {"$ref": "#/$defs/categoryTotals"},
+        "clean_imported_project": {"$ref": "#/$defs/categoryTotals"},
+        "other": {"$ref": "#/$defs/categoryTotals"}
+      }
+    },
+    "storageSnapshot": {
+      "type": "object", "additionalProperties": false,
+      "required": ["contract", "categories", "logical_references", "logical_bytes", "retained_logical_eof_bytes", "allocated_physical_bytes", "physical_objects"],
+      "properties": {
+        "contract": {"const": "graphforge-storage-attribution/1"},
+        "categories": {"$ref": "#/$defs/categories"},
+        "logical_references": {"$ref": "#/$defs/nonnegative"},
+        "logical_bytes": {"$ref": "#/$defs/nonnegative"},
+        "retained_logical_eof_bytes": {"$ref": "#/$defs/nonnegative"},
+        "allocated_physical_bytes": {"$ref": "#/$defs/nonnegative"},
+        "physical_objects": {"$ref": "#/$defs/nonnegative"}
+      }
+    },
+    "phaseTotals": {
+      "type": "object", "additionalProperties": false,
+      "required": ["read_bytes", "write_bytes", "read_calls", "write_calls", "object_count", "block_count", "fsync_calls"],
+      "properties": {
+        "read_bytes": {"$ref": "#/$defs/nonnegative"},
+        "write_bytes": {"$ref": "#/$defs/nonnegative"},
+        "read_calls": {"$ref": "#/$defs/nonnegative"},
+        "write_calls": {"$ref": "#/$defs/nonnegative"},
+        "object_count": {"$ref": "#/$defs/nonnegative"},
+        "block_count": {"$ref": "#/$defs/nonnegative"},
+        "fsync_calls": {"$ref": "#/$defs/nonnegative"}
+      }
+    },
+    "phaseMap": {
+      "type": "object", "additionalProperties": false,
+      "required": ["append_merge", "seal_authentication", "shape_consume_reauthentication", "encode_write_postwrite_authentication", "publication_preauthentication", "cas_install_read_write", "hydration_verification", "fsync_synchronization", "recovery_reauthentication"],
+      "properties": {
+        "append_merge": {"$ref": "#/$defs/phaseTotals"},
+        "seal_authentication": {"$ref": "#/$defs/phaseTotals"},
+        "shape_consume_reauthentication": {"$ref": "#/$defs/phaseTotals"},
+        "encode_write_postwrite_authentication": {"$ref": "#/$defs/phaseTotals"},
+        "publication_preauthentication": {"$ref": "#/$defs/phaseTotals"},
+        "cas_install_read_write": {"$ref": "#/$defs/phaseTotals"},
+        "hydration_verification": {"$ref": "#/$defs/phaseTotals"},
+        "fsync_synchronization": {"$ref": "#/$defs/phaseTotals"},
+        "recovery_reauthentication": {"$ref": "#/$defs/phaseTotals"}
+      }
+    },
+    "applicationIo": {
+      "type": "object", "additionalProperties": false,
+      "required": ["phases", "totals"],
+      "properties": {
+        "phases": {"$ref": "#/$defs/phaseMap"},
+        "totals": {"$ref": "#/$defs/phaseTotals"}
+      }
+    }
+  }
 }

--- a/benchmarks/tests/test_progressive_provider_plan.py
+++ b/benchmarks/tests/test_progressive_provider_plan.py
@@ -84,6 +84,8 @@ def storage_attribution(scale: int) -> dict:
         "imported": {**snapshot, "categories": {k: dict(v) for k, v in categories.items()}},
         "construction": {
             "application_io": {"phases": phases, "totals": phase},
+            "staging": category,
+            "staging_transient_peak_allocated_bytes": 0,
             "transient_peak_allocated_bytes": 300,
         },
         "portable_package": {

--- a/benchmarks/tests/test_progressive_provider_plan.py
+++ b/benchmarks/tests/test_progressive_provider_plan.py
@@ -24,6 +24,89 @@ COMMIT = subprocess.run(
 ).stdout.strip()
 
 
+def storage_attribution(scale: int) -> dict:
+    category = {
+        "logical_references": 0,
+        "logical_bytes": 0,
+        "physical_objects": 0,
+        "physical_logical_bytes": 0,
+        "allocated_bytes": 0,
+    }
+    categories = {
+        name: dict(category)
+        for name in (
+            "topology_nodes",
+            "topology_edges",
+            "properties",
+            "uuid_and_surrogates",
+            "adjacency",
+            "catalog_and_manifests",
+            "construction_staging",
+            "portable_package",
+            "clean_imported_project",
+            "other",
+        )
+    }
+    snapshot = {
+        "contract": "graphforge-storage-attribution/1",
+        "categories": categories,
+        "logical_references": 0,
+        "logical_bytes": 0,
+        "retained_logical_eof_bytes": 0,
+        "allocated_physical_bytes": 0,
+        "physical_objects": 0,
+    }
+    phase = {
+        "read_bytes": 0,
+        "write_bytes": 0,
+        "read_calls": 0,
+        "write_calls": 0,
+        "object_count": 0,
+        "block_count": 0,
+        "fsync_calls": 0,
+    }
+    phases = {
+        name: dict(phase)
+        for name in (
+            "append_merge",
+            "seal_authentication",
+            "shape_consume_reauthentication",
+            "encode_write_postwrite_authentication",
+            "publication_preauthentication",
+            "cas_install_read_write",
+            "hydration_verification",
+            "fsync_synchronization",
+            "recovery_reauthentication",
+        )
+    }
+    return {
+        "source": snapshot,
+        "imported": {**snapshot, "categories": {k: dict(v) for k, v in categories.items()}},
+        "construction": {
+            "application_io": {"phases": phases, "totals": phase},
+            "transient_peak_allocated_bytes": 300,
+        },
+        "portable_package": {
+            "contract": "graphforge-portable-export/2",
+            "allocation_logical_bytes": 0,
+            "allocation_allocated_bytes": 0,
+            "allocation_physical_objects": 0,
+        },
+        "lifecycle": {
+            "contract": "graphforge-lifecycle-storage/1",
+            "source_project_current_allocated_bytes": 105,
+            "retained_storage_bytes": 200,
+            "transient_peak_storage_bytes": 300,
+        },
+        "counts": {
+            "source_nodes": 1 << scale,
+            "source_edges": 16 * (1 << scale),
+            "imported_nodes": 1 << scale,
+            "imported_edges": 16 * (1 << scale),
+        },
+    }
+
+
 def rung(scale: int, *, source: str | None = None) -> dict:
     return {
         "assembly_contract": "graphforge-progressive-rung-assembly/2",
@@ -86,6 +169,7 @@ def rung(scale: int, *, source: str | None = None) -> dict:
             "reader_calls": 8,
             "publication_work_units": 9,
         },
+        "storage_attribution": storage_attribution(scale),
         "failure": None,
     }
 

--- a/benchmarks/tests/test_progressive_qualification.py
+++ b/benchmarks/tests/test_progressive_qualification.py
@@ -110,6 +110,14 @@ def storage_attribution(scale: int, multiplier: int) -> dict:
                     field: sum(phase[field] for phase in phases.values()) for field in io_fields
                 },
             },
+            "staging": {
+                "logical_references": 3,
+                "logical_bytes": 100_000 * multiplier,
+                "physical_objects": 3,
+                "physical_logical_bytes": 100_000 * multiplier,
+                "allocated_bytes": 120_000 * multiplier,
+            },
+            "staging_transient_peak_allocated_bytes": 200_000 * multiplier,
             "transient_peak_allocated_bytes": 1_500_000 * multiplier,
         },
         "portable_package": {

--- a/benchmarks/tests/test_progressive_qualification.py
+++ b/benchmarks/tests/test_progressive_qualification.py
@@ -25,6 +25,114 @@ CAPACITY = {
 }
 
 
+def storage_attribution(scale: int, multiplier: int) -> dict:
+    category_names = (
+        "topology_nodes",
+        "topology_edges",
+        "properties",
+        "uuid_and_surrogates",
+        "adjacency",
+        "catalog_and_manifests",
+        "construction_staging",
+        "portable_package",
+        "clean_imported_project",
+        "other",
+    )
+    empty = {
+        "logical_references": 0,
+        "logical_bytes": 0,
+        "physical_objects": 0,
+        "physical_logical_bytes": 0,
+        "allocated_bytes": 0,
+    }
+
+    def snapshot(node_bytes: int, edge_bytes: int) -> dict:
+        categories = {name: dict(empty) for name in category_names}
+        categories["topology_nodes"] = {
+            "logical_references": 1,
+            "logical_bytes": node_bytes,
+            "physical_objects": 1,
+            "physical_logical_bytes": node_bytes,
+            "allocated_bytes": node_bytes,
+        }
+        categories["topology_edges"] = {
+            "logical_references": 1,
+            "logical_bytes": edge_bytes,
+            "physical_objects": 1,
+            "physical_logical_bytes": edge_bytes,
+            "allocated_bytes": edge_bytes,
+        }
+        total = node_bytes + edge_bytes
+        return {
+            "contract": "graphforge-storage-attribution/1",
+            "categories": categories,
+            "logical_references": 2,
+            "logical_bytes": total,
+            "retained_logical_eof_bytes": total,
+            "allocated_physical_bytes": total,
+            "physical_objects": 2,
+        }
+
+    io_fields = (
+        "read_bytes",
+        "write_bytes",
+        "read_calls",
+        "write_calls",
+        "object_count",
+        "block_count",
+        "fsync_calls",
+    )
+    phase_names = (
+        "append_merge",
+        "seal_authentication",
+        "shape_consume_reauthentication",
+        "encode_write_postwrite_authentication",
+        "publication_preauthentication",
+        "cas_install_read_write",
+        "hydration_verification",
+        "fsync_synchronization",
+        "recovery_reauthentication",
+    )
+    phases = {name: dict.fromkeys(io_fields, 0) for name in phase_names}
+    phases["append_merge"].update(
+        read_bytes=2_000_000 * multiplier,
+        write_bytes=3_000_000 * multiplier,
+        read_calls=1_000 * multiplier,
+        write_calls=500 * multiplier,
+    )
+    return {
+        "source": snapshot(150_000 * multiplier, 250_000 * multiplier),
+        "imported": snapshot(150_000 * multiplier, 250_000 * multiplier),
+        "construction": {
+            "application_io": {
+                "phases": phases,
+                "totals": {
+                    field: sum(phase[field] for phase in phases.values()) for field in io_fields
+                },
+            },
+            "transient_peak_allocated_bytes": 1_500_000 * multiplier,
+        },
+        "portable_package": {
+            "contract": "graphforge-portable-export/2",
+            "allocation_logical_bytes": 300_000 * multiplier,
+            "allocation_allocated_bytes": 300_000 * multiplier,
+            "allocation_physical_objects": 1,
+        },
+        "lifecycle": {
+            "contract": "graphforge-lifecycle-storage/1",
+            "source_project_current_allocated_bytes": 450_000 * multiplier,
+            "retained_storage_bytes": 1_000_000 * multiplier,
+            "transient_peak_storage_bytes": 1_500_000 * multiplier,
+        },
+        "counts": {
+            "source_nodes": 1 << scale,
+            "source_edges": 16 * (1 << scale),
+            "imported_nodes": 1 << scale,
+            "imported_edges": 16 * (1 << scale),
+        },
+    }
+
+
 def rung(scale: int, *, rss: int = 1_000_000_000, wall: int = 100) -> dict:
     multiplier = 1 << max(0, scale - 18)
     return {
@@ -77,6 +185,7 @@ def rung(scale: int, *, rss: int = 1_000_000_000, wall: int = 100) -> dict:
             "reader_calls": 1_000 * multiplier,
             "publication_work_units": 2_000 * multiplier,
         },
+        "storage_attribution": storage_attribution(scale, multiplier),
         "failure": None,
     }
 

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 from pathlib import Path
 import tempfile
 import unittest
@@ -22,6 +23,7 @@ from graphforge_bench.progressive_run import (
     assemble_rung_evidence,
     build_plan,
     ingest_benchexec_result,
+    publish_json_no_clobber,
     repository_commit,
     require_bulk_ingest_capability,
     require_order,
@@ -367,6 +369,59 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         self.assertEqual(json.loads(path.read_text()), {"value": 1})
         self.assertEqual([item.name for item in self.base.glob(".immutable.json.*")], [])
 
+    def test_nested_publication_syncs_each_fresh_directory_parent(self) -> None:
+        path = self.base / "fresh" / "nested" / "evidence.json"
+        synced_inodes: list[int] = []
+        real_fsync = os.fsync
+
+        def record_fsync(descriptor: int) -> None:
+            synced_inodes.append(os.fstat(descriptor).st_ino)
+            real_fsync(descriptor)
+
+        with (
+            patch(
+                "graphforge_bench.progressive_run.os.fsync",
+                side_effect=record_fsync,
+            ),
+            patch(
+                "graphforge_bench.progressive_run.os.mkdir",
+                wraps=os.mkdir,
+            ) as mkdir,
+        ):
+            publish_json_no_clobber(path, {"value": 1})
+        expected_directories = (
+            self.base,
+            self.base / "fresh",
+            self.base / "fresh" / "nested",
+        )
+        self.assertTrue(
+            {item.stat().st_ino for item in expected_directories}.issubset(synced_inodes)
+        )
+        self.assertEqual([call.args[0] for call in mkdir.call_args_list], ["fresh", "nested"])
+        self.assertEqual(json.loads(path.read_text()), {"value": 1})
+
+    def test_interrupted_nested_publication_leaves_no_partial_file(self) -> None:
+        path = self.base / "fresh" / "nested" / "evidence.json"
+        with (
+            patch(
+                "graphforge_bench.progressive_run.os.link",
+                side_effect=OSError("injected interruption"),
+            ),
+            self.assertRaisesRegex(OSError, "injected interruption"),
+        ):
+            publish_json_no_clobber(path, {"value": 1})
+        self.assertFalse(path.exists())
+        self.assertEqual(list(path.parent.glob(f".{path.name}.*")), [])
+
+    def test_publication_refuses_symlinked_directory_components(self) -> None:
+        outside = self.base / "outside"
+        outside.mkdir()
+        linked = self.base / "linked"
+        linked.symlink_to(outside, target_is_directory=True)
+        with self.assertRaises(OSError):
+            publish_json_no_clobber(linked / "evidence.json", {"value": 1})
+        self.assertFalse((outside / "evidence.json").exists())
+
     def test_venv_python_path_is_not_dereferenced_out_of_its_environment(self) -> None:
         venv = self.base / "venv/bin"
         venv.mkdir(parents=True)
@@ -622,6 +677,28 @@ class ProgressiveRunControllerTests(unittest.TestCase):
                 receipts[phase].append(copy.deepcopy(receipts[phase][index]))
                 gf = graphforge(18, receipts)
                 with self.assertRaisesRegex(ControllerError, "missing, moved, or ambiguous"):
+                    assemble_rung_evidence(
+                        root=ROOT, scale=18, graphforge=gf, benchexec=benchexec(gf)
+                    )
+
+    def test_storage_and_query_receipts_reject_global_moves_and_duplicates(self) -> None:
+        cases = (
+            ("reopen", "query", "graphforge-storage-attribution-command/1", "moved"),
+            ("reopen", "query", "graphforge-storage-attribution-command/1", "duplicated"),
+            ("recount", "admission", "graphforge-result-sink/2", "moved"),
+            ("query", "export", "graphforge-result-sink/2", "duplicated"),
+        )
+        for source, destination, contract, mutation in cases:
+            with self.subTest(contract=contract, mutation=mutation):
+                receipts = authoritative_receipts(18)
+                selected = next(
+                    receipt for receipt in receipts[source] if receipt.get("contract") == contract
+                )
+                if mutation == "moved":
+                    receipts[source].remove(selected)
+                receipts[destination].append(copy.deepcopy(selected))
+                gf = graphforge(18, receipts)
+                with self.assertRaisesRegex(ControllerError, "inventory"):
                     assemble_rung_evidence(
                         root=ROOT, scale=18, graphforge=gf, benchexec=benchexec(gf)
                     )

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -696,7 +696,7 @@ class ProgressiveRunControllerTests(unittest.TestCase):
                 )
                 if mutation == "moved":
                     receipts[source].remove(selected)
-                receipts[destination].append(copy.deepcopy(selected))
+                receipts.setdefault(destination, []).append(copy.deepcopy(selected))
                 gf = graphforge(18, receipts)
                 with self.assertRaisesRegex(ControllerError, "inventory"):
                     assemble_rung_evidence(

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -97,6 +97,7 @@ def passed_rung(scale: int) -> dict:
             "reader_calls": 8,
             "publication_work_units": 9,
         },
+        "storage_attribution": rung_storage_attribution(scale),
         "failure": None,
     }
 
@@ -182,9 +183,7 @@ def authoritative_receipts(scale: int) -> dict[str, list[dict]]:
                 "input_rows": 65_536 * 64,
                 "input_batches": 64,
                 "transient_peak_allocated_bytes": 300,
-                "application_io": {
-                    "totals": {"read_bytes": 400, "write_bytes": 500, "read_calls": 8}
-                },
+                "application_io": application_io(),
                 "publication_work": {
                     "contract": "graphforge-publication-work/1",
                     "semantic_total_operations": 9,
@@ -204,6 +203,14 @@ def authoritative_receipts(scale: int) -> dict[str, list[dict]]:
         "reopen": [source_storage],
         "recount": [node_count, edge_count],
         "query": [one_hop, two_hop],
+        "export": [
+            {
+                "contract": "graphforge-portable-export/2",
+                "allocation_logical_bytes": 140,
+                "allocation_allocated_bytes": 150,
+                "allocation_physical_objects": 1,
+            }
+        ],
         "reopen_proof": [
             node_count,
             edge_count,
@@ -242,18 +249,79 @@ def storage_receipt(allocated: int, logical_eof: int) -> dict:
             "other",
         )
     }
+    categories["topology_nodes"] = {
+        "logical_references": 1,
+        "logical_bytes": logical_eof,
+        "physical_objects": 1,
+        "physical_logical_bytes": logical_eof,
+        "allocated_bytes": allocated,
+    }
     return {
         "contract": "graphforge-storage-attribution-command/1",
         "storage": {
             "contract": "graphforge-storage-attribution/1",
             "categories": categories,
-            "logical_references": 0,
-            "logical_bytes": 0,
+            "logical_references": 1,
+            "logical_bytes": logical_eof,
             "retained_logical_eof_bytes": logical_eof,
             "allocated_physical_bytes": allocated,
-            "physical_objects": 0,
+            "physical_objects": 1,
         },
         "reopen_agrees": True,
+    }
+
+
+def application_io() -> dict:
+    fields = (
+        "read_bytes",
+        "write_bytes",
+        "read_calls",
+        "write_calls",
+        "object_count",
+        "block_count",
+        "fsync_calls",
+    )
+    names = (
+        "append_merge",
+        "seal_authentication",
+        "shape_consume_reauthentication",
+        "encode_write_postwrite_authentication",
+        "publication_preauthentication",
+        "cas_install_read_write",
+        "hydration_verification",
+        "fsync_synchronization",
+        "recovery_reauthentication",
+    )
+    phases = {name: dict.fromkeys(fields, 0) for name in names}
+    phases["append_merge"].update(
+        read_bytes=400,
+        write_bytes=500,
+        read_calls=8,
+        write_calls=1,
+    )
+    return {
+        "phases": phases,
+        "totals": {field: sum(phase[field] for phase in phases.values()) for field in fields},
+    }
+
+
+def rung_storage_attribution(scale: int) -> dict:
+    receipts = authoritative_receipts(scale)
+    return {
+        "source": receipts["reopen"][0]["storage"],
+        "imported": receipts["reopen_proof"][4]["storage"],
+        "construction": {
+            "application_io": receipts["ingest"][0]["construction"]["application_io"],
+            "transient_peak_allocated_bytes": 300,
+        },
+        "portable_package": receipts["export"][0],
+        "lifecycle": receipts["reopen_proof"][-1],
+        "counts": {
+            "source_nodes": 1 << scale,
+            "source_edges": 16 * (1 << scale),
+            "imported_nodes": 1 << scale,
+            "imported_edges": 16 * (1 << scale),
+        },
     }
 
 
@@ -414,6 +482,9 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         self.assertEqual(rung["status"], "passed")
         self.assertEqual(rung["metrics"]["physical_read_bytes"], 0)
         self.assertEqual(rung["storage_components"]["source_project_current_allocated_bytes"], 105)
+        self.assertEqual(
+            rung["storage_attribution"]["portable_package"]["allocation_allocated_bytes"], 150
+        )
         for omitted in receipts:
             with self.subTest(omitted=omitted), self.assertRaises(ControllerError):
                 changed = {name: values for name, values in receipts.items() if name != omitted}
@@ -475,6 +546,29 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         del missing_publication["ingest"][0]["construction"]["publication_work"]
         changed_gf = graphforge(18, missing_publication)
         with self.assertRaisesRegex(ControllerError, "construction metrics"):
+            assemble_rung_evidence(
+                root=ROOT, scale=18, graphforge=changed_gf, benchexec=benchexec(changed_gf)
+            )
+        missing_portable = authoritative_receipts(18)
+        del missing_portable["export"]
+        changed_gf = graphforge(18, missing_portable)
+        with self.assertRaisesRegex(ControllerError, "graphforge-portable-export/2"):
+            assemble_rung_evidence(
+                root=ROOT, scale=18, graphforge=changed_gf, benchexec=benchexec(changed_gf)
+            )
+        malformed_categories = authoritative_receipts(18)
+        del malformed_categories["reopen"][0]["storage"]["categories"]["other"]
+        changed_gf = graphforge(18, malformed_categories)
+        with self.assertRaisesRegex(ControllerError, "categories are incomplete"):
+            assemble_rung_evidence(
+                root=ROOT, scale=18, graphforge=changed_gf, benchexec=benchexec(changed_gf)
+            )
+        malformed_phases = authoritative_receipts(18)
+        del malformed_phases["ingest"][0]["construction"]["application_io"]["phases"][
+            "recovery_reauthentication"
+        ]
+        changed_gf = graphforge(18, malformed_phases)
+        with self.assertRaisesRegex(ControllerError, "inventory is incomplete"):
             assemble_rung_evidence(
                 root=ROOT, scale=18, graphforge=changed_gf, benchexec=benchexec(changed_gf)
             )

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 import tempfile
@@ -183,6 +184,14 @@ def authoritative_receipts(scale: int) -> dict[str, list[dict]]:
                 "input_rows": 65_536 * 64,
                 "input_batches": 64,
                 "transient_peak_allocated_bytes": 300,
+                "construction_staging": {
+                    "logical_references": 3,
+                    "logical_bytes": 250,
+                    "physical_objects": 3,
+                    "physical_logical_bytes": 250,
+                    "allocated_bytes": 275,
+                },
+                "construction_staging_transient_peak_allocated_bytes": 290,
                 "application_io": application_io(),
                 "publication_work": {
                     "contract": "graphforge-publication-work/1",
@@ -312,6 +321,10 @@ def rung_storage_attribution(scale: int) -> dict:
         "imported": receipts["reopen_proof"][4]["storage"],
         "construction": {
             "application_io": receipts["ingest"][0]["construction"]["application_io"],
+            "staging": receipts["ingest"][0]["construction"]["construction_staging"],
+            "staging_transient_peak_allocated_bytes": receipts["ingest"][0]["construction"][
+                "construction_staging_transient_peak_allocated_bytes"
+            ],
             "transient_peak_allocated_bytes": 300,
         },
         "portable_package": receipts["export"][0],
@@ -485,6 +498,13 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         self.assertEqual(
             rung["storage_attribution"]["portable_package"]["allocation_allocated_bytes"], 150
         )
+        self.assertEqual(
+            rung["storage_attribution"]["construction"]["staging"]["allocated_bytes"], 275
+        )
+        self.assertEqual(
+            rung["storage_attribution"]["construction"]["staging_transient_peak_allocated_bytes"],
+            290,
+        )
         for omitted in receipts:
             with self.subTest(omitted=omitted), self.assertRaises(ControllerError):
                 changed = {name: values for name, values in receipts.items() if name != omitted}
@@ -572,6 +592,39 @@ class ProgressiveRunControllerTests(unittest.TestCase):
             assemble_rung_evidence(
                 root=ROOT, scale=18, graphforge=changed_gf, benchexec=benchexec(changed_gf)
             )
+        missing_staging = authoritative_receipts(18)
+        del missing_staging["ingest"][0]["construction"]["construction_staging"]
+        changed_gf = graphforge(18, missing_staging)
+        with self.assertRaisesRegex(ControllerError, "staging authority"):
+            assemble_rung_evidence(
+                root=ROOT, scale=18, graphforge=changed_gf, benchexec=benchexec(changed_gf)
+            )
+
+    def test_receipt_authorities_are_bound_to_their_ordinary_phases(self) -> None:
+        cases = (
+            ("ingest", "query", 0),
+            ("export", "query", 0),
+            ("reopen_proof", "query", -1),
+        )
+        for source_phase, destination_phase, index in cases:
+            with self.subTest(source_phase=source_phase):
+                receipts = authoritative_receipts(18)
+                moved = receipts[source_phase].pop(index)
+                receipts[destination_phase].append(moved)
+                gf = graphforge(18, receipts)
+                with self.assertRaisesRegex(ControllerError, "missing, moved, or ambiguous"):
+                    assemble_rung_evidence(
+                        root=ROOT, scale=18, graphforge=gf, benchexec=benchexec(gf)
+                    )
+        for phase, index in (("ingest", 0), ("export", 0), ("reopen_proof", -1)):
+            with self.subTest(duplicate=phase):
+                receipts = authoritative_receipts(18)
+                receipts[phase].append(copy.deepcopy(receipts[phase][index]))
+                gf = graphforge(18, receipts)
+                with self.assertRaisesRegex(ControllerError, "missing, moved, or ambiguous"):
+                    assemble_rung_evidence(
+                        root=ROOT, scale=18, graphforge=gf, benchexec=benchexec(gf)
+                    )
 
     def test_exact_benchexec_xml_and_log_are_normalized_into_passed_bundle(self) -> None:
         plan = build_plan(

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -413,6 +413,34 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         self.assertFalse(path.exists())
         self.assertEqual(list(path.parent.glob(f".{path.name}.*")), [])
 
+    def test_post_link_directory_fsync_failure_keeps_complete_no_clobber_target(
+        self,
+    ) -> None:
+        path = self.base / "evidence.json"
+        value = {"status": "complete", "value": 1}
+        real_fsync = os.fsync
+
+        def fail_after_link(descriptor: int) -> None:
+            temporary = list(path.parent.glob(f".{path.name}.*"))
+            if path.exists() and not temporary:
+                raise OSError("injected post-link directory fsync failure")
+            real_fsync(descriptor)
+
+        with (
+            patch(
+                "graphforge_bench.progressive_run.os.fsync",
+                side_effect=fail_after_link,
+            ),
+            self.assertRaisesRegex(OSError, "post-link directory fsync failure"),
+        ):
+            publish_json_no_clobber(path, value)
+        self.assertEqual(json.loads(path.read_text(encoding="utf-8")), value)
+        self.assertEqual(list(path.parent.glob(f".{path.name}.*")), [])
+        with self.assertRaises(FileExistsError):
+            publish_json_no_clobber(path, {"status": "replacement"})
+        self.assertEqual(json.loads(path.read_text(encoding="utf-8")), value)
+        self.assertEqual(list(path.parent.glob(f".{path.name}.*")), [])
+
     def test_publication_refuses_symlinked_directory_components(self) -> None:
         outside = self.base / "outside"
         outside.mkdir()

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from graphforge_bench.progressive_storage_qualification import (
+    StorageQualificationError,
+    build,
+    validate,
+    validate_source_rung,
+)
+from test_progressive_qualification import rung
+
+
+VOLUME_BYTES = 500 * 1024**3
+RESERVED_BYTES = 75 * 1024**3
+
+
+class ProgressiveStorageQualificationTests(unittest.TestCase):
+    def source_pair(self) -> list[dict]:
+        return [rung(20), rung(22)]
+
+    def test_two_complete_adjacent_rungs_produce_valid_exact_v3_evidence(self) -> None:
+        low, high = self.source_pair()
+        evidence = build(
+            [low, high],
+            volume_bytes=VOLUME_BYTES,
+            reserved_headroom_bytes=RESERVED_BYTES,
+        )
+        validate(evidence)
+        self.assertEqual(evidence["schema"], "graphforge-g500-ladder-qualification/3")
+        self.assertEqual(evidence["projection"]["source_rungs"], ["S20", "S22"])
+        self.assertEqual(
+            evidence["projection"]["rate"],
+            {
+                "numerator_bytes": high["storage_attribution"]["lifecycle"][
+                    "transient_peak_storage_bytes"
+                ],
+                "denominator_count": high["storage_attribution"]["counts"]["source_edges"],
+            },
+        )
+        self.assertEqual(len(evidence["rungs"][0]["artifacts"]), 9)
+        self.assertEqual(len(evidence["rungs"][0]["phases"]), 9)
+
+    def test_missing_portable_authority_and_historical_v1_are_rejected(self) -> None:
+        missing = self.source_pair()[0]
+        del missing["storage_attribution"]["portable_package"]
+        with self.assertRaisesRegex(StorageQualificationError, "portable_package"):
+            validate_source_rung(missing)
+        historical = self.source_pair()[0]
+        del historical["assembly_contract"]
+        del historical["storage_attribution"]
+        with self.assertRaisesRegex(StorageQualificationError, "historical rung"):
+            validate_source_rung(historical)
+
+    def test_malformed_category_and_application_phase_inventories_are_rejected(self) -> None:
+        missing_category = self.source_pair()[0]
+        del missing_category["storage_attribution"]["source"]["categories"]["other"]
+        with self.assertRaisesRegex(StorageQualificationError, "categories"):
+            validate_source_rung(missing_category)
+        missing_phase = self.source_pair()[0]
+        del missing_phase["storage_attribution"]["construction"]["application_io"]["phases"][
+            "recovery_reauthentication"
+        ]
+        with self.assertRaisesRegex(StorageQualificationError, "application I/O"):
+            validate_source_rung(missing_phase)
+
+    def test_one_rung_and_non_adjacent_rungs_are_rejected(self) -> None:
+        with self.assertRaisesRegex(StorageQualificationError, "exactly two"):
+            build(
+                [rung(20)],
+                volume_bytes=VOLUME_BYTES,
+                reserved_headroom_bytes=RESERVED_BYTES,
+            )
+        with self.assertRaisesRegex(StorageQualificationError, "ordered adjacent"):
+            build(
+                [rung(20), rung(24)],
+                volume_bytes=VOLUME_BYTES,
+                reserved_headroom_bytes=RESERVED_BYTES,
+            )
+
+    def test_reconciliation_contradictions_and_sensitive_content_are_rejected(self) -> None:
+        contradictory = self.source_pair()[0]
+        contradictory["storage_attribution"]["source"]["logical_bytes"] += 1
+        with self.assertRaisesRegex(StorageQualificationError, "do not reconcile"):
+            validate_source_rung(contradictory)
+        unsafe = self.source_pair()[0]
+        unsafe["storage_attribution"]["source"]["token"] = "must-not-escape"
+        with self.assertRaisesRegex(StorageQualificationError, "sensitive evidence key"):
+            validate_source_rung(unsafe)
+
+    def test_s26_storage_headroom_refuses_and_cannot_be_relabelled_admit(self) -> None:
+        baseline = build(
+            self.source_pair(),
+            volume_bytes=VOLUME_BYTES,
+            reserved_headroom_bytes=0,
+        )
+        projected = baseline["projection"]["projected_lifecycle_peak_bytes"]
+        refused = build(
+            self.source_pair(),
+            volume_bytes=projected - 1,
+            reserved_headroom_bytes=0,
+        )
+        self.assertEqual(refused["projection"]["decision"], "refuse")
+        self.assertEqual(refused["projection"]["headroom_bytes"], 0)
+        contradiction = copy.deepcopy(refused)
+        contradiction["projection"]["decision"] = "admit"
+        with self.assertRaisesRegex(StorageQualificationError, "decision contradicts"):
+            validate(contradiction)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -37,8 +37,15 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temporary.cleanup()
 
+    @staticmethod
+    def provider_rung(scale: int) -> dict:
+        value = rung(scale)
+        value["source"] = "canonical_ladder"
+        value["profile_id"] = f"graph500-s{scale}-provider"
+        return value
+
     def source_pair(self) -> list[dict]:
-        return [rung(20), rung(22)]
+        return [self.provider_rung(20), self.provider_rung(22)]
 
     def write_bundle(self, value: dict) -> Path:
         scale = value["scale"]
@@ -106,7 +113,7 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
         return rung_path
 
     def bound_pair(self, scales: tuple[int, int] = (20, 22)) -> list[Path]:
-        return [self.write_bundle(rung(scale)) for scale in scales]
+        return [self.write_bundle(self.provider_rung(scale)) for scale in scales]
 
     def build_pair(self, scales: tuple[int, int] = (20, 22), **overrides: int) -> dict:
         return build(
@@ -186,7 +193,7 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
     def test_one_rung_and_non_adjacent_rungs_are_rejected(self) -> None:
         with self.assertRaisesRegex(StorageQualificationError, "exactly two"):
             build(
-                [self.write_bundle(rung(20))],
+                [self.write_bundle(self.provider_rung(20))],
                 expected_commit=COMMIT,
                 expected_image_digest=IMAGE,
                 volume_bytes=VOLUME_BYTES,
@@ -234,7 +241,7 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
             ("profile_id", "graph500-s20-local"),
         ):
             with self.subTest(field=field):
-                invalid = rung(20)
+                invalid = self.provider_rung(20)
                 invalid[field] = value
                 with self.assertRaisesRegex(
                     StorageQualificationError, "canonical provider source/profile"

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 from pathlib import Path
+import subprocess
 import tempfile
 import unittest
 
 from graphforge_bench.progressive_storage_qualification import (
     StorageQualificationError,
+    _build_qualification,
     build,
     main,
     validate,
@@ -17,19 +20,106 @@ from tests.test_progressive_qualification import rung
 
 VOLUME_BYTES = 500 * 1024**3
 RESERVED_BYTES = 75 * 1024**3
+COMMIT = subprocess.run(
+    ["git", "-C", str(Path(__file__).resolve().parents[2]), "rev-parse", "HEAD"],
+    capture_output=True,
+    check=True,
+    text=True,
+).stdout.strip()
+IMAGE = "registry.fly.io/graphforge-bench@sha256:" + "1" * 64
 
 
 class ProgressiveStorageQualificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.base = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
     def source_pair(self) -> list[dict]:
         return [rung(20), rung(22)]
 
+    def write_bundle(self, value: dict) -> Path:
+        scale = value["scale"]
+        prefix = self.base / f"s{scale}"
+        rung_path = prefix.with_name(f"s{scale}-rung.json")
+        plan_path = prefix.with_name(f"s{scale}-plan.json")
+        benchexec_path = prefix.with_name(f"s{scale}-benchexec.json")
+        graphforge_path = prefix.with_name(f"s{scale}-graphforge.json")
+        result_path = prefix.with_name(f"s{scale}-result.json")
+        profile = Path(__file__).resolve().parents[1] / (
+            f"profiles/graph500/s{scale}-provider.json"
+        )
+        identities = {
+            "commit": COMMIT,
+            "profile_id": f"graph500-s{scale}-provider",
+            "profile_sha256": hashlib.sha256(profile.read_bytes()).hexdigest(),
+            "image_digest": IMAGE,
+            "generator": "sha256:" + "2" * 64,
+            "generator_executable_sha256": "3" * 64,
+            "gf_sha256": "4" * 64,
+            "certify_sha256": "5" * 64,
+            "benchexec_python_sha256": "6" * 64,
+            "benchexec_version": "3.30",
+            "admitted_plan_sha256": "7" * 64,
+            "source_tree_sha256": "8" * 64,
+        }
+        plan = {
+            "schema": "graphforge-progressive-provider-execution-plan/1",
+            "rung": f"S{scale}",
+            "execution": "provider_native_linux_benchexec",
+            "identities": identities,
+            "limits": {"wall_seconds": 14_400, "memory_bytes": 4_294_967_296, "cores": 16},
+            "outputs": [
+                f"s{scale}-plan.json",
+                f"s{scale}-benchexec.json",
+                f"s{scale}-graphforge.json",
+                f"s{scale}-rung.json",
+                f"s{scale}-result.json",
+            ],
+            "claim": "engineering_evidence_only",
+        }
+        rung_path.write_text(json.dumps(value), encoding="utf-8")
+        plan_path.write_text(json.dumps(plan), encoding="utf-8")
+        benchexec_path.write_text("{}\n", encoding="utf-8")
+        graphforge_path.write_text("{}\n", encoding="utf-8")
+        artifacts = {
+            name: hashlib.sha256(path.read_bytes()).hexdigest()
+            for name, path in {
+                "plan_sha256": plan_path,
+                "benchexec_sha256": benchexec_path,
+                "graphforge_sha256": graphforge_path,
+                "rung_sha256": rung_path,
+            }.items()
+        }
+        result = {
+            "schema": "graphforge-progressive-provider-run-result/1",
+            "rung": f"S{scale}",
+            "status": "passed",
+            "failure": None,
+            "identities": identities,
+            "artifacts": artifacts,
+            "claim": "engineering_evidence_only",
+        }
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        return rung_path
+
+    def bound_pair(self, scales: tuple[int, int] = (20, 22)) -> list[Path]:
+        return [self.write_bundle(rung(scale)) for scale in scales]
+
+    def build_pair(self, scales: tuple[int, int] = (20, 22), **overrides: int) -> dict:
+        return build(
+            self.bound_pair(scales),
+            expected_commit=COMMIT,
+            expected_image_digest=IMAGE,
+            volume_bytes=overrides.get("volume_bytes", VOLUME_BYTES),
+            reserved_headroom_bytes=overrides.get("reserved_headroom_bytes", RESERVED_BYTES),
+        )
+
     def test_two_complete_adjacent_rungs_produce_valid_exact_v3_evidence(self) -> None:
         low, high = self.source_pair()
-        evidence = build(
-            [low, high],
-            volume_bytes=VOLUME_BYTES,
-            reserved_headroom_bytes=RESERVED_BYTES,
-        )
+        evidence = self.build_pair()
         validate(evidence)
         self.assertEqual(evidence["schema"], "graphforge-g500-ladder-qualification/3")
         self.assertEqual(evidence["projection"]["source_rungs"], ["S20", "S22"])
@@ -44,6 +134,19 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
         )
         self.assertEqual(len(evidence["rungs"][0]["artifacts"]), 9)
         self.assertEqual(len(evidence["rungs"][0]["phases"]), 9)
+        staging = next(
+            item
+            for item in evidence["rungs"][0]["artifacts"]
+            if item["category"] == "construction_staging_spill"
+        )
+        self.assertEqual(
+            staging["allocated_bytes"],
+            low["storage_attribution"]["construction"]["staging"]["allocated_bytes"],
+        )
+        self.assertEqual(
+            staging["transient_peak_allocated_bytes"],
+            low["storage_attribution"]["construction"]["staging_transient_peak_allocated_bytes"],
+        )
 
     def test_missing_portable_authority_and_historical_v1_are_rejected(self) -> None:
         missing = self.source_pair()[0]
@@ -75,17 +178,25 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
                 )
                 with self.assertRaises(StorageQualificationError):
                     validate_source_rung(invalid)
+        missing_staging = self.source_pair()[0]
+        del missing_staging["storage_attribution"]["construction"]["staging"]
+        with self.assertRaisesRegex(StorageQualificationError, "staging"):
+            validate_source_rung(missing_staging)
 
     def test_one_rung_and_non_adjacent_rungs_are_rejected(self) -> None:
         with self.assertRaisesRegex(StorageQualificationError, "exactly two"):
             build(
-                [rung(20)],
+                [self.write_bundle(rung(20))],
+                expected_commit=COMMIT,
+                expected_image_digest=IMAGE,
                 volume_bytes=VOLUME_BYTES,
                 reserved_headroom_bytes=RESERVED_BYTES,
             )
         with self.assertRaisesRegex(StorageQualificationError, "ordered adjacent"):
             build(
-                [rung(20), rung(24)],
+                self.bound_pair((20, 24)),
+                expected_commit=COMMIT,
+                expected_image_digest=IMAGE,
                 volume_bytes=VOLUME_BYTES,
                 reserved_headroom_bytes=RESERVED_BYTES,
             )
@@ -100,18 +211,84 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
         with self.assertRaisesRegex(StorageQualificationError, "sensitive evidence key"):
             validate_source_rung(unsafe)
 
-    def test_s26_storage_headroom_refuses_and_cannot_be_relabelled_admit(self) -> None:
-        baseline = build(
+    def test_every_other_category_numeric_must_be_zero(self) -> None:
+        totals = {
+            "logical_references": "logical_references",
+            "logical_bytes": "logical_bytes",
+            "physical_objects": "physical_objects",
+            "physical_logical_bytes": "retained_logical_eof_bytes",
+            "allocated_bytes": "allocated_physical_bytes",
+        }
+        for field, total in totals.items():
+            with self.subTest(field=field):
+                invalid = self.source_pair()[0]
+                source = invalid["storage_attribution"]["source"]
+                source["categories"]["other"][field] = 1
+                source[total] += 1
+                with self.assertRaises(StorageQualificationError):
+                    validate_source_rung(invalid)
+
+    def test_provider_result_binds_source_profile_commit_image_and_rung_bytes(self) -> None:
+        for field, value in (
+            ("source", "progressive_profile"),
+            ("profile_id", "graph500-s20-local"),
+        ):
+            with self.subTest(field=field):
+                invalid = rung(20)
+                invalid[field] = value
+                with self.assertRaisesRegex(
+                    StorageQualificationError, "canonical provider source/profile"
+                ):
+                    validate_source_rung(invalid)
+
+        paths = self.bound_pair()
+        wrong_commit = "9" * 40
+        result_path = self.base / "s20-result.json"
+        plan_path = self.base / "s20-plan.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        result["identities"]["commit"] = wrong_commit
+        plan["identities"]["commit"] = wrong_commit
+        plan_path.write_text(json.dumps(plan), encoding="utf-8")
+        result["artifacts"]["plan_sha256"] = hashlib.sha256(plan_path.read_bytes()).hexdigest()
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        with self.assertRaisesRegex(StorageQualificationError, "expected commit"):
+            build(
+                paths,
+                expected_commit=COMMIT,
+                expected_image_digest=IMAGE,
+                volume_bytes=VOLUME_BYTES,
+                reserved_headroom_bytes=RESERVED_BYTES,
+            )
+
+        paths = self.bound_pair()
+        paths[0].write_text(paths[0].read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(StorageQualificationError, "artifacts do not match"):
+            build(
+                paths,
+                expected_commit=COMMIT,
+                expected_image_digest=IMAGE,
+                volume_bytes=VOLUME_BYTES,
+                reserved_headroom_bytes=RESERVED_BYTES,
+            )
+
+    def test_v3_schema_rejects_three_or_four_rungs_directly(self) -> None:
+        evidence = _build_qualification(
             self.source_pair(),
             volume_bytes=VOLUME_BYTES,
-            reserved_headroom_bytes=0,
+            reserved_headroom_bytes=RESERVED_BYTES,
         )
+        for count in (3, 4):
+            with self.subTest(count=count):
+                invalid = copy.deepcopy(evidence)
+                invalid["rungs"].extend(copy.deepcopy(evidence["rungs"][: count - 2]))
+                with self.assertRaisesRegex(StorageQualificationError, "schema violation"):
+                    validate(invalid)
+
+    def test_s26_storage_headroom_refuses_and_cannot_be_relabelled_admit(self) -> None:
+        baseline = self.build_pair(reserved_headroom_bytes=0)
         projected = baseline["projection"]["projected_lifecycle_peak_bytes"]
-        refused = build(
-            self.source_pair(),
-            volume_bytes=projected - 1,
-            reserved_headroom_bytes=0,
-        )
+        refused = self.build_pair(volume_bytes=projected - 1, reserved_headroom_bytes=0)
         self.assertEqual(refused["projection"]["decision"], "refuse")
         self.assertEqual(refused["projection"]["headroom_bytes"], 0)
         contradiction = copy.deepcopy(refused)
@@ -120,31 +297,52 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
             validate(contradiction)
 
     def test_cli_writes_only_the_validated_closed_contract(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            low, high = self.source_pair()
-            low_path = root / "s20-rung.json"
-            high_path = root / "s22-rung.json"
-            output = root / "qualification.json"
-            low_path.write_text(json.dumps(low), encoding="utf-8")
-            high_path.write_text(json.dumps(high), encoding="utf-8")
-            self.assertEqual(
-                main(
-                    [
-                        str(low_path),
-                        str(high_path),
-                        str(output),
-                        "--volume-bytes",
-                        str(VOLUME_BYTES),
-                        "--reserved-headroom-bytes",
-                        str(RESERVED_BYTES),
-                    ]
-                ),
-                0,
+        low_path, high_path = self.bound_pair()
+        output = self.base / "qualification.json"
+        self.assertEqual(
+            main(
+                [
+                    str(low_path),
+                    str(high_path),
+                    str(output),
+                    "--commit",
+                    COMMIT,
+                    "--image-digest",
+                    IMAGE,
+                    "--volume-bytes",
+                    str(VOLUME_BYTES),
+                    "--reserved-headroom-bytes",
+                    str(RESERVED_BYTES),
+                ]
+            ),
+            0,
+        )
+        evidence = json.loads(output.read_text(encoding="utf-8"))
+        validate(evidence)
+        self.assertNotIn(str(self.base), output.read_text(encoding="utf-8"))
+
+    def test_cli_never_replaces_an_existing_qualification(self) -> None:
+        low_path, high_path = self.bound_pair()
+        output = self.base / "qualification.json"
+        output.write_text("preserve-existing\n", encoding="utf-8")
+        with self.assertRaises(SystemExit):
+            main(
+                [
+                    str(low_path),
+                    str(high_path),
+                    str(output),
+                    "--commit",
+                    COMMIT,
+                    "--image-digest",
+                    IMAGE,
+                    "--volume-bytes",
+                    str(VOLUME_BYTES),
+                    "--reserved-headroom-bytes",
+                    str(RESERVED_BYTES),
+                ]
             )
-            evidence = json.loads(output.read_text(encoding="utf-8"))
-            validate(evidence)
-            self.assertNotIn(str(root), output.read_text(encoding="utf-8"))
+        self.assertEqual(output.read_text(encoding="utf-8"), "preserve-existing\n")
+        self.assertEqual(list(self.base.glob(".qualification.json.*")), [])
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -185,10 +185,12 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
                 )
                 with self.assertRaises(StorageQualificationError):
                     validate_source_rung(invalid)
-        missing_staging = self.source_pair()[0]
-        del missing_staging["storage_attribution"]["construction"]["staging"]
-        with self.assertRaisesRegex(StorageQualificationError, "staging"):
-            validate_source_rung(missing_staging)
+        for field in ("staging", "staging_transient_peak_allocated_bytes"):
+            with self.subTest(missing_construction_authority=field):
+                missing_staging = self.source_pair()[0]
+                del missing_staging["storage_attribution"]["construction"][field]
+                with self.assertRaisesRegex(StorageQualificationError, field):
+                    validate_source_rung(missing_staging)
 
     def test_one_rung_and_non_adjacent_rungs_are_rejected(self) -> None:
         with self.assertRaisesRegex(StorageQualificationError, "exactly two"):

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -9,7 +9,7 @@ from graphforge_bench.progressive_storage_qualification import (
     validate,
     validate_source_rung,
 )
-from test_progressive_qualification import rung
+from tests.test_progressive_qualification import rung
 
 
 VOLUME_BYTES = 500 * 1024**3
@@ -62,7 +62,7 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
         del missing_phase["storage_attribution"]["construction"]["application_io"]["phases"][
             "recovery_reauthentication"
         ]
-        with self.assertRaisesRegex(StorageQualificationError, "application I/O"):
+        with self.assertRaisesRegex(StorageQualificationError, "application_io"):
             validate_source_rung(missing_phase)
 
     def test_one_rung_and_non_adjacent_rungs_are_rejected(self) -> None:

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import copy
+import json
+from pathlib import Path
+import tempfile
 import unittest
 
 from graphforge_bench.progressive_storage_qualification import (
     StorageQualificationError,
     build,
+    main,
     validate,
     validate_source_rung,
 )
@@ -63,6 +67,14 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
         ]
         with self.assertRaisesRegex(StorageQualificationError, "application_io"):
             validate_source_rung(missing_phase)
+        for malformed in (True, -1, "1"):
+            with self.subTest(portable_allocation=malformed):
+                invalid = self.source_pair()[0]
+                invalid["storage_attribution"]["portable_package"]["allocation_allocated_bytes"] = (
+                    malformed
+                )
+                with self.assertRaises(StorageQualificationError):
+                    validate_source_rung(invalid)
 
     def test_one_rung_and_non_adjacent_rungs_are_rejected(self) -> None:
         with self.assertRaisesRegex(StorageQualificationError, "exactly two"):
@@ -106,6 +118,33 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
         contradiction["projection"]["decision"] = "admit"
         with self.assertRaisesRegex(StorageQualificationError, "decision contradicts"):
             validate(contradiction)
+
+    def test_cli_writes_only_the_validated_closed_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            low, high = self.source_pair()
+            low_path = root / "s20-rung.json"
+            high_path = root / "s22-rung.json"
+            output = root / "qualification.json"
+            low_path.write_text(json.dumps(low), encoding="utf-8")
+            high_path.write_text(json.dumps(high), encoding="utf-8")
+            self.assertEqual(
+                main(
+                    [
+                        str(low_path),
+                        str(high_path),
+                        str(output),
+                        "--volume-bytes",
+                        str(VOLUME_BYTES),
+                        "--reserved-headroom-bytes",
+                        str(RESERVED_BYTES),
+                    ]
+                ),
+                0,
+            )
+            evidence = json.loads(output.read_text(encoding="utf-8"))
+            validate(evidence)
+            self.assertNotIn(str(root), output.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -11,7 +11,6 @@ from graphforge_bench.progressive_storage_qualification import (
 )
 from tests.test_progressive_qualification import rung
 
-
 VOLUME_BYTES = 500 * 1024**3
 RESERVED_BYTES = 75 * 1024**3
 

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -115,9 +115,20 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
     def bound_pair(self, scales: tuple[int, int] = (20, 22)) -> list[Path]:
         return [self.write_bundle(self.provider_rung(scale)) for scale in scales]
 
+    def result_anchors(self, paths: list[Path]) -> list[str]:
+        result = []
+        for path in paths:
+            scale = json.loads(path.read_text(encoding="utf-8"))["scale"]
+            result.append(
+                hashlib.sha256((path.parent / f"s{scale}-result.json").read_bytes()).hexdigest()
+            )
+        return result
+
     def build_pair(self, scales: tuple[int, int] = (20, 22), **overrides: int) -> dict:
+        paths = self.bound_pair(scales)
         return build(
-            self.bound_pair(scales),
+            paths,
+            provider_result_sha256=self.result_anchors(paths),
             expected_commit=COMMIT,
             expected_image_digest=IMAGE,
             volume_bytes=overrides.get("volume_bytes", VOLUME_BYTES),
@@ -193,17 +204,21 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
                     validate_source_rung(missing_staging)
 
     def test_one_rung_and_non_adjacent_rungs_are_rejected(self) -> None:
+        single = [self.write_bundle(self.provider_rung(20))]
         with self.assertRaisesRegex(StorageQualificationError, "exactly two"):
             build(
-                [self.write_bundle(self.provider_rung(20))],
+                single,
+                provider_result_sha256=self.result_anchors(single),
                 expected_commit=COMMIT,
                 expected_image_digest=IMAGE,
                 volume_bytes=VOLUME_BYTES,
                 reserved_headroom_bytes=RESERVED_BYTES,
             )
+        nonadjacent = self.bound_pair((20, 24))
         with self.assertRaisesRegex(StorageQualificationError, "ordered adjacent"):
             build(
-                self.bound_pair((20, 24)),
+                nonadjacent,
+                provider_result_sha256=self.result_anchors(nonadjacent),
                 expected_commit=COMMIT,
                 expected_image_digest=IMAGE,
                 volume_bytes=VOLUME_BYTES,
@@ -264,6 +279,7 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
         with self.assertRaisesRegex(StorageQualificationError, "expected commit"):
             build(
                 paths,
+                provider_result_sha256=self.result_anchors(paths),
                 expected_commit=COMMIT,
                 expected_image_digest=IMAGE,
                 volume_bytes=VOLUME_BYTES,
@@ -271,15 +287,35 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
             )
 
         paths = self.bound_pair()
+        anchors = self.result_anchors(paths)
         paths[0].write_text(paths[0].read_text(encoding="utf-8") + "\n", encoding="utf-8")
-        with self.assertRaisesRegex(StorageQualificationError, "artifacts do not match"):
+        result_path = self.base / "s20-result.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["artifacts"]["rung_sha256"] = hashlib.sha256(paths[0].read_bytes()).hexdigest()
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        with self.assertRaisesRegex(StorageQualificationError, "external anchor"):
             build(
                 paths,
+                provider_result_sha256=anchors,
                 expected_commit=COMMIT,
                 expected_image_digest=IMAGE,
                 volume_bytes=VOLUME_BYTES,
                 reserved_headroom_bytes=RESERVED_BYTES,
             )
+
+    def test_provider_result_anchors_are_complete_ordered_and_well_formed(self) -> None:
+        paths = self.bound_pair()
+        anchors = self.result_anchors(paths)
+        for invalid in (anchors[:1], ["g" * 64, anchors[1]], list(reversed(anchors))):
+            with self.subTest(anchors=invalid), self.assertRaises(StorageQualificationError):
+                build(
+                    paths,
+                    provider_result_sha256=invalid,
+                    expected_commit=COMMIT,
+                    expected_image_digest=IMAGE,
+                    volume_bytes=VOLUME_BYTES,
+                    reserved_headroom_bytes=RESERVED_BYTES,
+                )
 
     def test_v3_schema_rejects_three_or_four_rungs_directly(self) -> None:
         evidence = _build_qualification(
@@ -307,6 +343,7 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
 
     def test_cli_writes_only_the_validated_closed_contract(self) -> None:
         low_path, high_path = self.bound_pair()
+        low_anchor, high_anchor = self.result_anchors([low_path, high_path])
         output = self.base / "qualification.json"
         self.assertEqual(
             main(
@@ -318,6 +355,10 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
                     COMMIT,
                     "--image-digest",
                     IMAGE,
+                    "--low-result-sha256",
+                    low_anchor,
+                    "--high-result-sha256",
+                    high_anchor,
                     "--volume-bytes",
                     str(VOLUME_BYTES),
                     "--reserved-headroom-bytes",
@@ -332,6 +373,7 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
 
     def test_cli_never_replaces_an_existing_qualification(self) -> None:
         low_path, high_path = self.bound_pair()
+        low_anchor, high_anchor = self.result_anchors([low_path, high_path])
         output = self.base / "qualification.json"
         output.write_text("preserve-existing\n", encoding="utf-8")
         with self.assertRaises(SystemExit):
@@ -344,6 +386,10 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
                     COMMIT,
                     "--image-digest",
                     IMAGE,
+                    "--low-result-sha256",
+                    low_anchor,
+                    "--high-result-sha256",
+                    high_anchor,
                     "--volume-bytes",
                     str(VOLUME_BYTES),
                     "--reserved-headroom-bytes",

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -1442,6 +1442,11 @@ mod tests {
             let (phase, reopened_progress) = reopened.import_session_status(session_uuid).unwrap();
             assert_eq!(phase, ImportPhase::Committed);
             assert_eq!(reopened_progress.construction.as_ref(), Some(&receipt));
+            let reopened_receipt = reopened_progress.construction.as_ref().unwrap();
+            assert!(
+                reopened_receipt.construction_staging_transient_peak_allocated_bytes
+                    >= reopened_receipt.construction_staging.allocated_bytes
+            );
             receipt
         }
 

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -159,6 +159,12 @@ pub struct ImportConstructionEvidence {
     pub peak_batch_bytes: u64,
     /// Exact transient allocation high-water retained across resume.
     pub transient_peak_allocated_bytes: u64,
+    /// Receipt-owned construction staging/spill category totals.
+    #[serde(default)]
+    pub construction_staging: graphforge_storage::ArtifactStorageTotals,
+    /// Peak allocated bytes for construction staging/spill specifically.
+    #[serde(default)]
+    pub construction_staging_transient_peak_allocated_bytes: u64,
 }
 
 /// Closed semantic publication-work contract for ordinary construction evidence.
@@ -727,6 +733,18 @@ impl GraphImportSession {
             graphforge_storage::ConstructionPhaseAttribution::from_construction(&progress.evidence);
         application_io.validate_for_qualification()?;
         let publication_work = PublicationWorkComponents::from_application_io(&application_io)?;
+        let construction_staging = progress
+            .evidence
+            .storage_current
+            .get(&graphforge_storage::ArtifactCategory::ConstructionStaging)
+            .cloned()
+            .unwrap_or_default();
+        let construction_staging_transient_peak_allocated_bytes = progress
+            .evidence
+            .storage_transient_peak_allocated_bytes
+            .get(&graphforge_storage::ArtifactCategory::ConstructionStaging)
+            .copied()
+            .unwrap_or_default();
         self.manifest.progress.construction = Some(ImportConstructionEvidence {
             configured_batch_rows: u64::try_from(self.manifest.limits.batch_rows)
                 .unwrap_or(u64::MAX),
@@ -745,6 +763,8 @@ impl GraphImportSession {
             transient_peak_allocated_bytes: progress
                 .evidence
                 .storage_transient_peak_total_allocated_bytes,
+            construction_staging,
+            construction_staging_transient_peak_allocated_bytes,
         });
         Ok(())
     }
@@ -1386,6 +1406,15 @@ mod tests {
             assert_eq!(receipt.input_rows, (4 * multiplier) as u64);
             assert_eq!(receipt.input_batches, multiplier as u64);
             assert_eq!(receipt.peak_batch_rows, 4);
+            assert!(receipt.construction_staging.logical_references > 0);
+            assert!(receipt.construction_staging.logical_bytes > 0);
+            assert!(receipt.construction_staging.physical_objects > 0);
+            assert!(receipt.construction_staging.physical_logical_bytes > 0);
+            assert!(receipt.construction_staging.allocated_bytes > 0);
+            assert!(
+                receipt.construction_staging_transient_peak_allocated_bytes
+                    >= receipt.construction_staging.allocated_bytes
+            );
             assert_eq!(
                 receipt.publication_work.contract,
                 "graphforge-publication-work/1"

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -4458,6 +4458,11 @@ fn record_encoded_active_artifacts(
             .physical_logical_bytes
             .saturating_add(usage.logical_bytes);
         totals.allocated_bytes = totals.allocated_bytes.saturating_add(usage.allocated_bytes);
+        evidence
+            .storage_transient_peak_allocated_bytes
+            .entry(crate::ArtifactCategory::ConstructionStaging)
+            .and_modify(|peak| *peak = (*peak).max(totals.allocated_bytes))
+            .or_insert(totals.allocated_bytes);
         let active_total = evidence
             .storage_active_identity_allocated_bytes
             .values()
@@ -8122,6 +8127,33 @@ mod tests {
             session.seal().unwrap();
             assert_eq!(session.state(), GraphConstructionState::Sealed);
             assert!(session.evidence().authentication_read_bytes > 0);
+            let sealed_staging =
+                &session.evidence().storage_current[&crate::ArtifactCategory::ConstructionStaging];
+            let sealed_staging_peak = session.evidence().storage_transient_peak_allocated_bytes
+                [&crate::ArtifactCategory::ConstructionStaging];
+            assert!(
+                sealed_staging_peak >= sealed_staging.allocated_bytes,
+                "encoded artifacts advanced current staging allocation without its category peak"
+            );
+            let sealed_current = session.evidence().storage_current.clone();
+            let sealed_peaks = session
+                .evidence()
+                .storage_transient_peak_allocated_bytes
+                .clone();
+            drop(session);
+            let resumed = GraphConstructionSession::resume_with_mode_and_lifecycle(
+                root.path(),
+                Uuid::from_u128(operation),
+                graphforge_core::OntologyMode::Exploratory,
+                GraphConstructionBudgets::default(),
+                crate::filesystem_admission::ProjectLifecycleMode::Durable,
+            )
+            .unwrap();
+            assert_eq!(resumed.evidence().storage_current, sealed_current);
+            assert_eq!(
+                resumed.evidence().storage_transient_peak_allocated_bytes,
+                sealed_peaks
+            );
         }
     }
 

--- a/docs/development/evidence/g500-ladder-qualification.schema.json
+++ b/docs/development/evidence/g500-ladder-qualification.schema.json
@@ -5,7 +5,7 @@
   "required": ["schema", "rungs", "projection"],
   "properties": {
     "schema": {"const": "graphforge-g500-ladder-qualification/3"},
-    "rungs": {"type": "array", "minItems": 2, "maxItems": 4, "items": {"$ref": "#/$defs/rung"}},
+    "rungs": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"$ref": "#/$defs/rung"}},
     "projection": {"$ref": "#/$defs/projection"}
   },
   "$defs": {

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -306,6 +306,8 @@ make -C benchmarks progressive-storage-qualification \
   EVIDENCE=build/g500-ladder-qualification.json \
   COMMIT=$(git rev-parse HEAD) \
   IMAGE_DIGEST=registry.fly.io/graphforge-bench@sha256:<64-hex-digest> \
+  LOW_RESULT_SHA256=<independently-recorded-s20-result-sha256> \
+  HIGH_RESULT_SHA256=<independently-recorded-s22-result-sha256> \
   VOLUME_BYTES=536870912000 \
   RESERVED_HEADROOM_BYTES=53687091200
 ```

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -212,7 +212,8 @@ rejected as certification evidence.
 ### Disk attribution and S26 admission
 
 The versioned `graphforge-g500-ladder-qualification/3` companion document is
-validated by `scripts/ci/validate-g500-ladder-qualification.py`. Every observed
+produced and validated by
+`graphforge_bench.progressive_storage_qualification`. Every observed
 rung has exactly one row for canonical node topology, canonical edge topology,
 properties, UUID/surrogate indexes, adjacency/CSR, catalogs/manifests,
 construction staging/spill, portable package, and clean import. Native file
@@ -295,13 +296,13 @@ canonical-edge allocation plus the lifecycle peak,
 volume headroom, and the admit/refuse decision. A single successful rung is not
 a projection, and insufficient reserved headroom always refuses SCALE-26.
 
-Build and validate a companion document from two adjacent real certification
-documents with:
+Build and validate a companion document from two adjacent complete progressive
+rung documents with:
 
 ```bash
-make g500-ladder-qualification \
-  LOW_CERT=build/s20-certification.json \
-  HIGH_CERT=build/s22-certification.json \
+make -C benchmarks progressive-storage-qualification \
+  LOW_RUNG=build/s20-rung.json \
+  HIGH_RUNG=build/s22-rung.json \
   EVIDENCE=build/g500-ladder-qualification.json \
   VOLUME_BYTES=536870912000 \
   RESERVED_HEADROOM_BYTES=53687091200

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -304,6 +304,8 @@ make -C benchmarks progressive-storage-qualification \
   LOW_RUNG=build/s20-rung.json \
   HIGH_RUNG=build/s22-rung.json \
   EVIDENCE=build/g500-ladder-qualification.json \
+  COMMIT=$(git rev-parse HEAD) \
+  IMAGE_DIGEST=registry.fly.io/graphforge-bench@sha256:<64-hex-digest> \
   VOLUME_BYTES=536870912000 \
   RESERVED_HEADROOM_BYTES=53687091200
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Close the remaining control-plane evidence gap for #951 by carrying complete, sanitized storage attribution through controller-produced progressive rung assembly `/2`, then adapting exactly two adjacent complete rungs into `graphforge-g500-ladder-qualification/3` without restoring retired scale orchestration.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ✅ Tests (adding or updating tests)
- [x] 📚 Documentation update

## Related Issues

Relates to #951
Relates to #952

## Changes Made

- Require assembly `/2` passed rungs to contain complete source/import storage categories, all nine application-I/O phases, portable writer allocation, lifecycle unions, and authoritative counts.
- Copy only Rust-owned ordinary receipts; reject absent, malformed, ambiguous, unreconciled, or unsafe evidence.
- Add a pure progressive-to-v3 storage qualification adapter for exactly adjacent S20/S22 or S22/S24 inputs.
- Reproduce conservative S26 projection, exact integer ratios, headroom decisions, and fail-closed reconciliation.
- Add the `progressive-storage-qualification` benchmark target and update the directly related runbook commands.

## Testing

- Focused storage adapter/controller tests: 58 passed.
- Full benchmark Python suite: 290 passed.
- Ruff and `cargo fmt`: passed.
- `make pre-push-fast`: passed.

### Test Coverage

- [x] Happy-path adjacent-rung adaptation
- [x] Missing portable and lifecycle authority refusal
- [x] Malformed category/phase and unsafe-content refusal
- [x] Historical, one-rung, and non-adjacent refusal
- [x] Contradictory and below-headroom projection refusal

## Checklist

- [x] One logical evidence-contract concern
- [x] No fallback inference or restored legacy orchestration
- [x] No paths, UUIDs, provider IDs, credentials, or graph content in output
- [x] No skipped tests or weakened assertions
- [x] No breaking public API changes

## Reviewer Notes

This PR completes deterministic construction of the qualification document but does not claim provider qualification. Closing #951 still requires two real adjacent complete provider rungs and the resulting validated `/3` evidence.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790930095&installation_model_id=20486&pr_number=1078&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1078&signature=a196aa6da6026fdbf546e80293b530bf507f114434febd07a4fd493c229aaa83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `progressive_storage_qualification` module and harden JSON publication
> - Adds [progressive_storage_qualification.py](https://github.com/CurateLabs/graphforge/pull/1078/files#diff-0678fb891f826c7c2925e4800f3c155d471b8c980a7c5b43505a645ea7ce6b0d), which validates two adjacent provider rung bundles and produces a version-3 S26 storage qualification with upward lifecycle-peak projections, capacity headroom checks, and an admit/refuse decision.
> - Replaces the JSON writer in [progressive_run.py](https://github.com/CurateLabs/graphforge/pull/1078/files#diff-0c7e145e0e3608068b322307c08079a6a1dc695792664b94487ad556d8bff04d) with `publish_json_no_clobber`, an exclusive, durable publisher that rejects symlinked directory components, fsyncs directories, and never replaces an existing destination. The old `_write_json` name is kept as an alias.
> - Rung evidence assembly in `assemble_rung_evidence` now requires phase-bound import, export, lifecycle, and portable-package receipts plus complete `storage_attribution` data (snapshots, construction I/O, staging, lifecycle totals).
> - Tracks `ConstructionStaging` transient allocation peaks in [graph_construction.rs](https://github.com/CurateLabs/graphforge/pull/1078/files#diff-d3b37de4c63039571c0368ca202359cdca86759d9553db25b147d92c23f84b1d) and persists them in `ImportConstructionEvidence` via [import_session.rs](https://github.com/CurateLabs/graphforge/pull/1078/files#diff-01644710d3847a4419b2d6b85cf69a0f641fba72bf195d95893dd73ce1cc1f31).
> - Risk: [g500-ladder-qualification.schema.json](https://github.com/CurateLabs/graphforge/pull/1078/files#diff-141853da1e9652d1ce977727fe0c579b587868e3b31bcdca675aacce5f95a6bb) reduces the maximum rungs array from four to two, and [progressive-qualification-rung-evidence.json](https://github.com/CurateLabs/graphforge/pull/1078/files#diff-d0fcfd7496c625b006c2c45553afdd9c2340633d19c4bb398f0e4e5a63264250) now requires `storage_attribution`; evidence produced under the old schemas will fail validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d636417.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->