### PR TITLE
fix(scale): reconcile measured lifecycle accounting and admission

### DIFF
--- a/benchmarks/harness/graphforge_bench/parity_gate.py
+++ b/benchmarks/harness/graphforge_bench/parity_gate.py
@@ -9,12 +9,13 @@ from typing import Any
 from graphforge_bench.ladder_bundle_ingest import validate_ladder_bundle
 from graphforge_bench.native_ladder_bundle import NativeBundleError, validate_native_bundle
 from graphforge_bench.progressive_provider_attempt import CANONICAL_RUNGS
+from graphforge_bench.progressive_qualification import PHASES
 from graphforge_bench.scale_parity import (
     compare_fixture_pair,
     compare_ladder_bundle,
     coverage_map,
     load_accepted_differences,
-    validate_historical_legacy_cert,
+    read_historical_legacy_cert,
     workspace_root,
 )
 
@@ -119,8 +120,11 @@ def parity_gate_status(root: Path | None = None) -> dict[str, Any]:
     historical_ok = False
     if historical_path.is_file():
         try:
-            validate_historical_legacy_cert(historical_path, expected_sha="a" * 40)
-            historical_ok = True
+            historical = read_historical_legacy_cert(historical_path, expected_sha="a" * 40)
+            historical_ok = (
+                historical.status == "passed"
+                and tuple(phase.phase for phase in historical.phases) == PHASES
+            )
         except Exception:
             historical_ok = False
 

--- a/benchmarks/harness/graphforge_bench/scale_parity.py
+++ b/benchmarks/harness/graphforge_bench/scale_parity.py
@@ -301,8 +301,18 @@ def coverage_map() -> dict[str, str]:
     }
 
 
-def validate_historical_legacy_cert(evidence_path: Path, *, expected_sha: str) -> None:
-    """Ensure preserved legacy certification evidence still passes the historical validator."""
+def validate_historical_legacy_cert(
+    evidence_path: Path,
+    *,
+    expected_sha: str,
+    provider_result_path: Path | None = None,
+    provider_result_sha256: str | None = None,
+) -> None:
+    """Validate legacy evidence only when an external provider result authenticates it."""
+    if provider_result_path is None or provider_result_sha256 is None:
+        raise ParityError(
+            "historical certification evidence requires an external provider-result anchor"
+        )
     import importlib.util
 
     script = workspace_root().parent / "scripts" / "ci" / "validate-g500-certification.py"
@@ -311,10 +321,17 @@ def validate_historical_legacy_cert(evidence_path: Path, *, expected_sha: str) -
         raise ParityError("unable to load validate-g500-certification.py")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    document = json.loads(evidence_path.read_text(encoding="utf-8"))
-    if not isinstance(document, dict):
-        raise ParityError("legacy certification fixture must be a JSON object")
-    module.validate(document, expected_sha)
+    try:
+        module.validate(
+            evidence_path.read_bytes(),
+            expected_sha,
+            provider_result_path.read_bytes(),
+            provider_result_sha256,
+        )
+    except (OSError, ValueError) as error:
+        raise ParityError(
+            "legacy certification evidence is not externally authenticated"
+        ) from error
 
 
 def compare_ladder_bundle(bundle_root: Path) -> list[dict[str, Any]]:

--- a/benchmarks/harness/graphforge_bench/scale_parity.py
+++ b/benchmarks/harness/graphforge_bench/scale_parity.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 from jsonschema import Draft202012Validator
@@ -299,6 +300,46 @@ def coverage_map() -> dict[str, str]:
             ".github/workflows/progressive-ladder.yml + config/gate-registry.json"
         ),
     }
+
+
+def read_historical_legacy_cert(evidence_path: Path, *, expected_sha: str) -> NormalizedEvidence:
+    """Read a preserved lifecycle fixture; this does not authenticate certification."""
+    try:
+        document = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        raise ParityError("historical lifecycle fixture is unreadable") from error
+    if not isinstance(document, dict) or document.get("schema") != LEGACY_CERT_SCHEMA:
+        raise ParityError("historical lifecycle fixture requires the legacy schema")
+    if (
+        re.fullmatch(r"[0-9a-f]{40}", expected_sha) is None
+        or document.get("git_sha") != expected_sha
+    ):
+        raise ParityError("historical lifecycle fixture git_sha mismatch")
+    run = document.get("run")
+    if not isinstance(run, dict) or type(run.get("scale")) is not int or run["scale"] <= 0:
+        raise ParityError("historical lifecycle fixture requires a positive scale")
+    if document.get("result") not in ("pass", "fail"):
+        raise ParityError("historical lifecycle fixture requires pass/fail result")
+    phases = document.get("phases")
+    if not isinstance(phases, list) or any(not isinstance(phase, dict) for phase in phases):
+        raise ParityError("historical lifecycle fixture requires phase objects")
+    expected_ids = set(_legacy_cert_phase_mapping(load_accepted_differences()))
+    ids = [phase.get("id") for phase in phases]
+    if (
+        any(not isinstance(phase_id, str) for phase_id in ids)
+        or len(ids) != len(expected_ids)
+        or set(ids) != expected_ids
+    ):
+        raise ParityError("historical lifecycle fixture requires each legacy phase exactly once")
+    for phase in phases:
+        if phase.get("status") not in ("pass", "fail"):
+            raise ParityError("historical lifecycle fixture requires pass/fail phase status")
+        for metric in ("elapsed_ms", "rss_peak_bytes"):
+            if type(phase.get(metric)) is not int or phase[metric] < 0:
+                raise ParityError(f"historical lifecycle fixture has invalid {metric}")
+    if document["result"] == "pass" and any(phase["status"] != "pass" for phase in phases):
+        raise ParityError("historical lifecycle result contradicts a failed phase")
+    return normalize_legacy_cert_lifecycle(document)
 
 
 def validate_historical_legacy_cert(

--- a/benchmarks/scale-parity-index.md
+++ b/benchmarks/scale-parity-index.md
@@ -2,7 +2,7 @@
 
 Maps retired legacy Graph500 scale orchestration to the isolated `benchmarks/` harness.
 Retirement is complete in-tree; the parity gate remains blocked on ingested #900 ladder
-bundles until Fly execution evidence is checked in (see `fixtures/parity/ladder-bundle/README.md`).
+bundles until native host execution evidence is ingested (see `fixtures/parity/ladder-bundle/README.md`).
 
 ## Coverage map
 
@@ -12,8 +12,8 @@ bundles until Fly execution evidence is checked in (see `fixtures/parity/ladder-
 | `make bench-g500-scale20` | `profiles/graph500/s20-*.json` + progressive qualification | tiny shadow OK; ladder bundle pending #900 |
 | `make g500-ladder-qualification` | progressive qualification schemas + controller | retired; harness authoritative |
 | `cargo test -p graphforge-api --test scale_g500_ladder` (S10 CI) | `benchmarks/scripts/test-tiny-lifecycle-certification.py` | bounded correctness retained in product CI |
-| `cargo test … certification_target_live…` (retired) | `qualification-operator GATE=progressive-ladder` | blocked on #900 Fly execution |
-| `scripts/ci/validate-g500-certification.py` | `graphforge_bench.scale_parity` + progressive schemas | historical fixture validates |
+| `cargo test … certification_target_live…` (retired) | `qualification-operator GATE=progressive-ladder` | blocked on #900 native host execution |
+| `scripts/ci/validate-g500-certification.py` | `graphforge_bench.scale_parity` + progressive schemas | historical lifecycle fixture remains readable |
 | `docs/development/perf-g500-ladder.md` | `benchmarks/README.md` | historical reference retained |
 | `.github/workflows/g500-certification.yml` | `.github/workflows/progressive-ladder.yml` | retired; progressive-ladder handoff wired |
 
@@ -38,12 +38,18 @@ PYTHONPATH=harness uv run --locked python -m unittest tests.test_scale_parity te
 # Historical legacy certification fixture readability
 PYTHONPATH=harness uv run --locked python -c "
 from pathlib import Path
-from graphforge_bench.scale_parity import validate_historical_legacy_cert, workspace_root
+from graphforge_bench.scale_parity import read_historical_legacy_cert, workspace_root
 fixture = workspace_root() / 'fixtures/parity/legacy/cert-s20-minimal.json'
-validate_historical_legacy_cert(fixture, expected_sha='a' * 40)
+historical = read_historical_legacy_cert(fixture, expected_sha='a' * 40)
+assert historical.status == 'passed' and len(historical.phases) == 10
 print('legacy cert fixture readable')
 "
 ```
+
+The historical reader checks the preserved fixture and lifecycle mapping only.
+It does not authenticate a benchmark result or satisfy full-ladder certification.
+`validate_historical_legacy_cert` separately requires an externally authenticated
+provider-result anchor before validating certification evidence.
 
 ## Retirement gate (#959 acceptance)
 

--- a/benchmarks/tests/test_parity_gate.py
+++ b/benchmarks/tests/test_parity_gate.py
@@ -75,6 +75,15 @@ class ParityGateTests(unittest.TestCase):
         )
         self.assertTrue(historical["met"])
 
+    def test_unreadable_history_blocks_structure_without_changing_ladder_parity(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_name:
+            base = _temporary_fixture_root(temp_name)
+            (base / "fixtures/parity/legacy/cert-s20-minimal.json").unlink()
+            status = parity_gate_status(base)
+        self.assertFalse(status["structural_retirement_ready"])
+        self.assertTrue(status["prefix_parity_ready"])
+        self.assertFalse(status["full_ladder_evidence_complete"])
+
     def test_ingested_ladder_bundle_runs_comparisons(self) -> None:
         comparisons = compare_ladder_bundle(ladder_bundle_root())
         self.assertEqual(len(comparisons), 2)

--- a/benchmarks/tests/test_scale_parity.py
+++ b/benchmarks/tests/test_scale_parity.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+import tempfile
 import unittest
 
 from graphforge_bench.scale_parity import (
@@ -15,6 +17,7 @@ from graphforge_bench.scale_parity import (
     normalize_legacy_evidence,
     normalize_new_evidence,
     normalize_rung_evidence,
+    read_historical_legacy_cert,
     validate_historical_legacy_cert,
     workspace_root,
 )
@@ -115,6 +118,48 @@ class ScaleParityTests(unittest.TestCase):
         fixture = FIXTURES / "legacy" / "cert-s20-minimal.json"
         with self.assertRaisesRegex(ParityError, "external provider-result anchor"):
             validate_historical_legacy_cert(fixture, expected_sha="a" * 40)
+
+    def test_historical_fixture_readability_does_not_authenticate_certification(self) -> None:
+        fixture = FIXTURES / "legacy" / "cert-s20-minimal.json"
+        historical = read_historical_legacy_cert(fixture, expected_sha="a" * 40)
+        self.assertEqual(historical.status, "passed")
+        self.assertEqual(len(historical.phases), 10)
+        with self.assertRaisesRegex(ParityError, "external provider-result anchor"):
+            validate_historical_legacy_cert(fixture, expected_sha="a" * 40)
+
+    def test_historical_reader_rejects_malformed_or_incomplete_lifecycles(self) -> None:
+        original = (FIXTURES / "legacy" / "cert-s20-minimal.json").read_text()
+        mutations = {
+            "wrong_schema": lambda d: d.update(schema="unknown"),
+            "wrong_sha": lambda d: d.update(git_sha="b" * 40),
+            "invalid_result": lambda d: d.update(result=[]),
+            "invalid_scale": lambda d: d["run"].update(scale=True),
+            "missing_phase": lambda d: d["phases"].pop(),
+            "duplicate_phase": lambda d: d["phases"].__setitem__(0, d["phases"][1]),
+            "invalid_phase": lambda d: d["phases"].__setitem__(0, None),
+            "invalid_id": lambda d: d["phases"][0].update(id=[]),
+            "invalid_status": lambda d: d["phases"][0].update(status=[]),
+            "invalid_elapsed": lambda d: d["phases"][0].update(elapsed_ms=True),
+            "negative_rss": lambda d: d["phases"][0].update(rss_peak_bytes=-1),
+            "failed_unmapped_drill": lambda d: d["phases"][-1].update(status="fail"),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "historical.json"
+            for name, mutate in mutations.items():
+                with self.subTest(name=name):
+                    document = json.loads(original)
+                    mutate(document)
+                    fixture.write_text(json.dumps(document))
+                    with self.assertRaises(ParityError):
+                        read_historical_legacy_cert(fixture, expected_sha="a" * 40)
+            for encoded in ("{", "[]"):
+                with self.subTest(encoded=encoded):
+                    fixture.write_text(encoded)
+                    with self.assertRaises(ParityError):
+                        read_historical_legacy_cert(fixture, expected_sha="a" * 40)
+            fixture.unlink()
+            with self.assertRaises(ParityError):
+                read_historical_legacy_cert(fixture, expected_sha="a" * 40)
 
     def test_coverage_map_lists_legacy_entrypoints(self) -> None:
         mapping = coverage_map()

--- a/benchmarks/tests/test_scale_parity.py
+++ b/benchmarks/tests/test_scale_parity.py
@@ -5,6 +5,7 @@ import unittest
 
 from graphforge_bench.scale_parity import (
     Outcome,
+    ParityError,
     assert_no_unexplained_gaps,
     compare_evidence,
     compare_fixture_pair,
@@ -110,9 +111,10 @@ class ScaleParityTests(unittest.TestCase):
         self.assertIn(matrix["overall"], {Outcome.MATCH.value, Outcome.ACCEPTED_DIFFERENCE.value})
         assert_no_unexplained_gaps(matrix)
 
-    def test_historical_legacy_cert_fixture_validates(self) -> None:
+    def test_historical_legacy_cert_fixture_fails_closed_without_provider_anchor(self) -> None:
         fixture = FIXTURES / "legacy" / "cert-s20-minimal.json"
-        validate_historical_legacy_cert(fixture, expected_sha="a" * 40)
+        with self.assertRaisesRegex(ParityError, "external provider-result anchor"):
+            validate_historical_legacy_cert(fixture, expected_sha="a" * 40)
 
     def test_coverage_map_lists_legacy_entrypoints(self) -> None:
         mapping = coverage_map()

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -800,8 +800,9 @@ impl GraphImportSession {
         &mut self,
         progress: &crate::GraphConstructionProgress,
     ) -> Result<(), GfError> {
-        let application_io =
-            graphforge_storage::ConstructionPhaseAttribution::from_construction(&progress.evidence);
+        let application_io = graphforge_storage::ConstructionPhaseAttribution::from_construction(
+            &progress.evidence,
+        )?;
         application_io.validate_for_qualification()?;
         let publication_work = PublicationWorkComponents::from_application_io(&application_io)?;
         let construction_staging = progress

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -4102,10 +4102,12 @@ fn materialize_compact_graph_target(
         strategy: graphforge_storage::GraphFilesOpenStrategy::PrivateMaterialize,
         files_validated: reused
             .files_validated
-            .saturating_add(copied.files_validated),
+            .checked_add(copied.files_validated)
+            .ok_or_else(|| GfError::Storage("hydration validated-file count overflows".into()))?,
         bytes_validated: reused
             .bytes_validated
-            .saturating_add(copied.bytes_validated),
+            .checked_add(copied.bytes_validated)
+            .ok_or_else(|| GfError::Storage("hydration validated-byte count overflows".into()))?,
         files_copied: copied.files_copied,
         bytes_copied: copied.bytes_copied,
         files_opened_in_place: 0,
@@ -4113,17 +4115,34 @@ fn materialize_compact_graph_target(
         bytes_reused: reused.bytes_reused,
         application_read_bytes: reused
             .application_read_bytes
-            .saturating_add(copied.application_read_bytes),
+            .checked_add(copied.application_read_bytes)
+            .ok_or_else(|| GfError::Storage("hydration read byte count overflows".into()))?,
         application_read_calls: reused
             .application_read_calls
-            .saturating_add(copied.application_read_calls),
+            .checked_add(copied.application_read_calls)
+            .ok_or_else(|| GfError::Storage("hydration read call count overflows".into()))?,
         application_write_bytes: reused
             .application_write_bytes
-            .saturating_add(copied.application_write_bytes),
+            .checked_add(copied.application_write_bytes)
+            .ok_or_else(|| GfError::Storage("hydration write byte count overflows".into()))?,
         application_write_calls: reused
             .application_write_calls
-            .saturating_add(copied.application_write_calls),
-        fsync_calls: reused.fsync_calls.saturating_add(copied.fsync_calls),
+            .checked_add(copied.application_write_calls)
+            .ok_or_else(|| GfError::Storage("hydration write call count overflows".into()))?,
+        fsync_calls: reused
+            .fsync_calls
+            .checked_add(copied.fsync_calls)
+            .ok_or_else(|| GfError::Storage("hydration fsync count overflows".into()))?,
+        file_fsync_calls: reused
+            .file_fsync_calls
+            .checked_add(copied.file_fsync_calls)
+            .ok_or_else(|| GfError::Storage("hydration file barrier count overflows".into()))?,
+        directory_fsync_calls: reused
+            .directory_fsync_calls
+            .checked_add(copied.directory_fsync_calls)
+            .ok_or_else(|| {
+                GfError::Storage("hydration directory barrier count overflows".into())
+            })?,
     };
     Ok(evidence)
 }

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -749,14 +749,18 @@ mod tests {
             assert!(evidence.publication_application_read_bytes > 0);
             assert!(evidence.cas_application_read_bytes > 0);
             assert!(evidence.hydration_application_read_bytes > 0);
-            let reconciled = evidence
-                .seal_application_read_bytes
-                .saturating_add(evidence.shape_application_read_bytes)
-                .saturating_add(evidence.encode_application_read_bytes)
-                .saturating_add(evidence.publication_application_read_bytes)
-                .saturating_add(evidence.cas_application_read_bytes)
-                .saturating_add(evidence.hydration_application_read_bytes);
-            assert_eq!(evidence.total_application_read_bytes(), reconciled);
+            let reconciled = [
+                evidence.seal_application_read_bytes,
+                evidence.shape_application_read_bytes,
+                evidence.encode_application_read_bytes,
+                evidence.publication_application_read_bytes,
+                evidence.cas_application_read_bytes,
+                evidence.hydration_application_read_bytes,
+            ]
+            .into_iter()
+            .try_fold(0_u64, u64::checked_add)
+            .unwrap();
+            assert_eq!(evidence.total_application_read_bytes().unwrap(), reconciled);
             let payload = evidence.write_bytes;
             assert!(
                 payload > 100_000,

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -779,10 +779,19 @@ mod tests {
                     "phase exceeded its fixed application bytes-per-staged-payload ceiling"
                 );
             }
-            assert_eq!(
-                evidence.cas_application_read_bytes,
-                evidence.canonical_output_bytes
-            );
+            let cas = &evidence.cas_publication_io;
+            assert_eq!(cas.payload.read_bytes, evidence.canonical_output_bytes);
+            assert!(cas.manifest_reads.read_bytes > 0);
+            assert!(cas.manifest_reads.read_calls > 0);
+            let measured_cas_reads = [
+                cas.payload.read_bytes,
+                cas.manifest.read_bytes,
+                cas.manifest_reads.read_bytes,
+            ]
+            .into_iter()
+            .try_fold(0_u64, u64::checked_add)
+            .unwrap();
+            assert_eq!(evidence.cas_application_read_bytes, measured_cas_reads);
             assert!(evidence.staged_and_retained_disk_bytes >= payload);
             observations.push((
                 payload,

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -19,7 +19,7 @@
 #![recursion_limit = "256"]
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BinaryHeap};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
@@ -122,7 +122,8 @@ struct CertificationProfile {
     schema: String,
     scale: u32,
     edgefactor: u32,
-    target_live_edges: u64,
+    #[serde(rename = "target_live_edges")]
+    _target_live_edges: u64,
     seed: u64,
     initiator: Initiator,
     envelope: Envelope,
@@ -406,10 +407,14 @@ fn generate_target_live_runs(
             &window_dir,
             Some(cancelled),
         );
-        combined.raw_attempts = combined.raw_attempts.saturating_add(generated.raw_attempts);
+        combined.raw_attempts = combined
+            .raw_attempts
+            .checked_add(generated.raw_attempts)
+            .expect("generated raw-attempt count overflow");
         combined.self_loops_rejected = combined
             .self_loops_rejected
-            .saturating_add(generated.self_loops_rejected);
+            .checked_add(generated.self_loops_rejected)
+            .expect("generated self-loop count overflow");
         combined.peak_buffer_len = combined.peak_buffer_len.max(generated.peak_buffer_len);
         combined.runs.extend(generated.runs);
         let compact_path = work.join(format!("accumulated-{window:04}.bin"));
@@ -505,21 +510,26 @@ fn exact_descriptor_allocation(paths: &[PathBuf]) -> Value {
     let mut logical_bytes = 0_u64;
     let mut allocated = 0_u64;
     for path in paths {
-        logical_bytes = logical_bytes.saturating_add(
-            fs::metadata(path)
-                .expect("generator descriptor metadata")
-                .len(),
-        );
+        logical_bytes = logical_bytes
+            .checked_add(
+                fs::metadata(path)
+                    .expect("generator descriptor metadata")
+                    .len(),
+            )
+            .expect("descriptor logical-byte count overflow");
         let file = File::open(path).expect("open exact allocation descriptor");
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt as _;
-            allocated = allocated.saturating_add(
-                file.metadata()
-                    .expect("exact descriptor metadata")
-                    .blocks()
-                    .saturating_mul(512),
-            );
+            allocated = allocated
+                .checked_add(
+                    file.metadata()
+                        .expect("exact descriptor metadata")
+                        .blocks()
+                        .checked_mul(512)
+                        .expect("descriptor block allocation overflow"),
+                )
+                .expect("descriptor allocated-byte count overflow");
         }
         #[cfg(not(unix))]
         panic!("certification descriptor allocation requires Unix stat blocks");
@@ -557,20 +567,101 @@ fn exact_descriptor_identities(paths: &[PathBuf]) -> BTreeMap<String, u64> {
         .collect()
 }
 
-fn portable_export_allocation(receipt: &graphforge_api::PortableV2ExportFacadeResult) -> Value {
+const CATEGORY_AUTHORITY_CONTRACT: &str = "graphforge-lifecycle-category-authority/2";
+
+fn portable_export_allocation(
+    receipt: &graphforge_api::PortableV2ExportFacadeResult,
+    rung: u64,
+    generation_sha256: &str,
+    live_nodes: u64,
+    live_edges: u64,
+) -> Value {
+    let allocated_bytes = receipt
+        .allocation_identity_allocated_bytes
+        .values()
+        .try_fold(0_u64, |total, allocated| total.checked_add(*allocated))
+        .expect("portable allocation authority overflow");
+    let authority = graphforge_storage::ArtifactStorageTotals {
+        logical_references: receipt.allocation_physical_objects,
+        logical_bytes: receipt.allocation_logical_bytes,
+        physical_objects: receipt.allocation_physical_objects,
+        physical_logical_bytes: receipt.allocation_logical_bytes,
+        allocated_bytes,
+    };
+    let native_identity_authority_sha256 =
+        safe_identity_authority_digest(&receipt.allocation_identity_allocated_bytes);
+    let empty_identity_authority_sha256 =
+        safe_identity_authority_digest(&BTreeMap::<String, u64>::new());
+    let mut native_category_identity_authority_sha256 = graphforge_storage::ArtifactCategory::ALL
+        .into_iter()
+        .map(|category| (category, empty_identity_authority_sha256.clone()))
+        .collect::<BTreeMap<_, _>>();
+    native_category_identity_authority_sha256.insert(
+        graphforge_storage::ArtifactCategory::PortablePackage,
+        native_identity_authority_sha256.clone(),
+    );
+    let context = graphforge_storage::ArtifactCategoryAuthorityContext {
+        contract: CATEGORY_AUTHORITY_CONTRACT.to_owned(),
+        version: 1,
+        rung,
+        generation_sha256: generation_sha256.to_owned(),
+        owner: "portable_package".to_owned(),
+        receipt_authority_sha256: safe_authority_digest(
+            b"graphforge-portable-receipt-authority-v1\0",
+            &[
+                receipt.package_digest.as_bytes(),
+                receipt.transport_digest.as_bytes(),
+                &receipt.allocation_logical_bytes.to_be_bytes(),
+                &receipt.allocation_physical_objects.to_be_bytes(),
+            ],
+        ),
+        native_identity_authority_sha256,
+        native_category_identity_authority_sha256,
+        live_nodes,
+        live_edges,
+    };
+    let authority_sha256 = graphforge_storage::artifact_category_authority_commitment(
+        &context,
+        graphforge_storage::ArtifactCategory::PortablePackage,
+        &authority,
+    );
     json!({
         "category": "portable_package",
         "logical_bytes": receipt.allocation_logical_bytes,
-        "allocated_bytes": receipt.allocation_identity_allocated_bytes.values().copied().sum::<u64>(),
+        "allocated_bytes": allocated_bytes,
         "logical_references": receipt.allocation_physical_objects,
         "physical_objects": receipt.allocation_physical_objects,
         "source": "portable_writer_receipt",
+        "category_authority": authority,
+        "category_authority_context": context,
+        "category_authority_sha256": authority_sha256,
     })
 }
 
-fn storage_attribution_value(project: &Path) -> Value {
-    let mut value =
-        serde_json::to_value(storage_attribution(project)).expect("serialize storage attribution");
+fn storage_attribution_value(
+    project: &Path,
+    owner: &str,
+    rung: u64,
+    live_nodes: u64,
+    live_edges: u64,
+) -> (Value, graphforge_storage::ArtifactCategoryAuthorityContext) {
+    let snapshot = storage_attribution(project);
+    let category_authorities = snapshot
+        .category_authorities()
+        .expect("storage-owned category authorities");
+    let context = snapshot
+        .category_authority_context(
+            CATEGORY_AUTHORITY_CONTRACT,
+            rung,
+            owner,
+            live_nodes,
+            live_edges,
+        )
+        .expect("storage-owned category authority context");
+    let category_authority_sha256 = snapshot
+        .category_authority_commitments(&context)
+        .expect("storage-owned category commitments");
+    let mut value = serde_json::to_value(snapshot).expect("serialize storage attribution");
     value
         .as_object_mut()
         .expect("storage attribution object")
@@ -580,6 +671,65 @@ fn storage_attribution_value(project: &Path) -> Value {
         .expect("storage attribution object")
         .remove("physical_identity_allocated_bytes");
     value
+        .as_object_mut()
+        .expect("storage attribution object")
+        .insert(
+            "category_authorities".into(),
+            serde_json::to_value(category_authorities)
+                .expect("serialize storage category authorities"),
+        );
+    value
+        .as_object_mut()
+        .expect("storage attribution object")
+        .insert(
+            "category_authority_sha256".into(),
+            serde_json::to_value(category_authority_sha256)
+                .expect("serialize storage category commitments"),
+        );
+    value
+        .as_object_mut()
+        .expect("storage attribution object")
+        .insert(
+            "category_authority_context".into(),
+            serde_json::to_value(&context).expect("serialize storage category authority context"),
+        );
+    (value, context)
+}
+
+fn safe_authority_digest(domain: &[u8], values: &[&[u8]]) -> String {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for value in values {
+        digest.update((value.len() as u128).to_be_bytes());
+        digest.update(value);
+    }
+    format!("sha256:{}", hex_encode(digest.finalize()))
+}
+
+fn safe_identity_authority_digest(identities: &BTreeMap<String, u64>) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-native-identity-authority-v1\0");
+    for (identity, allocated_bytes) in identities {
+        digest.update((identity.len() as u128).to_be_bytes());
+        digest.update(identity.as_bytes());
+        digest.update(allocated_bytes.to_be_bytes());
+    }
+    format!("sha256:{}", hex_encode(digest.finalize()))
+}
+
+fn contains_native_object_identity(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes.windows(49).enumerate().any(|(offset, candidate)| {
+        candidate[16] == b':'
+            && candidate[..16].iter().all(u8::is_ascii_hexdigit)
+            && candidate[17..].iter().all(u8::is_ascii_hexdigit)
+            && offset
+                .checked_sub(1)
+                .is_none_or(|before| !bytes[before].is_ascii_hexdigit())
+            && bytes
+                .get(offset + candidate.len())
+                .is_none_or(|after| !after.is_ascii_hexdigit())
+    })
 }
 
 fn reject_unsanitized_evidence(value: &Value) -> Result<(), String> {
@@ -616,6 +766,9 @@ fn reject_unsanitized_evidence(value: &Value) -> Result<(), String> {
                 if Uuid::parse_str(text).is_ok() {
                     return Err(format!("raw UUID at {trail}"));
                 }
+                if contains_native_object_identity(text) {
+                    return Err(format!("raw native object identity at {trail}"));
+                }
                 if text.starts_with('/')
                     || text.starts_with("\\\\")
                     || (text.len() >= 3
@@ -635,7 +788,30 @@ fn reject_unsanitized_evidence(value: &Value) -> Result<(), String> {
 
 fn sanitized_construction_evidence(
     evidence: &graphforge_storage::GraphConstructionEvidence,
+    rung: u64,
+    generation_sha256: &str,
+    live_nodes: u64,
+    live_edges: u64,
 ) -> Value {
+    let category_authorities = evidence
+        .storage_category_authorities()
+        .expect("construction receipt/identity category authorities");
+    let peak_authorities = evidence
+        .storage_transient_peak_authorities()
+        .expect("construction receipt peak authorities");
+    let context = evidence
+        .storage_category_authority_context(
+            CATEGORY_AUTHORITY_CONTRACT,
+            rung,
+            generation_sha256,
+            "construction",
+            live_nodes,
+            live_edges,
+        )
+        .expect("construction category authority context");
+    let (category_authority_sha256, peak_authority_sha256) = evidence
+        .storage_category_authority_commitments(&context)
+        .expect("construction category authority commitments");
     let mut value = serde_json::to_value(evidence).expect("serialize construction evidence");
     value
         .as_object_mut()
@@ -645,6 +821,53 @@ fn sanitized_construction_evidence(
         .as_object_mut()
         .expect("construction evidence object")
         .remove("storage_allocation_transitions");
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .remove("storage_receipt_category_authorities");
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .remove("storage_receipt_transient_peak_authorities");
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .insert(
+            "storage_category_authorities".into(),
+            serde_json::to_value(category_authorities)
+                .expect("serialize construction category authorities"),
+        );
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .insert(
+            "storage_category_authority_context".into(),
+            serde_json::to_value(context).expect("serialize construction authority context"),
+        );
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .insert(
+            "storage_category_authority_sha256".into(),
+            serde_json::to_value(category_authority_sha256)
+                .expect("serialize construction category commitments"),
+        );
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .insert(
+            "storage_transient_peak_authority_sha256".into(),
+            serde_json::to_value(peak_authority_sha256)
+                .expect("serialize construction peak commitments"),
+        );
+    value
+        .as_object_mut()
+        .expect("construction evidence object")
+        .insert(
+            "storage_transient_peak_authorities".into(),
+            serde_json::to_value(peak_authorities)
+                .expect("serialize construction peak authorities"),
+        );
     value
 }
 
@@ -1258,7 +1481,7 @@ fn linux_process_memory() -> Value {
                     .trim()
                     .parse::<u64>()
                     .ok()
-                    .map(|kb| kb.saturating_mul(1024))
+                    .and_then(|kb| kb.checked_mul(1024))
             })
         })
     };
@@ -1628,14 +1851,16 @@ fn run_rung(
         heartbeat.stop();
         drop(graph);
         let committed_snapshot = storage_attribution(&project);
-        let ingest_disk_used_bytes =
-            generator_allocated_bytes.saturating_add(committed_snapshot.allocated_bytes);
+        let ingest_disk_used_bytes = generator_allocated_bytes
+            .checked_add(committed_snapshot.allocated_bytes)
+            .expect("ingest disk union overflow");
         let committed_storage =
             serde_json::to_value(committed_snapshot).expect("serialize committed storage");
         let construction_phases =
             graphforge_storage::ConstructionPhaseAttribution::from_construction(
                 &construction_evidence,
-            );
+            )
+            .expect("derive construction phase attribution");
         construction_phases
             .validate_reconciliation()
             .expect("construction phase attribution reconciliation");
@@ -1727,8 +1952,9 @@ fn run_rung(
         let graph = GraphForge::new(Some(project.to_str().expect("utf8 project")))
             .expect("reopen GraphForge");
         let reopen_s = reopen_started.elapsed().as_secs_f64();
-        let reopen_disk_used_bytes =
-            generator_allocated_bytes.saturating_add(storage_attribution(&project).allocated_bytes);
+        let reopen_disk_used_bytes = generator_allocated_bytes
+            .checked_add(storage_attribution(&project).allocated_bytes)
+            .expect("reopen disk union overflow");
         let reopen_violation = envelope_violation(&env, ladder_started, reopen_disk_used_bytes);
         if let Some(class) = reopen_violation {
             first_failing_phase = Some("reopen");
@@ -1772,7 +1998,8 @@ fn run_rung(
             node_count = result.unwrap_or(0);
             let expected = 1u64 << rung.scale;
             let count_disk_used_bytes = generator_allocated_bytes
-                .saturating_add(storage_attribution(&project).allocated_bytes);
+                .checked_add(storage_attribution(&project).allocated_bytes)
+                .expect("node-count disk union overflow");
             let mut violation = envelope_violation(&env, ladder_started, count_disk_used_bytes);
             if failure.is_some() {
                 violation = Some("execution_failure");
@@ -1820,16 +2047,17 @@ fn run_rung(
             edge_count = result.as_ref().map_or(0, scalar_count);
             gsi = gsi_undirected(node_count, edge_count);
             let count_disk_used_bytes = generator_allocated_bytes
-                .saturating_add(storage_attribution(&project).allocated_bytes);
+                .checked_add(storage_attribution(&project).allocated_bytes)
+                .expect("edge-count disk union overflow");
             let mut violation = envelope_violation(&env, ladder_started, count_disk_used_bytes);
             if failure.is_some() {
                 violation = Some("execution_failure");
             } else if edge_count != live_unique_edges {
                 violation = Some("result_mismatch");
-            } else if work.memory_reserved_after
-                > work
-                    .memory_reserved_before
-                    .saturating_add(work.returned_batch_bytes)
+            } else if work
+                .memory_reserved_before
+                .checked_add(work.returned_batch_bytes)
+                .is_none_or(|bound| work.memory_reserved_after > bound)
             {
                 violation = Some("memory_retained");
             }
@@ -1881,7 +2109,8 @@ fn run_rung(
                 let failure = result.as_ref().err().map(ToString::to_string);
                 let rows = result.as_ref().map_or(0, row_count);
                 let query_disk_used_bytes = generator_allocated_bytes
-                    .saturating_add(storage_attribution(&project).allocated_bytes);
+                    .checked_add(storage_attribution(&project).allocated_bytes)
+                    .expect("query disk union overflow");
                 let mut violation = envelope_violation(&env, ladder_started, query_disk_used_bytes);
                 if failure.is_some() {
                     violation = Some("execution_failure");
@@ -1925,11 +2154,13 @@ fn run_rung(
         drop(graph);
     }
 
-    let disk_used_bytes = generator_allocated_bytes.saturating_add(
-        ingest_ran
-            .then(|| storage_attribution(&project).allocated_bytes)
-            .unwrap_or(0),
-    );
+    let disk_used_bytes = generator_allocated_bytes
+        .checked_add(
+            ingest_ran
+                .then(|| storage_attribution(&project).allocated_bytes)
+                .unwrap_or(0),
+        )
+        .expect("final disk union overflow");
     // Tri-state: reconciliation is only *evaluated* once ingest has run. A rung
     // stopped in the generate phase is reported as null (not evaluated), never
     // as a forced `true`.
@@ -2023,6 +2254,7 @@ struct EdgeSink<'a, 'graph> {
     session: &'a mut GraphConstructionSession<'graph>,
     cancellation: Option<&'a AtomicBool>,
     buf: Vec<(u32, u32)>,
+    chunk_rows: usize,
     chunk_index: u128,
     hasher: Sha256,
 }
@@ -2032,10 +2264,20 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
         session: &'a mut GraphConstructionSession<'graph>,
         cancellation: Option<&'a AtomicBool>,
     ) -> Self {
+        Self::with_chunk_rows(session, cancellation, CONSTRUCTION_BATCH_ROWS)
+    }
+
+    fn with_chunk_rows(
+        session: &'a mut GraphConstructionSession<'graph>,
+        cancellation: Option<&'a AtomicBool>,
+        chunk_rows: usize,
+    ) -> Self {
+        assert!(chunk_rows > 0, "edge chunk rows must be positive");
         EdgeSink {
             session,
             cancellation,
-            buf: Vec::with_capacity(CONSTRUCTION_BATCH_ROWS),
+            buf: Vec::with_capacity(chunk_rows),
+            chunk_rows,
             chunk_index: 0,
             hasher: Sha256::new(),
         }
@@ -2046,7 +2288,7 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
         self.hasher.update(src.to_le_bytes());
         self.hasher.update(dst.to_le_bytes());
         self.buf.push((src, dst));
-        if self.buf.len() >= CONSTRUCTION_BATCH_ROWS {
+        if self.buf.len() >= self.chunk_rows {
             self.flush();
         }
     }
@@ -2062,8 +2304,9 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
         for (local, &(src, dst)) in self.buf.iter().enumerate() {
             let ordinal = self
                 .chunk_index
-                .saturating_mul(CONSTRUCTION_BATCH_ROWS as u128)
-                .saturating_add(u128::try_from(local).expect("edge ordinal"));
+                .checked_mul(self.chunk_rows as u128)
+                .and_then(|value| value.checked_add(u128::try_from(local).expect("edge ordinal")))
+                .expect("edge ordinal overflow");
             edge_ids.push(uuidv7(0xE000_0000_0000u128 + ordinal + 1));
             sources.push(uuidv7(u128::from(src) + 1));
             targets.push(uuidv7(u128::from(dst) + 1));
@@ -2091,7 +2334,7 @@ impl<'a, 'graph> EdgeSink<'a, 'graph> {
             .append_edges(&format!("edges-{:016x}", self.chunk_index), &batch)
             .expect("append construction edge chunk");
         INGEST_CHUNK_INDEX.store(
-            u64::try_from(self.chunk_index).unwrap_or(u64::MAX),
+            u64::try_from(self.chunk_index).expect("edge chunk index exceeds u64"),
             Ordering::Relaxed,
         );
         INGEST_SUBPHASE.store(3, Ordering::Relaxed);
@@ -2121,6 +2364,16 @@ fn publish_nodes(
     vertex_count: u64,
     cancellation: Option<&AtomicBool>,
 ) {
+    publish_nodes_with_chunk_rows(session, vertex_count, cancellation, CONSTRUCTION_BATCH_ROWS);
+}
+
+fn publish_nodes_with_chunk_rows(
+    session: &mut GraphConstructionSession<'_>,
+    vertex_count: u64,
+    cancellation: Option<&AtomicBool>,
+    chunk_rows: usize,
+) {
+    assert!(chunk_rows > 0, "node chunk rows must be positive");
     let total = usize::try_from(vertex_count).expect("vertex count fits usize");
     let mut offset = 0usize;
     while offset < total {
@@ -2128,7 +2381,7 @@ fn publish_nodes(
             !cancellation.is_some_and(|flag| flag.load(Ordering::SeqCst)),
             "node publication cancelled"
         );
-        let end = (offset + CONSTRUCTION_BATCH_ROWS).min(total);
+        let end = (offset + chunk_rows).min(total);
         let count = end - offset;
         let ids = (offset..end)
             .map(|index| uuidv7(u128::try_from(index + 1).expect("node seed")))
@@ -2252,7 +2505,7 @@ fn peak_rss() -> Option<(u64, &'static str)> {
                     .trim()
                     .parse::<u64>()
                     .ok()?;
-                return Some((kb.saturating_mul(1024), "vmhwm"));
+                return kb.checked_mul(1024).map(|bytes| (bytes, "vmhwm"));
             }
         }
     }
@@ -2267,7 +2520,7 @@ fn peak_rss() -> Option<(u64, &'static str)> {
         .trim()
         .parse::<u64>()
         .ok()?;
-    Some((kb.saturating_mul(1024), "ps_sampled"))
+    kb.checked_mul(1024).map(|bytes| (bytes, "ps_sampled"))
 }
 
 struct SplitMix64(u64);
@@ -2672,7 +2925,8 @@ impl PhaseJournal {
         if let Some(code) = self.monitor.failure_code() {
             self.phases.push(json!({
                 "id": id, "status": "fail",
-                "elapsed_ms": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                "elapsed_ms": u64::try_from(started.elapsed().as_millis())
+                    .expect("lifecycle phase elapsed milliseconds exceed u64"),
                 "rss_peak_bytes": self.monitor.peak_rss.load(Ordering::Relaxed),
                 "disk_peak_bytes": self.monitor.peak_disk.load(Ordering::Relaxed),
                 "fingerprint": fingerprint, "detail": detail, "failure_code": code,
@@ -2684,7 +2938,8 @@ impl PhaseJournal {
         let disk_peak_bytes = self.monitor.peak_disk.swap(0, Ordering::SeqCst);
         self.phases.push(json!({
             "id": id, "status": "pass",
-            "elapsed_ms": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "elapsed_ms": u64::try_from(started.elapsed().as_millis())
+                .expect("lifecycle phase elapsed milliseconds exceed u64"),
             "rss_peak_bytes": rss_peak_bytes,
             "disk_peak_bytes": disk_peak_bytes,
             "fingerprint": fingerprint,
@@ -2699,7 +2954,8 @@ impl PhaseJournal {
             .observe_allocated_union(self.allocation.current_allocated_bytes());
         self.phases.push(json!({
             "id": id, "status": "fail",
-            "elapsed_ms": u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            "elapsed_ms": u64::try_from(started.elapsed().as_millis())
+                .expect("lifecycle phase elapsed milliseconds exceed u64"),
             "rss_peak_bytes": self.monitor.peak_rss.load(Ordering::Relaxed),
             "disk_peak_bytes": self.monitor.peak_disk.load(Ordering::Relaxed),
             "fingerprint": null, "detail": detail, "failure_code": code,
@@ -2757,6 +3013,12 @@ impl PhaseJournal {
 
     fn current_allocated_union(&self) -> u64 {
         self.allocation.current_allocated_bytes()
+    }
+
+    fn owner_allocated_union(&self, owners: &[&str]) -> u64 {
+        self.allocation
+            .owner_union_allocated_bytes(owners.iter().copied())
+            .expect("capture authoritative owner allocation union")
     }
 
     fn flush(&self) {
@@ -2849,9 +3111,8 @@ impl ResourceMonitor {
                 let code = if rss > envelope.rss_bytes {
                     1
                 } else if elapsed_before_process
-                    .saturating_add(started.elapsed())
-                    .as_secs()
-                    > envelope.timeout_s
+                    .checked_add(started.elapsed())
+                    .is_none_or(|elapsed| elapsed.as_secs() > envelope.timeout_s)
                 {
                     3
                 } else {
@@ -2923,7 +3184,7 @@ fn current_rss_bytes() -> Result<u64, &'static str> {
                 .parse::<u64>()
                 .ok()
         })
-        .map(|kibibytes| kibibytes.saturating_mul(1024))
+        .and_then(|kibibytes| kibibytes.checked_mul(1024))
         .or_else(|| peak_rss().map(|value| value.0))
         .ok_or("process RSS is unavailable")
 }
@@ -3134,6 +3395,61 @@ fn run_integrated_certification_with_edge_factor(
     target_live: Option<u64>,
     preflight_edge_factor: Option<u32>,
 ) -> Value {
+    run_integrated_certification_config(
+        root,
+        target_live,
+        preflight_edge_factor,
+        1,
+        CONSTRUCTION_BATCH_ROWS,
+        false,
+    )
+    .value
+}
+
+#[derive(Clone, Copy, Debug)]
+enum LinearityAxis {
+    Nodes,
+    Edges,
+}
+
+struct IntegratedCertificationEvidence {
+    value: Value,
+}
+
+fn checked_lifecycle_peak_allocation(
+    current_allocated_bytes: u64,
+    transient_allocated_bytes: u64,
+) -> Result<u64, String> {
+    current_allocated_bytes
+        .checked_add(transient_allocated_bytes)
+        .ok_or_else(|| "lifecycle peak allocation overflow".to_owned())
+}
+
+fn run_integrated_certification_for_linearity(
+    root: &Path,
+    axis: LinearityAxis,
+    factor: u32,
+) -> IntegratedCertificationEvidence {
+    // The production-sized append window would make every SCALE-10 preflight
+    // fit in one object. A small deterministic window lets the 1x/2x/4x proof
+    // observe byte, call, block, and object slopes without changing runtime
+    // behavior or the provider profile.
+    let (node_factor, edge_factor) = match axis {
+        LinearityAxis::Nodes => (factor, 1),
+        LinearityAxis::Edges => (1, factor),
+    };
+    run_integrated_certification_config(root, None, Some(edge_factor), node_factor, 256, true)
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_integrated_certification_config(
+    root: &Path,
+    target_live: Option<u64>,
+    preflight_edge_factor: Option<u32>,
+    preflight_node_factor: u32,
+    proof_chunk_rows: usize,
+    scale_recovery_drill: bool,
+) -> IntegratedCertificationEvidence {
     let source = root.join("source");
     let imported = root.join("imported");
     let package = root.join("project.gfpb");
@@ -3224,12 +3540,20 @@ fn run_integrated_certification_with_edge_factor(
     let mut construction = graph
         .begin_graph_construction(Default::default())
         .expect("begin certification construction");
-    publish_nodes(
+    let node_count = (1_u64 << scale)
+        .checked_mul(u64::from(preflight_node_factor))
+        .expect("linearity node count");
+    publish_nodes_with_chunk_rows(
         &mut construction,
-        1u64 << scale,
+        node_count,
         Some(journal.cancellation()),
+        proof_chunk_rows,
     );
-    let mut sink = EdgeSink::new(&mut construction, Some(journal.cancellation()));
+    let mut sink = EdgeSink::with_chunk_rows(
+        &mut construction,
+        Some(journal.cancellation()),
+        proof_chunk_rows,
+    );
     if let Some(edges) = edges {
         for (src, dst) in edges {
             sink.push(src, dst);
@@ -3250,7 +3574,8 @@ fn run_integrated_certification_with_edge_factor(
         .expect("publish certification construction");
     let construction_evidence = construction.progress().evidence;
     let mut construction_phases =
-        graphforge_storage::ConstructionPhaseAttribution::from_construction(&construction_evidence);
+        graphforge_storage::ConstructionPhaseAttribution::from_construction(&construction_evidence)
+            .expect("derive certification construction phases");
     construction_phases
         .validate_for_qualification()
         .expect("certification construction phase attribution");
@@ -3263,8 +3588,11 @@ fn run_integrated_certification_with_edge_factor(
     // already-open source project. The storage-owned numeric high-water mark
     // therefore restores peaks compacted out of durable checkpoint history.
     journal.monitor.observe_allocated_union(
-        pre_construction_union
-            .saturating_add(construction_evidence.storage_transient_peak_total_allocated_bytes),
+        checked_lifecycle_peak_allocation(
+            pre_construction_union,
+            construction_evidence.storage_transient_peak_total_allocated_bytes,
+        )
+        .expect("lifecycle peak allocation overflow"),
     );
     let committed_generation = graphforge_storage::resolve_project_generation(&source)
         .expect("resolve committed ingest generation");
@@ -3525,7 +3853,17 @@ fn run_integrated_certification_with_edge_factor(
         Some(imported_2hop.clone()),
         query_work_evidence(&imported_2hop_work),
     );
-    let source_storage = storage_attribution_value(&source);
+    let authority_rung = target_live.map_or_else(
+        || u64::from(preflight_node_factor.max(edge_factor)),
+        |_| u64::from(scale),
+    );
+    let (source_storage, source_context) = storage_attribution_value(
+        &source,
+        "source",
+        authority_rung,
+        source_nodes,
+        source_edges,
+    );
     let source_project_current_allocated_bytes =
         graphforge_storage::capture_project_storage_identity_union(
             &graphforge_storage::resolve_project_generation(&source)
@@ -3533,8 +3871,27 @@ fn run_integrated_certification_with_edge_factor(
         )
         .expect("capture authoritative source project identity union")
         .allocated_bytes;
-    let imported_storage = storage_attribution_value(&imported);
-    let package_storage = portable_export_allocation(&exported);
+    let (imported_storage, _) = storage_attribution_value(
+        &imported,
+        "clean_import",
+        authority_rung,
+        imported_nodes,
+        imported_edges,
+    );
+    let package_storage = portable_export_allocation(
+        &exported,
+        authority_rung,
+        &source_context.generation_sha256,
+        source_nodes,
+        source_edges,
+    );
+    let construction_storage = sanitized_construction_evidence(
+        &construction_evidence,
+        authority_rung,
+        &source_context.generation_sha256,
+        source_nodes,
+        source_edges,
+    );
     // Representative drills use the same verifier/import boundaries but never
     // repeat the billion-edge payload.
     let phase = Instant::now();
@@ -3637,8 +3994,13 @@ fn run_integrated_certification_with_edge_factor(
         capability_version: 1,
     })
     .collect::<Vec<_>>();
+    let recovery_package = if scale_recovery_drill {
+        &package
+    } else {
+        &drill_package
+    };
     let interrupted_error = graphforge_storage::import_complete_portable_v2_with_progress(
-        &drill_package,
+        recovery_package,
         &interrupted,
         interrupted_operation,
         interrupted_generation,
@@ -3654,10 +4016,12 @@ fn run_integrated_certification_with_edge_factor(
     .expect_err("cancelled finalization must fail");
     assert!(interrupted_error.recovery_reauthentication_read_bytes > 0);
     assert!(interrupted_error.recovery_reauthentication_read_calls > 0);
-    construction_phases.add_recovery_reauthentication(
-        interrupted_error.recovery_reauthentication_read_bytes,
-        interrupted_error.recovery_reauthentication_read_calls,
-    );
+    construction_phases
+        .add_recovery_reauthentication(
+            interrupted_error.recovery_reauthentication_read_bytes,
+            interrupted_error.recovery_reauthentication_read_calls,
+        )
+        .expect("accumulate interrupted recovery authority");
     construction_phases
         .validate_for_qualification()
         .expect("interrupted recovery phase attribution");
@@ -3679,6 +4043,46 @@ fn run_integrated_certification_with_edge_factor(
         format!("sha256:{}", hex_encode(digest.finalize()))
     };
     let workspace_current_allocated_bytes = journal.current_allocated_union();
+    let workspace_components = BTreeMap::from([
+        (
+            "source_project_and_construction",
+            journal.owner_allocated_union(&["source_project", "construction"]),
+        ),
+        (
+            "portable_package",
+            journal.owner_allocated_union(&["portable_package"]),
+        ),
+        (
+            "clean_import_project",
+            journal.owner_allocated_union(&["clean_import", "clean_import_project"]),
+        ),
+        (
+            "drill_project_and_construction",
+            journal.owner_allocated_union(&["drill_project", "drill_construction"]),
+        ),
+        (
+            "drill_package",
+            journal.owner_allocated_union(&["drill_package"]),
+        ),
+        (
+            "corrupt_drill_package",
+            journal.owner_allocated_union(&["corrupt_drill_package"]),
+        ),
+    ]);
+    assert_eq!(
+        workspace_components
+            .values()
+            .try_fold(0_u64, |total, allocated| total.checked_add(*allocated))
+            .expect("workspace component authority overflow"),
+        workspace_current_allocated_bytes,
+        "non-overlapping owner-group unions must reconcile to the workspace union"
+    );
+    let workspace_peak_allocated_bytes = journal
+        .phases
+        .iter()
+        .filter_map(|phase| phase["disk_peak_bytes"].as_u64())
+        .max()
+        .expect("completed lifecycle phase allocation peaks");
     let evidence = json!({
         "source_export_generation_authenticated": source_generation == exported.generation_uuid,
         "import_receipt_reopen_authenticated": current_generation_uuid(&imported_graph) == imported_receipt.generation_uuid,
@@ -3703,14 +4107,16 @@ fn run_integrated_certification_with_edge_factor(
             "source_project_current_allocated_bytes": source_project_current_allocated_bytes,
             "portable_package": package_storage,
             "clean_import": imported_storage,
-            "construction": sanitized_construction_evidence(&construction_evidence),
+            "construction": construction_storage,
             "application_io_phases": construction_phases,
             "workspace_current_allocated_bytes": workspace_current_allocated_bytes,
+            "workspace_peak_allocated_bytes": workspace_peak_allocated_bytes,
+            "workspace_components": workspace_components,
         },
         "phases": journal.phases,
     });
     reject_unsanitized_evidence(&evidence).expect("certification lifecycle evidence is sanitized");
-    evidence
+    IntegratedCertificationEvidence { value: evidence }
 }
 
 #[test]
@@ -3736,6 +4142,10 @@ fn certification_evidence_sanitizer_rejects_identity_paths_and_sensitive_keys() 
             "absolute host path",
         ),
         (
+            json!({"tools": {"build": "artifact=0011223344556677:00112233445566778899aabbccddeeff"}}),
+            "raw native object identity",
+        ),
+        (
             json!({"nested": {"api_token": "redacted"}}),
             "sensitive evidence key",
         ),
@@ -3748,91 +4158,3217 @@ fn certification_evidence_sanitizer_rejects_identity_paths_and_sensitive_keys() 
     }
     reject_unsanitized_evidence(&json!({
         "generation_authenticated": true,
-        "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "tools": {
+            "rustc": "rustc 1.90.0 (1159e78c4 2026-08-01)",
+            "llvm": "llvm:19.1.7"
+        }
     }))
     .expect("closed proof is safe");
 }
 
-#[test]
-fn equivalent_full_lifecycle_1x_2x_4x_has_bounded_phase_slopes() {
-    const FIELDS: [&str; 7] = [
-        "read_bytes",
-        "write_bytes",
-        "read_calls",
-        "write_calls",
-        "object_count",
-        "block_count",
-        "fsync_calls",
+const LINEARITY_PHASE_FIELDS: [&str; 7] = [
+    "read_bytes",
+    "write_bytes",
+    "read_calls",
+    "write_calls",
+    "object_count",
+    "block_count",
+    "fsync_calls",
+];
+
+#[derive(Clone, Copy)]
+enum RetainedMetricPolicy {
+    ScaleBearing,
+    FilesystemQuantized,
+    InventoryDerived,
+    NodeBearing,
+    EdgeBearing,
+    NodeFilesystemQuantized,
+    EdgeFilesystemQuantized,
+}
+
+const LINEARITY_RETAINED_FIELDS: [(&str, &str, RetainedMetricPolicy); 33] = [
+    (
+        "source.logical_references",
+        "/storage/source/logical_references",
+        RetainedMetricPolicy::InventoryDerived,
+    ),
+    (
+        "source.logical_bytes",
+        "/storage/source/logical_bytes",
+        RetainedMetricPolicy::ScaleBearing,
+    ),
+    (
+        "source.physical_objects",
+        "/storage/source/physical_objects",
+        RetainedMetricPolicy::InventoryDerived,
+    ),
+    (
+        "source.physical_logical_bytes",
+        "/storage/source/physical_logical_bytes",
+        RetainedMetricPolicy::ScaleBearing,
+    ),
+    (
+        "source.allocated_bytes",
+        "/storage/source/allocated_bytes",
+        RetainedMetricPolicy::FilesystemQuantized,
+    ),
+    (
+        "source.canonical_nodes.logical_bytes",
+        "/storage/source/categories/topology_nodes/logical_bytes",
+        RetainedMetricPolicy::NodeBearing,
+    ),
+    (
+        "source.canonical_nodes.physical_logical_bytes",
+        "/storage/source/categories/topology_nodes/physical_logical_bytes",
+        RetainedMetricPolicy::NodeBearing,
+    ),
+    (
+        "source.canonical_nodes.allocated_bytes",
+        "/storage/source/categories/topology_nodes/allocated_bytes",
+        RetainedMetricPolicy::NodeFilesystemQuantized,
+    ),
+    (
+        "source.canonical_edges.logical_bytes",
+        "/storage/source/categories/topology_edges/logical_bytes",
+        RetainedMetricPolicy::EdgeBearing,
+    ),
+    (
+        "source.canonical_edges.physical_logical_bytes",
+        "/storage/source/categories/topology_edges/physical_logical_bytes",
+        RetainedMetricPolicy::EdgeBearing,
+    ),
+    (
+        "source.canonical_edges.allocated_bytes",
+        "/storage/source/categories/topology_edges/allocated_bytes",
+        RetainedMetricPolicy::EdgeFilesystemQuantized,
+    ),
+    (
+        "clean_import.logical_references",
+        "/storage/clean_import/logical_references",
+        RetainedMetricPolicy::InventoryDerived,
+    ),
+    (
+        "clean_import.logical_bytes",
+        "/storage/clean_import/logical_bytes",
+        RetainedMetricPolicy::ScaleBearing,
+    ),
+    (
+        "clean_import.physical_objects",
+        "/storage/clean_import/physical_objects",
+        RetainedMetricPolicy::InventoryDerived,
+    ),
+    (
+        "clean_import.physical_logical_bytes",
+        "/storage/clean_import/physical_logical_bytes",
+        RetainedMetricPolicy::ScaleBearing,
+    ),
+    (
+        "clean_import.allocated_bytes",
+        "/storage/clean_import/allocated_bytes",
+        RetainedMetricPolicy::FilesystemQuantized,
+    ),
+    (
+        "clean_import.canonical_nodes.logical_bytes",
+        "/storage/clean_import/categories/topology_nodes/logical_bytes",
+        RetainedMetricPolicy::NodeBearing,
+    ),
+    (
+        "clean_import.canonical_nodes.physical_logical_bytes",
+        "/storage/clean_import/categories/topology_nodes/physical_logical_bytes",
+        RetainedMetricPolicy::NodeBearing,
+    ),
+    (
+        "clean_import.canonical_nodes.allocated_bytes",
+        "/storage/clean_import/categories/topology_nodes/allocated_bytes",
+        RetainedMetricPolicy::NodeFilesystemQuantized,
+    ),
+    (
+        "clean_import.canonical_edges.logical_bytes",
+        "/storage/clean_import/categories/topology_edges/logical_bytes",
+        RetainedMetricPolicy::EdgeBearing,
+    ),
+    (
+        "clean_import.canonical_edges.physical_logical_bytes",
+        "/storage/clean_import/categories/topology_edges/physical_logical_bytes",
+        RetainedMetricPolicy::EdgeBearing,
+    ),
+    (
+        "clean_import.canonical_edges.allocated_bytes",
+        "/storage/clean_import/categories/topology_edges/allocated_bytes",
+        RetainedMetricPolicy::EdgeFilesystemQuantized,
+    ),
+    (
+        "portable_package.logical_references",
+        "/storage/portable_package/logical_references",
+        RetainedMetricPolicy::InventoryDerived,
+    ),
+    (
+        "portable_package.logical_bytes",
+        "/storage/portable_package/logical_bytes",
+        RetainedMetricPolicy::ScaleBearing,
+    ),
+    (
+        "portable_package.physical_objects",
+        "/storage/portable_package/physical_objects",
+        RetainedMetricPolicy::InventoryDerived,
+    ),
+    (
+        "portable_package.allocated_bytes",
+        "/storage/portable_package/allocated_bytes",
+        RetainedMetricPolicy::FilesystemQuantized,
+    ),
+    (
+        "construction.canonical_output_bytes",
+        "/storage/construction/canonical_output_bytes",
+        RetainedMetricPolicy::ScaleBearing,
+    ),
+    (
+        "construction.staged_and_retained_disk_bytes",
+        "/storage/construction/staged_and_retained_disk_bytes",
+        RetainedMetricPolicy::ScaleBearing,
+    ),
+    (
+        "construction.transient_peak_total_allocated_bytes",
+        "/storage/construction/storage_transient_peak_total_allocated_bytes",
+        RetainedMetricPolicy::FilesystemQuantized,
+    ),
+    (
+        "source_project_current_allocated_bytes",
+        "/storage/source_project_current_allocated_bytes",
+        RetainedMetricPolicy::FilesystemQuantized,
+    ),
+    (
+        "workspace_current_allocated_bytes",
+        "/storage/workspace_current_allocated_bytes",
+        RetainedMetricPolicy::FilesystemQuantized,
+    ),
+    (
+        "workspace_peak_allocated_bytes",
+        "/storage/workspace_peak_allocated_bytes",
+        RetainedMetricPolicy::FilesystemQuantized,
+    ),
+    (
+        "construction.current_merge_temporary_allocated_bytes",
+        "/storage/construction/current_merge_temporary_allocated_bytes",
+        RetainedMetricPolicy::FilesystemQuantized,
+    ),
+];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LifecycleLinearityObservation {
+    phases: BTreeMap<String, [u64; LINEARITY_PHASE_FIELDS.len()]>,
+    retained: BTreeMap<String, u64>,
+    append_objects: u64,
+    input_rows: u64,
+    live_nodes: u64,
+    live_edges: u64,
+    shape_merge_bytes: [u64; 2],
+    shape_block_components: [u64; 2],
+    canonical_artifact_objects: u64,
+    cas_publication_io: graphforge_storage::GraphPublicationIo,
+    encode_fsync_components: [u64; 4],
+    hydration_files_copied: u64,
+    hydration_file_fsync_operations: u64,
+    hydration_directory_fsync_operations: u64,
+    shape_read_component_calls: [u64; 6],
+    shape_write_component_calls: [u64; 2],
+    encode_write_component_calls: [u64; 5],
+    category_metrics: BTreeMap<String, [u64; 6]>,
+    category_authority_metrics: BTreeMap<String, [u64; 6]>,
+    phase_disk_peaks: BTreeMap<String, u64>,
+}
+
+const fn category_name(category: graphforge_storage::ArtifactCategory) -> &'static str {
+    use graphforge_storage::ArtifactCategory;
+    match category {
+        ArtifactCategory::TopologyNodes => "topology_nodes",
+        ArtifactCategory::TopologyEdges => "topology_edges",
+        ArtifactCategory::Properties => "properties",
+        ArtifactCategory::UuidAndSurrogates => "uuid_and_surrogates",
+        ArtifactCategory::Adjacency => "adjacency",
+        ArtifactCategory::CatalogAndManifests => "catalog_and_manifests",
+        ArtifactCategory::ConstructionStaging => "construction_staging",
+        ArtifactCategory::PortablePackage => "portable_package",
+        ArtifactCategory::CleanImportedProject => "clean_imported_project",
+        ArtifactCategory::Other => "other",
+    }
+}
+
+fn artifact_fields(totals: &graphforge_storage::ArtifactStorageTotals) -> [u64; 5] {
+    let graphforge_storage::ArtifactStorageTotals {
+        logical_references,
+        logical_bytes,
+        physical_objects,
+        physical_logical_bytes,
+        allocated_bytes,
+    } = totals;
+    [
+        *logical_references,
+        *logical_bytes,
+        *physical_objects,
+        *physical_logical_bytes,
+        *allocated_bytes,
+    ]
+}
+
+fn exact_category_map(
+    value: Value,
+    owner: &str,
+) -> BTreeMap<graphforge_storage::ArtifactCategory, graphforge_storage::ArtifactStorageTotals> {
+    let categories: BTreeMap<_, _> =
+        serde_json::from_value(value).unwrap_or_else(|error| panic!("{owner}: {error}"));
+    let observed = categories.keys().copied().collect::<BTreeSet<_>>();
+    let expected = graphforge_storage::ArtifactCategory::ALL
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    assert_eq!(observed, expected, "{owner} category inventory");
+    categories
+}
+
+const fn phase_name(phase: graphforge_storage::StorageIoPhase) -> &'static str {
+    use graphforge_storage::StorageIoPhase;
+    match phase {
+        StorageIoPhase::AppendMerge => "append_merge",
+        StorageIoPhase::SealAuthentication => "seal_authentication",
+        StorageIoPhase::ShapeConsumeReauthentication => "shape_consume_reauthentication",
+        StorageIoPhase::EncodeWritePostwriteAuthentication => {
+            "encode_write_postwrite_authentication"
+        }
+        StorageIoPhase::PublicationPreauthentication => "publication_preauthentication",
+        StorageIoPhase::CasInstallReadWrite => "cas_install_read_write",
+        StorageIoPhase::HydrationVerification => "hydration_verification",
+        StorageIoPhase::FsyncSynchronization => "fsync_synchronization",
+        StorageIoPhase::RecoveryReauthentication => "recovery_reauthentication",
+    }
+}
+
+fn phase_fields(totals: &graphforge_storage::PhaseIoTotals) -> [u64; LINEARITY_PHASE_FIELDS.len()] {
+    let graphforge_storage::PhaseIoTotals {
+        read_bytes,
+        write_bytes,
+        read_calls,
+        write_calls,
+        object_count,
+        block_count,
+        fsync_calls,
+    } = totals;
+    [
+        *read_bytes,
+        *write_bytes,
+        *read_calls,
+        *write_calls,
+        *object_count,
+        *block_count,
+        *fsync_calls,
+    ]
+}
+
+fn lifecycle_linearity_observation(evidence: &Value) -> LifecycleLinearityObservation {
+    let attribution: graphforge_storage::ConstructionPhaseAttribution =
+        serde_json::from_value(evidence["storage"]["application_io_phases"].clone())
+            .expect("typed phase evidence");
+    let phases = attribution
+        .phases
+        .iter()
+        .map(|(phase, totals)| (phase_name(*phase).to_owned(), phase_fields(totals)))
+        .collect();
+    let retained = LINEARITY_RETAINED_FIELDS
+        .iter()
+        .map(|(name, pointer, _)| {
+            (
+                (*name).to_owned(),
+                evidence
+                    .pointer(pointer)
+                    .and_then(Value::as_u64)
+                    .unwrap_or_else(|| panic!("retained metric {name} is an integer")),
+            )
+        })
+        .collect();
+    let append_objects = evidence["storage"]["construction"]["input_batches"]
+        .as_u64()
+        .expect("construction input batches are an integer");
+    let input_rows = evidence["storage"]["construction"]["input_rows"]
+        .as_u64()
+        .expect("construction input rows are an integer");
+    let live_nodes = evidence["source_nodes"]
+        .as_u64()
+        .expect("authoritative live node count");
+    let live_edges = evidence["source_edges"]
+        .as_u64()
+        .expect("authoritative live edge count");
+    let construction = &evidence["storage"]["construction"];
+    let merge_read_bytes = construction["merge_read_bytes"]
+        .as_u64()
+        .expect("merge read bytes");
+    let merge_write_bytes = construction["merge_written_bytes"]
+        .as_u64()
+        .expect("merge write bytes");
+    let shape_block_components = [
+        construction["merge_read_blocks"]
+            .as_u64()
+            .expect("merge read block authority"),
+        construction["merge_write_blocks"]
+            .as_u64()
+            .expect("merge write block authority"),
     ];
-    let mut baseline: Option<BTreeMap<String, [u64; 7]>> = None;
-    for factor in [1_u32, 2, 4] {
-        let root = TempDir::new().expect("full lifecycle ladder root");
-        let evidence =
-            run_integrated_certification_with_edge_factor(root.path(), None, Some(factor));
-        assert_eq!(evidence["source_edges"], evidence["imported_edges"]);
-        let phases = evidence["storage"]["application_io_phases"]["phases"]
-            .as_object()
-            .expect("phase evidence object");
-        let attribution: graphforge_storage::ConstructionPhaseAttribution =
-            serde_json::from_value(evidence["storage"]["application_io_phases"].clone())
-                .expect("decode phase evidence");
-        attribution
-            .validate_for_qualification()
-            .expect("full lifecycle phase qualification");
-        let recovery = &phases["recovery_reauthentication"];
-        assert!(
-            recovery["read_bytes"].as_u64().unwrap_or(0) > 0,
-            "{factor}x interrupted-finalization recovery must report authenticated bytes"
+    let canonical_artifact_objects = construction["canonical_artifact_objects"]
+        .as_u64()
+        .expect("canonical artifact inventory");
+    let encode_fsync_components = [
+        construction["encode_output_fsync_operations"]
+            .as_u64()
+            .expect("encode output fsyncs"),
+        construction["encode_source_spool_fsync_operations"]
+            .as_u64()
+            .expect("encode spool fsyncs"),
+        construction["encode_membership_fsync_operations"]
+            .as_u64()
+            .expect("encode membership fsyncs"),
+        construction["encode_ordinal_fsync_operations"]
+            .as_u64()
+            .expect("encode ordinal fsyncs"),
+    ];
+    let hydration_files_copied = construction["hydration_files_copied"]
+        .as_u64()
+        .expect("hydration copied-file inventory");
+    let hydration_file_fsync_operations = construction["hydration_file_fsync_operations"]
+        .as_u64()
+        .expect("hydration file barrier inventory");
+    let hydration_directory_fsync_operations = construction["hydration_directory_fsync_operations"]
+        .as_u64()
+        .expect("hydration directory barrier inventory");
+    let shape_read_component_calls = [
+        construction["shape_input_validation_read_operations"]
+            .as_u64()
+            .expect("shape input reads"),
+        construction["merge_read_operations"]
+            .as_u64()
+            .expect("merge reads"),
+        construction["parquet_read_operations"]
+            .as_u64()
+            .expect("Parquet reads"),
+        construction["shaped_output_authentication_operations"]
+            .as_u64()
+            .expect("shape authentication reads"),
+        construction["parent_catalog_read_operations"]
+            .as_u64()
+            .expect("parent catalog reads"),
+        construction["retained_probe_block_loads"]
+            .as_u64()
+            .expect("retained probe reads"),
+    ];
+    let shape_write_component_calls = [
+        construction["merge_write_operations"]
+            .as_u64()
+            .expect("merge writes"),
+        construction["parquet_write_operations"]
+            .as_u64()
+            .expect("Parquet writes"),
+    ];
+    let encode_write_component_calls = [
+        construction["encode_output_write_operations"]
+            .as_u64()
+            .expect("encode output writes"),
+        construction["encode_membership_write_operations"]
+            .as_u64()
+            .expect("encode membership writes"),
+        construction["encode_source_spool_write_operations"]
+            .as_u64()
+            .expect("encode spool writes"),
+        construction["encode_ordinal_artifact_write_operations"]
+            .as_u64()
+            .expect("ordinal artifact writes"),
+        construction["encode_ordinal_publication_write_operations"]
+            .as_u64()
+            .expect("ordinal publication writes"),
+    ];
+    let mut category_metrics = BTreeMap::new();
+    let mut category_authority_metrics = BTreeMap::new();
+    for owner in ["source", "clean_import"] {
+        let categories =
+            exact_category_map(evidence["storage"][owner]["categories"].clone(), owner);
+        let authorities = exact_category_map(
+            evidence["storage"][owner]["category_authorities"].clone(),
+            &format!("{owner} authorities"),
         );
-        assert!(
-            recovery["read_calls"].as_u64().unwrap_or(0) > 0,
-            "{factor}x interrupted-finalization recovery must report authenticated calls"
-        );
-        let observations = phases
-            .iter()
-            .map(|(name, values)| {
-                let counters = std::array::from_fn(|index| {
-                    values[FIELDS[index]]
-                        .as_u64()
-                        .expect("phase counter is an integer")
-                });
-                (name.clone(), counters)
-            })
-            .collect::<BTreeMap<_, _>>();
-        if let Some(base) = &baseline {
-            assert_eq!(
-                base.keys().collect::<Vec<_>>(),
-                observations.keys().collect::<Vec<_>>()
+        for category in graphforge_storage::ArtifactCategory::ALL {
+            let fields = artifact_fields(&categories[&category]);
+            let authority = artifact_fields(&authorities[&category]);
+            category_metrics.insert(
+                format!("{owner}.{}", category_name(category)),
+                [
+                    fields[0], fields[1], fields[2], fields[3], fields[4], fields[4],
+                ],
             );
-            for (phase, current) in &observations {
-                for (index, value) in current.iter().enumerate() {
-                    let first = base[phase][index];
-                    if first == 0 {
-                        assert_eq!(
-                            *value, 0,
-                            "{phase}.{} appeared only at a larger rung",
-                            FIELDS[index]
-                        );
-                    } else {
-                        assert!(
-                            *value <= first.saturating_mul(u64::from(factor)).saturating_mul(2),
-                            "{phase}.{} exceeded the documented 2x constant-factor ceiling",
-                            FIELDS[index]
-                        );
+            category_authority_metrics.insert(
+                format!("{owner}.{}", category_name(category)),
+                [
+                    authority[0],
+                    authority[1],
+                    authority[2],
+                    authority[3],
+                    authority[4],
+                    authority[4],
+                ],
+            );
+        }
+    }
+    let construction_categories = exact_category_map(
+        construction["storage_current"].clone(),
+        "construction current",
+    );
+    let construction_peaks: BTreeMap<graphforge_storage::ArtifactCategory, u64> =
+        serde_json::from_value(construction["storage_transient_peak_allocated_bytes"].clone())
+            .expect("typed construction peak categories");
+    let construction_authorities = exact_category_map(
+        construction["storage_category_authorities"].clone(),
+        "construction authorities",
+    );
+    let construction_peak_authorities: BTreeMap<graphforge_storage::ArtifactCategory, u64> =
+        serde_json::from_value(construction["storage_transient_peak_authorities"].clone())
+            .expect("typed construction peak authorities");
+    assert_eq!(
+        construction_peaks.keys().copied().collect::<BTreeSet<_>>(),
+        graphforge_storage::ArtifactCategory::ALL
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        "construction peak category inventory"
+    );
+    for category in graphforge_storage::ArtifactCategory::ALL {
+        let fields = artifact_fields(&construction_categories[&category]);
+        category_metrics.insert(
+            format!("construction.{}", category_name(category)),
+            [
+                fields[0],
+                fields[1],
+                fields[2],
+                fields[3],
+                fields[4],
+                construction_peaks[&category],
+            ],
+        );
+        let authority = artifact_fields(&construction_authorities[&category]);
+        category_authority_metrics.insert(
+            format!("construction.{}", category_name(category)),
+            [
+                authority[0],
+                authority[1],
+                authority[2],
+                authority[3],
+                authority[4],
+                construction_peak_authorities[&category],
+            ],
+        );
+    }
+    let phase_disk_peaks = evidence["phases"]
+        .as_array()
+        .expect("lifecycle phase evidence")
+        .iter()
+        .map(|phase| {
+            (
+                phase["id"].as_str().expect("phase id").to_owned(),
+                phase["disk_peak_bytes"].as_u64().expect("phase disk peak"),
+            )
+        })
+        .collect();
+    LifecycleLinearityObservation {
+        phases,
+        retained,
+        append_objects,
+        input_rows,
+        live_nodes,
+        live_edges,
+        shape_merge_bytes: [merge_read_bytes, merge_write_bytes],
+        shape_block_components,
+        canonical_artifact_objects,
+        cas_publication_io: serde_json::from_value(construction["cas_publication_io"].clone())
+            .expect("native CAS component evidence"),
+        encode_fsync_components,
+        hydration_files_copied,
+        hydration_file_fsync_operations,
+        hydration_directory_fsync_operations,
+        shape_read_component_calls,
+        shape_write_component_calls,
+        encode_write_component_calls,
+        category_metrics,
+        category_authority_metrics,
+        phase_disk_peaks,
+    }
+}
+
+const ATTRIBUTION_CATEGORY_NAMES: [&str; 10] = [
+    "topology_nodes",
+    "topology_edges",
+    "properties",
+    "uuid_and_surrogates",
+    "adjacency",
+    "catalog_and_manifests",
+    "construction_staging",
+    "portable_package",
+    "clean_imported_project",
+    "other",
+];
+const ATTRIBUTION_TOTAL_FIELDS: [(&str, &str); 5] = [
+    ("logical_references", "logical_references"),
+    ("logical_bytes", "logical_bytes"),
+    ("physical_objects", "physical_objects"),
+    ("physical_logical_bytes", "physical_logical_bytes"),
+    ("allocated_bytes", "allocated_bytes"),
+];
+
+fn evidence_u64(value: &Value, pointer: &str) -> Result<u64, String> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("missing integer storage evidence at {pointer}"))
+}
+
+fn validate_category_authority_context(
+    context: &graphforge_storage::ArtifactCategoryAuthorityContext,
+    owner: &str,
+) -> Result<(), String> {
+    let expected_categories = graphforge_storage::ArtifactCategory::ALL
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    if context.contract != CATEGORY_AUTHORITY_CONTRACT
+        || context.version != 1
+        || context.owner != owner
+        || context.rung == 0
+        || context.live_nodes == 0
+        || context.live_edges == 0
+        || context
+            .native_category_identity_authority_sha256
+            .keys()
+            .copied()
+            .collect::<BTreeSet<_>>()
+            != expected_categories
+        || [
+            context.generation_sha256.as_str(),
+            context.receipt_authority_sha256.as_str(),
+            context.native_identity_authority_sha256.as_str(),
+        ]
+        .into_iter()
+        .chain(
+            context
+                .native_category_identity_authority_sha256
+                .values()
+                .map(String::as_str),
+        )
+        .any(|digest| {
+            digest.len() != 71
+                || !digest.starts_with("sha256:")
+                || !digest[7..].bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+    {
+        return Err(format!("{owner} category authority context is invalid"));
+    }
+    Ok(())
+}
+
+fn validate_attribution_owner(evidence: &Value, owner: &str) -> Result<(), String> {
+    let owner_value = evidence
+        .pointer(&format!("/storage/{owner}"))
+        .ok_or_else(|| format!("missing storage owner {owner}"))?;
+    let categories = owner_value["categories"]
+        .as_object()
+        .ok_or_else(|| format!("{owner} categories are absent"))?;
+    let authorities = owner_value["category_authorities"]
+        .as_object()
+        .ok_or_else(|| format!("{owner} category authorities are absent"))?;
+    if categories != authorities {
+        return Err(format!(
+            "{owner} category totals differ from storage-owned authorities"
+        ));
+    }
+    let typed_authorities = exact_category_map(
+        owner_value["category_authorities"].clone(),
+        &format!("{owner} category authorities"),
+    );
+    let commitments = owner_value["category_authority_sha256"]
+        .as_object()
+        .ok_or_else(|| format!("{owner} category commitments are absent"))?;
+    if commitments.len() != graphforge_storage::ArtifactCategory::ALL.len() {
+        return Err(format!(
+            "{owner} category commitment inventory is incomplete"
+        ));
+    }
+    let context: graphforge_storage::ArtifactCategoryAuthorityContext =
+        serde_json::from_value(owner_value["category_authority_context"].clone())
+            .map_err(|error| format!("{owner} category authority context: {error}"))?;
+    validate_category_authority_context(&context, owner)?;
+    for category in graphforge_storage::ArtifactCategory::ALL {
+        let name = category_name(category);
+        let expected = graphforge_storage::artifact_category_authority_commitment(
+            &context,
+            category,
+            &typed_authorities[&category],
+        );
+        if commitments.get(name).and_then(Value::as_str) != Some(expected.as_str()) {
+            return Err(format!(
+                "{owner}.{name} differs from its receipt-bound category commitment"
+            ));
+        }
+    }
+    let observed = categories
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let expected = ATTRIBUTION_CATEGORY_NAMES
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    if observed != expected {
+        return Err(format!(
+            "{owner} category inventory differs: observed={observed:?}"
+        ));
+    }
+    for (category, totals) in categories {
+        let fields = totals
+            .as_object()
+            .ok_or_else(|| format!("{owner}.{category} totals are not an object"))?;
+        let observed_fields = fields.keys().map(String::as_str).collect::<BTreeSet<_>>();
+        let expected_fields = ATTRIBUTION_TOTAL_FIELDS
+            .into_iter()
+            .map(|(field, _)| field)
+            .collect::<BTreeSet<_>>();
+        if observed_fields != expected_fields {
+            return Err(format!("{owner}.{category} quantity inventory differs"));
+        }
+        let references = totals["logical_references"]
+            .as_u64()
+            .ok_or_else(|| format!("{owner}.{category} references are absent"))?;
+        let objects = totals["physical_objects"]
+            .as_u64()
+            .ok_or_else(|| format!("{owner}.{category} objects are absent"))?;
+        if objects > references {
+            return Err(format!(
+                "{owner}.{category} physical objects exceed logical references"
+            ));
+        }
+    }
+    for (category_field, owner_field) in ATTRIBUTION_TOTAL_FIELDS {
+        let sum = categories.values().try_fold(0_u64, |sum, category| {
+            sum.checked_add(
+                category[category_field]
+                    .as_u64()
+                    .ok_or_else(|| format!("{owner}.{category_field} is absent"))?,
+            )
+            .ok_or_else(|| format!("{owner}.{category_field} sum overflow"))
+        })?;
+        let reported = owner_value[owner_field]
+            .as_u64()
+            .ok_or_else(|| format!("{owner}.{owner_field} is absent"))?;
+        if sum != reported {
+            return Err(format!(
+                "{owner}.{owner_field} does not reconcile: categories={sum} reported={reported}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+// This validates closed sanitized reconciliation, not provenance. Certification
+// authority is established outside this process by the provider-result digest
+// that binds the exact ordinary evidence bytes.
+fn validate_retained_reconciliation(evidence: &Value) -> Result<(), String> {
+    validate_attribution_owner(evidence, "source")?;
+    validate_attribution_owner(evidence, "clean_import")?;
+    let live_nodes = evidence_u64(evidence, "/source_nodes")?;
+    let live_edges = evidence_u64(evidence, "/source_edges")?;
+    if live_nodes == 0 || live_edges == 0 {
+        return Err("retained evidence has an invalid live-count denominator".into());
+    }
+    for category in ATTRIBUTION_CATEGORY_NAMES {
+        for (field, _) in ATTRIBUTION_TOTAL_FIELDS {
+            let source = evidence_u64(
+                evidence,
+                &format!("/storage/source/categories/{category}/{field}"),
+            )?;
+            let imported = evidence_u64(
+                evidence,
+                &format!("/storage/clean_import/categories/{category}/{field}"),
+            )?;
+            if source != imported {
+                return Err(format!(
+                    "round-trip category {category}.{field} differs between source and import"
+                ));
+            }
+        }
+    }
+    for owner in ["source", "clean_import"] {
+        let node_bytes = evidence_u64(
+            evidence,
+            &format!("/storage/{owner}/categories/topology_nodes/logical_bytes"),
+        )?;
+        let edge_bytes = evidence_u64(
+            evidence,
+            &format!("/storage/{owner}/categories/topology_edges/logical_bytes"),
+        )?;
+        if node_bytes < live_nodes || edge_bytes < live_edges {
+            return Err(format!(
+                "{owner} canonical category bytes are below live-count denominators"
+            ));
+        }
+        let topology_rows = live_nodes
+            .checked_add(live_edges)
+            .ok_or_else(|| "live topology denominator overflow".to_owned())?;
+        for category in ["uuid_and_surrogates", "adjacency"] {
+            let logical_bytes = evidence_u64(
+                evidence,
+                &format!("/storage/{owner}/categories/{category}/logical_bytes"),
+            )?;
+            if logical_bytes < topology_rows {
+                return Err(format!(
+                    "{owner}.{category} is below the topology denominator"
+                ));
+            }
+        }
+    }
+
+    let portable_references =
+        evidence_u64(evidence, "/storage/portable_package/logical_references")?;
+    let portable_objects = evidence_u64(evidence, "/storage/portable_package/physical_objects")?;
+    if portable_references == 0 || portable_references != portable_objects {
+        return Err("portable receipt inventory does not reconcile".into());
+    }
+    let portable_authority = &evidence["storage"]["portable_package"]["category_authority"];
+    for field in [
+        "logical_references",
+        "logical_bytes",
+        "physical_objects",
+        "allocated_bytes",
+    ] {
+        if portable_authority[field] != evidence["storage"]["portable_package"][field] {
+            return Err(format!(
+                "portable {field} differs from writer-owned category authority"
+            ));
+        }
+    }
+    let typed_portable_authority: graphforge_storage::ArtifactStorageTotals =
+        serde_json::from_value(portable_authority.clone())
+            .map_err(|error| format!("portable category authority: {error}"))?;
+    let portable_context: graphforge_storage::ArtifactCategoryAuthorityContext =
+        serde_json::from_value(
+            evidence["storage"]["portable_package"]["category_authority_context"].clone(),
+        )
+        .map_err(|error| format!("portable category authority context: {error}"))?;
+    validate_category_authority_context(&portable_context, "portable_package")?;
+    let expected_portable_commitment = graphforge_storage::artifact_category_authority_commitment(
+        &portable_context,
+        graphforge_storage::ArtifactCategory::PortablePackage,
+        &typed_portable_authority,
+    );
+    if evidence["storage"]["portable_package"]["category_authority_sha256"].as_str()
+        != Some(expected_portable_commitment.as_str())
+    {
+        return Err("portable package differs from writer authority commitment".into());
+    }
+
+    let current = evidence["storage"]["construction"]["storage_current"]
+        .as_object()
+        .ok_or_else(|| "construction current category evidence is absent".to_owned())?;
+    let transient = evidence["storage"]["construction"]["storage_transient_peak_allocated_bytes"]
+        .as_object()
+        .ok_or_else(|| "construction transient category evidence is absent".to_owned())?;
+    let construction_authorities =
+        evidence["storage"]["construction"]["storage_category_authorities"]
+            .as_object()
+            .ok_or_else(|| "construction category authorities are absent".to_owned())?;
+    if current != construction_authorities {
+        return Err("construction categories differ from receipt/identity authorities".into());
+    }
+    let peak_authorities =
+        evidence["storage"]["construction"]["storage_transient_peak_authorities"]
+            .as_object()
+            .ok_or_else(|| "construction peak authorities are absent".to_owned())?;
+    if transient != peak_authorities {
+        return Err("construction peaks differ from receipt authorities".into());
+    }
+    let typed_construction_authorities = exact_category_map(
+        evidence["storage"]["construction"]["storage_category_authorities"].clone(),
+        "construction category authorities",
+    );
+    let typed_peak_authorities: BTreeMap<graphforge_storage::ArtifactCategory, u64> =
+        serde_json::from_value(
+            evidence["storage"]["construction"]["storage_transient_peak_authorities"].clone(),
+        )
+        .map_err(|error| format!("construction peak authorities: {error}"))?;
+    let category_commitments =
+        evidence["storage"]["construction"]["storage_category_authority_sha256"]
+            .as_object()
+            .ok_or_else(|| "construction category commitments are absent".to_owned())?;
+    let peak_commitments =
+        evidence["storage"]["construction"]["storage_transient_peak_authority_sha256"]
+            .as_object()
+            .ok_or_else(|| "construction peak commitments are absent".to_owned())?;
+    let construction_context: graphforge_storage::ArtifactCategoryAuthorityContext =
+        serde_json::from_value(
+            evidence["storage"]["construction"]["storage_category_authority_context"].clone(),
+        )
+        .map_err(|error| format!("construction category authority context: {error}"))?;
+    validate_category_authority_context(&construction_context, "construction")?;
+    for category in graphforge_storage::ArtifactCategory::ALL {
+        let name = category_name(category);
+        let expected_category = graphforge_storage::artifact_category_authority_commitment(
+            &construction_context,
+            category,
+            &typed_construction_authorities[&category],
+        );
+        let expected_peak = graphforge_storage::artifact_category_peak_authority_commitment(
+            &construction_context,
+            category,
+            typed_peak_authorities[&category],
+        );
+        if category_commitments.get(name).and_then(Value::as_str)
+            != Some(expected_category.as_str())
+            || peak_commitments.get(name).and_then(Value::as_str) != Some(expected_peak.as_str())
+        {
+            return Err(format!(
+                "construction.{name} differs from its receipt-bound category commitment"
+            ));
+        }
+    }
+    let known_categories = ATTRIBUTION_CATEGORY_NAMES
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let current_categories = current.keys().map(String::as_str).collect::<BTreeSet<_>>();
+    let transient_categories = transient
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    if current_categories != known_categories || transient_categories != known_categories {
+        return Err("construction current/transient category inventory differs".into());
+    }
+    let mut maximum_current = 0_u64;
+    for category in ATTRIBUTION_CATEGORY_NAMES {
+        let current_totals = &current[category];
+        let fields = current_totals
+            .as_object()
+            .ok_or_else(|| format!("{category} construction totals are not an object"))?;
+        let observed_fields = fields.keys().map(String::as_str).collect::<BTreeSet<_>>();
+        let expected_fields = ATTRIBUTION_TOTAL_FIELDS
+            .into_iter()
+            .map(|(field, _)| field)
+            .collect::<BTreeSet<_>>();
+        if observed_fields != expected_fields {
+            return Err(format!(
+                "{category} construction quantity inventory differs"
+            ));
+        }
+        let current_allocated = current_totals["allocated_bytes"]
+            .as_u64()
+            .ok_or_else(|| format!("{category} construction allocation is absent"))?;
+        let references = current_totals["logical_references"]
+            .as_u64()
+            .ok_or_else(|| format!("{category} construction references are absent"))?;
+        let objects = current_totals["physical_objects"]
+            .as_u64()
+            .ok_or_else(|| format!("{category} construction objects are absent"))?;
+        if objects > references {
+            return Err(format!("{category} construction objects exceed references"));
+        }
+        let category_peak = transient[category]
+            .as_u64()
+            .ok_or_else(|| format!("{category} transient peak is absent"))?;
+        if category_peak < current_allocated {
+            return Err(format!(
+                "{category} transient allocation is below current allocation"
+            ));
+        }
+        maximum_current = maximum_current.max(current_allocated);
+    }
+    let total_peak = evidence_u64(
+        evidence,
+        "/storage/construction/storage_transient_peak_total_allocated_bytes",
+    )?;
+    if total_peak < maximum_current {
+        return Err("construction total peak is below a current category".into());
+    }
+
+    let source_allocated = evidence_u64(evidence, "/storage/source/allocated_bytes")?;
+    let imported_allocated = evidence_u64(evidence, "/storage/clean_import/allocated_bytes")?;
+    let package_allocated = evidence_u64(evidence, "/storage/portable_package/allocated_bytes")?;
+    let source_project = evidence_u64(evidence, "/storage/source_project_current_allocated_bytes")?;
+    if source_project < source_allocated {
+        return Err("source project allocation is below its generation snapshot".into());
+    }
+    let workspace = evidence_u64(evidence, "/storage/workspace_current_allocated_bytes")?;
+    let components = evidence["storage"]["workspace_components"]
+        .as_object()
+        .ok_or_else(|| "workspace component unions are absent".to_owned())?;
+    let expected_components = [
+        "source_project_and_construction",
+        "portable_package",
+        "clean_import_project",
+        "drill_project_and_construction",
+        "drill_package",
+        "corrupt_drill_package",
+    ]
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    if components
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>()
+        != expected_components
+    {
+        return Err("workspace component-union inventory differs".into());
+    }
+    let component_sum = components.values().try_fold(0_u64, |sum, value| {
+        sum.checked_add(
+            value
+                .as_u64()
+                .ok_or_else(|| "workspace component is not an integer".to_owned())?,
+        )
+        .ok_or_else(|| "workspace component sum overflow".to_owned())
+    })?;
+    if component_sum != workspace {
+        return Err("workspace authoritative identity unions do not reconcile".into());
+    }
+    if components["portable_package"].as_u64() != Some(package_allocated) {
+        return Err("portable owner union differs from its writer receipt".into());
+    }
+    if components["source_project_and_construction"]
+        .as_u64()
+        .is_none_or(|value| value < source_project)
+        || components["clean_import_project"]
+            .as_u64()
+            .is_none_or(|value| value < imported_allocated)
+    {
+        return Err("project owner union is below its generation attribution".into());
+    }
+    let workspace_peak = evidence_u64(evidence, "/storage/workspace_peak_allocated_bytes")?;
+    let phase_peak = evidence["phases"]
+        .as_array()
+        .ok_or_else(|| "phase peak evidence is absent".to_owned())?
+        .iter()
+        .map(|phase| phase["disk_peak_bytes"].as_u64())
+        .collect::<Option<Vec<_>>>()
+        .and_then(|values| values.into_iter().max())
+        .ok_or_else(|| "phase disk peak is absent".to_owned())?;
+    if workspace_peak != phase_peak || workspace_peak < workspace {
+        return Err("lifecycle peak does not reconcile to phase peaks/current union".into());
+    }
+    Ok(())
+}
+
+fn validate_axis_denominators(
+    axis: LinearityAxis,
+    observations: &[LifecycleLinearityObservation; 3],
+) -> Result<[u64; 3], String> {
+    let nodes = std::array::from_fn(|index| observations[index].live_nodes);
+    let edges = std::array::from_fn(|index| observations[index].live_edges);
+    if nodes.contains(&0) || edges.contains(&0) {
+        return Err(format!(
+            "{axis:?} has a zero authoritative denominator: nodes={nodes:?} edges={edges:?}"
+        ));
+    }
+    let (varying, controlled, varying_name, controlled_name) = match axis {
+        LinearityAxis::Nodes => (nodes, edges, "nodes", "edges"),
+        LinearityAxis::Edges => (edges, nodes, "edges", "nodes"),
+    };
+    if varying[0] >= varying[1] || varying[1] >= varying[2] {
+        return Err(format!(
+            "{axis:?} {varying_name} denominators are not strictly increasing: {varying:?}"
+        ));
+    }
+    if controlled[0] != controlled[1] || controlled[0] != controlled[2] {
+        return Err(format!(
+            "{axis:?} controlled {controlled_name} axis changed: {controlled:?}"
+        ));
+    }
+    Ok(varying)
+}
+
+fn checked_product(name: &str, factors: &[u128]) -> Result<u128, String> {
+    factors.iter().try_fold(1_u128, |product, factor| {
+        product
+            .checked_mul(*factor)
+            .ok_or_else(|| format!("{name} rational product overflows"))
+    })
+}
+
+fn checked_ceil_div(name: &str, numerator: u64, denominator: u64) -> Result<u64, String> {
+    if denominator == 0 {
+        return Err(format!("{name} has a zero quantization denominator"));
+    }
+    (numerator / denominator)
+        .checked_add(u64::from(numerator % denominator != 0))
+        .ok_or_else(|| format!("{name} ceil division overflows"))
+}
+
+/// Prove `fixed + slope * authoritative_denominator` without rounded ratios.
+///
+/// Cross multiplication compares the two adjacent rational slopes within a
+/// factor of two. The intercept and legacy constant-factor ceiling are also
+/// checked against the actual reopened live-count denominators.
+fn validate_affine_metric(
+    name: &str,
+    values: [u64; 3],
+    denominators: [u64; 3],
+) -> Result<(), String> {
+    let [one, two, four] = values;
+    if one == 0 {
+        return Err(format!(
+            "{name} designated scale-bearing metric is zero at its baseline: {values:?}"
+        ));
+    }
+    let base_denominator = u128::from(denominators[0]);
+    for rung in 1..3 {
+        let observed = checked_product(name, &[u128::from(values[rung]), base_denominator])?;
+        let ceiling = checked_product(name, &[u128::from(one), u128::from(denominators[rung]), 2])?;
+        if observed > ceiling {
+            return Err(format!(
+                "{name} exceeds the denominator-normalized constant-factor ceiling: values={values:?} denominators={denominators:?}"
+            ));
+        }
+    }
+    let d12 = two
+        .checked_sub(one)
+        .filter(|difference| *difference > 0)
+        .ok_or_else(|| format!("{name} has no positive 1x-to-2x growth: {values:?}"))?;
+    let d24 = four
+        .checked_sub(two)
+        .filter(|difference| *difference > 0)
+        .ok_or_else(|| format!("{name} has no positive 2x-to-4x growth: {values:?}"))?;
+    let denominator_12 = denominators[1] - denominators[0];
+    let denominator_24 = denominators[2] - denominators[1];
+    if checked_product(name, &[u128::from(d12), base_denominator])?
+        > checked_product(name, &[u128::from(one), u128::from(denominator_12)])?
+    {
+        return Err(format!(
+            "{name} implies a negative fixed-overhead intercept: values={values:?} denominators={denominators:?}"
+        ));
+    }
+    let first_slope = checked_product(name, &[u128::from(d12), u128::from(denominator_24)])?;
+    let second_slope = checked_product(name, &[u128::from(d24), u128::from(denominator_12)])?;
+    if first_slope > checked_product(name, &[second_slope, 2])?
+        || second_slope > checked_product(name, &[first_slope, 2])?
+    {
+        return Err(format!(
+            "{name} has unstable rational first-difference slopes: values={values:?} denominators={denominators:?}"
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PhaseMetricPolicy {
+    ScaleBearing,
+    NodeBearingBytes,
+    BufferedCalls {
+        byte_field: usize,
+        max_bytes_per_call: u64,
+    },
+    InventoryControlBytes {
+        maximum: u64,
+    },
+    ShapeReadComponentCalls,
+    ShapeWriteComponentCalls,
+    EncodeWriteComponentCalls,
+    AppendObjectInventory,
+    ShapeBlockInventory,
+    CasFsyncInventory,
+    CasReadComponentCalls,
+    CasWriteComponentCalls,
+    EncodeFsyncInventory,
+    HydrationFsyncInventory,
+    StructurallyZero,
+}
+
+#[derive(Clone, Copy)]
+struct PhasePolicyRow {
+    phase: &'static str,
+    fields: [PhaseMetricPolicy; LINEARITY_PHASE_FIELDS.len()],
+}
+
+const ZERO: PhaseMetricPolicy = PhaseMetricPolicy::StructurallyZero;
+const SCALE: PhaseMetricPolicy = PhaseMetricPolicy::ScaleBearing;
+const ENCODING_BUFFER_BYTES: u64 =
+    graphforge_storage::GRAPH_CONSTRUCTION_ENCODING_BUFFER_BYTES as u64;
+const OBJECT_BUFFER_BYTES: u64 = graphforge_storage::GRAPH_OBJECT_IO_BUFFER_BYTES as u64;
+const HYDRATION_BUFFER_BYTES: u64 = graphforge_storage::GRAPH_FILES_IO_BUFFER_BYTES as u64;
+const STAGING_BUFFER_BYTES: u64 = graphforge_storage::STAGE_FILE_BLOCK_BYTES as u64;
+
+// This is deliberately exhaustive: adding a storage phase or counter requires
+// choosing semantics here instead of silently inheriting an affine assertion.
+const PHASE_METRIC_POLICIES: [PhasePolicyRow; 9] = [
+    PhasePolicyRow {
+        phase: "append_merge",
+        fields: [
+            ZERO,
+            SCALE,
+            ZERO,
+            PhaseMetricPolicy::BufferedCalls {
+                byte_field: 1,
+                max_bytes_per_call: STAGING_BUFFER_BYTES,
+            },
+            PhaseMetricPolicy::AppendObjectInventory,
+            ZERO,
+            ZERO,
+        ],
+    },
+    PhasePolicyRow {
+        phase: "seal_authentication",
+        fields: [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO],
+    },
+    PhasePolicyRow {
+        phase: "shape_consume_reauthentication",
+        fields: [
+            SCALE,
+            SCALE,
+            PhaseMetricPolicy::ShapeReadComponentCalls,
+            PhaseMetricPolicy::ShapeWriteComponentCalls,
+            ZERO,
+            PhaseMetricPolicy::ShapeBlockInventory,
+            ZERO,
+        ],
+    },
+    PhasePolicyRow {
+        phase: "encode_write_postwrite_authentication",
+        fields: [
+            SCALE,
+            SCALE,
+            PhaseMetricPolicy::BufferedCalls {
+                byte_field: 0,
+                max_bytes_per_call: ENCODING_BUFFER_BYTES,
+            },
+            PhaseMetricPolicy::EncodeWriteComponentCalls,
+            ZERO,
+            ZERO,
+            PhaseMetricPolicy::EncodeFsyncInventory,
+        ],
+    },
+    PhasePolicyRow {
+        phase: "publication_preauthentication",
+        fields: [
+            PhaseMetricPolicy::InventoryControlBytes {
+                maximum: ENCODING_BUFFER_BYTES,
+            },
+            ZERO,
+            PhaseMetricPolicy::BufferedCalls {
+                byte_field: 0,
+                max_bytes_per_call: ENCODING_BUFFER_BYTES,
+            },
+            ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
+        ],
+    },
+    PhasePolicyRow {
+        phase: "cas_install_read_write",
+        fields: [
+            SCALE,
+            SCALE,
+            PhaseMetricPolicy::CasReadComponentCalls,
+            PhaseMetricPolicy::CasWriteComponentCalls,
+            ZERO,
+            ZERO,
+            PhaseMetricPolicy::CasFsyncInventory,
+        ],
+    },
+    PhasePolicyRow {
+        phase: "hydration_verification",
+        fields: [
+            SCALE,
+            PhaseMetricPolicy::NodeBearingBytes,
+            PhaseMetricPolicy::BufferedCalls {
+                byte_field: 0,
+                max_bytes_per_call: HYDRATION_BUFFER_BYTES,
+            },
+            PhaseMetricPolicy::BufferedCalls {
+                byte_field: 1,
+                max_bytes_per_call: HYDRATION_BUFFER_BYTES,
+            },
+            ZERO,
+            ZERO,
+            PhaseMetricPolicy::HydrationFsyncInventory,
+        ],
+    },
+    PhasePolicyRow {
+        phase: "fsync_synchronization",
+        fields: [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, SCALE],
+    },
+    PhasePolicyRow {
+        phase: "recovery_reauthentication",
+        fields: [
+            SCALE,
+            ZERO,
+            PhaseMetricPolicy::BufferedCalls {
+                byte_field: 0,
+                max_bytes_per_call: ENCODING_BUFFER_BYTES,
+            },
+            ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
+        ],
+    },
+];
+
+fn validate_phase_policy_table(
+    observed: &BTreeMap<String, [u64; LINEARITY_PHASE_FIELDS.len()]>,
+) -> Result<(), String> {
+    let policy_names = PHASE_METRIC_POLICIES
+        .iter()
+        .map(|row| row.phase)
+        .collect::<BTreeSet<_>>();
+    let observed_names = observed.keys().map(String::as_str).collect::<BTreeSet<_>>();
+    if policy_names.len() != PHASE_METRIC_POLICIES.len() || policy_names != observed_names {
+        return Err(format!(
+            "phase policy inventory differs from evidence: policy={policy_names:?} observed={observed_names:?}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_fixed_protocol_metric(
+    name: &str,
+    values: [u64; 3],
+    minimum: u64,
+    maximum: u64,
+) -> Result<(), String> {
+    if minimum == 0 || minimum > maximum {
+        return Err(format!("{name} has an invalid fixed-protocol policy"));
+    }
+    if values.windows(2).any(|pair| pair[1] < pair[0]) {
+        return Err(format!("{name} fixed protocol count decreased: {values:?}"));
+    }
+    if values
+        .iter()
+        .any(|value| !(minimum..=maximum).contains(value))
+    {
+        return Err(format!(
+            "{name} is outside fixed protocol bounds {minimum}..={maximum}: {values:?}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_buffered_calls(
+    name: &str,
+    calls: [u64; 3],
+    bytes: [u64; 3],
+    max_bytes_per_call: u64,
+) -> Result<(), String> {
+    if calls.windows(2).any(|pair| pair[1] < pair[0]) {
+        return Err(format!("{name} buffered calls decreased: {calls:?}"));
+    }
+    for (rung, (calls, bytes)) in calls.into_iter().zip(bytes).enumerate() {
+        if bytes == 0 || calls == 0 {
+            return Err(format!("{name} rung {rung} lacks paired buffered evidence"));
+        }
+        let minimum_calls = checked_ceil_div(name, bytes, max_bytes_per_call)?;
+        if calls < minimum_calls || calls > bytes {
+            return Err(format!(
+                "{name} rung {rung} violates buffered bounds {minimum_calls}..={bytes}: calls={calls}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_shape_block_inventory(
+    name: &str,
+    observed: u64,
+    observation: &LifecycleLinearityObservation,
+    rung: usize,
+) -> Result<(), String> {
+    let expected = observation
+        .shape_block_components
+        .into_iter()
+        .try_fold(0_u64, u64::checked_add)
+        .ok_or_else(|| format!("{name} native component sum overflows at rung {rung}"))?;
+    if observed != expected {
+        return Err(format!(
+            "{name} does not reconcile to merge_read_blocks + merge_write_blocks at rung {rung}: observed={observed} expected={expected}"
+        ));
+    }
+    for (direction, blocks, bytes) in [
+        (
+            "read",
+            observation.shape_block_components[0],
+            observation.shape_merge_bytes[0],
+        ),
+        (
+            "write",
+            observation.shape_block_components[1],
+            observation.shape_merge_bytes[1],
+        ),
+    ] {
+        if bytes == 0 {
+            if blocks != 0 {
+                return Err(format!(
+                    "{name} {direction} blocks lack merge bytes at rung {rung}"
+                ));
+            }
+            continue;
+        }
+        // Production accumulates ceil(artifact_bytes / block_bytes) for every
+        // authenticated artifact. Therefore ceil(total_bytes / block_bytes) is
+        // a strict lower bound, while one-byte blocks are the fail-closed upper
+        // bound without exposing per-artifact sizes.
+        let minimum = checked_ceil_div(name, bytes, STAGING_BUFFER_BYTES)?;
+        if blocks < minimum || blocks > bytes {
+            return Err(format!(
+                "{name} {direction} component violates per-artifact ceiling bounds {minimum}..={bytes} at rung {rung}: blocks={blocks}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_quantized_allocation(
+    name: &str,
+    values: [u64; 3],
+    denominators: [u64; 3],
+) -> Result<(), String> {
+    if values[0] == 0 || values.windows(2).any(|pair| pair[1] < pair[0]) {
+        return Err(format!(
+            "{name} filesystem-quantized allocation is missing or decreasing: {values:?}"
+        ));
+    }
+    validate_positive_normalized_ceiling(name, values, denominators)
+}
+
+fn validate_positive_normalized_ceiling(
+    name: &str,
+    values: [u64; 3],
+    denominators: [u64; 3],
+) -> Result<(), String> {
+    if values.contains(&0) || denominators.contains(&0) {
+        return Err(format!("{name} lacks positive values/denominators"));
+    }
+    for rung in 1..3 {
+        let observed = checked_product(
+            name,
+            &[u128::from(values[rung]), u128::from(denominators[0])],
+        )?;
+        let ceiling = checked_product(
+            name,
+            &[u128::from(values[0]), u128::from(denominators[rung]), 2],
+        )?;
+        if observed > ceiling {
+            return Err(format!(
+                "{name} exceeds its denominator ceiling: values={values:?} denominators={denominators:?}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum CategoryBehavior {
+    NodeBearing,
+    EdgeBearing,
+    Mixed,
+    FixedInventory,
+    StructurallyZero,
+}
+
+fn category_behavior(category: &str) -> Result<CategoryBehavior, String> {
+    match category {
+        "topology_nodes" => Ok(CategoryBehavior::NodeBearing),
+        // The controlled fixture adds isolated nodes on its node axis. Sparse
+        // CSR shards do not append trailing rows without edges; its adjacency
+        // payload therefore grows on the edge axis. This is fixture-specific.
+        "topology_edges" | "adjacency" => Ok(CategoryBehavior::EdgeBearing),
+        "uuid_and_surrogates" => Ok(CategoryBehavior::Mixed),
+        "catalog_and_manifests" => Ok(CategoryBehavior::FixedInventory),
+        "properties"
+        | "construction_staging"
+        | "portable_package"
+        | "clean_imported_project"
+        | "other" => Ok(CategoryBehavior::StructurallyZero),
+        _ => Err(format!("unclassified storage category {category}")),
+    }
+}
+
+fn validate_category_taxonomy(
+    axis: LinearityAxis,
+    observations: &[LifecycleLinearityObservation; 3],
+    denominators: [u64; 3],
+) -> Result<(), String> {
+    let expected = ["source", "clean_import", "construction"]
+        .into_iter()
+        .flat_map(|owner| {
+            ATTRIBUTION_CATEGORY_NAMES
+                .into_iter()
+                .map(move |category| format!("{owner}.{category}"))
+        })
+        .collect::<BTreeSet<_>>();
+    for observation in observations {
+        if observation.category_metrics != observation.category_authority_metrics {
+            return Err("retained category totals differ from storage-owned authorities".into());
+        }
+        let observed = observation
+            .category_metrics
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if observed != expected {
+            return Err("retained category/quantity inventory differs from policy".into());
+        }
+        for category in ATTRIBUTION_CATEGORY_NAMES {
+            if observation.category_metrics[&format!("source.{category}")]
+                != observation.category_metrics[&format!("clean_import.{category}")]
+            {
+                return Err(format!(
+                    "source/import category {category} does not reconcile field-for-field"
+                ));
+            }
+        }
+    }
+
+    for owner in ["source", "clean_import"] {
+        for category in ATTRIBUTION_CATEGORY_NAMES {
+            let behavior = category_behavior(category)?;
+            let key = format!("{owner}.{category}");
+            for field in 0..6 {
+                let values =
+                    std::array::from_fn(|rung| observations[rung].category_metrics[&key][field]);
+                let name = format!("{key}.field_{field}");
+                match (behavior, field) {
+                    (CategoryBehavior::StructurallyZero, _) if values == [0, 0, 0] => {}
+                    (CategoryBehavior::StructurallyZero, _) => {
+                        return Err(format!("{name} must be structurally zero: {values:?}"));
+                    }
+                    (CategoryBehavior::FixedInventory, 1 | 3) => {
+                        // Catalog shape/object count is fixed; textual numeric
+                        // lengths in its JSON manifests can gain digits.
+                        validate_positive_normalized_ceiling(&name, values, denominators)?;
+                    }
+                    (CategoryBehavior::FixedInventory, 4 | 5) => {
+                        validate_quantized_allocation(&name, values, denominators)?;
+                    }
+                    (_, 0 | 2)
+                        if values[0] > 0 && values[0] == values[1] && values[0] == values[2] => {}
+                    (_, 0 | 2) => {
+                        return Err(format!("{name} object inventory changed: {values:?}"));
+                    }
+                    (CategoryBehavior::NodeBearing, 1 | 3)
+                        if matches!(axis, LinearityAxis::Nodes) =>
+                    {
+                        validate_affine_metric(&name, values, denominators)?;
+                    }
+                    (CategoryBehavior::EdgeBearing, 1 | 3)
+                        if matches!(axis, LinearityAxis::Edges) =>
+                    {
+                        validate_affine_metric(&name, values, denominators)?;
+                    }
+                    (CategoryBehavior::Mixed, 1 | 3) => {
+                        validate_affine_metric(&name, values, denominators)?;
+                    }
+                    (CategoryBehavior::NodeBearing, 4 | 5)
+                        if matches!(axis, LinearityAxis::Nodes) =>
+                    {
+                        validate_quantized_allocation(&name, values, denominators)?;
+                    }
+                    (CategoryBehavior::EdgeBearing, 4 | 5)
+                        if matches!(axis, LinearityAxis::Edges) =>
+                    {
+                        validate_quantized_allocation(&name, values, denominators)?;
+                    }
+                    (CategoryBehavior::Mixed, 4 | 5) => {
+                        validate_quantized_allocation(&name, values, denominators)?;
+                    }
+                    (_, 1 | 3 | 4 | 5) if values[0] == values[1] && values[0] == values[2] => {}
+                    _ => {
+                        return Err(format!("{name} changed on its controlled axis: {values:?}"));
                     }
                 }
             }
-        } else {
-            baseline = Some(observations);
         }
-        let interrupted = evidence["phases"]
-            .as_array()
-            .expect("lifecycle phases")
-            .iter()
-            .find(|phase| phase["id"] == "drill_interrupted_finalization")
-            .expect("interrupted-finalization recovery drill");
-        assert_eq!(interrupted["status"], "pass");
     }
+
+    let staging_key = "construction.construction_staging";
+    for field in 0..6 {
+        let values =
+            std::array::from_fn(|rung| observations[rung].category_metrics[staging_key][field]);
+        if field < 4 {
+            validate_affine_metric(
+                &format!("{staging_key}.field_{field}"),
+                values,
+                denominators,
+            )?;
+        } else {
+            validate_quantized_allocation(
+                &format!("{staging_key}.field_{field}"),
+                values,
+                denominators,
+            )?;
+        }
+    }
+    for category in ATTRIBUTION_CATEGORY_NAMES {
+        if category == "construction_staging" {
+            continue;
+        }
+        let key = format!("construction.{category}");
+        for rung in observations {
+            if rung.category_metrics[&key] != [0; 6] {
+                return Err(format!("{key} must be structurally zero"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn checked_category_sum(
+    observation: &LifecycleLinearityObservation,
+    prefix: &str,
+    field: usize,
+) -> Result<u64, String> {
+    observation
+        .category_metrics
+        .iter()
+        .filter(|(key, _)| key.starts_with(prefix))
+        .try_fold(0_u64, |total, (_, fields)| {
+            total
+                .checked_add(fields[field])
+                .ok_or_else(|| format!("{prefix} category inventory overflows"))
+        })
+}
+
+fn validate_fresh_cas_control_bound(
+    observation: &LifecycleLinearityObservation,
+) -> Result<(), String> {
+    let io = &observation.cas_publication_io;
+    let paths = observation.canonical_artifact_objects;
+    if io.publications != 1 || io.initial_entries != 0 || io.changed_paths != paths {
+        return Err("CAS growth proof requires one fresh publication with every changed path in the canonical inventory".into());
+    }
+    // A radix update consumes at least one of 64 nibbles per recursive branch.
+    // A split installs at most three nodes; a collapse can load one extra child.
+    // The fresh empty root adds one install before the P updates.
+    let installs = paths
+        .checked_mul(67)
+        .and_then(|value| value.checked_add(1))
+        .ok_or("CAS manifest install bound overflows")?;
+    let reads = paths
+        .checked_mul(130)
+        .ok_or("CAS manifest read bound overflows")?;
+    let inventory_bytes = observation.phases["publication_preauthentication"][0];
+    // Encoding inventory contains each path, byte length and digest verbatim.
+    // Manifest entries add at most 43 bytes of keys/role; the 1319-byte maximal
+    // branch also bounds the leaf header. Storage tests verify both constants
+    // with maximal branches, every role, escaped paths and u64 byte lengths.
+    let node_bytes = paths
+        .checked_mul(graphforge_storage::GRAPH_MANIFEST_ENTRY_ENCODING_OVERHEAD_BYTES)
+        .and_then(|value| value.checked_add(inventory_bytes))
+        .and_then(|value| value.checked_add(graphforge_storage::GRAPH_MANIFEST_BRANCH_MAX_BYTES))
+        .ok_or("CAS manifest encoded-node bound overflows")?;
+    let requests = io
+        .manifest
+        .installed_objects
+        .checked_add(io.manifest.reused_objects)
+        .ok_or("CAS manifest request count overflows")?;
+    let minimum_requests = paths
+        .checked_add(1)
+        .ok_or("CAS minimum request bound overflows")?;
+    if requests < minimum_requests
+        || io.manifest.read_calls < requests
+        || io.manifest_reads.read_calls < paths
+    {
+        return Err("CAS manifest work is below mandatory bootstrap/update authentication".into());
+    }
+    let install_bytes = installs
+        .checked_mul(node_bytes)
+        .ok_or("CAS manifest install-byte bound overflows")?;
+    let path_bytes = reads
+        .checked_mul(node_bytes)
+        .ok_or("CAS manifest path-byte bound overflows")?;
+    if requests > installs
+        || io.manifest.read_bytes > install_bytes
+        || io.manifest.write_bytes > install_bytes
+        || io.manifest.installed_bytes > io.manifest.write_bytes
+        || io.manifest.write_calls != io.manifest.install_attempts
+        || io.manifest_reads.read_bytes > path_bytes
+    {
+        return Err("CAS manifest work exceeds native path/object/encoded-inventory bounds".into());
+    }
+    for component in [&io.manifest, &io.manifest_reads] {
+        // Read may legally return fewer bytes than requested. Keep the physical
+        // nonempty-read bounds instead of inventing one syscall per node.
+        if component.read_calls < component.read_bytes.div_ceil(OBJECT_BUFFER_BYTES)
+            || component.read_calls > component.read_bytes
+        {
+            return Err("CAS manifest reads violate native buffer bounds".into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_lifecycle_metric_policies_for_axis(
+    axis: LinearityAxis,
+    observations: &[LifecycleLinearityObservation; 3],
+) -> Result<(), String> {
+    let baseline = &observations[0];
+    let denominators = validate_axis_denominators(axis, observations)?;
+    validate_phase_policy_table(&baseline.phases)?;
+    for observation in &observations[1..] {
+        if observation.phases.keys().ne(baseline.phases.keys()) {
+            return Err("application-I/O phase inventories differ between rungs".into());
+        }
+        if observation.retained.keys().ne(baseline.retained.keys()) {
+            return Err("retained-output metric inventories differ between rungs".into());
+        }
+    }
+    for (rung, observation) in observations.iter().enumerate() {
+        let append_write_bytes = observation.phases["append_merge"][1];
+        if append_write_bytes < observation.input_rows {
+            return Err(format!(
+                "append bytes are below accepted row count at rung {rung}"
+            ));
+        }
+        for (metric, denominator) in [
+            (
+                "source.canonical_nodes.logical_bytes",
+                observation.live_nodes,
+            ),
+            (
+                "clean_import.canonical_nodes.logical_bytes",
+                observation.live_nodes,
+            ),
+            (
+                "source.canonical_edges.logical_bytes",
+                observation.live_edges,
+            ),
+            (
+                "clean_import.canonical_edges.logical_bytes",
+                observation.live_edges,
+            ),
+        ] {
+            if observation.retained[metric] < denominator {
+                return Err(format!(
+                    "{metric} is below its authoritative live-count denominator at rung {rung}"
+                ));
+            }
+        }
+        let topology_rows = observation
+            .live_nodes
+            .checked_add(observation.live_edges)
+            .ok_or_else(|| "live topology denominator overflow".to_owned())?;
+        for owner in ["source", "clean_import"] {
+            for category in ["uuid_and_surrogates", "adjacency"] {
+                let key = format!("{owner}.{category}");
+                if observation.category_metrics[&key][1] < topology_rows {
+                    return Err(format!(
+                        "{key} logical bytes are below the authoritative topology-row denominator at rung {rung}"
+                    ));
+                }
+            }
+        }
+    }
+    for policy_row in PHASE_METRIC_POLICIES {
+        let phase = policy_row.phase;
+        for (index, (field, policy)) in LINEARITY_PHASE_FIELDS
+            .iter()
+            .zip(policy_row.fields)
+            .enumerate()
+        {
+            let name = format!("{phase}.{field}");
+            let values = [
+                baseline.phases[phase][index],
+                observations[1].phases[phase][index],
+                observations[2].phases[phase][index],
+            ];
+            match policy {
+                PhaseMetricPolicy::ScaleBearing => {
+                    validate_affine_metric(&name, values, denominators)?;
+                }
+                PhaseMetricPolicy::NodeBearingBytes => {
+                    // Only private ordinal-V4 files are copied during this
+                    // fresh hydration; other immutable objects are hardlinked.
+                    // The controlled edge axis retains the identical node map.
+                    if matches!(axis, LinearityAxis::Nodes) {
+                        validate_affine_metric(&name, values, denominators)?;
+                    } else {
+                        validate_fixed_protocol_metric(&name, values, values[0], values[0])?;
+                    }
+                }
+                PhaseMetricPolicy::BufferedCalls {
+                    byte_field,
+                    max_bytes_per_call,
+                } => {
+                    validate_buffered_calls(
+                        &name,
+                        values,
+                        [
+                            baseline.phases[phase][byte_field],
+                            observations[1].phases[phase][byte_field],
+                            observations[2].phases[phase][byte_field],
+                        ],
+                        max_bytes_per_call,
+                    )?;
+                }
+                PhaseMetricPolicy::InventoryControlBytes { maximum } => {
+                    if values[0] == 0
+                        || values.windows(2).any(|pair| pair[1] < pair[0])
+                        || values.iter().any(|value| *value > maximum)
+                    {
+                        return Err(format!(
+                            "{name} inventory-control bytes violate 1..={maximum}: {values:?}"
+                        ));
+                    }
+                }
+                PhaseMetricPolicy::ShapeReadComponentCalls
+                | PhaseMetricPolicy::ShapeWriteComponentCalls
+                | PhaseMetricPolicy::EncodeWriteComponentCalls => {
+                    for (rung, observation) in observations.iter().enumerate() {
+                        let components: &[u64] = match policy {
+                            PhaseMetricPolicy::ShapeReadComponentCalls => {
+                                &observation.shape_read_component_calls
+                            }
+                            PhaseMetricPolicy::ShapeWriteComponentCalls => {
+                                &observation.shape_write_component_calls
+                            }
+                            PhaseMetricPolicy::EncodeWriteComponentCalls => {
+                                &observation.encode_write_component_calls
+                            }
+                            _ => unreachable!("matched component policy"),
+                        };
+                        let expected = components.iter().try_fold(0_u64, |total, value| {
+                            total
+                                .checked_add(*value)
+                                .ok_or_else(|| format!("{name} component sum overflows"))
+                        })?;
+                        if expected == 0 || values[rung] != expected {
+                            return Err(format!(
+                                "{name} does not reconcile to native component calls at rung {rung}"
+                            ));
+                        }
+                    }
+                }
+                PhaseMetricPolicy::AppendObjectInventory => {
+                    validate_affine_metric(&name, values, denominators)?;
+                    for (rung, observation) in observations.iter().enumerate() {
+                        if values[rung] != observation.append_objects {
+                            return Err(format!(
+                                "{name} does not reconcile to append inventory at rung {rung}"
+                            ));
+                        }
+                    }
+                }
+                PhaseMetricPolicy::ShapeBlockInventory => {
+                    for (rung, observation) in observations.iter().enumerate() {
+                        validate_shape_block_inventory(&name, values[rung], observation, rung)?;
+                    }
+                }
+                PhaseMetricPolicy::CasReadComponentCalls
+                | PhaseMetricPolicy::CasWriteComponentCalls => {
+                    let read = policy == PhaseMetricPolicy::CasReadComponentCalls;
+                    let payload_calls = observations.each_ref().map(|observation| {
+                        let payload = &observation.cas_publication_io.payload;
+                        if read {
+                            payload.read_calls
+                        } else {
+                            payload.write_calls
+                        }
+                    });
+                    let payload_bytes = observations.each_ref().map(|observation| {
+                        let payload = &observation.cas_publication_io.payload;
+                        if read {
+                            payload.read_bytes
+                        } else {
+                            payload.write_bytes
+                        }
+                    });
+                    validate_buffered_calls(
+                        &format!("{name}.payload"),
+                        payload_calls,
+                        payload_bytes,
+                        OBJECT_BUFFER_BYTES,
+                    )?;
+                    for observation in observations {
+                        validate_fresh_cas_control_bound(observation)?;
+                    }
+                }
+                PhaseMetricPolicy::CasFsyncInventory => {
+                    for (rung, observation) in observations.iter().enumerate() {
+                        let components = &observation.cas_publication_io;
+                        let totals = components.totals().map_err(|error| error.to_string())?;
+                        let expected = totals
+                            .file_fsync_calls
+                            .checked_add(totals.directory_fsync_calls)
+                            .ok_or_else(|| format!("{name} component sum overflows"))?;
+                        let expected_phase = [
+                            totals.read_bytes,
+                            totals.write_bytes,
+                            totals.read_calls,
+                            totals.write_calls,
+                            0,
+                            0,
+                            expected,
+                        ];
+                        if observation.phases["cas_install_read_write"] != expected_phase {
+                            return Err(format!(
+                                "{name} native CAS components do not reconcile at rung {rung}"
+                            ));
+                        }
+                        let requests = components
+                            .payload
+                            .installed_objects
+                            .checked_add(components.payload.reused_objects)
+                            .ok_or_else(|| format!("{name} payload inventory overflows"))?;
+                        if requests != observation.canonical_artifact_objects {
+                            return Err(format!(
+                                "{name} payload requests differ from canonical inventory at rung {rung}"
+                            ));
+                        }
+                        for (kind, component) in [
+                            ("payload", &components.payload),
+                            ("manifest", &components.manifest),
+                        ] {
+                            let requests = component
+                                .installed_objects
+                                .checked_add(component.reused_objects)
+                                .ok_or_else(|| format!("{name} object request total overflows"))?;
+                            if component.install_attempts < component.installed_objects
+                                || component.install_attempts > requests
+                                || component.install_attempts.checked_mul(2)
+                                    != Some(component.directory_fsync_calls)
+                                || component.file_fsync_calls < component.install_attempts
+                                || (kind == "manifest"
+                                    && component.file_fsync_calls != component.install_attempts)
+                            {
+                                return Err(format!(
+                                    "{name} {kind} durability components differ at rung {rung}"
+                                ));
+                            }
+                        }
+                        let reads = &components.manifest_reads;
+                        if reads.write_bytes != 0
+                            || reads.write_calls != 0
+                            || reads.file_fsync_calls != 0
+                            || reads.directory_fsync_calls != 0
+                            || reads.installed_objects != 0
+                            || reads.install_attempts != 0
+                            || reads.reused_objects != 0
+                            || reads.installed_bytes != 0
+                        {
+                            return Err(format!(
+                                "{name} path authentication reports non-read work at rung {rung}"
+                            ));
+                        }
+                    }
+                }
+                PhaseMetricPolicy::EncodeFsyncInventory => {
+                    for (rung, observation) in observations.iter().enumerate() {
+                        let expected = observation
+                            .encode_fsync_components
+                            .into_iter()
+                            .try_fold(0_u64, |total, value| total.checked_add(value))
+                            .ok_or_else(|| format!("{name} component sum overflows"))?;
+                        if values[rung] != expected {
+                            return Err(format!(
+                                "{name} does not reconcile output/spool/membership/ordinal barriers at rung {rung}"
+                            ));
+                        }
+                    }
+                }
+                PhaseMetricPolicy::HydrationFsyncInventory => {
+                    for (rung, observation) in observations.iter().enumerate() {
+                        let expected = observation
+                            .hydration_file_fsync_operations
+                            .checked_add(observation.hydration_directory_fsync_operations)
+                            .ok_or_else(|| format!("{name} protocol bound overflow"))?;
+                        if observation.hydration_files_copied == 0
+                            || expected == 0
+                            || values[rung] != expected
+                        {
+                            return Err(format!(
+                                "{name} does not reconcile file plus directory barriers at rung {rung}"
+                            ));
+                        }
+                    }
+                }
+                PhaseMetricPolicy::StructurallyZero if values == [0, 0, 0] => {}
+                PhaseMetricPolicy::StructurallyZero => {
+                    return Err(format!("{name} must remain structurally zero: {values:?}"));
+                }
+            }
+        }
+    }
+    let retained_policy_names = LINEARITY_RETAINED_FIELDS
+        .iter()
+        .map(|(name, _, _)| *name)
+        .collect::<BTreeSet<_>>();
+    let retained_names = baseline
+        .retained
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    if retained_policy_names != retained_names {
+        return Err("retained-output policy inventory differs from evidence".into());
+    }
+    for (name, _, policy) in LINEARITY_RETAINED_FIELDS {
+        let values = [
+            baseline.retained[name],
+            observations[1].retained[name],
+            observations[2].retained[name],
+        ];
+        match policy {
+            RetainedMetricPolicy::ScaleBearing => {
+                validate_affine_metric(name, values, denominators)?;
+            }
+            RetainedMetricPolicy::FilesystemQuantized => {
+                validate_quantized_allocation(name, values, denominators)?;
+            }
+            RetainedMetricPolicy::NodeBearing if matches!(axis, LinearityAxis::Nodes) => {
+                validate_affine_metric(name, values, denominators)?;
+            }
+            RetainedMetricPolicy::EdgeBearing if matches!(axis, LinearityAxis::Edges) => {
+                validate_affine_metric(name, values, denominators)?;
+            }
+            RetainedMetricPolicy::NodeFilesystemQuantized
+                if matches!(axis, LinearityAxis::Nodes) =>
+            {
+                validate_quantized_allocation(name, values, denominators)?;
+            }
+            RetainedMetricPolicy::EdgeFilesystemQuantized
+                if matches!(axis, LinearityAxis::Edges) =>
+            {
+                validate_quantized_allocation(name, values, denominators)?;
+            }
+            RetainedMetricPolicy::InventoryDerived => {
+                for (rung, observation) in observations.iter().enumerate() {
+                    let expected = match name {
+                        "source.logical_references" => {
+                            checked_category_sum(observation, "source.", 0)?
+                        }
+                        "source.physical_objects" => {
+                            checked_category_sum(observation, "source.", 2)?
+                        }
+                        "clean_import.logical_references" => {
+                            checked_category_sum(observation, "clean_import.", 0)?
+                        }
+                        "clean_import.physical_objects" => {
+                            checked_category_sum(observation, "clean_import.", 2)?
+                        }
+                        "portable_package.logical_references"
+                        | "portable_package.physical_objects" => 1,
+                        _ => return Err(format!("unclassified retained inventory {name}")),
+                    };
+                    if values[rung] != expected {
+                        return Err(format!(
+                            "{name} does not reconcile to authoritative inventory at rung {rung}"
+                        ));
+                    }
+                }
+            }
+            RetainedMetricPolicy::NodeBearing
+            | RetainedMetricPolicy::EdgeBearing
+            | RetainedMetricPolicy::NodeFilesystemQuantized
+            | RetainedMetricPolicy::EdgeFilesystemQuantized => {
+                validate_fixed_protocol_metric(name, values, values[0], values[0])?;
+            }
+        }
+    }
+    validate_category_taxonomy(axis, observations, denominators)?;
+    let expected_phase_peaks = CERTIFICATION_PHASES.into_iter().collect::<BTreeSet<_>>();
+    for observation in observations {
+        let observed = observation
+            .phase_disk_peaks
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        if observed != expected_phase_peaks {
+            return Err("lifecycle phase disk-peak inventory differs".into());
+        }
+    }
+    for phase in CERTIFICATION_PHASES {
+        let values = std::array::from_fn(|rung| observations[rung].phase_disk_peaks[phase]);
+        if values != [0, 0, 0] {
+            validate_quantized_allocation(
+                &format!("{phase}.disk_peak_bytes"),
+                values,
+                denominators,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_lifecycle_metric_policies(
+    observations: &[LifecycleLinearityObservation; 3],
+) -> Result<(), String> {
+    validate_lifecycle_metric_policies_for_axis(LinearityAxis::Nodes, observations)
+}
+
+fn synthetic_category_metrics(axis: LinearityAxis, factor: u64) -> BTreeMap<String, [u64; 6]> {
+    let mut metrics = BTreeMap::new();
+    for owner in ["source", "clean_import"] {
+        for category in ATTRIBUTION_CATEGORY_NAMES {
+            let bearing = match category_behavior(category).unwrap() {
+                CategoryBehavior::NodeBearing => matches!(axis, LinearityAxis::Nodes),
+                CategoryBehavior::EdgeBearing => matches!(axis, LinearityAxis::Edges),
+                CategoryBehavior::Mixed => true,
+                CategoryBehavior::FixedInventory => false,
+                CategoryBehavior::StructurallyZero => {
+                    metrics.insert(format!("{owner}.{category}"), [0; 6]);
+                    continue;
+                }
+            };
+            let scale = if bearing { factor } else { 1 };
+            metrics.insert(
+                format!("{owner}.{category}"),
+                [
+                    1,
+                    100 + 900 * scale,
+                    1,
+                    100 + 900 * scale,
+                    4096 * scale,
+                    4096 * scale,
+                ],
+            );
+        }
+    }
+    for category in ATTRIBUTION_CATEGORY_NAMES {
+        metrics.insert(format!("construction.{category}"), [0; 6]);
+    }
+    metrics.insert(
+        "construction.construction_staging".into(),
+        [
+            6 + 2 * factor,
+            100 + 900 * factor,
+            6 + 2 * factor,
+            100 + 900 * factor,
+            4096 * factor,
+            8192 * factor,
+        ],
+    );
+    metrics
+}
+
+fn synthetic_linearity_observations_for_axis(
+    axis: LinearityAxis,
+) -> [LifecycleLinearityObservation; 3] {
+    [1_u64, 2, 4].map(|factor| {
+        let append_objects = 6 + 2 * factor;
+        let (live_nodes, live_edges) = match axis {
+            LinearityAxis::Nodes => (100 * factor, 80),
+            LinearityAxis::Edges => (100, 70 * factor),
+        };
+        LifecycleLinearityObservation {
+            phases: BTreeMap::from([
+                (
+                    "append_merge".into(),
+                    [0, 100 + 800 * factor, 0, factor, append_objects, 0, 0],
+                ),
+                ("seal_authentication".into(), [0, 0, 0, 0, 0, 0, 0]),
+                (
+                    "shape_consume_reauthentication".into(),
+                    [
+                        100 + 900 * factor,
+                        100 + 800 * factor,
+                        factor,
+                        factor,
+                        0,
+                        6 + 2 * factor,
+                        0,
+                    ],
+                ),
+                (
+                    "encode_write_postwrite_authentication".into(),
+                    [
+                        100 + 900 * factor,
+                        100 + 800 * factor,
+                        807,
+                        factor,
+                        0,
+                        0,
+                        43,
+                    ],
+                ),
+                (
+                    "publication_preauthentication".into(),
+                    [512, 0, 1, 0, 0, 0, 0],
+                ),
+                (
+                    "cas_install_read_write".into(),
+                    [
+                        119 + 900 * factor,
+                        100 + 800 * factor,
+                        19 * factor + 39,
+                        19 * factor + 1,
+                        0,
+                        0,
+                        60,
+                    ],
+                ),
+                (
+                    "hydration_verification".into(),
+                    [
+                        100 + 900 * factor,
+                        if matches!(axis, LinearityAxis::Nodes) {
+                            100 + 800 * factor
+                        } else {
+                            900
+                        },
+                        factor,
+                        factor,
+                        0,
+                        0,
+                        38,
+                    ],
+                ),
+                (
+                    "fsync_synchronization".into(),
+                    [0, 0, 0, 0, 0, 0, 2 * factor],
+                ),
+                (
+                    "recovery_reauthentication".into(),
+                    [100 + 900 * factor, 0, factor, 0, 0, 0, 0],
+                ),
+            ]),
+            retained: LINEARITY_RETAINED_FIELDS
+                .iter()
+                .map(|(name, _, policy)| {
+                    let value = match policy {
+                        RetainedMetricPolicy::ScaleBearing => 100 + 900 * factor,
+                        RetainedMetricPolicy::FilesystemQuantized => 4096 * factor,
+                        RetainedMetricPolicy::InventoryDerived => {
+                            if name.starts_with("portable_package") {
+                                1
+                            } else {
+                                5
+                            }
+                        }
+                        RetainedMetricPolicy::NodeBearing => {
+                            if matches!(axis, LinearityAxis::Nodes) {
+                                100 + 900 * factor
+                            } else {
+                                900
+                            }
+                        }
+                        RetainedMetricPolicy::EdgeBearing => {
+                            if matches!(axis, LinearityAxis::Edges) {
+                                100 + 900 * factor
+                            } else {
+                                900
+                            }
+                        }
+                        RetainedMetricPolicy::NodeFilesystemQuantized => {
+                            if matches!(axis, LinearityAxis::Nodes) {
+                                4096 * factor
+                            } else {
+                                4096
+                            }
+                        }
+                        RetainedMetricPolicy::EdgeFilesystemQuantized => {
+                            if matches!(axis, LinearityAxis::Edges) {
+                                4096 * factor
+                            } else {
+                                4096
+                            }
+                        }
+                    };
+                    ((*name).to_owned(), value)
+                })
+                .collect(),
+            append_objects,
+            input_rows: live_nodes + live_edges,
+            live_nodes,
+            live_edges,
+            shape_merge_bytes: [100 + 900 * factor, 100 + 800 * factor],
+            shape_block_components: [3 + factor, 3 + factor],
+            canonical_artifact_objects: 19,
+            cas_publication_io: graphforge_storage::GraphPublicationIo {
+                publications: 1,
+                initial_entries: 0,
+                changed_paths: 19,
+                payload: graphforge_storage::GraphObjectIoTotals {
+                    read_bytes: 900 * factor,
+                    read_calls: 19 * factor,
+                    write_bytes: 800 * factor,
+                    write_calls: 19 * factor,
+                    file_fsync_calls: 19,
+                    directory_fsync_calls: 38,
+                    installed_objects: 19,
+                    install_attempts: 19,
+                    installed_bytes: 800 * factor,
+                    ..Default::default()
+                },
+                manifest: graphforge_storage::GraphObjectIoTotals {
+                    read_bytes: 100,
+                    read_calls: 20,
+                    reused_objects: 19,
+                    write_bytes: 100,
+                    write_calls: 1,
+                    file_fsync_calls: 1,
+                    directory_fsync_calls: 2,
+                    installed_objects: 1,
+                    install_attempts: 1,
+                    installed_bytes: 100,
+                    ..Default::default()
+                },
+                manifest_reads: graphforge_storage::GraphObjectIoTotals {
+                    read_bytes: 19,
+                    read_calls: 19,
+                    ..Default::default()
+                },
+            },
+            encode_fsync_components: [10, 5, 8, 20],
+            hydration_files_copied: 19,
+            hydration_file_fsync_operations: 19,
+            hydration_directory_fsync_operations: 19,
+            shape_read_component_calls: [factor, 0, 0, 0, 0, 0],
+            shape_write_component_calls: [factor, 0],
+            encode_write_component_calls: [factor, 0, 0, 0, 0],
+            category_metrics: synthetic_category_metrics(axis, factor),
+            category_authority_metrics: synthetic_category_metrics(axis, factor),
+            phase_disk_peaks: CERTIFICATION_PHASES
+                .into_iter()
+                .map(|phase| (phase.to_owned(), 4096 * factor))
+                .collect(),
+        }
+    })
+}
+
+fn synthetic_linearity_observations() -> [LifecycleLinearityObservation; 3] {
+    synthetic_linearity_observations_for_axis(LinearityAxis::Nodes)
+}
+
+fn synthetic_authority_context(
+    owner: &str,
+) -> graphforge_storage::ArtifactCategoryAuthorityContext {
+    let native_category_identity_authority_sha256 = graphforge_storage::ArtifactCategory::ALL
+        .into_iter()
+        .map(|category| {
+            (
+                category,
+                safe_authority_digest(
+                    b"synthetic-category-identity-authority\0",
+                    &[owner.as_bytes(), category_name(category).as_bytes()],
+                ),
+            )
+        })
+        .collect();
+    graphforge_storage::ArtifactCategoryAuthorityContext {
+        contract: CATEGORY_AUTHORITY_CONTRACT.to_owned(),
+        version: 1,
+        rung: 1,
+        generation_sha256: format!("sha256:{}", "a".repeat(64)),
+        owner: owner.to_owned(),
+        receipt_authority_sha256: safe_authority_digest(
+            b"synthetic-receipt-authority\0",
+            &[owner.as_bytes()],
+        ),
+        native_identity_authority_sha256: safe_authority_digest(
+            b"synthetic-native-identity-authority\0",
+            &[owner.as_bytes()],
+        ),
+        native_category_identity_authority_sha256,
+        live_nodes: 100,
+        live_edges: 80,
+    }
+}
+
+fn category_commitments(
+    context: &graphforge_storage::ArtifactCategoryAuthorityContext,
+    categories: &serde_json::Map<String, Value>,
+) -> Value {
+    Value::Object(
+        graphforge_storage::ArtifactCategory::ALL
+            .into_iter()
+            .map(|category| {
+                let name = category_name(category);
+                let totals: graphforge_storage::ArtifactStorageTotals =
+                    serde_json::from_value(categories[name].clone()).unwrap();
+                (
+                    name.to_owned(),
+                    json!(graphforge_storage::artifact_category_authority_commitment(
+                        context, category, &totals
+                    )),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn peak_commitments(
+    context: &graphforge_storage::ArtifactCategoryAuthorityContext,
+    peaks: &serde_json::Map<String, Value>,
+) -> Value {
+    Value::Object(
+        graphforge_storage::ArtifactCategory::ALL
+            .into_iter()
+            .map(|category| {
+                let name = category_name(category);
+                (
+                    name.to_owned(),
+                    json!(
+                        graphforge_storage::artifact_category_peak_authority_commitment(
+                            context,
+                            category,
+                            peaks[name].as_u64().unwrap(),
+                        )
+                    ),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn synthetic_attribution_owner(
+    owner: &str,
+) -> (Value, graphforge_storage::ArtifactCategoryAuthorityContext) {
+    let mut categories = serde_json::Map::new();
+    for category in ATTRIBUTION_CATEGORY_NAMES {
+        categories.insert(
+            category.to_owned(),
+            json!({
+                "logical_references": 0,
+                "logical_bytes": 0,
+                "physical_objects": 0,
+                "physical_logical_bytes": 0,
+                "allocated_bytes": 0,
+            }),
+        );
+    }
+    categories.insert(
+        "topology_nodes".into(),
+        json!({
+            "logical_references": 1,
+            "logical_bytes": 100,
+            "physical_objects": 1,
+            "physical_logical_bytes": 100,
+            "allocated_bytes": 4096,
+        }),
+    );
+    categories.insert(
+        "topology_edges".into(),
+        json!({
+            "logical_references": 1,
+            "logical_bytes": 80,
+            "physical_objects": 1,
+            "physical_logical_bytes": 80,
+            "allocated_bytes": 4096,
+        }),
+    );
+    for category in ["uuid_and_surrogates", "adjacency"] {
+        categories.insert(
+            category.into(),
+            json!({
+                "logical_references": 1,
+                "logical_bytes": 180,
+                "physical_objects": 1,
+                "physical_logical_bytes": 180,
+                "allocated_bytes": 4096,
+            }),
+        );
+    }
+    let context = synthetic_authority_context(owner);
+    let authority_sha256 = category_commitments(&context, &categories);
+    (
+        json!({
+        "categories": categories.clone(),
+        "category_authorities": categories,
+        "category_authority_context": context.clone(),
+        "category_authority_sha256": authority_sha256,
+        "logical_references": 4,
+        "logical_bytes": 540,
+        "physical_objects": 4,
+        "physical_logical_bytes": 540,
+        "allocated_bytes": 16384,
+        }),
+        context,
+    )
+}
+
+fn synthetic_retained_evidence() -> Value {
+    let mut construction_current = serde_json::Map::new();
+    let mut construction_peaks = serde_json::Map::new();
+    for category in ATTRIBUTION_CATEGORY_NAMES {
+        construction_current.insert(
+            category.to_owned(),
+            json!({
+                "logical_references": 0,
+                "logical_bytes": 0,
+                "physical_objects": 0,
+                "physical_logical_bytes": 0,
+                "allocated_bytes": 0,
+            }),
+        );
+        construction_peaks.insert(category.to_owned(), json!(0));
+    }
+    construction_current.insert(
+        "construction_staging".into(),
+        json!({
+            "logical_references": 1,
+            "logical_bytes": 100,
+            "physical_objects": 1,
+            "physical_logical_bytes": 100,
+            "allocated_bytes": 4096,
+        }),
+    );
+    construction_peaks.insert("construction_staging".into(), json!(8192));
+    let construction_context = synthetic_authority_context("construction");
+    let construction_authority_sha256 =
+        category_commitments(&construction_context, &construction_current);
+    let construction_peak_authority_sha256 =
+        peak_commitments(&construction_context, &construction_peaks);
+    let portable_authority = graphforge_storage::ArtifactStorageTotals {
+        logical_references: 1,
+        logical_bytes: 200,
+        physical_objects: 1,
+        physical_logical_bytes: 200,
+        allocated_bytes: 4096,
+    };
+    let portable_context = synthetic_authority_context("portable_package");
+    let portable_authority_sha256 = graphforge_storage::artifact_category_authority_commitment(
+        &portable_context,
+        graphforge_storage::ArtifactCategory::PortablePackage,
+        &portable_authority,
+    );
+    let (source, _) = synthetic_attribution_owner("source");
+    let (clean_import, _) = synthetic_attribution_owner("clean_import");
+    json!({
+        "source_nodes": 100,
+        "source_edges": 80,
+        "storage": {
+            "source": source,
+            "clean_import": clean_import,
+            "portable_package": {
+                "logical_references": 1,
+                "logical_bytes": 200,
+                "physical_objects": 1,
+                "allocated_bytes": 4096,
+                "category_authority": portable_authority,
+                "category_authority_context": portable_context,
+                "category_authority_sha256": portable_authority_sha256,
+            },
+            "construction": {
+                "storage_current": construction_current.clone(),
+                "storage_category_authorities": construction_current,
+                "storage_category_authority_context": construction_context,
+                "storage_category_authority_sha256": construction_authority_sha256,
+                "storage_transient_peak_allocated_bytes": construction_peaks.clone(),
+                "storage_transient_peak_authorities": construction_peaks,
+                "storage_transient_peak_authority_sha256": construction_peak_authority_sha256,
+                "storage_transient_peak_total_allocated_bytes": 8192,
+            },
+            "source_project_current_allocated_bytes": 16384,
+            "workspace_current_allocated_bytes": 49152,
+            "workspace_peak_allocated_bytes": 57344,
+            "workspace_components": {
+                "source_project_and_construction": 16384,
+                "portable_package": 4096,
+                "clean_import_project": 16384,
+                "drill_project_and_construction": 4096,
+                "drill_package": 4096,
+                "corrupt_drill_package": 4096,
+            },
+        },
+        "phases": [
+            {"id": "ingest", "disk_peak_bytes": 49152},
+            {"id": "import", "disk_peak_bytes": 57344},
+        ],
+    })
+}
+
+#[test]
+fn cas_control_proof_accepts_path_variation_and_rejects_coherent_overcounts() {
+    let mut observations = synthetic_linearity_observations();
+    for (observation, installed) in observations.iter_mut().zip([1, 2, 1]) {
+        let io = &mut observation.cas_publication_io;
+        io.manifest.installed_objects = installed;
+        io.manifest.install_attempts = installed;
+        io.manifest.read_calls = installed + io.manifest.reused_objects;
+        io.manifest.write_calls = installed;
+        io.manifest.file_fsync_calls = installed;
+        io.manifest.directory_fsync_calls = 2 * installed;
+        let totals = io.totals().unwrap();
+        observation.phases.insert(
+            "cas_install_read_write".into(),
+            [
+                totals.read_bytes,
+                totals.write_bytes,
+                totals.read_calls,
+                totals.write_calls,
+                0,
+                0,
+                totals.file_fsync_calls + totals.directory_fsync_calls,
+            ],
+        );
+    }
+    validate_lifecycle_metric_policies(&observations).unwrap();
+    let mut missing_manifest = observations[0].clone();
+    missing_manifest.cas_publication_io.manifest = Default::default();
+    missing_manifest.cas_publication_io.manifest_reads = Default::default();
+    let totals = missing_manifest.cas_publication_io.totals().unwrap();
+    missing_manifest.phases.insert(
+        "cas_install_read_write".into(),
+        [
+            totals.read_bytes,
+            totals.write_bytes,
+            totals.read_calls,
+            totals.write_calls,
+            0,
+            0,
+            totals.file_fsync_calls + totals.directory_fsync_calls,
+        ],
+    );
+    assert!(
+        validate_fresh_cas_control_bound(&missing_manifest)
+            .unwrap_err()
+            .contains("mandatory bootstrap")
+    );
+    let mut excessive = observations[0].clone();
+    let installed = 67 * excessive.canonical_artifact_objects + 2;
+    let manifest = &mut excessive.cas_publication_io.manifest;
+    manifest.installed_objects = installed;
+    manifest.install_attempts = installed;
+    manifest.read_calls = installed + manifest.reused_objects;
+    manifest.read_bytes = manifest.read_calls;
+    manifest.write_calls = installed;
+    manifest.file_fsync_calls = installed;
+    manifest.directory_fsync_calls = 2 * installed;
+    let totals = excessive.cas_publication_io.totals().unwrap();
+    excessive.phases.insert(
+        "cas_install_read_write".into(),
+        [
+            totals.read_bytes,
+            totals.write_bytes,
+            totals.read_calls,
+            totals.write_calls,
+            0,
+            0,
+            totals.file_fsync_calls + totals.directory_fsync_calls,
+        ],
+    );
+    assert!(
+        validate_fresh_cas_control_bound(&excessive)
+            .unwrap_err()
+            .contains("native path/object")
+    );
+    for invalid in ["repeated", "prior", "tombstoned"] {
+        let mut changed = observations[0].clone();
+        match invalid {
+            "repeated" => changed.cas_publication_io.publications = 2,
+            "prior" => changed.cas_publication_io.initial_entries = 1,
+            "tombstoned" => changed.cas_publication_io.changed_paths += 1,
+            _ => unreachable!(),
+        }
+        assert!(
+            validate_fresh_cas_control_bound(&changed)
+                .unwrap_err()
+                .contains("one fresh publication")
+        );
+    }
+    let mut excess_bytes = observations[0].clone();
+    excess_bytes.cas_publication_io.manifest_reads.read_bytes = u64::MAX;
+    excess_bytes.cas_publication_io.manifest_reads.read_calls = u64::MAX;
+    assert!(validate_fresh_cas_control_bound(&excess_bytes).is_err());
+}
+
+#[test]
+fn controlled_fixture_policies_reject_coherent_zero_and_excess_work() {
+    for axis in [LinearityAxis::Nodes, LinearityAxis::Edges] {
+        let mut observations = synthetic_linearity_observations_for_axis(axis);
+        for (rung, observation) in observations.iter_mut().enumerate() {
+            for owner in ["source", "clean_import"] {
+                let key = format!("{owner}.catalog_and_manifests");
+                for metrics in [
+                    &mut observation.category_metrics,
+                    &mut observation.category_authority_metrics,
+                ] {
+                    for field in [1, 3] {
+                        metrics.get_mut(&key).unwrap()[field] += rung as u64;
+                    }
+                }
+            }
+        }
+        validate_lifecycle_metric_policies_for_axis(axis, &observations)
+            .expect("catalog text lengths may gain digits without adding objects");
+        for (category, field) in [
+            ("catalog_and_manifests", 1),
+            ("catalog_and_manifests", 3),
+            ("catalog_and_manifests", 4),
+            ("catalog_and_manifests", 5),
+            ("adjacency", 1),
+            ("adjacency", 3),
+        ] {
+            for value in [0, u64::MAX] {
+                let mut invalid = observations.clone();
+                for owner in ["source", "clean_import"] {
+                    let key = format!("{owner}.{category}");
+                    invalid[2].category_metrics.get_mut(&key).unwrap()[field] = value;
+                    invalid[2].category_authority_metrics.get_mut(&key).unwrap()[field] = value;
+                }
+                let error = validate_lifecycle_metric_policies_for_axis(axis, &invalid)
+                    .expect_err("coherent category mutations still fail native growth policy");
+                assert!(error.contains(category), "{error}");
+            }
+        }
+        for value in [0, u64::MAX] {
+            let mut invalid = observations.clone();
+            invalid[2].phases.get_mut("hydration_verification").unwrap()[1] = value;
+            let error = validate_lifecycle_metric_policies_for_axis(axis, &invalid)
+                .expect_err("private ordinal copies cannot omit bytes or exceed their axis bound");
+            assert!(error.contains("hydration_verification"), "{error}");
+        }
+        let mut omitted_copies = observations;
+        for observation in &mut omitted_copies {
+            observation
+                .phases
+                .get_mut("hydration_verification")
+                .unwrap()[1] = 0;
+        }
+        assert!(validate_lifecycle_metric_policies_for_axis(axis, &omitted_copies).is_err());
+    }
+}
+
+#[test]
+fn lifecycle_metric_policy_accepts_bounded_fixed_protocol_and_rejects_false_growth() {
+    let observations = synthetic_linearity_observations();
+    validate_lifecycle_metric_policies(&observations)
+        .expect("scale-bearing slopes and bounded fixed protocol overhead");
+    let retained_evidence = synthetic_retained_evidence();
+    validate_retained_reconciliation(&retained_evidence)
+        .expect("synthetic retained evidence reconciles");
+
+    let mut category_underreport = retained_evidence.clone();
+    category_underreport["storage"]["source"]["categories"]["topology_nodes"]["logical_bytes"] =
+        json!(99);
+    assert!(validate_retained_reconciliation(&category_underreport).is_err());
+
+    let mut inventory_mismatch = retained_evidence.clone();
+    inventory_mismatch["storage"]["portable_package"]["physical_objects"] = json!(2);
+    assert!(validate_retained_reconciliation(&inventory_mismatch).is_err());
+
+    let mut transient_underreport = retained_evidence.clone();
+    transient_underreport["storage"]["construction"]["storage_transient_peak_allocated_bytes"]["construction_staging"] =
+        json!(2048);
+    assert!(validate_retained_reconciliation(&transient_underreport).is_err());
+
+    let mut retained_owner_underreport = retained_evidence.clone();
+    retained_owner_underreport["storage"]["workspace_current_allocated_bytes"] = json!(8192);
+    assert!(validate_retained_reconciliation(&retained_owner_underreport).is_err());
+
+    let mut missing_construction_category = retained_evidence.clone();
+    missing_construction_category["storage"]["construction"]["storage_current"]
+        .as_object_mut()
+        .unwrap()
+        .remove("properties");
+    assert!(validate_retained_reconciliation(&missing_construction_category).is_err());
+
+    let mut extra_construction_category = retained_evidence.clone();
+    extra_construction_category["storage"]["construction"]["storage_transient_peak_allocated_bytes"]
+        ["unknown"] = json!(0);
+    assert!(validate_retained_reconciliation(&extra_construction_category).is_err());
+
+    let mut double_counted_component = retained_evidence.clone();
+    double_counted_component["storage"]["workspace_components"]["clean_import_project"] =
+        json!(20_480);
+    assert!(validate_retained_reconciliation(&double_counted_component).is_err());
+
+    let mut overflowing_components = retained_evidence.clone();
+    overflowing_components["storage"]["workspace_components"]["source_project_and_construction"] =
+        json!(u64::MAX);
+    overflowing_components["storage"]["workspace_components"]["clean_import_project"] =
+        json!(u64::MAX);
+    assert!(validate_retained_reconciliation(&overflowing_components).is_err());
+
+    assert!(checked_product("boundary", &[u128::MAX, 2]).is_err());
+    assert!(checked_lifecycle_peak_allocation(u64::MAX, 1).is_err());
+    assert!(
+        validate_affine_metric(
+            "boundary",
+            [u64::MAX - 2, u64::MAX - 1, u64::MAX],
+            [u64::MAX - 2, u64::MAX - 1, u64::MAX],
+        )
+        .is_err()
+    );
+
+    let shared = BTreeMap::from([("cas-object".to_owned(), 4096)]);
+    let mut allocation = graphforge_storage::StorageAllocationLifecycle::default();
+    allocation
+        .replace_owner("source", &shared)
+        .expect("install source CAS identity");
+    allocation
+        .replace_owner("import", &shared)
+        .expect("shared CAS identity is a second reference, not a second allocation");
+    assert_eq!(allocation.current_allocated_bytes(), 4096);
+    assert!(
+        allocation
+            .replace_owner(
+                "invalid",
+                &BTreeMap::from([("cas-object".to_owned(), 8192)])
+            )
+            .is_err(),
+        "the same CAS identity with contradictory allocation must fail"
+    );
+
+    for (phase, field, field_name) in [
+        ("append_merge", 1, "append write bytes"),
+        ("append_merge", 4, "append objects"),
+        ("shape_consume_reauthentication", 5, "shape logical blocks"),
+        ("fsync_synchronization", 6, "append/merge fsync work"),
+        ("recovery_reauthentication", 0, "recovery read bytes"),
+    ] {
+        let mut held_constant = observations.clone();
+        held_constant[1].phases.get_mut(phase).unwrap()[field] =
+            held_constant[0].phases[phase][field];
+        held_constant[2].phases.get_mut(phase).unwrap()[field] =
+            held_constant[0].phases[phase][field];
+        assert!(
+            validate_lifecycle_metric_policies(&held_constant).is_err(),
+            "held-constant {field_name} must fail"
+        );
+
+        let mut underreported = observations.clone();
+        underreported[2].phases.get_mut(phase).unwrap()[field] =
+            underreported[1].phases[phase][field] + 1;
+        assert!(
+            validate_lifecycle_metric_policies(&underreported).is_err(),
+            "underreported 4x {field_name} must fail"
+        );
+    }
+    let mut missing_phase = observations.clone();
+    missing_phase[1].phases.remove("hydration_verification");
+    assert!(validate_lifecycle_metric_policies(&missing_phase).is_err());
+
+    let mut underreported_shape_aggregate = observations.clone();
+    underreported_shape_aggregate[2]
+        .phases
+        .get_mut("shape_consume_reauthentication")
+        .unwrap()[5] -= 1;
+    assert!(validate_lifecycle_metric_policies(&underreported_shape_aggregate).is_err());
+
+    let mut overreported_shape_aggregate = observations.clone();
+    overreported_shape_aggregate[2]
+        .phases
+        .get_mut("shape_consume_reauthentication")
+        .unwrap()[5] += 1;
+    assert!(validate_lifecycle_metric_policies(&overreported_shape_aggregate).is_err());
+
+    let mut underreported_shape_component = observations.clone();
+    underreported_shape_component[2].shape_block_components[0] = 0;
+    underreported_shape_component[2]
+        .phases
+        .get_mut("shape_consume_reauthentication")
+        .unwrap()[5] = underreported_shape_component[2].shape_block_components[1];
+    assert!(validate_lifecycle_metric_policies(&underreported_shape_component).is_err());
+
+    let mut overreported_shape_component = observations.clone();
+    overreported_shape_component[2].shape_block_components[1] = overreported_shape_component[2]
+        .shape_merge_bytes[1]
+        .checked_add(1)
+        .expect("synthetic overreported component");
+    overreported_shape_component[2]
+        .phases
+        .get_mut("shape_consume_reauthentication")
+        .unwrap()[5] = overreported_shape_component[2]
+        .shape_block_components
+        .into_iter()
+        .try_fold(0_u64, u64::checked_add)
+        .expect("synthetic component total");
+    assert!(validate_lifecycle_metric_policies(&overreported_shape_component).is_err());
+
+    let mut overflowing_shape_components = observations.clone();
+    overflowing_shape_components[2].shape_block_components = [u64::MAX, 1];
+    overflowing_shape_components[2]
+        .phases
+        .get_mut("shape_consume_reauthentication")
+        .unwrap()[5] = u64::MAX;
+    assert!(validate_lifecycle_metric_policies(&overflowing_shape_components).is_err());
+
+    let mut nonzero_structural_field = observations.clone();
+    nonzero_structural_field[2]
+        .phases
+        .get_mut("append_merge")
+        .unwrap()[0] = 1;
+    assert!(validate_lifecycle_metric_policies(&nonzero_structural_field).is_err());
+
+    for field in [0, 2] {
+        let mut nonzero_seal_field = observations.clone();
+        nonzero_seal_field[2]
+            .phases
+            .get_mut("seal_authentication")
+            .unwrap()[field] = 1;
+        assert!(
+            validate_lifecycle_metric_policies(&nonzero_seal_field).is_err(),
+            "seal structural field {field} must remain zero"
+        );
+    }
+
+    let mut zero_scale_phase = observations.clone();
+    for observation in &mut zero_scale_phase {
+        observation
+            .phases
+            .get_mut("encode_write_postwrite_authentication")
+            .unwrap()[1] = 0;
+    }
+    assert!(validate_lifecycle_metric_policies(&zero_scale_phase).is_err());
+
+    let mut zero_scale_retained = observations.clone();
+    for observation in &mut zero_scale_retained {
+        observation
+            .retained
+            .insert("source.logical_bytes".into(), 0);
+    }
+    assert!(validate_lifecycle_metric_policies(&zero_scale_retained).is_err());
+
+    let mut underreported_buffered_calls = observations.clone();
+    underreported_buffered_calls[2]
+        .phases
+        .get_mut("hydration_verification")
+        .unwrap()[2] = 0;
+    assert!(validate_lifecycle_metric_policies(&underreported_buffered_calls).is_err());
+
+    let mut underreported_shape_calls = observations.clone();
+    underreported_shape_calls[2]
+        .phases
+        .get_mut("shape_consume_reauthentication")
+        .unwrap()[2] = 1;
+    assert!(validate_lifecycle_metric_policies(&underreported_shape_calls).is_err());
+
+    let mut inflated_encode_calls = observations.clone();
+    inflated_encode_calls[2]
+        .phases
+        .get_mut("encode_write_postwrite_authentication")
+        .unwrap()[3] += 1;
+    assert!(validate_lifecycle_metric_policies(&inflated_encode_calls).is_err());
+
+    let mut component_call_plateau = observations.clone();
+    for observation in &mut component_call_plateau {
+        observation
+            .phases
+            .get_mut("shape_consume_reauthentication")
+            .unwrap()[2] = 2;
+        observation.shape_read_component_calls = [2, 0, 0, 0, 0, 0];
+    }
+    validate_lifecycle_metric_policies(&component_call_plateau)
+        .expect("native component-call plateau");
+
+    let mut oversized_inventory_control = observations.clone();
+    oversized_inventory_control[2]
+        .phases
+        .get_mut("publication_preauthentication")
+        .unwrap()[0] = ENCODING_BUFFER_BYTES + 1;
+    assert!(validate_lifecycle_metric_policies(&oversized_inventory_control).is_err());
+
+    let mut zero_denominator = observations.clone();
+    zero_denominator[1].live_nodes = 0;
+    assert!(validate_lifecycle_metric_policies(&zero_denominator).is_err());
+    let mut nonmonotone_denominator = observations.clone();
+    nonmonotone_denominator[2].live_nodes = nonmonotone_denominator[1].live_nodes;
+    assert!(validate_lifecycle_metric_policies(&nonmonotone_denominator).is_err());
+    let mut changed_controlled_axis = observations.clone();
+    changed_controlled_axis[2].live_edges += 1;
+    assert!(validate_lifecycle_metric_policies(&changed_controlled_axis).is_err());
+
+    let mut below_row_bound = observations.clone();
+    below_row_bound[2].phases.get_mut("append_merge").unwrap()[1] =
+        below_row_bound[2].input_rows - 1;
+    assert!(validate_lifecycle_metric_policies(&below_row_bound).is_err());
+
+    let mut compensated_category_shift = observations.clone();
+    for observation in &mut compensated_category_shift {
+        for owner in ["source", "clean_import"] {
+            let node_key = format!("{owner}.topology_nodes");
+            let edge_key = format!("{owner}.topology_edges");
+            for field in [1, 3] {
+                observation.category_metrics.get_mut(&node_key).unwrap()[field] -= 1;
+                observation.category_metrics.get_mut(&edge_key).unwrap()[field] += 1;
+            }
+        }
+    }
+    assert_eq!(
+        validate_lifecycle_metric_policies(&compensated_category_shift),
+        Err("retained category totals differ from storage-owned authorities".into())
+    );
+
+    let edge_observations = synthetic_linearity_observations_for_axis(LinearityAxis::Edges);
+    validate_lifecycle_metric_policies_for_axis(LinearityAxis::Edges, &edge_observations)
+        .expect("edge-axis denominator proof");
+    let mut edge_underreport = edge_observations;
+    edge_underreport[2].retained.insert(
+        "source.canonical_edges.logical_bytes".into(),
+        edge_underreport[1].retained["source.canonical_edges.logical_bytes"],
+    );
+    assert!(
+        validate_lifecycle_metric_policies_for_axis(LinearityAxis::Edges, &edge_underreport)
+            .is_err()
+    );
+    for (retained, _, policy) in LINEARITY_RETAINED_FIELDS {
+        if !matches!(
+            policy,
+            RetainedMetricPolicy::ScaleBearing | RetainedMetricPolicy::NodeBearing
+        ) {
+            continue;
+        }
+        let mut held_constant = observations.clone();
+        held_constant[1]
+            .retained
+            .insert(retained.to_owned(), held_constant[0].retained[retained]);
+        held_constant[2]
+            .retained
+            .insert(retained.to_owned(), held_constant[0].retained[retained]);
+        assert!(
+            validate_lifecycle_metric_policies(&held_constant).is_err(),
+            "held-constant retained metric {retained} must fail"
+        );
+
+        let mut underreported = observations.clone();
+        underreported[2]
+            .retained
+            .insert(retained.to_owned(), underreported[1].retained[retained] + 1);
+        assert!(
+            validate_lifecycle_metric_policies(&underreported).is_err(),
+            "underreported 4x retained metric {retained} must fail"
+        );
+    }
+    let mut decreasing_allocated = observations.clone();
+    decreasing_allocated[2]
+        .retained
+        .insert("source.allocated_bytes".into(), 1);
+    assert!(validate_lifecycle_metric_policies(&decreasing_allocated).is_err());
+
+    let mut quantized_plateau = observations.clone();
+    for rung in 1..3 {
+        for owner in ["source", "clean_import"] {
+            let key = format!("{owner}.topology_nodes");
+            for field in [4, 5] {
+                let baseline = quantized_plateau[0].category_metrics[&key][field];
+                quantized_plateau[rung]
+                    .category_metrics
+                    .get_mut(&key)
+                    .unwrap()[field] = baseline;
+                quantized_plateau[rung]
+                    .category_authority_metrics
+                    .get_mut(&key)
+                    .unwrap()[field] = baseline;
+            }
+        }
+    }
+    validate_lifecycle_metric_policies(&quantized_plateau)
+        .expect("legitimate filesystem-allocation plateau");
+
+    let mut quantized_upper_bound = observations.clone();
+    for owner in ["source", "clean_import"] {
+        let key = format!("{owner}.topology_nodes");
+        quantized_upper_bound[2]
+            .category_metrics
+            .get_mut(&key)
+            .unwrap()[4] = u64::MAX;
+        quantized_upper_bound[2]
+            .category_authority_metrics
+            .get_mut(&key)
+            .unwrap()[4] = u64::MAX;
+    }
+    assert!(validate_lifecycle_metric_policies(&quantized_upper_bound).is_err());
+
+    let mut changed_retained_inventory = observations.clone();
+    changed_retained_inventory[2]
+        .retained
+        .insert("source.physical_objects".into(), 20);
+    assert!(validate_lifecycle_metric_policies(&changed_retained_inventory).is_err());
+
+    let mut excess_retained_shape = observations.clone();
+    excess_retained_shape[2].retained.insert(
+        "construction.current_merge_temporary_allocated_bytes".into(),
+        u64::MAX,
+    );
+    assert!(validate_lifecycle_metric_policies(&excess_retained_shape).is_err());
+
+    let fsync_index = LINEARITY_PHASE_FIELDS
+        .iter()
+        .position(|field| *field == "fsync_calls")
+        .unwrap();
+    let mut decreasing_fixed = observations.clone();
+    decreasing_fixed[1]
+        .phases
+        .get_mut("cas_install_read_write")
+        .unwrap()[fsync_index] = 38;
+    assert!(
+        validate_lifecycle_metric_policies(&decreasing_fixed).is_err(),
+        "decreasing fixed protocol count must fail"
+    );
+
+    let mut inflated_fixed = observations.clone();
+    inflated_fixed[2]
+        .phases
+        .get_mut("cas_install_read_write")
+        .unwrap()[fsync_index] = 40;
+    assert!(
+        validate_lifecycle_metric_policies(&inflated_fixed).is_err(),
+        "inflated fixed protocol count must fail"
+    );
+    let mut changed_canonical_inventory = observations.clone();
+    changed_canonical_inventory[2].canonical_artifact_objects += 1;
+    assert!(validate_lifecycle_metric_policies(&changed_canonical_inventory).is_err());
+
+    let mut changed_encode_inventory = observations.clone();
+    changed_encode_inventory[2].encode_fsync_components[0] += 1;
+    assert!(validate_lifecycle_metric_policies(&changed_encode_inventory).is_err());
+
+    for (file_delta, directory_delta) in [(1_i64, 0_i64), (-1, 0), (0, 1), (0, -1)] {
+        let mut changed_hydration_inventory = observations.clone();
+        let observation = &mut changed_hydration_inventory[2];
+        observation.hydration_file_fsync_operations = observation
+            .hydration_file_fsync_operations
+            .checked_add_signed(file_delta)
+            .unwrap();
+        observation.hydration_directory_fsync_operations = observation
+            .hydration_directory_fsync_operations
+            .checked_add_signed(directory_delta)
+            .unwrap();
+        assert!(validate_lifecycle_metric_policies(&changed_hydration_inventory).is_err());
+    }
+
+    let read_calls_index = LINEARITY_PHASE_FIELDS
+        .iter()
+        .position(|field| *field == "read_calls")
+        .unwrap();
+    validate_buffered_calls(
+        "legitimate plateau",
+        [2, 2, 2],
+        [
+            ENCODING_BUFFER_BYTES + 1,
+            ENCODING_BUFFER_BYTES + 2,
+            ENCODING_BUFFER_BYTES + 3,
+        ],
+        ENCODING_BUFFER_BYTES,
+    )
+    .expect("quantized call plateau");
+    assert!(
+        validate_buffered_calls(
+            "below derived bound",
+            [1, 1, 1],
+            [ENCODING_BUFFER_BYTES + 1; 3],
+            ENCODING_BUFFER_BYTES,
+        )
+        .is_err()
+    );
+    assert!(
+        validate_buffered_calls(
+            "above derived bound",
+            [2, 2, 3],
+            [2, 2, 2],
+            ENCODING_BUFFER_BYTES,
+        )
+        .is_err()
+    );
+
+    let mut missing_encoding_reads = observations;
+    for observation in &mut missing_encoding_reads {
+        observation
+            .phases
+            .get_mut("encode_write_postwrite_authentication")
+            .unwrap()[read_calls_index] = 0;
+    }
+    assert!(validate_lifecycle_metric_policies(&missing_encoding_reads).is_err());
+
+    let mut decreasing_encoding_fsyncs = synthetic_linearity_observations();
+    decreasing_encoding_fsyncs[1]
+        .phases
+        .get_mut("encode_write_postwrite_authentication")
+        .unwrap()[fsync_index] = 42;
+    assert!(
+        validate_lifecycle_metric_policies(&decreasing_encoding_fsyncs).is_err(),
+        "decreasing encoding fsync count must fail"
+    );
+
+    let mut inflated_encoding_fsyncs = synthetic_linearity_observations();
+    inflated_encoding_fsyncs[2]
+        .phases
+        .get_mut("encode_write_postwrite_authentication")
+        .unwrap()[fsync_index] = 44;
+    assert!(
+        validate_lifecycle_metric_policies(&inflated_encoding_fsyncs).is_err(),
+        "inflated encoding fsync count must fail"
+    );
+
+    let mut missing_encoding_fsyncs = synthetic_linearity_observations();
+    for observation in &mut missing_encoding_fsyncs {
+        observation
+            .phases
+            .get_mut("encode_write_postwrite_authentication")
+            .unwrap()[fsync_index] = 0;
+    }
+    assert!(
+        validate_lifecycle_metric_policies(&missing_encoding_fsyncs).is_err(),
+        "missing encoding fsync evidence must fail"
+    );
+}
+
+#[test]
+fn equivalent_full_lifecycle_1x_2x_4x_has_bounded_metric_policies() {
+    let mut failures = Vec::new();
+    for axis in [LinearityAxis::Nodes, LinearityAxis::Edges] {
+        let mut observations = Vec::new();
+        let mut live_counts = Vec::new();
+        for factor in [1_u32, 2, 4] {
+            let root = TempDir::new().expect("full lifecycle ladder root");
+            let integrated = run_integrated_certification_for_linearity(root.path(), axis, factor);
+            let evidence = integrated.value;
+            assert_eq!(evidence["source_nodes"], evidence["imported_nodes"]);
+            assert_eq!(evidence["source_edges"], evidence["imported_edges"]);
+            live_counts.push((
+                evidence["source_nodes"]
+                    .as_u64()
+                    .expect("source node count"),
+                evidence["source_edges"]
+                    .as_u64()
+                    .expect("source edge count"),
+            ));
+            let attribution: graphforge_storage::ConstructionPhaseAttribution =
+                serde_json::from_value(evidence["storage"]["application_io_phases"].clone())
+                    .expect("decode phase evidence");
+            attribution
+                .validate_for_qualification()
+                .expect("full lifecycle phase qualification");
+            validate_retained_reconciliation(&evidence)
+                .expect("full lifecycle retained/category reconciliation");
+            let recovery = &evidence["storage"]["application_io_phases"]["phases"]["recovery_reauthentication"];
+            assert!(
+                recovery["read_bytes"].as_u64().unwrap_or(0) > 0,
+                "{axis:?} {factor}x recovery must report authenticated bytes"
+            );
+            assert!(
+                recovery["read_calls"].as_u64().unwrap_or(0) > 0,
+                "{axis:?} {factor}x recovery must report authenticated calls"
+            );
+            observations.push(lifecycle_linearity_observation(&evidence));
+            let interrupted = evidence["phases"]
+                .as_array()
+                .expect("lifecycle phases")
+                .iter()
+                .find(|phase| phase["id"] == "drill_interrupted_finalization")
+                .expect("interrupted-finalization recovery drill");
+            assert_eq!(interrupted["status"], "pass");
+        }
+        match axis {
+            LinearityAxis::Nodes => {
+                assert_eq!(live_counts[1].0, live_counts[0].0 * 2);
+                assert_eq!(live_counts[2].0, live_counts[0].0 * 4);
+                assert_eq!(live_counts[0].1, live_counts[1].1);
+                assert_eq!(live_counts[0].1, live_counts[2].1);
+            }
+            LinearityAxis::Edges => {
+                assert_eq!(live_counts[0].0, live_counts[1].0);
+                assert_eq!(live_counts[0].0, live_counts[2].0);
+                assert!(live_counts[0].1 < live_counts[1].1);
+                assert!(live_counts[1].1 < live_counts[2].1);
+            }
+        }
+        let observations: [LifecycleLinearityObservation; 3] = observations
+            .try_into()
+            .expect("exact 1x/2x/4x observations");
+        if let Err(error) = validate_lifecycle_metric_policies_for_axis(axis, &observations) {
+            failures.push(format!(
+                "{axis:?} full lifecycle metric proof failed: {error}; live_counts={live_counts:?}; categories={:?}; phases={:?}; retained={:?}",
+                observations.each_ref().map(|observation| &observation.category_metrics),
+                observations.each_ref().map(|observation| &observation.phases),
+                observations.each_ref().map(|observation| &observation.retained)
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
 #[test]
@@ -4005,7 +7541,8 @@ fn million_edge_sink_uses_sixteen_durable_chunks_and_replays_stably() {
 fn submitted_chunk_count(evidence: &graphforge_storage::GraphConstructionEvidence) -> u64 {
     evidence
         .input_batches
-        .saturating_add(evidence.replayed_chunks)
+        .checked_add(evidence.replayed_chunks)
+        .expect("submitted construction chunk count overflow")
 }
 
 #[test]
@@ -4149,8 +7686,11 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
                     assert!(
                         *observed
                             <= base
-                                .saturating_mul(factor)
-                                .saturating_add(fixed_edge_merge_window_bytes),
+                                .checked_mul(factor)
+                                .and_then(|bound| {
+                                    bound.checked_add(fixed_edge_merge_window_bytes)
+                                })
+                                .expect("merge footprint bound overflow"),
                         "disk-backed merge footprint exceeded linear work: baseline={base} observed={observed} factor={factor}"
                     );
                     continue;
@@ -4163,7 +7703,10 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
                     continue;
                 }
                 assert!(
-                    *observed <= base.saturating_add(tolerance),
+                    *observed
+                        <= base
+                            .checked_add(tolerance)
+                            .expect("saturated peak tolerance overflow"),
                     "saturated peak field {index} grew with scale: baseline={base} observed={observed} tolerance={tolerance}"
                 );
             }
@@ -4176,7 +7719,8 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         assert_ne!(receipt.generation_uuid, before);
         assert_eq!(current_generation_uuid(&graph), receipt.generation_uuid);
         let phases =
-            graphforge_storage::ConstructionPhaseAttribution::from_construction(&progress.evidence);
+            graphforge_storage::ConstructionPhaseAttribution::from_construction(&progress.evidence)
+                .unwrap();
         phases.validate_reconciliation().unwrap();
         let shape =
             &phases.phases[&graphforge_storage::StorageIoPhase::ShapeConsumeReauthentication];
@@ -4187,25 +7731,30 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             progress
                 .evidence
                 .merge_written_bytes
-                .saturating_add(progress.evidence.parquet_write_bytes)
+                .checked_add(progress.evidence.parquet_write_bytes)
+                .expect("shape write-byte reconciliation overflow")
         );
         assert_eq!(
             shape.write_calls,
             progress
                 .evidence
                 .merge_write_operations
-                .saturating_add(progress.evidence.parquet_write_operations)
+                .checked_add(progress.evidence.parquet_write_operations)
+                .expect("shape write-operation reconciliation overflow")
         );
         assert_eq!(
             shape.read_calls,
-            progress
-                .evidence
-                .shape_input_validation_read_operations
-                .saturating_add(progress.evidence.merge_read_operations)
-                .saturating_add(progress.evidence.parquet_read_operations)
-                .saturating_add(progress.evidence.shaped_output_authentication_operations)
-                .saturating_add(progress.evidence.parent_catalog_read_operations)
-                .saturating_add(progress.evidence.retained_probe_block_loads)
+            [
+                progress.evidence.shape_input_validation_read_operations,
+                progress.evidence.merge_read_operations,
+                progress.evidence.parquet_read_operations,
+                progress.evidence.shaped_output_authentication_operations,
+                progress.evidence.parent_catalog_read_operations,
+                progress.evidence.retained_probe_block_loads,
+            ]
+            .into_iter()
+            .try_fold(0_u64, u64::checked_add)
+            .expect("shape read-operation reconciliation overflow")
         );
         let phase_observation = (
             phases.totals.read_bytes,
@@ -4217,7 +7766,11 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             // Each lifecycle has fixed authenticated control work. Preserve a
             // documented 2x constant-factor ceiling around ideal linear growth
             // instead of pretending the intercept is zero at the 1x fixture.
-            let ceiling = |base: u64| base.saturating_mul(factor).saturating_mul(2);
+            let ceiling = |base: u64| {
+                base.checked_mul(factor)
+                    .and_then(|bound| bound.checked_mul(2))
+                    .expect("phase I/O ceiling overflow")
+            };
             assert!(phase_observation.0 <= ceiling(baseline.0));
             assert!(phase_observation.1 <= ceiling(baseline.1));
             assert!(phase_observation.2 <= ceiling(baseline.2));
@@ -4238,11 +7791,17 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
         );
         if let Some((base_logical, base_allocated)) = baseline_storage {
             assert!(
-                storage.logical_bytes <= base_logical.saturating_mul(factor),
+                storage.logical_bytes
+                    <= base_logical
+                        .checked_mul(factor)
+                        .expect("storage logical-byte bound overflow"),
                 "authenticated logical bytes exceeded linear growth"
             );
             assert!(
-                storage.allocated_bytes <= base_allocated.saturating_mul(factor),
+                storage.allocated_bytes
+                    <= base_allocated
+                        .checked_mul(factor)
+                        .expect("storage allocation bound overflow"),
                 "deduplicated allocated bytes exceeded linear growth"
             );
         } else {

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -367,13 +367,13 @@ pub struct GraphConstructionEvidence {
     /// Actual non-empty durable-control reads immediately before publication.
     #[serde(default)]
     pub publication_application_read_operations: u64,
-    /// Application-observed source or reused-object payload bytes read by CAS adoption.
+    /// Application-observed CAS payload, manifest-install and manifest-path read bytes.
     #[serde(default)]
     pub cas_application_read_bytes: u64,
-    /// Actual non-empty CAS source/authentication reads.
+    /// Actual non-empty CAS payload and manifest source/authentication reads.
     #[serde(default)]
     pub cas_application_read_operations: u64,
-    /// Payload bytes submitted to CAS temporary-object writers.
+    /// Payload and manifest bytes submitted to CAS temporary-object writers.
     #[serde(default)]
     pub cas_application_write_bytes: u64,
     /// Actual CAS temporary-object write submissions.

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -105,6 +105,9 @@ pub static CONSTRUCTION_EDGE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     ]))
 });
 
+/// Fixed application buffer used by canonical construction encoding streams.
+pub const GRAPH_CONSTRUCTION_ENCODING_BUFFER_BYTES: usize = 1 << 20;
+
 fn storage(error: impl std::fmt::Display) -> GfError {
     GfError::Storage(format!("graph construction session: {error}"))
 }
@@ -325,9 +328,39 @@ pub struct GraphConstructionEvidence {
     /// Actual canonical artifact write submissions.
     #[serde(default)]
     pub encode_application_write_operations: u64,
+    /// Canonical output writer submissions.
+    #[serde(default)]
+    pub encode_output_write_operations: u64,
+    /// UUID-membership writer submissions, including carry.
+    #[serde(default)]
+    pub encode_membership_write_operations: u64,
+    /// Authenticated source-spool writer submissions.
+    #[serde(default)]
+    pub encode_source_spool_write_operations: u64,
+    /// Ordinal payload writer submissions.
+    #[serde(default)]
+    pub encode_ordinal_artifact_write_operations: u64,
+    /// Ordinal publication-control writer submissions.
+    #[serde(default)]
+    pub encode_ordinal_publication_write_operations: u64,
     /// Canonical encoding file and directory durability barriers.
     #[serde(default)]
     pub encode_fsync_operations: u64,
+    /// Completed canonical objects in the encoded inventory.
+    #[serde(default)]
+    pub canonical_artifact_objects: u64,
+    /// Canonical output file and directory barriers.
+    #[serde(default)]
+    pub encode_output_fsync_operations: u64,
+    /// Authenticated source-spool durability barriers.
+    #[serde(default)]
+    pub encode_source_spool_fsync_operations: u64,
+    /// UUID-membership durability barriers.
+    #[serde(default)]
+    pub encode_membership_fsync_operations: u64,
+    /// Ordinal-index payload and publication durability barriers.
+    #[serde(default)]
+    pub encode_ordinal_fsync_operations: u64,
     /// Application-observed durable control bytes read immediately before publication.
     #[serde(default)]
     pub publication_application_read_bytes: u64,
@@ -349,6 +382,9 @@ pub struct GraphConstructionEvidence {
     /// CAS file and directory durability barriers.
     #[serde(default)]
     pub cas_fsync_operations: u64,
+    /// Actual payload, manifest-install and manifest-path-read work components.
+    #[serde(default)]
+    pub cas_publication_io: crate::graph_object_store::GraphPublicationIo,
     /// Application-observed published payload bytes read while hydrating the workspace.
     #[serde(default)]
     pub hydration_application_read_bytes: u64,
@@ -364,6 +400,15 @@ pub struct GraphConstructionEvidence {
     /// Hydration file and directory durability barriers.
     #[serde(default)]
     pub hydration_fsync_operations: u64,
+    /// Canonical files copied into the private hydrated workspace.
+    #[serde(default)]
+    pub hydration_files_copied: u64,
+    /// Hydration durability barriers completed on materialized files.
+    #[serde(default)]
+    pub hydration_file_fsync_operations: u64,
+    /// Hydration durability barriers completed on containing directories.
+    #[serde(default)]
+    pub hydration_directory_fsync_operations: u64,
     /// Artifact bytes authenticated while repairing an interrupted append.
     #[serde(default)]
     pub recovery_application_read_bytes: u64,
@@ -380,11 +425,18 @@ pub struct GraphConstructionEvidence {
     /// Persisted in the checkpoint so resume never scans the session tree.
     #[serde(default)]
     pub storage_current: BTreeMap<crate::ArtifactCategory, crate::ArtifactStorageTotals>,
+    /// Independently accumulated receipt and category-scoped identity totals.
+    #[serde(default)]
+    pub storage_receipt_category_authorities:
+        BTreeMap<crate::ArtifactCategory, crate::ArtifactStorageTotals>,
     /// Per-category peak allocated bytes observed as receipt-backed staging
     /// artifacts accumulated. These are transient construction bytes, not
     /// committed-generation allocation.
     #[serde(default)]
     pub storage_transient_peak_allocated_bytes: BTreeMap<crate::ArtifactCategory, u64>,
+    /// Independently accumulated category-scoped receipt high-water marks.
+    #[serde(default)]
+    pub storage_receipt_transient_peak_authorities: BTreeMap<crate::ArtifactCategory, u64>,
     /// High-water mark of the union of all simultaneously retained,
     /// receipt-authenticated construction artifacts. Unlike the per-category
     /// diagnostics above, this is a total and categories are never treated as
@@ -528,17 +580,195 @@ pub struct GraphConstructionEvidence {
     pub parquet_write_operations: u64,
 }
 
+/// Sanitized current and peak commitments to independent category ledgers.
+pub type StorageCategoryAuthorityCommitments = (
+    BTreeMap<crate::ArtifactCategory, String>,
+    BTreeMap<crate::ArtifactCategory, String>,
+);
+
 impl GraphConstructionEvidence {
+    /// Identity-free category authorities derived from accepted construction
+    /// receipts and the active native-identity union.
+    pub fn storage_category_authorities(
+        &self,
+    ) -> Result<BTreeMap<crate::ArtifactCategory, crate::ArtifactStorageTotals>, GfError> {
+        if self.storage_current.len() != crate::ArtifactCategory::ALL.len()
+            || self.storage_receipt_category_authorities.len() != crate::ArtifactCategory::ALL.len()
+            || crate::ArtifactCategory::ALL.iter().any(|category| {
+                !self.storage_current.contains_key(category)
+                    || !self
+                        .storage_receipt_category_authorities
+                        .contains_key(category)
+            })
+            || self.storage_current != self.storage_receipt_category_authorities
+        {
+            return Err(storage(
+                "construction storage category authority is incomplete",
+            ));
+        }
+        let category_allocated = self
+            .storage_receipt_category_authorities
+            .values()
+            .try_fold(0_u64, |total, category| {
+                total
+                    .checked_add(category.allocated_bytes)
+                    .ok_or_else(|| storage("construction category authority overflows"))
+            })?;
+        let identity_allocated = self
+            .storage_active_identity_allocated_bytes
+            .values()
+            .try_fold(0_u64, |total, allocated| {
+                total
+                    .checked_add(*allocated)
+                    .ok_or_else(|| storage("construction identity authority overflows"))
+            })?;
+        if category_allocated != identity_allocated {
+            return Err(storage(
+                "construction category authority differs from identity union",
+            ));
+        }
+        Ok(self.storage_receipt_category_authorities.clone())
+    }
+
+    /// Identity-free per-category high-water authorities derived from accepted
+    /// construction receipt transitions.
+    pub fn storage_transient_peak_authorities(
+        &self,
+    ) -> Result<BTreeMap<crate::ArtifactCategory, u64>, GfError> {
+        if self.storage_transient_peak_allocated_bytes.len() != crate::ArtifactCategory::ALL.len()
+            || self.storage_receipt_transient_peak_authorities.len()
+                != crate::ArtifactCategory::ALL.len()
+            || crate::ArtifactCategory::ALL.iter().any(|category| {
+                !self
+                    .storage_transient_peak_allocated_bytes
+                    .contains_key(category)
+                    || !self
+                        .storage_receipt_transient_peak_authorities
+                        .contains_key(category)
+            })
+            || self.storage_transient_peak_allocated_bytes
+                != self.storage_receipt_transient_peak_authorities
+        {
+            return Err(storage(
+                "construction peak category authority is incomplete",
+            ));
+        }
+        for category in crate::ArtifactCategory::ALL {
+            if self.storage_transient_peak_allocated_bytes[&category]
+                < self.storage_current[&category].allocated_bytes
+            {
+                return Err(storage(
+                    "construction peak category authority is below current allocation",
+                ));
+            }
+        }
+        Ok(self.storage_receipt_transient_peak_authorities.clone())
+    }
+
+    /// Sanitized commitments to independent current and peak category authority.
+    pub fn storage_category_authority_commitments(
+        &self,
+        context: &crate::ArtifactCategoryAuthorityContext,
+    ) -> Result<StorageCategoryAuthorityCommitments, GfError> {
+        let current = self.storage_category_authorities()?;
+        let peaks = self.storage_transient_peak_authorities()?;
+        Ok((
+            current
+                .iter()
+                .map(|(category, totals)| {
+                    (
+                        *category,
+                        crate::artifact_category_authority_commitment(context, *category, totals),
+                    )
+                })
+                .collect(),
+            peaks
+                .iter()
+                .map(|(category, allocated)| {
+                    (
+                        *category,
+                        crate::artifact_category_peak_authority_commitment(
+                            context, *category, *allocated,
+                        ),
+                    )
+                })
+                .collect(),
+        ))
+    }
+
+    /// Build safe context from hidden construction receipt and identity ledgers.
+    pub fn storage_category_authority_context(
+        &self,
+        contract: &str,
+        rung: u64,
+        generation_sha256: &str,
+        owner: &str,
+        live_nodes: u64,
+        live_edges: u64,
+    ) -> Result<crate::ArtifactCategoryAuthorityContext, GfError> {
+        self.storage_category_authorities()?;
+        if contract.is_empty()
+            || generation_sha256.is_empty()
+            || owner.is_empty()
+            || rung == 0
+            || live_nodes == 0
+            || live_edges == 0
+        {
+            return Err(storage(
+                "construction category authority context is invalid",
+            ));
+        }
+        let empty_identities = BTreeMap::new();
+        let mut category_identity_authorities = crate::ArtifactCategory::ALL
+            .into_iter()
+            .map(|category| {
+                (
+                    category,
+                    crate::storage_attribution::identity_map_authority_sha256(&empty_identities),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        category_identity_authorities.insert(
+            crate::ArtifactCategory::ConstructionStaging,
+            crate::storage_attribution::identity_map_authority_sha256(
+                &self.storage_active_identity_allocated_bytes,
+            ),
+        );
+        Ok(crate::ArtifactCategoryAuthorityContext {
+            contract: contract.to_owned(),
+            version: 1,
+            rung,
+            generation_sha256: generation_sha256.to_owned(),
+            owner: owner.to_owned(),
+            receipt_authority_sha256: crate::storage_attribution::category_map_authority_sha256(
+                b"graphforge-construction-receipt-authority-v1\0",
+                &self.storage_receipt_category_authorities,
+            ),
+            native_identity_authority_sha256:
+                crate::storage_attribution::identity_map_authority_sha256(
+                    &self.storage_active_identity_allocated_bytes,
+                ),
+            native_category_identity_authority_sha256: category_identity_authorities,
+            live_nodes,
+            live_edges,
+        })
+    }
+
     /// Reconciled application-observed payload/control bytes read across construction.
-    #[must_use]
-    pub const fn total_application_read_bytes(&self) -> u64 {
-        self.seal_application_read_bytes
-            .saturating_add(self.shape_application_read_bytes)
-            .saturating_add(self.encode_application_read_bytes)
-            .saturating_add(self.publication_application_read_bytes)
-            .saturating_add(self.cas_application_read_bytes)
-            .saturating_add(self.hydration_application_read_bytes)
-            .saturating_add(self.recovery_application_read_bytes)
+    pub fn total_application_read_bytes(&self) -> Result<u64, GfError> {
+        checked_evidence_sum(
+            "total application read bytes",
+            0,
+            &[
+                self.seal_application_read_bytes,
+                self.shape_application_read_bytes,
+                self.encode_application_read_bytes,
+                self.publication_application_read_bytes,
+                self.cas_application_read_bytes,
+                self.hydration_application_read_bytes,
+                self.recovery_application_read_bytes,
+            ],
+        )
     }
 }
 
@@ -1046,60 +1276,11 @@ impl GraphConstructionSession {
             &mut cancelled,
         )?;
         record_encoded_active_artifacts(&self.root, &encoded, &mut self.checkpoint.evidence)?;
-        let invocation = &encoded.invocation.evidence;
-        self.checkpoint.evidence.encode_application_read_bytes = self
-            .checkpoint
-            .evidence
-            .encode_application_read_bytes
-            .saturating_add(invocation.input_read_bytes)
-            .saturating_add(invocation.membership_read_bytes);
-        self.checkpoint.evidence.encode_application_read_operations = self
-            .checkpoint
-            .evidence
-            .encode_application_read_operations
-            .saturating_add(invocation.input_read_operations)
-            .saturating_add(invocation.membership_read_operations)
-            .saturating_add(invocation.source_spool_read_operations);
-        self.checkpoint.evidence.encode_application_write_bytes = self
-            .checkpoint
-            .evidence
-            .encode_application_write_bytes
-            .saturating_add(invocation.output_write_bytes)
-            .saturating_add(invocation.membership_total_write_bytes)
-            .saturating_add(invocation.source_spool_write_bytes)
-            .saturating_add(invocation.ordinal_artifact_write_bytes)
-            .saturating_add(invocation.ordinal_publication_write_bytes);
-        self.checkpoint.evidence.encode_application_write_operations = self
-            .checkpoint
-            .evidence
-            .encode_application_write_operations
-            .saturating_add(invocation.output_write_operations)
-            .saturating_add(invocation.membership_write_operations)
-            .saturating_add(invocation.source_spool_write_operations)
-            .saturating_add(invocation.ordinal_artifact_write_operations)
-            .saturating_add(invocation.ordinal_publication_write_operations);
-        self.checkpoint.evidence.encode_fsync_operations = self
-            .checkpoint
-            .evidence
-            .encode_fsync_operations
-            .saturating_add(invocation.fsync_operations)
-            .saturating_add(invocation.membership_fsync_operations)
-            .saturating_add(invocation.source_spool_fsync_operations)
-            .saturating_add(invocation.ordinal_fsync_operations);
-        account_encoding_cache_release(invocation, &mut self.checkpoint.evidence);
-        self.checkpoint.evidence.canonical_output_bytes = encoded
-            .artifacts
-            .iter()
-            .map(|artifact| artifact.bytes)
-            .sum();
-        self.checkpoint.evidence.staged_and_retained_disk_bytes =
-            self.checkpoint.evidence.write_bytes.saturating_add(
-                encoded
-                    .retained_artifacts
-                    .iter()
-                    .map(|artifact| artifact.bytes)
-                    .sum(),
-            );
+        record_encoding_io_evidence(&mut self.checkpoint.evidence, &encoded)?;
+        account_encoding_cache_release(
+            &encoded.invocation.evidence,
+            &mut self.checkpoint.evidence,
+        )?;
         let inventory_authority =
             crate::graph_construction_encoding::inventory_authority_sha256(&encoded)?;
         match self.checkpoint.encoding_inventory_sha256.as_deref() {
@@ -1183,7 +1364,13 @@ impl GraphConstructionSession {
         {
             return Err(storage("publication encoding authority changed"));
         }
-        if encoding.generation != self.checkpoint.parent_topology_generation.saturating_add(1) {
+        if encoding.generation
+            != self
+                .checkpoint
+                .parent_topology_generation
+                .checked_add(1)
+                .ok_or_else(|| storage("publication topology generation overflows"))?
+        {
             return Err(storage("publication topology generation changed"));
         }
         let inventory_control =
@@ -1194,14 +1381,16 @@ impl GraphConstructionSession {
             .checkpoint
             .evidence
             .publication_application_read_bytes
-            .saturating_add(inventory_control.read_bytes);
+            .checked_add(inventory_control.read_bytes)
+            .ok_or_else(|| storage("publication read byte count overflows"))?;
         self.checkpoint
             .evidence
             .publication_application_read_operations = self
             .checkpoint
             .evidence
             .publication_application_read_operations
-            .saturating_add(inventory_control.read_calls);
+            .checked_add(inventory_control.read_calls)
+            .ok_or_else(|| storage("publication read operation count overflows"))?;
         let admission = crate::filesystem_admission::admit_project_lifecycle(
             &self.project_path,
             self.checkpoint.lifecycle_mode,
@@ -1216,7 +1405,7 @@ impl GraphConstructionSession {
         }
 
         let lease = crate::begin_graph_object_publication(admission.root())?;
-        let (mut manifest_state, manifest_read_bytes) =
+        let (mut manifest_state, manifest_read_bytes, manifest_read_calls) =
             match parent.declared_graph_files_participant()? {
                 Some(crate::GraphFilesParticipant::V2(root)) => {
                     let (state, evidence) = crate::graph_object_store::GraphManifestState::open(
@@ -1224,23 +1413,36 @@ impl GraphConstructionSession {
                         root,
                         crate::GraphManifestLimits::default(),
                     )?;
-                    (state, evidence.decoded_bytes)
+                    (
+                        state,
+                        evidence.decoded_bytes,
+                        evidence.application_read_calls,
+                    )
                 }
                 Some(crate::GraphFilesParticipant::V1(inventory)) if inventory.file_count == 0 => {
-                    (crate::graph_object_store::GraphManifestState::empty(), 0)
+                    (crate::graph_object_store::GraphManifestState::empty(), 0, 0)
                 }
                 Some(crate::GraphFilesParticipant::V1(_)) => {
                     return Err(storage(
                         "nonempty construction parent requires compact graph root",
                     ));
                 }
-                None => (crate::graph_object_store::GraphManifestState::empty(), 0),
+                None => (crate::graph_object_store::GraphManifestState::empty(), 0, 0),
             };
         self.checkpoint.evidence.publication_application_read_bytes = self
             .checkpoint
             .evidence
             .publication_application_read_bytes
-            .saturating_add(manifest_read_bytes);
+            .checked_add(manifest_read_bytes)
+            .ok_or_else(|| storage("publication manifest read byte count overflows"))?;
+        self.checkpoint
+            .evidence
+            .publication_application_read_operations = self
+            .checkpoint
+            .evidence
+            .publication_application_read_operations
+            .checked_add(manifest_read_calls)
+            .ok_or_else(|| storage("publication manifest read call count overflows"))?;
         for retained in &encoding.retained_artifacts {
             let entry = manifest_state
                 .entries()
@@ -1291,27 +1493,36 @@ impl GraphConstructionSession {
             .checkpoint
             .evidence
             .cas_application_read_bytes
-            .saturating_add(cas_evidence.payload_bytes_hashed);
+            .checked_add(cas_evidence.publication_io.totals()?.read_bytes)
+            .ok_or_else(|| storage("CAS read byte count overflows"))?;
         self.checkpoint.evidence.cas_application_read_operations = self
             .checkpoint
             .evidence
             .cas_application_read_operations
-            .saturating_add(cas_evidence.read_calls);
+            .checked_add(cas_evidence.read_calls)
+            .ok_or_else(|| storage("CAS read operation count overflows"))?;
         self.checkpoint.evidence.cas_application_write_bytes = self
             .checkpoint
             .evidence
             .cas_application_write_bytes
-            .saturating_add(cas_evidence.write_bytes);
+            .checked_add(cas_evidence.write_bytes)
+            .ok_or_else(|| storage("CAS write byte count overflows"))?;
         self.checkpoint.evidence.cas_application_write_operations = self
             .checkpoint
             .evidence
             .cas_application_write_operations
-            .saturating_add(cas_evidence.write_calls);
+            .checked_add(cas_evidence.write_calls)
+            .ok_or_else(|| storage("CAS write operation count overflows"))?;
         self.checkpoint.evidence.cas_fsync_operations = self
             .checkpoint
             .evidence
             .cas_fsync_operations
-            .saturating_add(cas_evidence.fsync_calls);
+            .checked_add(cas_evidence.fsync_calls)
+            .ok_or_else(|| storage("CAS fsync count overflows"))?;
+        self.checkpoint
+            .evidence
+            .cas_publication_io
+            .checked_add_assign(&cas_evidence.publication_io)?;
         if graphforge_filesystem::path_identity(&workspace).map_err(storage)?
             != encoded_directory.identity()
         {
@@ -1884,6 +2095,32 @@ impl GraphConstructionSession {
             session_lock,
             _reservation: reservation,
         };
+        for category in crate::ArtifactCategory::ALL {
+            session
+                .checkpoint
+                .evidence
+                .storage_current
+                .entry(category)
+                .or_default();
+            session
+                .checkpoint
+                .evidence
+                .storage_receipt_category_authorities
+                .entry(category)
+                .or_default();
+            session
+                .checkpoint
+                .evidence
+                .storage_transient_peak_allocated_bytes
+                .entry(category)
+                .or_default();
+            session
+                .checkpoint
+                .evidence
+                .storage_receipt_transient_peak_authorities
+                .entry(category)
+                .or_default();
+        }
         recover_shape_intent(&session.root, &mut session.checkpoint)?;
         session.recover_intent()?;
         if session
@@ -2028,31 +2265,56 @@ impl GraphConstructionSession {
             .checkpoint
             .evidence
             .hydration_application_read_bytes
-            .saturating_add(hydration.application_read_bytes);
+            .checked_add(hydration.application_read_bytes)
+            .ok_or_else(|| storage("hydration read byte count overflows"))?;
         self.checkpoint
             .evidence
             .hydration_application_read_operations = self
             .checkpoint
             .evidence
             .hydration_application_read_operations
-            .saturating_add(hydration.application_read_calls);
+            .checked_add(hydration.application_read_calls)
+            .ok_or_else(|| storage("hydration read operation count overflows"))?;
         self.checkpoint.evidence.hydration_application_write_bytes = self
             .checkpoint
             .evidence
             .hydration_application_write_bytes
-            .saturating_add(hydration.application_write_bytes);
+            .checked_add(hydration.application_write_bytes)
+            .ok_or_else(|| storage("hydration write byte count overflows"))?;
         self.checkpoint
             .evidence
             .hydration_application_write_operations = self
             .checkpoint
             .evidence
             .hydration_application_write_operations
-            .saturating_add(hydration.application_write_calls);
+            .checked_add(hydration.application_write_calls)
+            .ok_or_else(|| storage("hydration write operation count overflows"))?;
         self.checkpoint.evidence.hydration_fsync_operations = self
             .checkpoint
             .evidence
             .hydration_fsync_operations
-            .saturating_add(hydration.fsync_calls);
+            .checked_add(hydration.fsync_calls)
+            .ok_or_else(|| storage("hydration fsync count overflows"))?;
+        self.checkpoint.evidence.hydration_files_copied = self
+            .checkpoint
+            .evidence
+            .hydration_files_copied
+            .checked_add(hydration.files_copied)
+            .ok_or_else(|| storage("hydration copied-file count overflows"))?;
+        self.checkpoint.evidence.hydration_file_fsync_operations = self
+            .checkpoint
+            .evidence
+            .hydration_file_fsync_operations
+            .checked_add(hydration.file_fsync_calls)
+            .ok_or_else(|| storage("hydration file barrier count overflows"))?;
+        self.checkpoint
+            .evidence
+            .hydration_directory_fsync_operations = self
+            .checkpoint
+            .evidence
+            .hydration_directory_fsync_operations
+            .checked_add(hydration.directory_fsync_calls)
+            .ok_or_else(|| storage("hydration directory barrier count overflows"))?;
         replace_checkpoint_control(&self.root, &self.checkpoint)
     }
 
@@ -2136,14 +2398,20 @@ impl GraphConstructionSession {
                     .checkpoint
                     .evidence
                     .replay_validation_read_bytes
-                    .saturating_add(work.bytes);
+                    .checked_add(work.bytes)
+                    .ok_or_else(|| storage("replay validation byte count overflows"))?;
                 self.checkpoint.evidence.replay_validation_read_operations = self
                     .checkpoint
                     .evidence
                     .replay_validation_read_operations
-                    .saturating_add(work.operations);
-                self.checkpoint.evidence.replayed_chunks =
-                    self.checkpoint.evidence.replayed_chunks.saturating_add(1);
+                    .checked_add(work.operations)
+                    .ok_or_else(|| storage("replay validation operation count overflows"))?;
+                self.checkpoint.evidence.replayed_chunks = self
+                    .checkpoint
+                    .evidence
+                    .replayed_chunks
+                    .checked_add(1)
+                    .ok_or_else(|| storage("replayed chunk count overflows"))?;
                 replace_checkpoint_control(&self.root, &self.checkpoint)?;
                 return Ok(receipt);
             }
@@ -2159,12 +2427,13 @@ impl GraphConstructionSession {
                 &self.checkpoint.node_schema_sha256,
             ),
         };
+        let schema_groups = known_schemas
+            .len()
+            .checked_add(other_schemas.len())
+            .and_then(|count| count.checked_add(1))
+            .ok_or_else(|| storage("construction schema-group count overflow"))?;
         if !known_schemas.contains(&schema_sha256)
-            && known_schemas
-                .len()
-                .saturating_add(other_schemas.len())
-                .saturating_add(1)
-                > self.checkpoint.budgets.max_schema_groups
+            && schema_groups > self.checkpoint.budgets.max_schema_groups
         {
             return Err(storage("construction schema-group budget exhausted"));
         }
@@ -2172,8 +2441,9 @@ impl GraphConstructionSession {
         let run_records = arrays
             .identities
             .len()
-            .saturating_add(arrays.endpoints.len())
-            .saturating_add(batch.num_rows());
+            .checked_add(arrays.endpoints.len())
+            .and_then(|count| count.checked_add(batch.num_rows()))
+            .ok_or_else(|| storage("construction run record count overflow"))?;
         if run_records > self.checkpoint.budgets.max_run_records {
             return Err(storage("construction run window exhausted"));
         }
@@ -2209,18 +2479,39 @@ impl GraphConstructionSession {
         let fixed_bytes = arrays
             .identities
             .len()
-            .saturating_mul(IDENTITY_WIDTH)
-            .saturating_add(arrays.endpoints.len().saturating_mul(ENDPOINT_WIDTH))
-            .saturating_add(match &arrays.details {
-                DetailRuns::Node(records) => records.len().saturating_mul(NODE_DETAIL_WIDTH),
-                DetailRuns::Edge(records) => records.len().saturating_mul(EDGE_DETAIL_WIDTH),
-            });
+            .checked_mul(IDENTITY_WIDTH)
+            .and_then(|bytes| {
+                arrays
+                    .endpoints
+                    .len()
+                    .checked_mul(ENDPOINT_WIDTH)
+                    .and_then(|endpoint_bytes| bytes.checked_add(endpoint_bytes))
+            })
+            .and_then(|bytes| {
+                let detail_bytes = match &arrays.details {
+                    DetailRuns::Node(records) => records.len().checked_mul(NODE_DETAIL_WIDTH),
+                    DetailRuns::Edge(records) => records.len().checked_mul(EDGE_DETAIL_WIDTH),
+                };
+                detail_bytes.and_then(|detail_bytes| bytes.checked_add(detail_bytes))
+            })
+            .ok_or_else(|| storage("construction fixed-width byte count overflow"))?;
         let sorted_bytes = sorted_batch.get_array_memory_size();
-        intent.accounted_live_bytes = input_bytes
-            .saturating_add(fixed_bytes)
-            .saturating_add(sorted_bytes.saturating_mul(2))
-            .saturating_add(BLOCK_BYTES.saturating_mul(2))
-            as u64;
+        intent.accounted_live_bytes = u64::try_from(
+            input_bytes
+                .checked_add(fixed_bytes)
+                .and_then(|bytes| {
+                    sorted_bytes
+                        .checked_mul(2)
+                        .and_then(|sorted| bytes.checked_add(sorted))
+                })
+                .and_then(|bytes| {
+                    BLOCK_BYTES
+                        .checked_mul(2)
+                        .and_then(|blocks| bytes.checked_add(blocks))
+                })
+                .ok_or_else(|| storage("construction live-byte count overflow"))?,
+        )
+        .map_err(storage)?;
         replace_control(&self.root, INTENT, &intent)?;
         intent.parquet = Some(write_parquet(
             &self.root,
@@ -2309,9 +2600,13 @@ impl GraphConstructionSession {
             }
             if authenticate_artifacts {
                 let work = validate_receipt_artifacts(&self.root, &receipt)?;
-                account_cache_release(work.cache_release, &mut self.checkpoint.evidence);
-                read_bytes = read_bytes.saturating_add(work.bytes);
-                read_operations = read_operations.saturating_add(work.operations);
+                account_cache_release(work.cache_release, &mut self.checkpoint.evidence)?;
+                read_bytes = read_bytes
+                    .checked_add(work.bytes)
+                    .ok_or_else(|| storage("read_bytes overflows"))?;
+                read_operations = read_operations
+                    .checked_add(work.operations)
+                    .ok_or_else(|| storage("read_operations overflows"))?;
             }
             let body = serde_json::to_vec(&receipt).map_err(storage)?;
             prior_digest = Some(sha256(&body));
@@ -2326,17 +2621,20 @@ impl GraphConstructionSession {
             .checkpoint
             .evidence
             .authentication_read_bytes
-            .saturating_add(read_bytes);
+            .checked_add(read_bytes)
+            .ok_or_else(|| storage("authentication read byte count overflows"))?;
         self.checkpoint.evidence.authentication_read_operations = self
             .checkpoint
             .evidence
             .authentication_read_operations
-            .saturating_add(read_operations);
+            .checked_add(read_operations)
+            .ok_or_else(|| storage("authentication read operation count overflows"))?;
         self.checkpoint.evidence.seal_application_read_bytes = self
             .checkpoint
             .evidence
             .seal_application_read_bytes
-            .saturating_add(read_bytes);
+            .checked_add(read_bytes)
+            .ok_or_else(|| storage("seal application read byte count overflows"))?;
         self.checkpoint.state = GraphConstructionState::Sealed;
         self.checkpoint.publication_state = Some(ConstructionPublicationState::Sealed);
         replace_checkpoint_control(&self.root, &self.checkpoint)
@@ -2406,23 +2704,31 @@ impl GraphConstructionSession {
             // decoder cannot establish a whole-file digest, so retain exactly
             // one explicit whole-file authentication pass for that artifact.
             let mut work = authenticate_artifact(&self.root, &receipt.parquet)?;
-            account_cache_release(work.cache_release, &mut self.checkpoint.evidence);
+            account_cache_release(work.cache_release, &mut self.checkpoint.evidence)?;
             let metadata_work = validate_parquet_metadata(&self.root, &receipt)?;
-            account_cache_release(metadata_work.cache_release, &mut self.checkpoint.evidence);
-            work.bytes = work.bytes.saturating_add(metadata_work.bytes);
-            work.operations = work.operations.saturating_add(metadata_work.operations);
+            account_cache_release(metadata_work.cache_release, &mut self.checkpoint.evidence)?;
+            work.bytes = work
+                .bytes
+                .checked_add(metadata_work.bytes)
+                .ok_or_else(|| storage("bytes overflows"))?;
+            work.operations = work
+                .operations
+                .checked_add(metadata_work.operations)
+                .ok_or_else(|| storage("operations overflows"))?;
             self.checkpoint.evidence.shape_input_validation_read_bytes = self
                 .checkpoint
                 .evidence
                 .shape_input_validation_read_bytes
-                .saturating_add(work.bytes);
+                .checked_add(work.bytes)
+                .ok_or_else(|| storage("shape input validation byte count overflows"))?;
             self.checkpoint
                 .evidence
                 .shape_input_validation_read_operations = self
                 .checkpoint
                 .evidence
                 .shape_input_validation_read_operations
-                .saturating_add(work.operations);
+                .checked_add(work.operations)
+                .ok_or_else(|| storage("shape input validation operation count overflows"))?;
             let kind = u8::from(receipt.kind == ConstructionChunkKind::Edge);
             catalog_authority.update([kind]);
             catalog_authority.update(receipt.schema_sha256.as_bytes());
@@ -2505,22 +2811,24 @@ impl GraphConstructionSession {
                     )?;
                 }
             }
+            let row_group_names = row_groups
+                .values()
+                .try_fold(0_usize, |count, group| {
+                    count.checked_add(group.slot_count())
+                })
+                .ok_or_else(|| storage("row-group name-slot count overflow"))?;
             let retained_names = unified
                 .slot_count()
-                .saturating_add(node_details.slot_count())
-                .saturating_add(edge_details.slot_count())
-                .saturating_add(endpoints.slot_count())
-                .saturating_add(
-                    row_groups
-                        .values()
-                        .map(RowMergeAccumulator::slot_count)
-                        .sum::<usize>(),
-                );
+                .checked_add(node_details.slot_count())
+                .and_then(|count| count.checked_add(edge_details.slot_count()))
+                .and_then(|count| count.checked_add(endpoints.slot_count()))
+                .and_then(|count| count.checked_add(row_group_names))
+                .ok_or_else(|| storage("merge name-slot count overflow"))?;
             self.checkpoint.evidence.peak_merge_name_slots = self
                 .checkpoint
                 .evidence
                 .peak_merge_name_slots
-                .max(retained_names as u64);
+                .max(u64::try_from(retained_names).map_err(storage)?);
         }
         let staged_identities = unified.finish_optional::<BASE_IDENTITY_WIDTH>(
             &self.root,
@@ -2600,12 +2908,14 @@ impl GraphConstructionSession {
             .checkpoint
             .base_work
             .live_nodes
-            .saturating_add(new_nodes);
+            .checked_add(new_nodes)
+            .ok_or_else(|| storage("node count overflows"))?;
         let edge_count = self
             .checkpoint
             .base_work
             .live_edges
-            .saturating_add(new_edges);
+            .checked_add(new_edges)
+            .ok_or_else(|| storage("edge count overflows"))?;
         let max_node_surrogate = base_max_node
             .checked_add(new_nodes)
             .ok_or_else(|| storage("node surrogate overflow"))?;
@@ -2677,31 +2987,42 @@ impl GraphConstructionSession {
             .chain(std::iter::once(&shape.runtime_catalog))
         {
             let (output, work) = receipt_for_existing_with_work(&self.root, name)?;
-            inventory_work.bytes = inventory_work.bytes.saturating_add(work.bytes);
-            inventory_work.operations = inventory_work.operations.saturating_add(work.operations);
+            inventory_work.bytes = inventory_work
+                .bytes
+                .checked_add(work.bytes)
+                .ok_or_else(|| storage("shape output authentication bytes overflow"))?;
+            inventory_work.operations = inventory_work
+                .operations
+                .checked_add(work.operations)
+                .ok_or_else(|| storage("shape output authentication operations overflow"))?;
             outputs.push(output);
         }
         self.checkpoint.evidence.shaped_output_authentication_bytes = self
             .checkpoint
             .evidence
             .shaped_output_authentication_bytes
-            .saturating_add(inventory_work.bytes);
+            .checked_add(inventory_work.bytes)
+            .ok_or_else(|| storage("shaped output authentication bytes overflow"))?;
         self.checkpoint
             .evidence
             .shaped_output_authentication_operations = self
             .checkpoint
             .evidence
             .shaped_output_authentication_operations
-            .saturating_add(inventory_work.operations);
-        self.checkpoint.evidence.shape_application_read_bytes = self
-            .checkpoint
-            .evidence
-            .shape_input_validation_read_bytes
-            .saturating_add(self.checkpoint.evidence.merge_read_bytes)
-            .saturating_add(self.checkpoint.evidence.parquet_read_bytes)
-            .saturating_add(self.checkpoint.evidence.shaped_output_authentication_bytes)
-            .saturating_add(self.checkpoint.evidence.parent_catalog_read_bytes)
-            .saturating_add(self.checkpoint.evidence.retained_probe_read_bytes);
+            .checked_add(inventory_work.operations)
+            .ok_or_else(|| storage("shaped output authentication operations overflow"))?;
+        self.checkpoint.evidence.shape_application_read_bytes = checked_evidence_sum(
+            "shape application read bytes",
+            0,
+            &[
+                self.checkpoint.evidence.shape_input_validation_read_bytes,
+                self.checkpoint.evidence.merge_read_bytes,
+                self.checkpoint.evidence.parquet_read_bytes,
+                self.checkpoint.evidence.shaped_output_authentication_bytes,
+                self.checkpoint.evidence.parent_catalog_read_bytes,
+                self.checkpoint.evidence.retained_probe_read_bytes,
+            ],
+        )?;
         let shape_authority_sha256 = shape_authority_sha256(&shape, &outputs)?;
         self.checkpoint.shape_authority_sha256 = Some(shape_authority_sha256.clone());
         replace_control(
@@ -2772,11 +3093,14 @@ impl GraphConstructionSession {
             .checkpoint
             .budgets
             .max_chunks
-            .saturating_mul(16)
-            .saturating_add(
-                u64::try_from(self.checkpoint.budgets.max_schema_groups).unwrap_or(u64::MAX),
-            )
-            .saturating_add(4_096);
+            .checked_mul(16)
+            .and_then(|limit| {
+                u64::try_from(self.checkpoint.budgets.max_schema_groups)
+                    .ok()
+                    .and_then(|groups| limit.checked_add(groups))
+            })
+            .and_then(|limit| limit.checked_add(4_096))
+            .ok_or_else(|| storage("construction discard traversal bound overflow"))?;
         crate::file_lock::unlock(&self.session_lock).map_err(storage)?;
         drop(self);
         remove_owned_directory_tree(
@@ -2809,14 +3133,16 @@ impl GraphConstructionSession {
                     .checkpoint
                     .evidence
                     .recovery_application_read_bytes
-                    .saturating_add(recovery_work.bytes);
+                    .checked_add(recovery_work.bytes)
+                    .ok_or_else(|| storage("recovery read byte count overflows"))?;
                 self.checkpoint
                     .evidence
                     .recovery_application_read_operations = self
                     .checkpoint
                     .evidence
                     .recovery_application_read_operations
-                    .saturating_add(recovery_work.operations);
+                    .checked_add(recovery_work.operations)
+                    .ok_or_else(|| storage("recovery read operation count overflows"))?;
                 let body = serde_json::to_vec(&receipt).map_err(storage)?;
                 if intent.sequence < self.checkpoint.next_sequence
                     && self.checkpoint.last_receipt_sha256.as_deref()
@@ -2866,19 +3192,21 @@ impl GraphConstructionSession {
                     account_cache_release(
                         recovery_work.cache_release,
                         &mut self.checkpoint.evidence,
-                    );
+                    )?;
                     self.checkpoint.evidence.recovery_application_read_bytes = self
                         .checkpoint
                         .evidence
                         .recovery_application_read_bytes
-                        .saturating_add(recovery_work.bytes);
+                        .checked_add(recovery_work.bytes)
+                        .ok_or_else(|| storage("recovery read byte count overflows"))?;
                     self.checkpoint
                         .evidence
                         .recovery_application_read_operations = self
                         .checkpoint
                         .evidence
                         .recovery_application_read_operations
-                        .saturating_add(recovery_work.operations);
+                        .checked_add(recovery_work.operations)
+                        .ok_or_else(|| storage("recovery read operation count overflows"))?;
                     unlink_artifact(&self.root, &artifact)?;
                 }
                 let stem = artifact_stem(intent.sequence, intent.kind);
@@ -2958,10 +3286,22 @@ impl GraphConstructionSession {
             return Err(storage("receipt sequence is not checkpoint successor"));
         }
         let evidence = &mut self.checkpoint.evidence;
-        evidence.input_rows = evidence.input_rows.saturating_add(receipt.rows);
-        evidence.input_batches = evidence.input_batches.saturating_add(1);
-        evidence.parquet_shards = evidence.parquet_shards.saturating_add(1);
-        evidence.run_records = evidence.run_records.saturating_add(receipt.run_records);
+        evidence.input_rows = evidence
+            .input_rows
+            .checked_add(receipt.rows)
+            .ok_or_else(|| storage("construction input row count overflows"))?;
+        evidence.input_batches = evidence
+            .input_batches
+            .checked_add(1)
+            .ok_or_else(|| storage("construction input batch count overflows"))?;
+        evidence.parquet_shards = evidence
+            .parquet_shards
+            .checked_add(1)
+            .ok_or_else(|| storage("construction Parquet shard count overflows"))?;
+        evidence.run_records = evidence
+            .run_records
+            .checked_add(receipt.run_records)
+            .ok_or_else(|| storage("construction run record count overflows"))?;
         evidence.peak_batch_rows = evidence.peak_batch_rows.max(receipt.rows);
         evidence.peak_batch_bytes = evidence.peak_batch_bytes.max(receipt.input_bytes);
         evidence.peak_run_records = evidence.peak_run_records.max(receipt.run_records);
@@ -2975,7 +3315,10 @@ impl GraphConstructionSession {
             .into_iter()
             .chain(receipt.endpoints.iter())
         {
-            evidence.immutable_artifacts = evidence.immutable_artifacts.saturating_add(1);
+            evidence.immutable_artifacts = evidence
+                .immutable_artifacts
+                .checked_add(1)
+                .ok_or_else(|| storage("construction artifact count overflows"))?;
             let identity_key = format!(
                 "{:016x}:{}",
                 artifact.identity.volume_serial, artifact.identity.file_id
@@ -2986,41 +3329,25 @@ impl GraphConstructionSession {
                 artifact.allocated_bytes,
                 "construction artifact identity was already active",
             )?;
-            evidence.write_bytes = evidence.write_bytes.saturating_add(artifact.bytes);
+            evidence.write_bytes = evidence
+                .write_bytes
+                .checked_add(artifact.bytes)
+                .ok_or_else(|| storage("construction write byte count overflows"))?;
             evidence.write_operations = evidence
                 .write_operations
-                .saturating_add(artifact.write_operations);
+                .checked_add(artifact.write_operations)
+                .ok_or_else(|| storage("construction write operation count overflows"))?;
             evidence.fsync_operations = evidence
                 .fsync_operations
-                .saturating_add(artifact.fsync_operations);
-            let totals = evidence
-                .storage_current
-                .entry(crate::ArtifactCategory::ConstructionStaging)
-                .or_default();
-            totals.logical_references = totals.logical_references.saturating_add(1);
-            totals.logical_bytes = totals.logical_bytes.saturating_add(artifact.bytes);
-            totals.physical_objects = totals.physical_objects.saturating_add(1);
-            totals.physical_logical_bytes =
-                totals.physical_logical_bytes.saturating_add(artifact.bytes);
-            totals.allocated_bytes = totals
-                .allocated_bytes
-                .saturating_add(artifact.allocated_bytes);
-            evidence
-                .storage_transient_peak_allocated_bytes
-                .entry(crate::ArtifactCategory::ConstructionStaging)
-                .and_modify(|peak| *peak = (*peak).max(totals.allocated_bytes))
-                .or_insert(totals.allocated_bytes);
-            let current_union = evidence
-                .storage_current
-                .values()
-                .fold(0_u64, |total, item| {
-                    total.saturating_add(item.allocated_bytes)
-                });
-            evidence.storage_transient_peak_total_allocated_bytes = evidence
-                .storage_transient_peak_total_allocated_bytes
-                .max(current_union);
+                .checked_add(artifact.fsync_operations)
+                .ok_or_else(|| storage("construction fsync count overflows"))?;
+            record_category_install(evidence, artifact.bytes, artifact.allocated_bytes)?;
         }
-        self.checkpoint.next_sequence = self.checkpoint.next_sequence.saturating_add(1);
+        self.checkpoint.next_sequence = self
+            .checkpoint
+            .next_sequence
+            .checked_add(1)
+            .ok_or_else(|| storage("construction sequence overflows"))?;
         self.checkpoint.saw_edge |= receipt.kind == ConstructionChunkKind::Edge;
         match receipt.kind {
             ConstructionChunkKind::Node => {
@@ -3160,7 +3487,12 @@ fn extract_runs(kind: ConstructionChunkKind, batch: &RecordBatch) -> Result<RunA
             .as_any()
             .downcast_ref::<StringArray>()
             .ok_or_else(|| storage("canonical edge route is not Utf8"))?;
-        endpoints.reserve(batch.num_rows().saturating_mul(2));
+        endpoints.reserve(
+            batch
+                .num_rows()
+                .checked_mul(2)
+                .ok_or_else(|| storage("edge endpoint capacity overflow"))?,
+        );
         let mut details = Vec::with_capacity(batch.num_rows());
         for row in 0..batch.num_rows() {
             let edge = uuid_value(edges, row)?;
@@ -3468,13 +3800,16 @@ impl IoCounter {
         }
     }
 
-    fn add_to(&self, evidence: &mut GraphConstructionEvidence) {
+    fn add_to(&self, evidence: &mut GraphConstructionEvidence) -> Result<(), GfError> {
         evidence.parquet_read_bytes = evidence
             .parquet_read_bytes
-            .saturating_add(self.bytes.load(Ordering::Relaxed));
+            .checked_add(self.bytes.load(Ordering::Relaxed))
+            .ok_or_else(|| storage("Parquet read byte count overflows"))?;
         evidence.parquet_read_operations = evidence
             .parquet_read_operations
-            .saturating_add(self.operations.load(Ordering::Relaxed));
+            .checked_add(self.operations.load(Ordering::Relaxed))
+            .ok_or_else(|| storage("Parquet read operation count overflows"))?;
+        Ok(())
     }
 
     pub(crate) fn values(&self) -> (u64, u64) {
@@ -3627,8 +3962,13 @@ impl Write for HashingWriter {
     fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
         let written = self.inner.write(bytes)?;
         self.digest.update(&bytes[..written]);
-        self.bytes = self.bytes.saturating_add(written as u64);
-        self.operations = self.operations.saturating_add(1);
+        self.bytes = self
+            .bytes
+            .checked_add(written as u64)
+            .ok_or_else(|| std::io::Error::other("construction writer byte count overflows"))?;
+        self.operations = self.operations.checked_add(1).ok_or_else(|| {
+            std::io::Error::other("construction writer operation count overflows")
+        })?;
         Ok(written)
     }
 
@@ -3640,37 +3980,45 @@ impl Write for HashingWriter {
 fn account_cache_release(
     released: graphforge_filesystem::FileCacheReleaseEvidence,
     evidence: &mut GraphConstructionEvidence,
-) {
+) -> Result<(), GfError> {
     evidence.cache_release_operations = evidence
         .cache_release_operations
-        .saturating_add(released.release_operations);
+        .checked_add(released.release_operations)
+        .ok_or_else(|| storage("cache release operations overflows"))?;
     evidence.cache_release_unsupported_operations = evidence
         .cache_release_unsupported_operations
-        .saturating_add(released.unsupported_operations);
+        .checked_add(released.unsupported_operations)
+        .ok_or_else(|| storage("cache release unsupported operations overflows"))?;
     evidence.cache_released_bytes = evidence
         .cache_released_bytes
-        .saturating_add(released.released_bytes);
+        .checked_add(released.released_bytes)
+        .ok_or_else(|| storage("cache released bytes overflows"))?;
     evidence.peak_cache_release_window_bytes = evidence
         .peak_cache_release_window_bytes
         .max(released.peak_window_bytes);
+    Ok(())
 }
 
 fn account_encoding_cache_release(
     released: &GraphConstructionEncodingEvidence,
     evidence: &mut GraphConstructionEvidence,
-) {
+) -> Result<(), GfError> {
     evidence.cache_release_operations = evidence
         .cache_release_operations
-        .saturating_add(released.cache_release_operations);
+        .checked_add(released.cache_release_operations)
+        .ok_or_else(|| storage("cache release operations overflows"))?;
     evidence.cache_release_unsupported_operations = evidence
         .cache_release_unsupported_operations
-        .saturating_add(released.cache_release_unsupported_operations);
+        .checked_add(released.cache_release_unsupported_operations)
+        .ok_or_else(|| storage("cache release unsupported operations overflows"))?;
     evidence.cache_released_bytes = evidence
         .cache_released_bytes
-        .saturating_add(released.cache_released_bytes);
+        .checked_add(released.cache_released_bytes)
+        .ok_or_else(|| storage("cache released bytes overflows"))?;
     evidence.peak_cache_release_window_bytes = evidence
         .peak_cache_release_window_bytes
         .max(released.peak_cache_release_window_bytes);
+    Ok(())
 }
 
 fn write_parquet(
@@ -3693,7 +4041,7 @@ fn write_parquet(
     let hashing = parquet.inner_mut().get_mut();
     hashing.inner.sync_all_and_release().map_err(storage)?;
     let cache_release = hashing.inner.evidence();
-    account_cache_release(cache_release, evidence);
+    account_cache_release(cache_release, evidence)?;
     construction_failpoint(&format!("artifact.after_temp_fsync.{name}"));
     let receipt = ArtifactReceipt {
         name: name.to_owned(),
@@ -3704,7 +4052,10 @@ fn write_parquet(
         sha256: hex(&hashing.digest.clone().finalize()),
         identity: identity.into(),
         write_operations: hashing.operations,
-        fsync_operations: 4_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+        fsync_operations: cache_release
+            .sync_operations
+            .checked_add(3)
+            .ok_or_else(|| storage("artifact synchronization count overflows"))?,
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(name))
@@ -3739,7 +4090,7 @@ fn write_fixed_run<const N: usize>(
     writer.flush().map_err(storage)?;
     writer.inner.sync_all_and_release().map_err(storage)?;
     let cache_release = writer.inner.evidence();
-    account_cache_release(cache_release, evidence);
+    account_cache_release(cache_release, evidence)?;
     construction_failpoint(&format!("artifact.after_temp_fsync.{name}"));
     let receipt = ArtifactReceipt {
         name: name.to_owned(),
@@ -3750,7 +4101,10 @@ fn write_fixed_run<const N: usize>(
         sha256: hex(&writer.digest.finalize()),
         identity: identity.into(),
         write_operations: writer.operations,
-        fsync_operations: 3_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+        fsync_operations: cache_release
+            .sync_operations
+            .checked_add(2)
+            .ok_or_else(|| storage("artifact synchronization count overflows"))?,
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(name))
@@ -3890,8 +4244,12 @@ fn persisted_evidence_equivalent(
 
 fn copy_post_shape_io(target: &mut GraphConstructionEvidence, source: &GraphConstructionEvidence) {
     target.storage_current = source.storage_current.clone();
+    target.storage_receipt_category_authorities =
+        source.storage_receipt_category_authorities.clone();
     target.storage_transient_peak_allocated_bytes =
         source.storage_transient_peak_allocated_bytes.clone();
+    target.storage_receipt_transient_peak_authorities =
+        source.storage_receipt_transient_peak_authorities.clone();
     target.storage_transient_peak_total_allocated_bytes =
         source.storage_transient_peak_total_allocated_bytes;
     target.storage_active_identity_allocated_bytes =
@@ -3909,7 +4267,19 @@ fn copy_post_shape_io(target: &mut GraphConstructionEvidence, source: &GraphCons
     target.encode_application_read_operations = source.encode_application_read_operations;
     target.encode_application_write_bytes = source.encode_application_write_bytes;
     target.encode_application_write_operations = source.encode_application_write_operations;
+    target.encode_output_write_operations = source.encode_output_write_operations;
+    target.encode_membership_write_operations = source.encode_membership_write_operations;
+    target.encode_source_spool_write_operations = source.encode_source_spool_write_operations;
+    target.encode_ordinal_artifact_write_operations =
+        source.encode_ordinal_artifact_write_operations;
+    target.encode_ordinal_publication_write_operations =
+        source.encode_ordinal_publication_write_operations;
     target.encode_fsync_operations = source.encode_fsync_operations;
+    target.canonical_artifact_objects = source.canonical_artifact_objects;
+    target.encode_output_fsync_operations = source.encode_output_fsync_operations;
+    target.encode_source_spool_fsync_operations = source.encode_source_spool_fsync_operations;
+    target.encode_membership_fsync_operations = source.encode_membership_fsync_operations;
+    target.encode_ordinal_fsync_operations = source.encode_ordinal_fsync_operations;
     target.publication_application_read_bytes = source.publication_application_read_bytes;
     target.publication_application_read_operations = source.publication_application_read_operations;
     target.cas_application_read_bytes = source.cas_application_read_bytes;
@@ -3917,11 +4287,15 @@ fn copy_post_shape_io(target: &mut GraphConstructionEvidence, source: &GraphCons
     target.cas_application_write_bytes = source.cas_application_write_bytes;
     target.cas_application_write_operations = source.cas_application_write_operations;
     target.cas_fsync_operations = source.cas_fsync_operations;
+    target.cas_publication_io = source.cas_publication_io.clone();
     target.hydration_application_read_bytes = source.hydration_application_read_bytes;
     target.hydration_application_read_operations = source.hydration_application_read_operations;
     target.hydration_application_write_bytes = source.hydration_application_write_bytes;
     target.hydration_application_write_operations = source.hydration_application_write_operations;
     target.hydration_fsync_operations = source.hydration_fsync_operations;
+    target.hydration_files_copied = source.hydration_files_copied;
+    target.hydration_file_fsync_operations = source.hydration_file_fsync_operations;
+    target.hydration_directory_fsync_operations = source.hydration_directory_fsync_operations;
     target.canonical_output_bytes = source.canonical_output_bytes;
     target.staged_and_retained_disk_bytes = source.staged_and_retained_disk_bytes;
 }
@@ -4296,8 +4670,12 @@ fn receipt_for_existing_with_work(
                 break;
             }
             digest.update(&block[..count]);
-            bytes = bytes.saturating_add(count as u64);
-            operations = operations.saturating_add(1);
+            bytes = bytes
+                .checked_add(count as u64)
+                .ok_or_else(|| storage("bytes overflows"))?;
+            operations = operations
+                .checked_add(1)
+                .ok_or_else(|| storage("operations overflows"))?;
         }
         Ok((
             ArtifactReceipt {
@@ -4511,6 +4889,103 @@ fn record_active_identity_remove(
     Ok(removed)
 }
 
+fn checked_category_install(
+    current: &crate::ArtifactStorageTotals,
+    logical_bytes: u64,
+    allocated_bytes: u64,
+) -> Result<crate::ArtifactStorageTotals, GfError> {
+    Ok(crate::ArtifactStorageTotals {
+        logical_references: current
+            .logical_references
+            .checked_add(1)
+            .ok_or_else(|| storage("category logical-reference authority overflows"))?,
+        logical_bytes: current
+            .logical_bytes
+            .checked_add(logical_bytes)
+            .ok_or_else(|| storage("category logical-byte authority overflows"))?,
+        physical_objects: current
+            .physical_objects
+            .checked_add(1)
+            .ok_or_else(|| storage("category physical-object authority overflows"))?,
+        physical_logical_bytes: current
+            .physical_logical_bytes
+            .checked_add(logical_bytes)
+            .ok_or_else(|| storage("category physical-logical authority overflows"))?,
+        allocated_bytes: current
+            .allocated_bytes
+            .checked_add(allocated_bytes)
+            .ok_or_else(|| storage("category allocated-byte authority overflows"))?,
+    })
+}
+
+fn record_category_install(
+    evidence: &mut GraphConstructionEvidence,
+    logical_bytes: u64,
+    allocated_bytes: u64,
+) -> Result<(), GfError> {
+    let category = crate::ArtifactCategory::ConstructionStaging;
+    let reported = checked_category_install(
+        &evidence.storage_current[&category],
+        logical_bytes,
+        allocated_bytes,
+    )?;
+    let authority = checked_category_install(
+        &evidence.storage_receipt_category_authorities[&category],
+        logical_bytes,
+        allocated_bytes,
+    )?;
+    evidence.storage_current.insert(category, reported.clone());
+    evidence
+        .storage_receipt_category_authorities
+        .insert(category, authority.clone());
+    evidence
+        .storage_transient_peak_allocated_bytes
+        .entry(category)
+        .and_modify(|peak| *peak = (*peak).max(reported.allocated_bytes));
+    evidence
+        .storage_receipt_transient_peak_authorities
+        .entry(category)
+        .and_modify(|peak| *peak = (*peak).max(authority.allocated_bytes));
+    let active_total = evidence
+        .storage_active_identity_allocated_bytes
+        .values()
+        .try_fold(0_u64, |total, value| total.checked_add(*value))
+        .ok_or_else(|| storage("active construction allocation overflows"))?;
+    evidence.storage_transient_peak_total_allocated_bytes = evidence
+        .storage_transient_peak_total_allocated_bytes
+        .max(active_total);
+    Ok(())
+}
+
+fn checked_category_remove(
+    current: &crate::ArtifactStorageTotals,
+    logical_bytes: u64,
+    allocated_bytes: u64,
+) -> Result<crate::ArtifactStorageTotals, GfError> {
+    Ok(crate::ArtifactStorageTotals {
+        logical_references: current
+            .logical_references
+            .checked_sub(1)
+            .ok_or_else(|| storage("category logical-reference authority underflows"))?,
+        logical_bytes: current
+            .logical_bytes
+            .checked_sub(logical_bytes)
+            .ok_or_else(|| storage("category logical-byte authority underflows"))?,
+        physical_objects: current
+            .physical_objects
+            .checked_sub(1)
+            .ok_or_else(|| storage("category physical-object authority underflows"))?,
+        physical_logical_bytes: current
+            .physical_logical_bytes
+            .checked_sub(logical_bytes)
+            .ok_or_else(|| storage("category physical-logical authority underflows"))?,
+        allocated_bytes: current
+            .allocated_bytes
+            .checked_sub(allocated_bytes)
+            .ok_or_else(|| storage("category allocated-byte authority underflows"))?,
+    })
+}
+
 fn record_shape_artifact_install(
     evidence: &mut GraphConstructionEvidence,
     receipt: &ArtifactReceipt,
@@ -4525,38 +5000,157 @@ fn record_shape_artifact_install(
         receipt.allocated_bytes,
         "shape artifact identity installed twice",
     )?;
-    let totals = evidence
-        .storage_current
-        .entry(crate::ArtifactCategory::ConstructionStaging)
-        .or_default();
-    totals.logical_references = totals.logical_references.saturating_add(1);
-    totals.logical_bytes = totals.logical_bytes.saturating_add(receipt.bytes);
-    totals.physical_objects = totals.physical_objects.saturating_add(1);
-    totals.physical_logical_bytes = totals.physical_logical_bytes.saturating_add(receipt.bytes);
-    totals.allocated_bytes = totals
-        .allocated_bytes
-        .saturating_add(receipt.allocated_bytes);
+    record_category_install(evidence, receipt.bytes, receipt.allocated_bytes)?;
     evidence.current_merge_temporary_allocated_bytes = evidence
         .current_merge_temporary_allocated_bytes
-        .saturating_add(receipt.allocated_bytes);
+        .checked_add(receipt.allocated_bytes)
+        .ok_or_else(|| storage("current merge allocation overflows"))?;
     evidence.peak_merge_temporary_bytes = evidence
         .peak_merge_temporary_bytes
         .max(evidence.current_merge_temporary_allocated_bytes);
-    evidence
-        .storage_transient_peak_allocated_bytes
-        .entry(crate::ArtifactCategory::ConstructionStaging)
-        .and_modify(|peak| *peak = (*peak).max(totals.allocated_bytes))
-        .or_insert(totals.allocated_bytes);
-    let union = evidence
-        .storage_current
-        .values()
-        .fold(0_u64, |total, item| {
-            total.saturating_add(item.allocated_bytes)
-        });
-    evidence.storage_transient_peak_total_allocated_bytes = evidence
-        .storage_transient_peak_total_allocated_bytes
-        .max(union);
     Ok(())
+}
+
+fn record_encoding_io_evidence(
+    evidence: &mut GraphConstructionEvidence,
+    encoded: &GraphConstructionEncoding,
+) -> Result<(), GfError> {
+    let measured = &encoded.invocation.evidence;
+    record_encoding_components(evidence, measured)?;
+    evidence.encode_application_read_bytes = checked_evidence_sum(
+        "encoding read bytes",
+        evidence.encode_application_read_bytes,
+        &[measured.input_read_bytes, measured.membership_read_bytes],
+    )?;
+    evidence.encode_application_read_operations = checked_evidence_sum(
+        "encoding read operations",
+        evidence.encode_application_read_operations,
+        &[
+            measured.input_read_operations,
+            measured.membership_read_operations,
+            measured.source_spool_read_operations,
+        ],
+    )?;
+    evidence.encode_application_write_bytes = checked_evidence_sum(
+        "encoding write bytes",
+        evidence.encode_application_write_bytes,
+        &[
+            measured.output_write_bytes,
+            measured.membership_total_write_bytes,
+            measured.source_spool_write_bytes,
+            measured.ordinal_artifact_write_bytes,
+            measured.ordinal_publication_write_bytes,
+        ],
+    )?;
+    evidence.encode_application_write_operations = checked_evidence_sum(
+        "encoding write operations",
+        evidence.encode_application_write_operations,
+        &[
+            measured.output_write_operations,
+            measured.membership_write_operations,
+            measured.source_spool_write_operations,
+            measured.ordinal_artifact_write_operations,
+            measured.ordinal_publication_write_operations,
+        ],
+    )?;
+    evidence.encode_fsync_operations = checked_evidence_sum(
+        "encoding fsync operations",
+        evidence.encode_fsync_operations,
+        &[
+            measured.fsync_operations,
+            measured.membership_fsync_operations,
+            measured.source_spool_fsync_operations,
+            measured.ordinal_fsync_operations,
+        ],
+    )?;
+    evidence.canonical_artifact_objects = u64::try_from(encoded.artifacts.len())
+        .map_err(|_| storage("canonical artifact inventory exceeds u64"))?;
+    evidence.canonical_output_bytes =
+        encoded
+            .artifacts
+            .iter()
+            .try_fold(0_u64, |total, artifact| {
+                total
+                    .checked_add(artifact.bytes)
+                    .ok_or_else(|| storage("canonical output inventory overflows"))
+            })?;
+    let retained_bytes = encoded
+        .retained_artifacts
+        .iter()
+        .try_fold(0_u64, |total, artifact| {
+            total
+                .checked_add(artifact.bytes)
+                .ok_or_else(|| storage("retained artifact inventory overflows"))
+        })?;
+    evidence.staged_and_retained_disk_bytes = evidence
+        .write_bytes
+        .checked_add(retained_bytes)
+        .ok_or_else(|| storage("staged and retained inventory overflows"))?;
+    Ok(())
+}
+
+fn record_encoding_components(
+    evidence: &mut GraphConstructionEvidence,
+    measured: &GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    for (counter, value, name) in [
+        (
+            &mut evidence.encode_output_write_operations,
+            measured.output_write_operations,
+            "encode_output_write_operations",
+        ),
+        (
+            &mut evidence.encode_membership_write_operations,
+            measured.membership_write_operations,
+            "encode_membership_write_operations",
+        ),
+        (
+            &mut evidence.encode_source_spool_write_operations,
+            measured.source_spool_write_operations,
+            "encode_source_spool_write_operations",
+        ),
+        (
+            &mut evidence.encode_ordinal_artifact_write_operations,
+            measured.ordinal_artifact_write_operations,
+            "encode_ordinal_artifact_write_operations",
+        ),
+        (
+            &mut evidence.encode_ordinal_publication_write_operations,
+            measured.ordinal_publication_write_operations,
+            "encode_ordinal_publication_write_operations",
+        ),
+        (
+            &mut evidence.encode_output_fsync_operations,
+            measured.fsync_operations,
+            "encode_output_fsync_operations",
+        ),
+        (
+            &mut evidence.encode_source_spool_fsync_operations,
+            measured.source_spool_fsync_operations,
+            "encode_source_spool_fsync_operations",
+        ),
+        (
+            &mut evidence.encode_membership_fsync_operations,
+            measured.membership_fsync_operations,
+            "encode_membership_fsync_operations",
+        ),
+        (
+            &mut evidence.encode_ordinal_fsync_operations,
+            measured.ordinal_fsync_operations,
+            "encode_ordinal_fsync_operations",
+        ),
+    ] {
+        *counter = checked_evidence_sum(name, *counter, &[value])?;
+    }
+    Ok(())
+}
+
+fn checked_evidence_sum(name: &str, initial: u64, values: &[u64]) -> Result<u64, GfError> {
+    values.iter().try_fold(initial, |total, value| {
+        total
+            .checked_add(*value)
+            .ok_or_else(|| storage(format!("{name} overflow")))
+    })
 }
 
 fn record_encoded_active_artifacts(
@@ -4606,30 +5200,7 @@ fn record_encoded_active_artifacts(
             usage.allocated_bytes,
             "encoded artifact identity installed twice",
         )?;
-        let totals = evidence
-            .storage_current
-            .entry(crate::ArtifactCategory::ConstructionStaging)
-            .or_default();
-        totals.logical_references = totals.logical_references.saturating_add(1);
-        totals.logical_bytes = totals.logical_bytes.saturating_add(usage.logical_bytes);
-        totals.physical_objects = totals.physical_objects.saturating_add(1);
-        totals.physical_logical_bytes = totals
-            .physical_logical_bytes
-            .saturating_add(usage.logical_bytes);
-        totals.allocated_bytes = totals.allocated_bytes.saturating_add(usage.allocated_bytes);
-        evidence
-            .storage_transient_peak_allocated_bytes
-            .entry(crate::ArtifactCategory::ConstructionStaging)
-            .and_modify(|peak| *peak = (*peak).max(totals.allocated_bytes))
-            .or_insert(totals.allocated_bytes);
-        let active_total = evidence
-            .storage_active_identity_allocated_bytes
-            .values()
-            .try_fold(0_u64, |total, value| total.checked_add(*value))
-            .ok_or_else(|| storage("active construction allocation overflow"))?;
-        evidence.storage_transient_peak_total_allocated_bytes = evidence
-            .storage_transient_peak_total_allocated_bytes
-            .max(active_total);
+        record_category_install(evidence, usage.logical_bytes, usage.allocated_bytes)?;
     }
     Ok(())
 }
@@ -4653,30 +5224,27 @@ fn unlink_shape_artifact(
     if removed != receipt.allocated_bytes {
         return Err(storage("shape active identity allocation changed"));
     }
-    let totals = evidence
-        .storage_current
-        .get_mut(&crate::ArtifactCategory::ConstructionStaging)
-        .ok_or_else(|| storage("shape allocation ledger is absent"))?;
-    totals.logical_references = totals
-        .logical_references
-        .checked_sub(1)
-        .ok_or_else(|| storage("shape logical-reference ledger underflow"))?;
-    totals.logical_bytes = totals
-        .logical_bytes
-        .checked_sub(receipt.bytes)
-        .ok_or_else(|| storage("shape logical-byte ledger underflow"))?;
-    totals.physical_objects = totals
-        .physical_objects
-        .checked_sub(1)
-        .ok_or_else(|| storage("shape physical-object ledger underflow"))?;
-    totals.physical_logical_bytes = totals
-        .physical_logical_bytes
-        .checked_sub(receipt.bytes)
-        .ok_or_else(|| storage("shape physical-logical ledger underflow"))?;
-    totals.allocated_bytes = totals
-        .allocated_bytes
-        .checked_sub(receipt.allocated_bytes)
-        .ok_or_else(|| storage("shape allocated-byte ledger underflow"))?;
+    let category = crate::ArtifactCategory::ConstructionStaging;
+    let reported = checked_category_remove(
+        evidence
+            .storage_current
+            .get(&category)
+            .ok_or_else(|| storage("shape allocation ledger is absent"))?,
+        receipt.bytes,
+        receipt.allocated_bytes,
+    )?;
+    let authority = checked_category_remove(
+        evidence
+            .storage_receipt_category_authorities
+            .get(&category)
+            .ok_or_else(|| storage("shape authority ledger is absent"))?,
+        receipt.bytes,
+        receipt.allocated_bytes,
+    )?;
+    evidence.storage_current.insert(category, reported);
+    evidence
+        .storage_receipt_category_authorities
+        .insert(category, authority);
     evidence.current_merge_temporary_allocated_bytes = evidence
         .current_merge_temporary_allocated_bytes
         .checked_sub(receipt.allocated_bytes)
@@ -4684,30 +5252,55 @@ fn unlink_shape_artifact(
     Ok(())
 }
 
-fn account_merge_read<const N: usize>(evidence: &mut GraphConstructionEvidence) {
+fn account_merge_read<const N: usize>(
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
     let _ = N;
-    evidence.merge_read_records = evidence.merge_read_records.saturating_add(1);
+    evidence.merge_read_records = evidence
+        .merge_read_records
+        .checked_add(1)
+        .ok_or_else(|| storage("merge read record count overflows"))?;
+    Ok(())
 }
 
-fn account_merge_write<const N: usize>(evidence: &mut GraphConstructionEvidence) {
-    evidence.merge_written_records = evidence.merge_written_records.saturating_add(1);
-    evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(N as u64);
+fn account_merge_write<const N: usize>(
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    evidence.merge_written_records = evidence
+        .merge_written_records
+        .checked_add(1)
+        .ok_or_else(|| storage("merge written record count overflows"))?;
+    evidence.merge_written_bytes = evidence
+        .merge_written_bytes
+        .checked_add(N as u64)
+        .ok_or_else(|| storage("merge written byte count overflows"))?;
+    Ok(())
 }
 
-fn account_sequential_read(bytes: u64, evidence: &mut GraphConstructionEvidence) {
+fn account_sequential_read(
+    bytes: u64,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
     if bytes != 0 {
         evidence.merge_read_blocks = evidence
             .merge_read_blocks
-            .saturating_add(bytes.div_ceil(BLOCK_BYTES as u64));
+            .checked_add(bytes.div_ceil(BLOCK_BYTES as u64))
+            .ok_or_else(|| storage("merge read block count overflows"))?;
     }
+    Ok(())
 }
 
-fn account_sequential_write(bytes: u64, evidence: &mut GraphConstructionEvidence) {
+fn account_sequential_write(
+    bytes: u64,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
     if bytes != 0 {
         evidence.merge_write_blocks = evidence
             .merge_write_blocks
-            .saturating_add(bytes.div_ceil(BLOCK_BYTES as u64));
+            .checked_add(bytes.div_ceil(BLOCK_BYTES as u64))
+            .ok_or_else(|| storage("merge write block count overflows"))?;
     }
+    Ok(())
 }
 
 fn account_fixed_read_operations(
@@ -4718,8 +5311,14 @@ fn account_fixed_read_operations(
     if (bytes == 0) != (operations == 0) {
         return Err(storage("fixed-run read bytes and submissions disagree"));
     }
-    evidence.merge_read_bytes = evidence.merge_read_bytes.saturating_add(bytes);
-    evidence.merge_read_operations = evidence.merge_read_operations.saturating_add(operations);
+    evidence.merge_read_bytes = evidence
+        .merge_read_bytes
+        .checked_add(bytes)
+        .ok_or_else(|| storage("merge read byte count overflows"))?;
+    evidence.merge_read_operations = evidence
+        .merge_read_operations
+        .checked_add(operations)
+        .ok_or_else(|| storage("merge read operation count overflows"))?;
     Ok(())
 }
 
@@ -4735,7 +5334,7 @@ fn open_counted_fixed_reader(
     GfError,
 > {
     let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
-    account_sequential_read(file.metadata().map_err(storage)?.len(), evidence);
+    account_sequential_read(file.metadata().map_err(storage)?.len(), evidence)?;
     let counter = IoCounter::default();
     let cache_window =
         graphforge_filesystem::cache_release_window_for_streams(4).map_err(storage)?;
@@ -4761,7 +5360,7 @@ fn release_counted_reader_cache(
     evidence: &mut GraphConstructionEvidence,
 ) -> Result<(), GfError> {
     let released = reader.get_mut().inner.finish().map_err(storage)?;
-    account_cache_release(released, evidence);
+    account_cache_release(released, evidence)?;
     #[cfg(test)]
     SHAPE_CLEANUP_FAILURES.with(|failures| {
         if failures.borrow().input_release {
@@ -4815,7 +5414,7 @@ fn cleanup_failed_shape_output(
         .sync_all_and_release()
         .map_err(storage);
     let cache_release = writer.get_ref().inner.evidence();
-    account_cache_release(cache_release, evidence);
+    account_cache_release(cache_release, evidence)?;
     let finalized =
         combine_secondary_cleanup(flushed, synchronized, "shape output synchronization");
     drop(writer);
@@ -4913,7 +5512,8 @@ fn account_fixed_write_operations(
     }
     evidence.merge_write_operations = evidence
         .merge_write_operations
-        .saturating_add(receipt.write_operations);
+        .checked_add(receipt.write_operations)
+        .ok_or_else(|| storage("merge write operation count overflows"))?;
     Ok(())
 }
 
@@ -4928,7 +5528,7 @@ fn convert_identity_run(
     let input = root
         .open_child_file(OsStr::new(&receipt.identities.name))
         .map_err(storage)?;
-    account_sequential_read(receipt.identities.bytes, evidence);
+    account_sequential_read(receipt.identities.bytes, evidence)?;
     if !receipt
         .identities
         .identity
@@ -4993,13 +5593,15 @@ fn convert_identity_run(
     let copied = (|| -> Result<(), GfError> {
         while let Some(uuid) = read_fixed::<IDENTITY_WIDTH>(&mut reader)? {
             digest.update(uuid);
-            bytes = bytes.saturating_add(IDENTITY_WIDTH as u64);
+            bytes = bytes
+                .checked_add(IDENTITY_WIDTH as u64)
+                .ok_or_else(|| storage("bytes overflows"))?;
             let mut record = [0_u8; BASE_IDENTITY_WIDTH];
             record[..16].copy_from_slice(&uuid);
             record[16] = u8::from(receipt.kind == ConstructionChunkKind::Edge);
             writer.write_all(&record).map_err(storage)?;
-            account_merge_read::<IDENTITY_WIDTH>(evidence);
-            account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+            account_merge_read::<IDENTITY_WIDTH>(evidence)?;
+            account_merge_write::<BASE_IDENTITY_WIDTH>(evidence)?;
             reject_cancelled(cancelled)?;
         }
         if bytes != receipt.identities.bytes || hex(&digest.finalize()) != receipt.identities.sha256
@@ -5029,7 +5631,7 @@ fn convert_identity_run(
     let prepared = (|| -> Result<(_, _), GfError> {
         shape_publication_failure("fsync_evidence_overflow")?;
         let mut committed_evidence = evidence.clone();
-        account_cache_release(cache_release, &mut committed_evidence);
+        account_cache_release(cache_release, &mut committed_evidence)?;
         let aggregate_peak = reader
             .get_ref()
             .inner
@@ -5041,7 +5643,7 @@ fn convert_identity_run(
         committed_evidence.peak_cache_release_window_bytes = committed_evidence
             .peak_cache_release_window_bytes
             .max(aggregate_peak);
-        account_sequential_write(writer.get_ref().bytes, &mut committed_evidence);
+        account_sequential_write(writer.get_ref().bytes, &mut committed_evidence)?;
         shape_publication_failure("final_file_identity")?;
         if file_identity(writer.get_ref().inner.file()).map_err(storage)?
             != publication.identity().map_err(storage)?
@@ -5060,12 +5662,17 @@ fn convert_identity_run(
             sha256: hex(&writer.get_ref().digest.clone().finalize()),
             identity: identity.into(),
             write_operations: writer.get_ref().operations,
-            fsync_operations: 2_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+            fsync_operations: cache_release
+                .sync_operations
+                .checked_add(1)
+                .ok_or_else(|| storage("artifact synchronization count overflows"))?,
         };
         record_shape_artifact_install(&mut committed_evidence, &output_receipt)?;
         account_fixed_write_operations(&output_receipt, &mut committed_evidence)?;
-        committed_evidence.merge_fsync_operations =
-            committed_evidence.merge_fsync_operations.saturating_add(2);
+        committed_evidence.merge_fsync_operations = committed_evidence
+            .merge_fsync_operations
+            .checked_add(output_receipt.fsync_operations)
+            .ok_or_else(|| storage("merge fsync operations overflows"))?;
         Ok((output_receipt, committed_evidence))
     })();
     let (output_receipt, committed_evidence) = match prepared {
@@ -5120,7 +5727,7 @@ fn copy_authenticated_run<const N: usize>(
     let input = root
         .open_child_file(OsStr::new(&receipt.name))
         .map_err(storage)?;
-    account_sequential_read(receipt.bytes, evidence);
+    account_sequential_read(receipt.bytes, evidence)?;
     if !receipt
         .identity
         .matches(file_identity(&input).map_err(storage)?)
@@ -5185,10 +5792,12 @@ fn copy_authenticated_run<const N: usize>(
     let copied = (|| -> Result<(), GfError> {
         while let Some(record) = read_fixed::<N>(&mut reader)? {
             digest.update(record);
-            bytes = bytes.saturating_add(N as u64);
+            bytes = bytes
+                .checked_add(N as u64)
+                .ok_or_else(|| storage("bytes overflows"))?;
             writer.write_all(&record).map_err(storage)?;
-            account_merge_read::<N>(evidence);
-            account_merge_write::<N>(evidence);
+            account_merge_read::<N>(evidence)?;
+            account_merge_write::<N>(evidence)?;
             reject_cancelled(cancelled)?;
         }
         if bytes != receipt.bytes || hex(&digest.finalize()) != receipt.sha256 {
@@ -5217,7 +5826,7 @@ fn copy_authenticated_run<const N: usize>(
     let prepared = (|| -> Result<(_, _), GfError> {
         shape_publication_failure("fsync_evidence_overflow")?;
         let mut committed_evidence = evidence.clone();
-        account_cache_release(cache_release, &mut committed_evidence);
+        account_cache_release(cache_release, &mut committed_evidence)?;
         let aggregate_peak = reader
             .get_ref()
             .inner
@@ -5229,7 +5838,7 @@ fn copy_authenticated_run<const N: usize>(
         committed_evidence.peak_cache_release_window_bytes = committed_evidence
             .peak_cache_release_window_bytes
             .max(aggregate_peak);
-        account_sequential_write(bytes, &mut committed_evidence);
+        account_sequential_write(bytes, &mut committed_evidence)?;
         shape_publication_failure("final_file_identity")?;
         if file_identity(writer.get_ref().inner.file()).map_err(storage)?
             != publication.identity().map_err(storage)?
@@ -5250,12 +5859,17 @@ fn copy_authenticated_run<const N: usize>(
             sha256: receipt.sha256.clone(),
             identity: identity.into(),
             write_operations: writer.get_ref().operations,
-            fsync_operations: 2_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+            fsync_operations: cache_release
+                .sync_operations
+                .checked_add(1)
+                .ok_or_else(|| storage("artifact synchronization count overflows"))?,
         };
         record_shape_artifact_install(&mut committed_evidence, &output_receipt)?;
         account_fixed_write_operations(&output_receipt, &mut committed_evidence)?;
-        committed_evidence.merge_fsync_operations =
-            committed_evidence.merge_fsync_operations.saturating_add(2);
+        committed_evidence.merge_fsync_operations = committed_evidence
+            .merge_fsync_operations
+            .checked_add(output_receipt.fsync_operations)
+            .ok_or_else(|| storage("merge fsync operations overflows"))?;
         Ok((output_receipt, committed_evidence))
     })();
     let (output_receipt, committed_evidence) = match prepared {
@@ -5318,7 +5932,9 @@ fn online_merge_name_slot_bound(mut inputs: u64, fan_in: usize) -> u64 {
     let radix = fan_in as u64;
     let mut slots = 0_u64;
     while inputs != 0 {
-        slots = slots.saturating_add(inputs % radix);
+        slots = slots
+            .checked_add(inputs % radix)
+            .expect("online merge slot bound overflow");
         inputs /= radix;
     }
     slots.max(1)
@@ -5347,7 +5963,10 @@ impl FixedMergeAccumulator {
         cancelled: &mut impl FnMut() -> bool,
         evidence: &mut GraphConstructionEvidence,
     ) -> Result<(), GfError> {
-        self.inputs = self.inputs.saturating_add(1);
+        self.inputs = self
+            .inputs
+            .checked_add(1)
+            .ok_or_else(|| storage("fixed merge input count overflow"))?;
         let mut level = 0;
         loop {
             if self.levels.len() <= level {
@@ -5360,8 +5979,15 @@ impl FixedMergeAccumulator {
             }
             let inputs = std::mem::take(&mut self.levels[level]);
             let group = self.groups[level];
-            self.groups[level] = group.saturating_add(1);
-            evidence.merge_passes = evidence.merge_passes.max(level as u64 + 1);
+            self.groups[level] = group
+                .checked_add(1)
+                .ok_or_else(|| storage("fixed merge group count overflow"))?;
+            evidence.merge_passes = evidence.merge_passes.max(
+                u64::try_from(level)
+                    .map_err(storage)?
+                    .checked_add(1)
+                    .ok_or_else(|| storage("fixed merge pass count overflow"))?,
+            );
             name = format!("{}-l{level:03}-g{group:08}.run", self.prefix);
             merge_fixed_group::<N>(
                 root,
@@ -5419,8 +6045,15 @@ impl FixedMergeAccumulator {
                 inputs[0].clone()
             } else {
                 let group = self.groups[level];
-                self.groups[level] = group.saturating_add(1);
-                evidence.merge_passes = evidence.merge_passes.max(level as u64 + 1);
+                self.groups[level] = group
+                    .checked_add(1)
+                    .ok_or_else(|| storage("fixed merge group count overflow"))?;
+                evidence.merge_passes = evidence.merge_passes.max(
+                    u64::try_from(level)
+                        .map_err(storage)?
+                        .checked_add(1)
+                        .ok_or_else(|| storage("fixed merge pass count overflow"))?,
+                );
                 let output = format!("{}-l{level:03}-g{group:08}.run", self.prefix);
                 merge_fixed_group::<N>(
                     root,
@@ -5465,26 +6098,21 @@ fn merge_fixed_group<const N: usize>(
         graphforge_filesystem::cache_release_window_for_streams(active_streams).map_err(storage)?;
     let mut readers = inputs
         .iter()
-        .map(|name| {
-            root.open_child_file(OsStr::new(name))
-                .and_then(|file| {
-                    if let Ok(metadata) = file.metadata() {
-                        account_sequential_read(metadata.len(), evidence);
-                    }
-                    Ok(BufReader::with_capacity(
-                        BLOCK_BYTES,
-                        CountingRead {
-                            inner:
-                                graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
-                                    file,
-                                    reader_cache_window,
-                                    graphforge_filesystem::FileCacheReleaseTracker::default(),
-                                )?,
-                            counter: read_counter.clone(),
-                        },
-                    ))
-                })
-                .map_err(storage)
+        .map(|name| -> Result<_, GfError> {
+            let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+            account_sequential_read(file.metadata().map_err(storage)?.len(), evidence)?;
+            Ok(BufReader::with_capacity(
+                BLOCK_BYTES,
+                CountingRead {
+                    inner: graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                        file,
+                        reader_cache_window,
+                        graphforge_filesystem::FileCacheReleaseTracker::default(),
+                    )
+                    .map_err(storage)?,
+                    counter: read_counter.clone(),
+                },
+            ))
         })
         .collect::<Result<Vec<_>, _>>()?;
     evidence.peak_merge_inputs = evidence.peak_merge_inputs.max(readers.len() as u64);
@@ -5499,7 +6127,7 @@ fn merge_fixed_group<const N: usize>(
     for (index, reader) in readers.iter_mut().enumerate() {
         if let Some(record) = read_fixed::<N>(reader)? {
             heap.push(Reverse((record, index)));
-            account_merge_read::<N>(evidence);
+            account_merge_read::<N>(evidence)?;
         }
     }
     let mut previous = None;
@@ -5512,14 +6140,14 @@ fn merge_fixed_group<const N: usize>(
             return Err(storage("duplicate identity across construction runs"));
         }
         writer.write_all(&record).map_err(storage)?;
-        account_merge_write::<N>(evidence);
+        account_merge_write::<N>(evidence)?;
         previous = Some(record);
         if evidence.merge_written_records.is_multiple_of(4096) {
             reject_cancelled(cancelled)?;
         }
         if let Some(next) = read_fixed::<N>(&mut readers[index])? {
             heap.push(Reverse((next, index)));
-            account_merge_read::<N>(evidence);
+            account_merge_read::<N>(evidence)?;
         }
     }
     writer.flush().map_err(storage)?;
@@ -5533,7 +6161,7 @@ fn merge_fixed_group<const N: usize>(
         .sync_all_and_release()
         .map_err(storage)?;
     let cache_release = writer.get_ref().inner.evidence();
-    account_cache_release(cache_release, evidence);
+    account_cache_release(cache_release, evidence)?;
     let aggregate_peak =
         readers
             .iter()
@@ -5550,7 +6178,7 @@ fn merge_fixed_group<const N: usize>(
             })?;
     evidence.peak_cache_release_window_bytes =
         evidence.peak_cache_release_window_bytes.max(aggregate_peak);
-    account_sequential_write(writer.get_ref().bytes, evidence);
+    account_sequential_write(writer.get_ref().bytes, evidence)?;
     let receipt = ArtifactReceipt {
         name: output.to_owned(),
         bytes: writer.get_ref().bytes,
@@ -5560,7 +6188,10 @@ fn merge_fixed_group<const N: usize>(
         sha256: hex(&writer.get_ref().digest.clone().finalize()),
         identity: identity.into(),
         write_operations: writer.get_ref().operations,
-        fsync_operations: 2_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+        fsync_operations: cache_release
+            .sync_operations
+            .checked_add(1)
+            .ok_or_else(|| storage("artifact synchronization count overflows"))?,
     };
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
@@ -5572,8 +6203,12 @@ fn merge_fixed_group<const N: usize>(
     account_fixed_write_operations(&receipt, evidence)?;
     evidence.merge_fsync_operations = evidence
         .merge_fsync_operations
-        .saturating_add(receipt.fsync_operations);
-    evidence.merge_groups = evidence.merge_groups.saturating_add(1);
+        .checked_add(receipt.fsync_operations)
+        .ok_or_else(|| storage("merge fsync operations overflows"))?;
+    evidence.merge_groups = evidence
+        .merge_groups
+        .checked_add(1)
+        .ok_or_else(|| storage("merge groups overflows"))?;
     Ok(receipt)
 }
 
@@ -5617,7 +6252,12 @@ fn materialize_selected_rows(
             let refs = data.iter().collect::<Vec<_>>();
             let mut mutable = MutableArrayData::new(refs, false, selected.len());
             for (source, (_, row)) in selected.iter().enumerate() {
-                mutable.extend(source, *row, row.saturating_add(1));
+                mutable.extend(
+                    source,
+                    *row,
+                    row.checked_add(1)
+                        .ok_or_else(|| storage("selected row bound overflow"))?,
+                );
             }
             Ok(make_array(mutable.freeze()))
         })
@@ -5692,10 +6332,10 @@ fn merge_row_group(
                 tracker.check_error().map_err(storage),
                 "row merge source",
             );
-            account_cache_release(tracker.evidence(), evidence);
+            account_cache_release(tracker.evidence(), evidence)?;
         }
         for counter in counters {
-            counter.add_to(evidence);
+            counter.add_to(evidence)?;
         }
         return result;
     }
@@ -5734,30 +6374,41 @@ fn merge_row_group(
                     .slice(cursor.row, 1)
                     .to_data()
                     .get_slice_memory_size()
-                    .map(|bytes| total.saturating_add(bytes))
-                    .map_err(storage)
+                    .map_err(storage)?
+                    .checked_add(total)
+                    .ok_or_else(|| storage("merge row byte total overflows"))
             })?;
             if row_bytes > output_bytes {
                 return Err(storage("one normalized row exceeds merge byte window"));
             }
             if !selected.is_empty()
                 && (selected.len() == output_rows
-                    || selected_bytes.saturating_add(row_bytes) > output_bytes)
+                    || selected_bytes
+                        .checked_add(row_bytes)
+                        .ok_or_else(|| storage("merge selected bytes overflow"))?
+                        > output_bytes)
             {
                 let output_batch = materialize_selected_rows(schema.clone(), &selected)?;
                 evidence.merge_read_records = evidence
                     .merge_read_records
-                    .saturating_add(output_batch.num_rows() as u64);
+                    .checked_add(output_batch.num_rows() as u64)
+                    .ok_or_else(|| storage("merge read records overflows"))?;
                 writer.write(&output_batch).map_err(storage)?;
                 evidence.merge_written_records = evidence
                     .merge_written_records
-                    .saturating_add(output_batch.num_rows() as u64);
+                    .checked_add(output_batch.num_rows() as u64)
+                    .ok_or_else(|| storage("merge written records overflows"))?;
                 selected.clear();
                 selected_bytes = 0;
             }
             selected.push((batch.clone(), cursor.row));
-            selected_bytes = selected_bytes.saturating_add(row_bytes);
-            cursor.row = cursor.row.saturating_add(1);
+            selected_bytes = selected_bytes
+                .checked_add(row_bytes)
+                .ok_or_else(|| storage("merge selected bytes overflow"))?;
+            cursor.row = cursor
+                .row
+                .checked_add(1)
+                .ok_or_else(|| storage("merge row index overflows"))?;
             if let Some(next) = cursor.advance()? {
                 heap.push((Reverse(next), Reverse(source)));
             }
@@ -5765,11 +6416,13 @@ fn merge_row_group(
                 let batch = materialize_selected_rows(schema.clone(), &selected)?;
                 evidence.merge_read_records = evidence
                     .merge_read_records
-                    .saturating_add(batch.num_rows() as u64);
+                    .checked_add(batch.num_rows() as u64)
+                    .ok_or_else(|| storage("merge read records overflows"))?;
                 writer.write(&batch).map_err(storage)?;
                 evidence.merge_written_records = evidence
                     .merge_written_records
-                    .saturating_add(batch.num_rows() as u64);
+                    .checked_add(batch.num_rows() as u64)
+                    .ok_or_else(|| storage("merge written records overflows"))?;
                 selected.clear();
                 selected_bytes = 0;
             }
@@ -5790,10 +6443,10 @@ fn merge_row_group(
         reader_cache_peak = reader_cache_peak
             .checked_add(cache_release.peak_window_bytes)
             .ok_or_else(|| storage("row merge reader cache window overflow"))?;
-        account_cache_release(cache_release, evidence);
+        account_cache_release(cache_release, evidence)?;
     }
     for counter in counters {
-        counter.add_to(evidence);
+        counter.add_to(evidence)?;
     }
     merged?;
     writer
@@ -5804,7 +6457,7 @@ fn merge_row_group(
         .map_err(storage)?;
     let hashing = writer.inner().get_ref();
     let cache_release = hashing.inner.evidence();
-    account_cache_release(cache_release, evidence);
+    account_cache_release(cache_release, evidence)?;
     let aggregate_peak = reader_cache_peak
         .checked_add(cache_release.peak_window_bytes)
         .ok_or_else(|| storage("row merge aggregate cache window overflow"))?;
@@ -5819,7 +6472,10 @@ fn merge_row_group(
         sha256: hex(&hashing.digest.clone().finalize()),
         identity: identity.into(),
         write_operations: hashing.operations,
-        fsync_operations: 4_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+        fsync_operations: cache_release
+            .sync_operations
+            .checked_add(3)
+            .ok_or_else(|| storage("artifact synchronization count overflows"))?,
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
@@ -5830,12 +6486,20 @@ fn merge_row_group(
     record_shape_artifact_install(evidence, &receipt)?;
     evidence.merge_fsync_operations = evidence
         .merge_fsync_operations
-        .saturating_add(receipt.fsync_operations);
-    evidence.merge_groups = evidence.merge_groups.saturating_add(1);
-    evidence.parquet_write_bytes = evidence.parquet_write_bytes.saturating_add(receipt.bytes);
+        .checked_add(receipt.fsync_operations)
+        .ok_or_else(|| storage("merge fsync operations overflows"))?;
+    evidence.merge_groups = evidence
+        .merge_groups
+        .checked_add(1)
+        .ok_or_else(|| storage("merge groups overflows"))?;
+    evidence.parquet_write_bytes = evidence
+        .parquet_write_bytes
+        .checked_add(receipt.bytes)
+        .ok_or_else(|| storage("parquet write bytes overflows"))?;
     evidence.parquet_write_operations = evidence
         .parquet_write_operations
-        .saturating_add(receipt.write_operations);
+        .checked_add(receipt.write_operations)
+        .ok_or_else(|| storage("parquet write operations overflows"))?;
     Ok(receipt)
 }
 
@@ -5872,7 +6536,10 @@ impl RowMergeAccumulator {
         cancelled: &mut impl FnMut() -> bool,
         evidence: &mut GraphConstructionEvidence,
     ) -> Result<(), GfError> {
-        self.inputs = self.inputs.saturating_add(1);
+        self.inputs = self
+            .inputs
+            .checked_add(1)
+            .ok_or_else(|| storage("row merge input count overflow"))?;
         let mut level = 0;
         loop {
             if self.levels.len() <= level {
@@ -5885,8 +6552,15 @@ impl RowMergeAccumulator {
             }
             let inputs = std::mem::take(&mut self.levels[level]);
             let group = self.groups[level];
-            self.groups[level] = group.saturating_add(1);
-            evidence.merge_passes = evidence.merge_passes.max(level as u64 + 1);
+            self.groups[level] = group
+                .checked_add(1)
+                .ok_or_else(|| storage("row merge group count overflow"))?;
+            evidence.merge_passes = evidence.merge_passes.max(
+                u64::try_from(level)
+                    .map_err(storage)?
+                    .checked_add(1)
+                    .ok_or_else(|| storage("row merge pass count overflow"))?,
+            );
             name = format!(
                 "merge-rows-{}-l{level:03}-g{group:020}.parquet",
                 self.namespace
@@ -5956,8 +6630,15 @@ impl RowMergeAccumulator {
                 inputs[0].clone()
             } else {
                 let group = self.groups[level];
-                self.groups[level] = group.saturating_add(1);
-                evidence.merge_passes = evidence.merge_passes.max(level as u64 + 1);
+                self.groups[level] = group
+                    .checked_add(1)
+                    .ok_or_else(|| storage("row merge group count overflow"))?;
+                evidence.merge_passes = evidence.merge_passes.max(
+                    u64::try_from(level)
+                        .map_err(storage)?
+                        .checked_add(1)
+                        .ok_or_else(|| storage("row merge pass count overflow"))?,
+                );
                 let output_name = format!(
                     "merge-rows-{}-l{level:03}-g{group:020}.parquet",
                     self.namespace
@@ -6079,7 +6760,13 @@ fn build_runtime_catalog(
                             if !batch.column(required + offset).is_null(row) {
                                 admit_catalog_identifier(
                                     !catalog.contains_property(field.name(), Some(owner_name)),
-                                    field.name().len().saturating_add(owner_name.len()),
+                                    field
+                                        .name()
+                                        .len()
+                                        .checked_add(owner_name.len())
+                                        .ok_or_else(|| {
+                                            storage("catalog identifier length overflows")
+                                        })?,
                                     &mut catalog_entries,
                                     &mut identifier_bytes,
                                     budgets,
@@ -6107,20 +6794,26 @@ fn build_runtime_catalog(
                     )));
                 }
             }
-            account_cache_release(cache_release.evidence(), evidence);
-            counter.add_to(evidence);
+            account_cache_release(cache_release.evidence(), evidence)?;
+            counter.add_to(evidence)?;
         }
     }
     let output = "shaped-runtime-catalog.parquet";
     let receipt = write_parquet(root, output, &catalog.to_record_batch(), evidence)?;
+    record_shape_artifact_install(evidence, &receipt)?;
     evidence.merge_fsync_operations = evidence
         .merge_fsync_operations
-        .saturating_add(receipt.fsync_operations);
-    evidence.parquet_write_bytes = evidence.parquet_write_bytes.saturating_add(receipt.bytes);
+        .checked_add(receipt.fsync_operations)
+        .ok_or_else(|| storage("merge fsync count overflows"))?;
+    evidence.parquet_write_bytes = evidence
+        .parquet_write_bytes
+        .checked_add(receipt.bytes)
+        .ok_or_else(|| storage("Parquet write byte count overflows"))?;
     evidence.parquet_write_operations = evidence
         .parquet_write_operations
-        .saturating_add(receipt.write_operations);
-    account_sequential_write(receipt.bytes, evidence);
+        .checked_add(receipt.write_operations)
+        .ok_or_else(|| storage("Parquet write operation count overflows"))?;
+    account_sequential_write(receipt.bytes, evidence)?;
     Ok(output.to_owned())
 }
 
@@ -6196,8 +6889,14 @@ fn load_parent_runtime_catalog(
                 break;
             }
             digest.update(&block[..count]);
-            work.bytes = work.bytes.saturating_add(count as u64);
-            work.operations = work.operations.saturating_add(1);
+            work.bytes = work
+                .bytes
+                .checked_add(count as u64)
+                .ok_or_else(|| storage("bytes overflows"))?;
+            work.operations = work
+                .operations
+                .checked_add(1)
+                .ok_or_else(|| storage("operations overflows"))?;
         }
         Ok(())
     })();
@@ -6255,13 +6954,15 @@ fn load_parent_runtime_catalog(
         cache_release.check_error().map_err(storage),
         "parent runtime catalog",
     )?;
-    merge_cache_release_evidence(&mut work.cache_release, cache_release.evidence());
+    merge_cache_release_evidence(&mut work.cache_release, cache_release.evidence())?;
     work.bytes = work
         .bytes
-        .saturating_add(counter.bytes.load(Ordering::Relaxed));
+        .checked_add(counter.bytes.load(Ordering::Relaxed))
+        .ok_or_else(|| storage("parent catalog Parquet read bytes overflow"))?;
     work.operations = work
         .operations
-        .saturating_add(counter.operations.load(Ordering::Relaxed));
+        .checked_add(counter.operations.load(Ordering::Relaxed))
+        .ok_or_else(|| storage("parent catalog Parquet read operations overflow"))?;
     let named = topology
         .open_child_file(OsStr::new("runtime_catalog.parquet"))
         .map_err(storage)?;
@@ -6392,12 +7093,24 @@ fn validate_staged_details(
             return Err(storage("staged identity record is not canonical"));
         }
         match record[16] {
-            0 => nodes = nodes.saturating_add(1),
-            1 => edges = edges.saturating_add(1),
+            0 => {
+                nodes = nodes
+                    .checked_add(1)
+                    .ok_or_else(|| storage("staged node count overflows"))?;
+            }
+            1 => {
+                edges = edges
+                    .checked_add(1)
+                    .ok_or_else(|| storage("staged edge count overflows"))?;
+            }
             _ => return Err(storage("invalid staged identity kind")),
         }
-        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
-        if nodes.saturating_add(edges).is_multiple_of(4096) {
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
+        if nodes
+            .checked_add(edges)
+            .ok_or_else(|| storage("staged identity count overflows"))?
+            .is_multiple_of(4096)
+        {
             reject_cancelled(cancelled)?;
         }
     }
@@ -6454,7 +7167,7 @@ fn reject_staged_base_conflicts(
             let Some(record) = read_fixed::<BASE_IDENTITY_WIDTH>(&mut reader)? else {
                 break;
             };
-            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
             requested.push(Uuid::from_bytes(
                 record[..16].try_into().expect("fixed UUID"),
             ));
@@ -6464,8 +7177,8 @@ fn reject_staged_base_conflicts(
         }
         let (nodes, node_work) = base.probe(UuidIndexKind::Node, &requested)?;
         let (edges, edge_work) = base.probe(UuidIndexKind::Edge, &requested)?;
-        account_probe_work(&node_work, evidence);
-        account_probe_work(&edge_work, evidence);
+        account_probe_work(&node_work, evidence)?;
+        account_probe_work(&edge_work, evidence)?;
         if nodes
             .into_iter()
             .zip(edges)
@@ -6517,7 +7230,7 @@ fn validate_unified_and_details(
             }
             _ => return Err(storage("invalid identity kind in unified merge")),
         }
-        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
         if (node_count + edge_count).is_multiple_of(4096) {
             reject_cancelled(cancelled)?;
         }
@@ -6591,7 +7304,7 @@ fn validate_detail_domain<const N: usize>(
     let (mut details, details_counter) = open_counted_fixed_reader(root, details_name, evidence)?;
     let mut identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
     if identity.is_some() {
-        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
     }
     let mut count = 0_u64;
     while let Some(detail) = read_fixed::<N>(&mut details)? {
@@ -6600,7 +7313,7 @@ fn validate_detail_domain<const N: usize>(
             .is_some_and(|item| item[17] == 1 || item[16] != kind || item[..16] < detail[..16])
         {
             identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
-            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
         }
         if identity
             .as_ref()
@@ -6610,9 +7323,9 @@ fn validate_detail_domain<const N: usize>(
                 "canonical detail UUID differs from identity domain",
             ));
         }
-        account_merge_read::<N>(evidence);
+        account_merge_read::<N>(evidence)?;
         identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
-        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
         count += 1;
         if count.is_multiple_of(4096) {
             reject_cancelled(cancelled)?;
@@ -6666,7 +7379,7 @@ fn validate_endpoints(
             .is_some_and(|item| item[..16] < endpoint[..16])
         {
             identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
-            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+            account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
         }
         let Some(node) = identity.as_ref() else {
             return Err(storage("edge endpoint UUID does not exist"));
@@ -6677,13 +7390,19 @@ fn validate_endpoints(
         if endpoint[32] > 1 || endpoint[33..].iter().any(|byte| *byte != 0) {
             return Err(storage("endpoint run record is not canonical"));
         }
-        endpoint_count += 1;
-        account_merge_read::<ENDPOINT_WIDTH>(evidence);
+        endpoint_count = endpoint_count
+            .checked_add(1)
+            .ok_or_else(|| storage("endpoint validation count overflow"))?;
+        account_merge_read::<ENDPOINT_WIDTH>(evidence)?;
         if endpoint_count.is_multiple_of(4096) {
             reject_cancelled(cancelled)?;
         }
     }
-    if endpoint_count != new_edges.saturating_mul(2) {
+    if endpoint_count
+        != new_edges
+            .checked_mul(2)
+            .ok_or_else(|| storage("expected endpoint count overflow"))?
+    {
         return Err(storage(
             "edge endpoint cardinality differs from edge domain",
         ));
@@ -6735,8 +7454,8 @@ fn assign_surrogates(
             return Err(storage("invalid retained identity marker during shaping"));
         }
         writer.write_all(&record).map_err(storage)?;
-        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
-        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+        account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
+        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence)?;
         count += 1;
         if count.is_multiple_of(4096) {
             reject_cancelled(cancelled)?;
@@ -6750,8 +7469,8 @@ fn assign_surrogates(
         .sync_all_and_release()
         .map_err(storage)?;
     let cache_release = writer.get_ref().inner.evidence();
-    account_cache_release(cache_release, evidence);
-    account_sequential_write(writer.get_ref().bytes, evidence);
+    account_cache_release(cache_release, evidence)?;
+    account_sequential_write(writer.get_ref().bytes, evidence)?;
     let output_receipt = ArtifactReceipt {
         name: output.to_owned(),
         bytes: writer.get_ref().bytes,
@@ -6761,7 +7480,10 @@ fn assign_surrogates(
         sha256: hex(&writer.get_ref().digest.clone().finalize()),
         identity: identity.into(),
         write_operations: writer.get_ref().operations,
-        fsync_operations: 2_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+        fsync_operations: cache_release
+            .sync_operations
+            .checked_add(1)
+            .ok_or_else(|| storage("artifact synchronization count overflows"))?,
     };
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
@@ -6772,7 +7494,8 @@ fn assign_surrogates(
     account_fixed_write_operations(&output_receipt, evidence)?;
     evidence.merge_fsync_operations = evidence
         .merge_fsync_operations
-        .saturating_add(output_receipt.fsync_operations);
+        .checked_add(output_receipt.fsync_operations)
+        .ok_or_else(|| storage("merge fsync operations overflows"))?;
     Ok(output.to_owned())
 }
 
@@ -6818,7 +7541,7 @@ fn resolve_endpoint_surrogates(
                 .is_some_and(|record| record[..16] < endpoint[..16])
             {
                 identity = read_fixed::<BASE_IDENTITY_WIDTH>(&mut identities)?;
-                account_merge_read::<BASE_IDENTITY_WIDTH>(evidence);
+                account_merge_read::<BASE_IDENTITY_WIDTH>(evidence)?;
             }
             if let Some(node) = identity
                 .as_ref()
@@ -6838,7 +7561,7 @@ fn resolve_endpoint_surrogates(
                 .as_deref_mut()
                 .ok_or_else(|| storage("endpoint UUID lacks node surrogate"))?
                 .lookup_node_surrogates(&base_requests)?;
-            account_probe_work(&probe_work, evidence);
+            account_probe_work(&probe_work, evidence)?;
             for (position, surrogate) in base_positions.into_iter().zip(resolved) {
                 surrogates[position] = surrogate;
             }
@@ -6852,29 +7575,35 @@ fn resolve_endpoint_surrogates(
             resolved[16] = endpoint[32];
             resolved[24..32].copy_from_slice(&surrogate.to_be_bytes());
             window.push(resolved);
-            account_merge_read::<ENDPOINT_WIDTH>(evidence);
+            account_merge_read::<ENDPOINT_WIDTH>(evidence)?;
         }
         if window.len() == window_rows {
             window.sort_unstable();
             let name = format!("merge-resolved-source-{sequence:020}.run");
             let receipt = write_fixed_run(root, &name, &window, evidence)?;
             record_shape_artifact_install(evidence, &receipt)?;
-            evidence.merge_written_bytes =
-                evidence.merge_written_bytes.saturating_add(receipt.bytes);
+            evidence.merge_written_bytes = evidence
+                .merge_written_bytes
+                .checked_add(receipt.bytes)
+                .ok_or_else(|| storage("merge written byte count overflows"))?;
             account_fixed_write_operations(&receipt, evidence)?;
             evidence.merge_written_records = evidence
                 .merge_written_records
-                .saturating_add(window.len() as u64);
+                .checked_add(window.len() as u64)
+                .ok_or_else(|| storage("merge written record count overflows"))?;
             evidence.merge_fsync_operations = evidence
                 .merge_fsync_operations
-                .saturating_add(receipt.fsync_operations);
-            account_sequential_write(receipt.bytes, evidence);
+                .checked_add(receipt.fsync_operations)
+                .ok_or_else(|| storage("merge fsync count overflows"))?;
+            account_sequential_write(receipt.bytes, evidence)?;
             resolved.push::<RESOLVED_ENDPOINT_WIDTH>(root, name, cancelled, evidence)?;
             evidence.peak_resolved_endpoint_name_slots = evidence
                 .peak_resolved_endpoint_name_slots
                 .max(resolved.slot_count() as u64);
             window.clear();
-            sequence = sequence.saturating_add(1);
+            sequence = sequence
+                .checked_add(1)
+                .ok_or_else(|| storage("resolved endpoint sequence overflows"))?;
             reject_cancelled(cancelled)?;
         }
     }
@@ -6883,15 +7612,20 @@ fn resolve_endpoint_surrogates(
         let name = format!("merge-resolved-source-{sequence:020}.run");
         let receipt = write_fixed_run(root, &name, &window, evidence)?;
         record_shape_artifact_install(evidence, &receipt)?;
-        evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(receipt.bytes);
+        evidence.merge_written_bytes = evidence
+            .merge_written_bytes
+            .checked_add(receipt.bytes)
+            .ok_or_else(|| storage("merge written byte count overflows"))?;
         account_fixed_write_operations(&receipt, evidence)?;
         evidence.merge_written_records = evidence
             .merge_written_records
-            .saturating_add(window.len() as u64);
+            .checked_add(window.len() as u64)
+            .ok_or_else(|| storage("merge written record count overflows"))?;
         evidence.merge_fsync_operations = evidence
             .merge_fsync_operations
-            .saturating_add(receipt.fsync_operations);
-        account_sequential_write(receipt.bytes, evidence);
+            .checked_add(receipt.fsync_operations)
+            .ok_or_else(|| storage("merge fsync count overflows"))?;
+        account_sequential_write(receipt.bytes, evidence)?;
         resolved.push::<RESOLVED_ENDPOINT_WIDTH>(root, name, cancelled, evidence)?;
         evidence.peak_resolved_endpoint_name_slots = evidence
             .peak_resolved_endpoint_name_slots
@@ -6905,15 +7639,18 @@ fn resolve_endpoint_surrogates(
 fn account_probe_work(
     work: &crate::uuid_membership::UuidProbeMetrics,
     evidence: &mut GraphConstructionEvidence,
-) {
-    evidence.retained_probe_read_bytes = evidence
-        .retained_probe_read_bytes
-        .saturating_add(work.identity_bytes_read)
-        .saturating_add(work.surrogate_bytes_read);
-    evidence.retained_probe_block_loads = evidence
-        .retained_probe_block_loads
-        .saturating_add(work.identity_blocks_read)
-        .saturating_add(work.surrogate_blocks_read);
+) -> Result<(), GfError> {
+    evidence.retained_probe_read_bytes = checked_evidence_sum(
+        "retained probe read bytes",
+        evidence.retained_probe_read_bytes,
+        &[work.identity_bytes_read, work.surrogate_bytes_read],
+    )?;
+    evidence.retained_probe_block_loads = checked_evidence_sum(
+        "retained probe block loads",
+        evidence.retained_probe_block_loads,
+        &[work.identity_blocks_read, work.surrogate_blocks_read],
+    )?;
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -6965,8 +7702,12 @@ fn authenticate_artifact(
                 break;
             }
             digest.update(&block[..count]);
-            bytes = bytes.saturating_add(count as u64);
-            operations = operations.saturating_add(1);
+            bytes = bytes
+                .checked_add(count as u64)
+                .ok_or_else(|| storage("bytes overflows"))?;
+            operations = operations
+                .checked_add(1)
+                .ok_or_else(|| storage("operations overflows"))?;
             if let Some(width) = width {
                 pending.extend_from_slice(&block[..count]);
                 let complete = pending.len() / width * width;
@@ -7187,29 +7928,47 @@ fn validate_receipt_artifacts(
         .chain(receipt.endpoints.iter())
     {
         let artifact_work = authenticate_artifact(root, artifact)?;
-        work.bytes = work.bytes.saturating_add(artifact_work.bytes);
-        work.operations = work.operations.saturating_add(artifact_work.operations);
-        merge_cache_release_evidence(&mut work.cache_release, artifact_work.cache_release);
+        work.bytes = work
+            .bytes
+            .checked_add(artifact_work.bytes)
+            .ok_or_else(|| storage("bytes overflows"))?;
+        work.operations = work
+            .operations
+            .checked_add(artifact_work.operations)
+            .ok_or_else(|| storage("operations overflows"))?;
+        merge_cache_release_evidence(&mut work.cache_release, artifact_work.cache_release)?;
     }
     let parquet_work = validate_parquet_shape(root, receipt)?;
-    work.bytes = work.bytes.saturating_add(parquet_work.bytes);
-    work.operations = work.operations.saturating_add(parquet_work.operations);
-    merge_cache_release_evidence(&mut work.cache_release, parquet_work.cache_release);
+    work.bytes = work
+        .bytes
+        .checked_add(parquet_work.bytes)
+        .ok_or_else(|| storage("bytes overflows"))?;
+    work.operations = work
+        .operations
+        .checked_add(parquet_work.operations)
+        .ok_or_else(|| storage("operations overflows"))?;
+    merge_cache_release_evidence(&mut work.cache_release, parquet_work.cache_release)?;
     Ok(work)
 }
 
 fn merge_cache_release_evidence(
     target: &mut graphforge_filesystem::FileCacheReleaseEvidence,
     source: graphforge_filesystem::FileCacheReleaseEvidence,
-) {
+) -> Result<(), GfError> {
     target.release_operations = target
         .release_operations
-        .saturating_add(source.release_operations);
+        .checked_add(source.release_operations)
+        .ok_or_else(|| storage("release operations overflows"))?;
     target.unsupported_operations = target
         .unsupported_operations
-        .saturating_add(source.unsupported_operations);
-    target.released_bytes = target.released_bytes.saturating_add(source.released_bytes);
+        .checked_add(source.unsupported_operations)
+        .ok_or_else(|| storage("unsupported operations overflows"))?;
+    target.released_bytes = target
+        .released_bytes
+        .checked_add(source.released_bytes)
+        .ok_or_else(|| storage("released bytes overflows"))?;
     target.peak_window_bytes = target.peak_window_bytes.max(source.peak_window_bytes);
+    Ok(())
 }
 
 fn validate_parquet_shape(
@@ -7326,20 +8085,39 @@ fn validate_parquet_metadata(
 
 fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), GfError> {
     let stem = artifact_stem(intent.sequence, intent.kind);
-    let expected_run_records =
-        intent
-            .rows
-            .saturating_mul(if intent.kind == ConstructionChunkKind::Edge {
-                4
-            } else {
-                2
-            });
+    let expected_run_records = intent
+        .rows
+        .checked_mul(if intent.kind == ConstructionChunkKind::Edge {
+            4
+        } else {
+            2
+        })
+        .ok_or_else(|| storage("intent run record count overflow"))?;
+    let prior_sequence = intent.sequence.checked_add(1);
+    let expected_identity_bytes = intent
+        .rows
+        .checked_mul(IDENTITY_WIDTH as u64)
+        .ok_or_else(|| storage("intent identity byte count overflow"))?;
+    let expected_endpoint_bytes = intent
+        .rows
+        .checked_mul(2)
+        .and_then(|rows| rows.checked_mul(ENDPOINT_WIDTH as u64))
+        .ok_or_else(|| storage("intent endpoint byte count overflow"))?;
+    let detail_width = if intent.kind == ConstructionChunkKind::Node {
+        NODE_DETAIL_WIDTH
+    } else {
+        EDGE_DETAIL_WIDTH
+    };
+    let expected_detail_bytes = intent
+        .rows
+        .checked_mul(detail_width as u64)
+        .ok_or_else(|| storage("intent detail byte count overflow"))?;
     if intent.format_version != FORMAT_VERSION
         || intent.operation_uuid != checkpoint.operation_uuid
         || intent.project_identity != checkpoint.project_identity
         || intent.session_identity != checkpoint.session_identity
         || !(intent.sequence == checkpoint.next_sequence
-            || intent.sequence.saturating_add(1) == checkpoint.next_sequence)
+            || prior_sequence == Some(checkpoint.next_sequence))
         || intent.parent_topology_generation != checkpoint.parent_topology_generation
         || intent.ontology_mode != checkpoint.ontology_mode
         || intent.semantic_authority_sha256 != checkpoint.semantic_authority_sha256
@@ -7360,16 +8138,12 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
             .is_some_and(|artifact| artifact.name != format!("{stem}.parquet"))
         || intent.identities.as_ref().is_some_and(|artifact| {
             artifact.name != format!("{stem}.identities.run")
-                || artifact.bytes != intent.rows.saturating_mul(IDENTITY_WIDTH as u64)
+                || artifact.bytes != expected_identity_bytes
         })
         || intent.endpoints.as_ref().is_some_and(|artifact| {
             intent.kind != ConstructionChunkKind::Edge
                 || artifact.name != format!("{stem}.endpoints.run")
-                || artifact.bytes
-                    != intent
-                        .rows
-                        .saturating_mul(2)
-                        .saturating_mul(ENDPOINT_WIDTH as u64)
+                || artifact.bytes != expected_endpoint_bytes
         })
         || intent.details.as_ref().is_some_and(|artifact| {
             artifact.name
@@ -7381,14 +8155,7 @@ fn validate_intent(intent: &ChunkIntent, checkpoint: &Checkpoint) -> Result<(), 
                         "edge"
                     }
                 )
-                || artifact.bytes
-                    != intent
-                        .rows
-                        .saturating_mul(if intent.kind == ConstructionChunkKind::Node {
-                            NODE_DETAIL_WIDTH
-                        } else {
-                            EDGE_DETAIL_WIDTH
-                        } as u64)
+                || artifact.bytes != expected_detail_bytes
         })
     {
         return Err(storage("durable intent is inconsistent with checkpoint"));
@@ -7411,6 +8178,19 @@ fn validate_checkpoint(
     parent_generation_uuid: Uuid,
     parent_generation_manifest_sha256: &str,
 ) -> Result<(), GfError> {
+    let minimum_artifacts = checkpoint
+        .next_sequence
+        .checked_mul(3)
+        .ok_or_else(|| storage("checkpoint artifact lower bound overflow"))?;
+    let maximum_artifacts = checkpoint
+        .next_sequence
+        .checked_mul(4)
+        .ok_or_else(|| storage("checkpoint artifact upper bound overflow"))?;
+    let schema_groups = checkpoint
+        .node_schema_sha256
+        .len()
+        .checked_add(checkpoint.edge_schema_sha256.len())
+        .ok_or_else(|| storage("checkpoint schema-group count overflow"))?;
     if checkpoint.format_version != FORMAT_VERSION
         || checkpoint.operation_uuid != operation
         || !checkpoint.project_identity.matches(project)
@@ -7470,10 +8250,8 @@ fn validate_checkpoint(
         || checkpoint.evidence.input_batches != checkpoint.next_sequence
         || checkpoint.evidence.parquet_shards != checkpoint.next_sequence
         || checkpoint.evidence.immutable_artifacts != 0
-            && (checkpoint.evidence.immutable_artifacts
-                < checkpoint.next_sequence.saturating_mul(3)
-                || checkpoint.evidence.immutable_artifacts
-                    > checkpoint.next_sequence.saturating_mul(4))
+            && (checkpoint.evidence.immutable_artifacts < minimum_artifacts
+                || checkpoint.evidence.immutable_artifacts > maximum_artifacts)
         || checkpoint.evidence.peak_batch_rows > budgets.max_batch_rows as u64
         || checkpoint.evidence.peak_batch_bytes > budgets.max_batch_bytes as u64
         || checkpoint.evidence.peak_run_records > budgets.max_run_records as u64
@@ -7487,11 +8265,7 @@ fn validate_checkpoint(
             .edge_schema_sha256
             .iter()
             .any(|digest| !is_canonical_sha256(digest))
-        || checkpoint
-            .node_schema_sha256
-            .len()
-            .saturating_add(checkpoint.edge_schema_sha256.len())
-            > budgets.max_schema_groups
+        || schema_groups > budgets.max_schema_groups
     {
         return Err(storage("checkpoint authority or resume parameters changed"));
     }
@@ -7701,7 +8475,12 @@ struct BoundedControlWriter {
 
 impl Write for BoundedControlWriter {
     fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-        if self.body.len().saturating_add(bytes.len()) > self.limit {
+        let new_length = self
+            .body
+            .len()
+            .checked_add(bytes.len())
+            .ok_or_else(|| std::io::Error::other("control record length overflow"))?;
+        if new_length > self.limit {
             return Err(std::io::Error::other("control record exceeds bound"));
         }
         self.body.extend_from_slice(bytes);
@@ -7828,12 +8607,15 @@ fn remove_unrecorded_artifact(
             return Err(storage("unrecorded artifact name is not canonical"));
         };
         let expected_records = if width == ENDPOINT_WIDTH {
-            rows.saturating_mul(2)
+            rows.checked_mul(2)
+                .ok_or_else(|| storage("unrecorded endpoint count overflow"))?
         } else {
             rows
         };
-        if file.metadata().map_err(storage)?.len() != expected_records.saturating_mul(width as u64)
-        {
+        let expected_bytes = expected_records
+            .checked_mul(u64::try_from(width).map_err(storage)?)
+            .ok_or_else(|| storage("unrecorded fixed run byte count overflow"))?;
+        if file.metadata().map_err(storage)?.len() != expected_bytes {
             return Err(storage("unrecorded fixed run row count changed"));
         }
         validate_sorted_run(file, width)?;
@@ -7932,7 +8714,13 @@ fn authenticated_receipt_artifact_count(
         {
             return Err(storage("legacy receipt authority or chain changed"));
         }
-        count = count.saturating_add(3 + u64::from(receipt.endpoints.is_some()));
+        count = count
+            .checked_add(
+                3_u64
+                    .checked_add(u64::from(receipt.endpoints.is_some()))
+                    .ok_or_else(|| storage("receipt artifact increment overflow"))?,
+            )
+            .ok_or_else(|| storage("authenticated receipt artifact count overflow"))?;
         let body = serde_json::to_vec(&receipt).map_err(storage)?;
         prior_digest = Some(sha256(&body));
     }
@@ -8852,6 +9640,20 @@ mod tests {
         )
         .unwrap();
         let mut evidence = GraphConstructionEvidence::default();
+        for category in crate::ArtifactCategory::ALL {
+            evidence
+                .storage_current
+                .insert(category, Default::default());
+            evidence
+                .storage_receipt_category_authorities
+                .insert(category, Default::default());
+            evidence
+                .storage_transient_peak_allocated_bytes
+                .insert(category, 0);
+            evidence
+                .storage_receipt_transient_peak_authorities
+                .insert(category, 0);
+        }
         write_parquet(&private, "nodes.parquet", &rows, &mut evidence).unwrap();
         let project_root = StableDirectory::open(project.path()).unwrap();
         let (parent_catalog, parent_catalog_sha256, _) =
@@ -9134,6 +9936,28 @@ mod tests {
                         .len()
                 })
                 .sum::<u64>();
+            let retained_shape_files = session
+                .root
+                .child_names()
+                .unwrap()
+                .into_iter()
+                .filter(|name| name.to_str().is_some_and(is_shape_artifact_name))
+                .collect::<Vec<_>>();
+            let expected_retained_allocation = retained_shape_files
+                .iter()
+                .map(|name| {
+                    let file = session.root.open_child_file(name).unwrap();
+                    graphforge_filesystem::file_space_usage(&file)
+                        .unwrap()
+                        .allocated_bytes
+                })
+                .sum::<u64>();
+            assert!(expected_retained_allocation > 0);
+            assert_eq!(
+                session.evidence().current_merge_temporary_allocated_bytes,
+                expected_retained_allocation,
+                "retained authenticated shape allocation differs from the actual file inventory: {retained_shape_files:?}"
+            );
             let expected_capability_bytes = shaped_outputs
                 .map(|name| {
                     session
@@ -9359,7 +10183,10 @@ mod tests {
             );
             assert!(
                 evidence.shape_input_validation_read_bytes
-                    <= evidence.write_bytes.saturating_mul(3),
+                    <= evidence
+                        .write_bytes
+                        .checked_mul(3)
+                        .expect("shape write-byte bound overflow"),
                 "shape authentication exceeded three staged-byte passes"
             );
             observations.push((rows, evidence.shape_input_validation_read_bytes));
@@ -9370,7 +10197,10 @@ mod tests {
             assert_eq!(larger_rows, smaller_rows * 2);
             assert!(larger_bytes >= smaller_bytes);
             assert!(
-                larger_bytes <= smaller_bytes.saturating_mul(3),
+                larger_bytes
+                    <= smaller_bytes
+                        .checked_mul(3)
+                        .expect("shape growth bound overflow"),
                 "doubling rows exceeded the bounded linear byte envelope"
             );
         }
@@ -9572,7 +10402,8 @@ mod tests {
                 <= retained_endpoints
                     .evidence()
                     .retained_probe_block_loads
-                    .saturating_mul(BLOCK_BYTES as u64)
+                    .checked_mul(BLOCK_BYTES as u64)
+                    .expect("retained probe byte bound overflow")
         );
         let mut resolved = BufReader::new(
             retained_endpoints
@@ -9979,7 +10810,7 @@ mod tests {
                     "nodes",
                     &node_batch(1, 8),
                     || {
-                        polls = polls.saturating_add(1);
+                        polls = polls.checked_add(1).expect("cancellation poll overflow");
                         polls == 2
                     },
                 )
@@ -10512,8 +11343,8 @@ mod tests {
                     || artifact.path.ends_with("ordinal-v4-manifest.json")
                     || artifact.path.ends_with("ordinal-v4.lock")
             })
-            .map(|artifact| artifact.bytes)
-            .sum::<u64>();
+            .try_fold(0_u64, |bytes, artifact| bytes.checked_add(artifact.bytes))
+            .expect("ordinal publication byte sum overflow");
         assert_eq!(
             encoding.evidence.ordinal_publication_write_bytes,
             ordinal_publication_bytes
@@ -10523,7 +11354,8 @@ mod tests {
             encoding
                 .evidence
                 .ordinal_artifact_write_bytes
-                .saturating_add(ordinal_publication_bytes)
+                .checked_add(ordinal_publication_bytes)
+                .expect("ordinal peak byte sum overflow")
         );
 
         let graph = root

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -57,7 +57,7 @@ const IDENTITY_WIDTH: usize = 32;
 const NODE_DETAIL_WIDTH: usize = 272;
 const EDGE_DETAIL_WIDTH: usize = 304;
 const RESOLVED_ENDPOINT_WIDTH: usize = 32;
-const COPY_BUFFER_BYTES: usize = 1 << 20;
+const COPY_BUFFER_BYTES: usize = crate::GRAPH_CONSTRUCTION_ENCODING_BUFFER_BYTES;
 
 #[cfg(test)]
 type SourceSpoolHook = Box<dyn FnMut(&str)>;
@@ -82,6 +82,13 @@ fn run_source_spool_hook(phase: &str) {
 
 #[cfg(not(test))]
 fn run_source_spool_hook(_phase: &str) {}
+
+fn add_evidence_counter(counter: &mut u64, value: u64, name: &str) -> Result<(), GfError> {
+    *counter = counter
+        .checked_add(value)
+        .ok_or_else(|| storage(format!("{name} overflow")))?;
+    Ok(())
+}
 
 struct CountingWriter {
     inner: graphforge_filesystem::DurableFileCacheWriter,
@@ -171,14 +178,8 @@ fn authenticated_source_spool<'a>(
             }
             digest.update(&buffer[..read]);
             spool.write_all(&buffer[..read]).map_err(storage)?;
-            bytes = bytes.saturating_add(read as u64);
-            evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(read as u64);
-            evidence.input_read_operations = evidence.input_read_operations.saturating_add(1);
-            evidence.source_spool_write_bytes = evidence
-                .source_spool_write_bytes
-                .saturating_add(read as u64);
-            evidence.source_spool_write_operations =
-                evidence.source_spool_write_operations.saturating_add(1);
+            add_evidence_counter(&mut bytes, read as u64, "read bytes")?;
+            account_spooled_bytes(evidence, read as u64)?;
         }
         if file_identity(authenticated.file()).map_err(storage)? != expected_identity
             || file_link_count(authenticated.file()).map_err(storage)? != 1
@@ -202,14 +203,16 @@ fn authenticated_source_spool<'a>(
             )));
         }
     };
-    account_cache_release(source_release, evidence);
+    account_cache_release(source_release, evidence)?;
     spool.flush().map_err(storage)?;
     spool.sync_all_and_release().map_err(storage)?;
-    evidence.source_spool_fsync_operations = evidence
-        .source_spool_fsync_operations
-        .saturating_add(spool.evidence().sync_operations);
+    add_evidence_counter(
+        &mut evidence.source_spool_fsync_operations,
+        spool.evidence().sync_operations,
+        "source spool fsync operations",
+    )?;
     let spool_release = spool.evidence();
-    account_cache_release(spool_release, evidence);
+    account_cache_release(spool_release, evidence)?;
     let aggregate_peak = source_release
         .peak_window_bytes
         .checked_add(spool_release.peak_window_bytes)
@@ -221,6 +224,33 @@ fn authenticated_source_spool<'a>(
     let mut spool = spool.into_file();
     spool.rewind().map_err(storage)?;
     Ok((spool, guard))
+}
+
+fn account_spooled_bytes(
+    evidence: &mut GraphConstructionEncodingEvidence,
+    bytes: u64,
+) -> Result<(), GfError> {
+    for (counter, value, name) in [
+        (&mut evidence.input_read_bytes, bytes, "input read bytes"),
+        (
+            &mut evidence.input_read_operations,
+            1,
+            "input read operations",
+        ),
+        (
+            &mut evidence.source_spool_write_bytes,
+            bytes,
+            "source spool write bytes",
+        ),
+        (
+            &mut evidence.source_spool_write_operations,
+            1,
+            "source spool write operations",
+        ),
+    ] {
+        add_evidence_counter(counter, value, name)?;
+    }
+    Ok(())
 }
 
 impl<R: Read> Read for CountingInput<R> {
@@ -247,43 +277,61 @@ impl Write for CountingWriter {
 fn account_cache_release(
     released: graphforge_filesystem::FileCacheReleaseEvidence,
     evidence: &mut GraphConstructionEncodingEvidence,
-) {
-    evidence.cache_release_operations = evidence
-        .cache_release_operations
-        .saturating_add(released.release_operations);
-    evidence.cache_release_unsupported_operations = evidence
-        .cache_release_unsupported_operations
-        .saturating_add(released.unsupported_operations);
-    evidence.cache_released_bytes = evidence
-        .cache_released_bytes
-        .saturating_add(released.released_bytes);
+) -> Result<(), GfError> {
+    add_evidence_counter(
+        &mut evidence.cache_release_operations,
+        released.release_operations,
+        "cache release operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.cache_release_unsupported_operations,
+        released.unsupported_operations,
+        "cache release unsupported operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.cache_released_bytes,
+        released.released_bytes,
+        "cache released bytes",
+    )?;
     evidence.peak_cache_release_window_bytes = evidence
         .peak_cache_release_window_bytes
         .max(released.peak_window_bytes);
+    Ok(())
 }
 
 fn merge_encoding_evidence(
     target: &mut GraphConstructionEncodingEvidence,
     source: &GraphConstructionEncodingEvidence,
-) {
-    target.input_read_bytes = target
-        .input_read_bytes
-        .saturating_add(source.input_read_bytes);
-    target.input_read_operations = target
-        .input_read_operations
-        .saturating_add(source.input_read_operations);
-    target.cache_release_operations = target
-        .cache_release_operations
-        .saturating_add(source.cache_release_operations);
-    target.cache_release_unsupported_operations = target
-        .cache_release_unsupported_operations
-        .saturating_add(source.cache_release_unsupported_operations);
-    target.cache_released_bytes = target
-        .cache_released_bytes
-        .saturating_add(source.cache_released_bytes);
+) -> Result<(), GfError> {
+    add_evidence_counter(
+        &mut target.input_read_bytes,
+        source.input_read_bytes,
+        "input read bytes",
+    )?;
+    add_evidence_counter(
+        &mut target.input_read_operations,
+        source.input_read_operations,
+        "input read operations",
+    )?;
+    add_evidence_counter(
+        &mut target.cache_release_operations,
+        source.cache_release_operations,
+        "cache release operations",
+    )?;
+    add_evidence_counter(
+        &mut target.cache_release_unsupported_operations,
+        source.cache_release_unsupported_operations,
+        "cache release unsupported operations",
+    )?;
+    add_evidence_counter(
+        &mut target.cache_released_bytes,
+        source.cache_released_bytes,
+        "cache released bytes",
+    )?;
     target.peak_cache_release_window_bytes = target
         .peak_cache_release_window_bytes
         .max(source.peak_cache_release_window_bytes);
+    Ok(())
 }
 
 fn storage(error: impl std::fmt::Display) -> GfError {
@@ -514,7 +562,11 @@ pub(crate) fn encode(
     if shape.semantic_authority_sha256 != semantic_digest {
         return Err(storage("shape semantic authority differs from session"));
     }
-    if generation != shape.parent_topology_generation.saturating_add(1) {
+    let expected_generation = shape
+        .parent_topology_generation
+        .checked_add(1)
+        .ok_or_else(|| storage("encoded generation overflow"))?;
+    if generation != expected_generation {
         return Err(storage(
             "encoded generation is not consecutive to its parent",
         ));
@@ -663,11 +715,12 @@ pub(crate) fn encode(
         evidence.ordinal_publication_write_operations = publication.write_operations;
         evidence.ordinal_fsync_operations = metrics
             .fsync_operations
-            .saturating_add(publication.fsync_operations);
+            .checked_add(publication.fsync_operations)
+            .ok_or_else(|| storage("ordinal fsync operation count overflow"))?;
         evidence.ordinal_peak_temporary_bytes = metrics
             .peak_temporary_bytes
             .max(publication.peak_temporary_bytes);
-        account_cache_release(metrics.cache_release, &mut evidence);
+        account_cache_release(metrics.cache_release, &mut evidence)?;
         crate::graph_construction::construction_failpoint("encode.after_v4_before_inventory");
         index.artifacts.extend(v4_artifacts);
     }
@@ -712,7 +765,7 @@ pub(crate) fn encode(
     evidence.membership_created_runs = index.created_runs;
     evidence.membership_peak_buffer_bytes = index.peak_buffer_bytes;
     evidence.membership_peak_temporary_bytes = index.peak_temporary_bytes;
-    account_cache_release(index.cache_release, &mut evidence);
+    account_cache_release(index.cache_release, &mut evidence)?;
     evidence.retained_index_runs = index.retained_runs;
     evidence.retained_index_payload_bytes = index.retained_payload_bytes;
     let retained_artifacts = index
@@ -745,7 +798,7 @@ pub(crate) fn encode(
     let authentication = authenticate_inventory(&output, &completed, parent_index)?;
     remove_encoding_intent(&output)?;
     let mut invocation = completed.evidence.clone();
-    merge_encoding_evidence(&mut invocation, &authentication);
+    merge_encoding_evidence(&mut invocation, &authentication)?;
     completed.invocation = GraphConstructionEncodingInvocationEvidence {
         performed: true,
         reused: false,
@@ -1185,7 +1238,9 @@ fn encode_node_properties(
                             cache_window,
                             evidence,
                         )?);
-                        *ordinal = ordinal.saturating_add(1);
+                        *ordinal = ordinal
+                            .checked_add(1)
+                            .ok_or_else(|| storage("encoded ordinal overflows"))?;
                     }
                 }
             }
@@ -1197,14 +1252,28 @@ fn encode_node_properties(
             cache_release.check_error().map_err(storage),
             "node property",
         )?;
-        account_cache_release(cache_release.evidence(), evidence);
+        account_cache_release(cache_release.evidence(), evidence)?;
         let (bytes, operations) = counter.values();
-        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
-        evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
-        evidence.source_spool_read_bytes = evidence.source_spool_read_bytes.saturating_add(bytes);
-        evidence.source_spool_read_operations = evidence
-            .source_spool_read_operations
-            .saturating_add(operations);
+        add_evidence_counter(
+            &mut evidence.input_read_bytes,
+            bytes,
+            "node input read bytes",
+        )?;
+        add_evidence_counter(
+            &mut evidence.input_read_operations,
+            operations,
+            "node input read operations",
+        )?;
+        add_evidence_counter(
+            &mut evidence.source_spool_read_bytes,
+            bytes,
+            "node spool read bytes",
+        )?;
+        add_evidence_counter(
+            &mut evidence.source_spool_read_operations,
+            operations,
+            "node spool read operations",
+        )?;
     }
     Ok(())
 }
@@ -1538,7 +1607,9 @@ fn encode_edge_properties(
                             cache_window,
                             evidence,
                         )?);
-                        *ordinal = ordinal.saturating_add(1);
+                        *ordinal = ordinal
+                            .checked_add(1)
+                            .ok_or_else(|| storage("encoded ordinal overflows"))?;
                     }
                 }
             }
@@ -1550,14 +1621,28 @@ fn encode_edge_properties(
             cache_release.check_error().map_err(storage),
             "edge property",
         )?;
-        account_cache_release(cache_release.evidence(), evidence);
+        account_cache_release(cache_release.evidence(), evidence)?;
         let (bytes, operations) = counter.values();
-        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
-        evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
-        evidence.source_spool_read_bytes = evidence.source_spool_read_bytes.saturating_add(bytes);
-        evidence.source_spool_read_operations = evidence
-            .source_spool_read_operations
-            .saturating_add(operations);
+        add_evidence_counter(
+            &mut evidence.input_read_bytes,
+            bytes,
+            "edge input read bytes",
+        )?;
+        add_evidence_counter(
+            &mut evidence.input_read_operations,
+            operations,
+            "edge input read operations",
+        )?;
+        add_evidence_counter(
+            &mut evidence.source_spool_read_bytes,
+            bytes,
+            "edge spool read bytes",
+        )?;
+        add_evidence_counter(
+            &mut evidence.source_spool_read_operations,
+            operations,
+            "edge spool read operations",
+        )?;
     }
     Ok(())
 }
@@ -1777,14 +1862,28 @@ fn read_runtime_label_ids(
         cache_release.check_error().map_err(storage),
         "runtime catalog",
     )?;
-    account_cache_release(cache_release.evidence(), evidence);
+    account_cache_release(cache_release.evidence(), evidence)?;
     let (bytes, operations) = counter.values();
-    evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
-    evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
-    evidence.source_spool_read_bytes = evidence.source_spool_read_bytes.saturating_add(bytes);
-    evidence.source_spool_read_operations = evidence
-        .source_spool_read_operations
-        .saturating_add(operations);
+    add_evidence_counter(
+        &mut evidence.input_read_bytes,
+        bytes,
+        "runtime catalog read bytes",
+    )?;
+    add_evidence_counter(
+        &mut evidence.input_read_operations,
+        operations,
+        "runtime catalog read operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.source_spool_read_bytes,
+        bytes,
+        "runtime catalog spool read bytes",
+    )?;
+    add_evidence_counter(
+        &mut evidence.source_spool_read_operations,
+        operations,
+        "runtime catalog spool read operations",
+    )?;
     Ok(labels)
 }
 
@@ -1857,7 +1956,7 @@ fn write_parquet(
     let mut writer = writer.into_inner().map_err(storage)?;
     writer.inner.sync_all_and_release().map_err(storage)?;
     let cache_release = writer.inner.evidence();
-    account_cache_release(cache_release, evidence);
+    account_cache_release(cache_release, evidence)?;
     crate::graph_construction::construction_failpoint(&format!(
         "encode.parquet.after_temp_fsync.{relative}"
     ));
@@ -1875,12 +1974,26 @@ fn write_parquet(
     crate::graph_construction::construction_failpoint(&format!(
         "encode.parquet.after_install.{relative}"
     ));
-    evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(written);
-    evidence.output_write_operations = evidence.output_write_operations.saturating_add(operations);
-    evidence.fsync_operations = evidence
-        .fsync_operations
-        .saturating_add(1)
-        .saturating_add(cache_release.sync_operations);
+    add_evidence_counter(
+        &mut evidence.output_write_bytes,
+        written,
+        "output write bytes",
+    )?;
+    add_evidence_counter(
+        &mut evidence.output_write_operations,
+        operations,
+        "output write operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.fsync_operations,
+        1,
+        "namespace fsync operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.fsync_operations,
+        cache_release.sync_operations,
+        "file fsync operations",
+    )?;
     Ok(artifact)
 }
 
@@ -1935,7 +2048,7 @@ fn copy_artifact<R: Read + Seek>(
         .sync_all_and_release()
         .map_err(storage)?;
     let cache_release = writer.get_ref().inner.evidence();
-    account_cache_release(cache_release, evidence);
+    account_cache_release(cache_release, evidence)?;
     crate::graph_construction::construction_failpoint(&format!(
         "encode.copy.after_temp_fsync.{relative}"
     ));
@@ -1957,32 +2070,74 @@ fn copy_artifact<R: Read + Seek>(
     crate::graph_construction::construction_failpoint(&format!(
         "encode.copy.after_install.{relative}"
     ));
-    evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
-    let (read_bytes, read_operations) = read_counter.values();
+    record_copied_artifact_io(
+        evidence,
+        bytes,
+        read_counter.values(),
+        (write_bytes, write_operations),
+        cache_release.sync_operations,
+    )?;
+    artifacts.push(artifact);
+    Ok(())
+}
+
+fn record_copied_artifact_io(
+    evidence: &mut GraphConstructionEncodingEvidence,
+    bytes: u64,
+    read: (u64, u64),
+    written: (u64, u64),
+    file_sync_operations: u64,
+) -> Result<(), GfError> {
+    let (read_bytes, read_operations) = read;
+    let (write_bytes, write_operations) = written;
+    add_evidence_counter(
+        &mut evidence.input_read_bytes,
+        bytes,
+        "copied artifact input bytes",
+    )?;
     if read_bytes != bytes {
         return Err(storage("copied canonical artifact read accounting differs"));
     }
-    evidence.input_read_operations = evidence
-        .input_read_operations
-        .saturating_add(read_operations);
-    evidence.source_spool_read_bytes = evidence.source_spool_read_bytes.saturating_add(read_bytes);
-    evidence.source_spool_read_operations = evidence
-        .source_spool_read_operations
-        .saturating_add(read_operations);
-    evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(bytes);
+    add_evidence_counter(
+        &mut evidence.input_read_operations,
+        read_operations,
+        "copied artifact input operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.source_spool_read_bytes,
+        read_bytes,
+        "copied artifact spool read bytes",
+    )?;
+    add_evidence_counter(
+        &mut evidence.source_spool_read_operations,
+        read_operations,
+        "copied artifact spool read operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.output_write_bytes,
+        bytes,
+        "copied artifact output bytes",
+    )?;
     if write_bytes != bytes {
         return Err(storage(
             "copied canonical artifact write accounting differs",
         ));
     }
-    evidence.output_write_operations = evidence
-        .output_write_operations
-        .saturating_add(write_operations);
-    evidence.fsync_operations = evidence
-        .fsync_operations
-        .saturating_add(1)
-        .saturating_add(cache_release.sync_operations);
-    artifacts.push(artifact);
+    add_evidence_counter(
+        &mut evidence.output_write_operations,
+        write_operations,
+        "output write operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.fsync_operations,
+        1,
+        "namespace fsync operations",
+    )?;
+    add_evidence_counter(
+        &mut evidence.fsync_operations,
+        file_sync_operations,
+        "file fsync operations",
+    )?;
     Ok(())
 }
 
@@ -2005,7 +2160,7 @@ fn copy_file_artifact(
     let released = source.finish().map_err(storage);
     match (copied, released) {
         (Ok(()), Ok(released)) => {
-            account_cache_release(released, evidence);
+            account_cache_release(released, evidence)?;
             Ok(())
         }
         (Ok(()), Err(error)) => Err(error),
@@ -2068,8 +2223,8 @@ fn authenticate_file(
                 break;
             }
             digest.update(&buffer[..read]);
-            bytes = bytes.saturating_add(read as u64);
-            operations = operations.saturating_add(1);
+            add_evidence_counter(&mut bytes, read as u64, "read bytes")?;
+            add_evidence_counter(&mut operations, 1, "read operations")?;
         }
         Ok(ConstructionEncodedArtifact {
             path: path.to_owned(),
@@ -2143,9 +2298,15 @@ fn cleanup_encoding_temps(
     budgets: GraphConstructionBudgets,
 ) -> Result<(), GfError> {
     let limit = usize::try_from(budgets.max_chunks)
-        .unwrap_or(usize::MAX)
-        .saturating_mul(12)
-        .saturating_add(budgets.max_schema_groups.saturating_mul(8))
+        .map_err(storage)?
+        .checked_mul(12)
+        .and_then(|value| {
+            budgets
+                .max_schema_groups
+                .checked_mul(8)
+                .and_then(|groups| value.checked_add(groups))
+        })
+        .ok_or_else(|| storage("encoding cleanup inventory bound overflow"))?
         .max(1024);
     let mut visited = 0_usize;
     cleanup_encoding_directory(root, limit, &mut visited)
@@ -2158,7 +2319,9 @@ fn cleanup_encoding_directory(
 ) -> Result<(), GfError> {
     let mut changed = false;
     for name in directory.child_names().map_err(storage)? {
-        *visited = visited.saturating_add(1);
+        *visited = visited
+            .checked_add(1)
+            .ok_or_else(|| storage("encoding cleanup visit count overflow"))?;
         if *visited > limit {
             return Err(storage("private encoding cleanup inventory exceeds bound"));
         }
@@ -2241,9 +2404,17 @@ fn authenticate_inventory(
         if &actual != expected {
             return Err(storage("canonical artifact differs from inventory"));
         }
-        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(actual.bytes);
-        evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
-        account_cache_release(released, &mut evidence);
+        add_evidence_counter(
+            &mut evidence.input_read_bytes,
+            actual.bytes,
+            "input read bytes",
+        )?;
+        add_evidence_counter(
+            &mut evidence.input_read_operations,
+            operations,
+            "input read operations",
+        )?;
+        account_cache_release(released, &mut evidence)?;
     }
     if inventory.retained_artifacts.is_empty() {
         if inventory.evidence.retained_index_runs != 0 {
@@ -2417,7 +2588,10 @@ impl<const N: usize> FixedReader<N> {
             read += amount;
         }
         self.digest.update(record);
-        self.consumed_bytes = self.consumed_bytes.saturating_add(N as u64);
+        self.consumed_bytes = self
+            .consumed_bytes
+            .checked_add(u64::try_from(N).map_err(storage)?)
+            .ok_or_else(|| storage("fixed-width source byte count overflow"))?;
         Ok(Some(record))
     }
 
@@ -2445,7 +2619,7 @@ impl<const N: usize> FixedReader<N> {
         };
         let released = self.reader.get_mut().inner.finish().map_err(storage);
         match (authentication, released) {
-            (Ok(()), Ok(released)) => account_cache_release(released, evidence),
+            (Ok(()), Ok(released)) => account_cache_release(released, evidence)?,
             (Ok(()), Err(release)) => return Err(release),
             (Err(primary), Ok(_)) => return Err(primary),
             (Err(primary), Err(release)) => {
@@ -2455,8 +2629,16 @@ impl<const N: usize> FixedReader<N> {
             }
         }
         let (bytes, operations) = self.counter.values();
-        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
-        evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
+        add_evidence_counter(
+            &mut evidence.input_read_bytes,
+            bytes,
+            "fixed-width input read bytes",
+        )?;
+        add_evidence_counter(
+            &mut evidence.input_read_operations,
+            operations,
+            "fixed-width input read operations",
+        )?;
         Ok(())
     }
 }
@@ -2484,4 +2666,17 @@ fn hex(bytes: &[u8]) -> String {
         out.push(DIGITS[(byte & 0x0f) as usize] as char);
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_counter_addition_rejects_overflow_without_clamping() {
+        let mut counter = u64::MAX;
+        let error = add_evidence_counter(&mut counter, 1, "mutation").unwrap_err();
+        assert!(error.to_string().contains("mutation overflow"));
+        assert_eq!(counter, u64::MAX);
+    }
 }

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -35,7 +35,9 @@ pub const GRAPH_TREE_DIR: &str = "graph";
 const GRAPH_FILES_FORMAT: &str = "graphforge-graph-files";
 const GRAPH_FILES_FORMAT_VERSION: u32 = 1;
 const MAX_GRAPH_FILES: usize = 100_000;
-const HASH_BUFFER_BYTES: usize = 64 * 1024;
+/// Maximum bytes consumed by one instrumented graph-file copy/hash operation.
+pub const GRAPH_FILES_IO_BUFFER_BYTES: usize = 64 * 1024;
+const HASH_BUFFER_BYTES: usize = GRAPH_FILES_IO_BUFFER_BYTES;
 const GRAPH_FILES_SCHEMA_CANONICAL_BYTES: &[u8] =
     b"graphforge-graph-files/1|relative_path|byte_length|content_sha256|role";
 const GRAPH_FILES_V2_SCHEMA_CANONICAL_BYTES: &[u8] =
@@ -125,6 +127,10 @@ pub struct GraphFilesOpenEvidence {
     pub application_write_calls: u64,
     /// File and directory durability barriers completed while hydrating.
     pub fsync_calls: u64,
+    /// Durability barriers completed on materialized files.
+    pub file_fsync_calls: u64,
+    /// Durability barriers completed on containing directories.
+    pub directory_fsync_calls: u64,
 }
 
 /// Open/materialization strategy for a file-backed graph.
@@ -345,26 +351,49 @@ pub fn stage_graph_tree(
         let digest = copied.digest;
         evidence.application_read_bytes = evidence
             .application_read_bytes
-            .saturating_add(copied.read_bytes);
+            .checked_add(copied.read_bytes)
+            .ok_or_else(|| validation("graph staging read byte count overflows"))?;
         evidence.application_read_calls = evidence
             .application_read_calls
-            .saturating_add(copied.read_calls);
+            .checked_add(copied.read_calls)
+            .ok_or_else(|| validation("graph staging read call count overflows"))?;
         evidence.application_write_bytes = evidence
             .application_write_bytes
-            .saturating_add(copied.write_bytes);
+            .checked_add(copied.write_bytes)
+            .ok_or_else(|| validation("graph staging write byte count overflows"))?;
         evidence.application_write_calls = evidence
             .application_write_calls
-            .saturating_add(copied.write_calls);
-        evidence.fsync_calls = evidence.fsync_calls.saturating_add(copied.fsync_calls);
+            .checked_add(copied.write_calls)
+            .ok_or_else(|| validation("graph staging write call count overflows"))?;
+        evidence.fsync_calls = evidence
+            .fsync_calls
+            .checked_add(copied.fsync_calls)
+            .ok_or_else(|| validation("graph staging fsync count overflows"))?;
+        evidence.file_fsync_calls = evidence
+            .file_fsync_calls
+            .checked_add(copied.fsync_calls)
+            .ok_or_else(|| validation("graph staging file barrier count overflows"))?;
         if hex_digest(digest) != entry.content_sha256 {
             return Err(validation(
                 "graph tree source digest does not match inventory",
             ));
         }
-        evidence.files_validated = evidence.files_validated.saturating_add(1);
-        evidence.bytes_validated = evidence.bytes_validated.saturating_add(entry.byte_length);
-        evidence.files_copied = evidence.files_copied.saturating_add(1);
-        evidence.bytes_copied = evidence.bytes_copied.saturating_add(entry.byte_length);
+        evidence.files_validated = evidence
+            .files_validated
+            .checked_add(1)
+            .ok_or_else(|| validation("graph staging validated-file count overflows"))?;
+        evidence.bytes_validated = evidence
+            .bytes_validated
+            .checked_add(entry.byte_length)
+            .ok_or_else(|| validation("graph staging validated-byte count overflows"))?;
+        evidence.files_copied = evidence
+            .files_copied
+            .checked_add(1)
+            .ok_or_else(|| validation("graph staging copied-file count overflows"))?;
+        evidence.bytes_copied = evidence
+            .bytes_copied
+            .checked_add(entry.byte_length)
+            .ok_or_else(|| validation("graph staging copied-byte count overflows"))?;
         // Fail after at least one graph file is durable so interrupted staging
         // can prove CURRENT remains on the prior complete generation.
         project_failpoint::hit(
@@ -375,9 +404,15 @@ pub fn stage_graph_tree(
             false,
         )?;
     }
+    let directory_fsync_calls = sync_directory_tree(&destination_root)?;
+    evidence.directory_fsync_calls = evidence
+        .directory_fsync_calls
+        .checked_add(directory_fsync_calls)
+        .ok_or_else(|| validation("graph staging directory barrier count overflows"))?;
     evidence.fsync_calls = evidence
         .fsync_calls
-        .saturating_add(sync_directory_tree(&destination_root)?);
+        .checked_add(directory_fsync_calls)
+        .ok_or_else(|| validation("graph staging fsync count overflows"))?;
     verify_graph_tree(&destination_root, inventory)?;
     Ok(evidence)
 }
@@ -459,7 +494,8 @@ pub fn materialize_graph_tree(
     verify_graph_tree(graph_root, inventory)?;
     let mut evidence = GraphFilesOpenEvidence {
         strategy: GraphFilesOpenStrategy::PrivateMaterialize,
-        files_validated: u64::try_from(inventory.files.len()).unwrap_or(u64::MAX),
+        files_validated: u64::try_from(inventory.files.len())
+            .map_err(|_| validation("graph hydration file inventory exceeds u64"))?,
         bytes_validated: inventory.total_byte_length,
         ..GraphFilesOpenEvidence::default()
     };
@@ -474,21 +510,45 @@ pub fn materialize_graph_tree(
         let copied = copy_regular_file(&source, &destination)?;
         evidence.application_read_bytes = evidence
             .application_read_bytes
-            .saturating_add(copied.read_bytes);
+            .checked_add(copied.read_bytes)
+            .ok_or_else(|| validation("graph hydration read byte count overflows"))?;
         evidence.application_read_calls = evidence
             .application_read_calls
-            .saturating_add(copied.read_calls);
+            .checked_add(copied.read_calls)
+            .ok_or_else(|| validation("graph hydration read call count overflows"))?;
         evidence.application_write_bytes = evidence
             .application_write_bytes
-            .saturating_add(copied.write_bytes);
+            .checked_add(copied.write_bytes)
+            .ok_or_else(|| validation("graph hydration write byte count overflows"))?;
         evidence.application_write_calls = evidence
             .application_write_calls
-            .saturating_add(copied.write_calls);
-        evidence.fsync_calls = evidence.fsync_calls.saturating_add(copied.fsync_calls);
+            .checked_add(copied.write_calls)
+            .ok_or_else(|| validation("graph hydration write call count overflows"))?;
+        evidence.fsync_calls = evidence
+            .fsync_calls
+            .checked_add(copied.fsync_calls)
+            .ok_or_else(|| validation("graph hydration fsync count overflows"))?;
+        evidence.file_fsync_calls = evidence
+            .file_fsync_calls
+            .checked_add(copied.fsync_calls)
+            .ok_or_else(|| validation("graph hydration file barrier count overflows"))?;
         make_private_copy_owner_writable(&destination)?;
-        evidence.fsync_calls = evidence.fsync_calls.saturating_add(1);
-        evidence.files_copied = evidence.files_copied.saturating_add(1);
-        evidence.bytes_copied = evidence.bytes_copied.saturating_add(entry.byte_length);
+        evidence.fsync_calls = evidence
+            .fsync_calls
+            .checked_add(1)
+            .ok_or_else(|| validation("graph hydration fsync count overflows"))?;
+        evidence.file_fsync_calls = evidence
+            .file_fsync_calls
+            .checked_add(1)
+            .ok_or_else(|| validation("graph hydration file barrier count overflows"))?;
+        evidence.files_copied = evidence
+            .files_copied
+            .checked_add(1)
+            .ok_or_else(|| validation("graph hydration copied-file count overflows"))?;
+        evidence.bytes_copied = evidence
+            .bytes_copied
+            .checked_add(entry.byte_length)
+            .ok_or_else(|| validation("graph hydration copied-byte count overflows"))?;
     }
     Ok(evidence)
 }
@@ -870,8 +930,12 @@ fn hash_file_io_counted(path: &Path) -> Result<([u8; 32], u64, u64), GfError> {
             break;
         }
         digest.update(&buffer[..read]);
-        bytes = bytes.saturating_add(read as u64);
-        calls = calls.saturating_add(1);
+        bytes = bytes
+            .checked_add(read as u64)
+            .ok_or_else(|| validation("graph file hash byte count overflows"))?;
+        calls = calls
+            .checked_add(1)
+            .ok_or_else(|| validation("graph file hash call count overflows"))?;
     }
     Ok((digest.finalize().into(), bytes, calls))
 }
@@ -1599,6 +1663,8 @@ mod tests {
         );
         assert_eq!(evidence.application_write_calls, 2);
         assert_eq!(evidence.fsync_calls, 4);
+        assert_eq!(evidence.file_fsync_calls, 2);
+        assert_eq!(evidence.directory_fsync_calls, 2);
 
         let sealed_source = graph_tree_root(generation.path()).join("properties/Person.parquet");
         let mut sealed_permissions = fs::metadata(&sealed_source).unwrap().permissions();
@@ -1619,6 +1685,8 @@ mod tests {
         assert_eq!(opened.application_write_bytes, inventory.total_byte_length);
         assert_eq!(opened.application_write_calls, 2);
         assert_eq!(opened.fsync_calls, 4);
+        assert_eq!(opened.file_fsync_calls, 4);
+        assert_eq!(opened.directory_fsync_calls, 0);
         let private_copy = private.path().join("properties/Person.parquet");
         assert!(
             fs::metadata(&sealed_source)

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -16,6 +16,12 @@ pub const GRAPH_MANIFEST_NODE_FORMAT: &str = "graphforge-graph-manifest-radix-no
 pub const GRAPH_MANIFEST_NODE_VERSION: u32 = 2;
 /// Number of SHA-256 nibbles consumed by the Patricia trie.
 pub const GRAPH_RADIX_DEPTH: u8 = 64;
+/// Largest canonical branch: 16 references, a 63-nibble prefix, JSON header and newline.
+#[cfg(any(test, feature = "test-support"))]
+pub const GRAPH_MANIFEST_BRANCH_MAX_BYTES: u64 = 1319;
+/// Maximum extra JSON bytes per manifest entry over its canonical encoding artifact.
+#[cfg(any(test, feature = "test-support"))]
+pub const GRAPH_MANIFEST_ENTRY_ENCODING_OVERHEAD_BYTES: u64 = 43;
 
 /// Generation participant root naming one immutable radix root and its totals.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -101,6 +107,8 @@ pub struct GraphManifestResolveEvidence {
     pub entries_examined: u64,
     /// Aggregate encoded bytes admitted for decoding.
     pub decoded_bytes: u64,
+    /// Nonempty reads performed by a storage-backed resolver; zero for in-memory resolution.
+    pub application_read_calls: u64,
     /// Aggregate node, child-reference, and entry work performed.
     pub work_units: u64,
 }
@@ -623,6 +631,77 @@ fn validation(message: impl Into<String>) -> GfError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn publication_control_byte_bounds_cover_maximal_branches_and_escaped_entries() {
+        let mut largest_branch = 0;
+        for depth in 0..GRAPH_RADIX_DEPTH {
+            let mut node = branch(
+                depth,
+                (0..16)
+                    .map(|nibble| (format!("{nibble:x}"), format!("{nibble:064x}")))
+                    .collect(),
+            );
+            node.prefix = "f".repeat(usize::from(GRAPH_RADIX_DEPTH - depth - 1));
+            largest_branch = largest_branch.max(encode_node(&node).unwrap().len() as u64);
+        }
+        assert_eq!(largest_branch, GRAPH_MANIFEST_BRANCH_MAX_BYTES);
+        let mut largest_entry_overhead = 0;
+        for path in [
+            "plain.parquet",
+            "nested/quote\"and\u{0001}control.parquet",
+            "unicode/雪.parquet",
+        ] {
+            for role in [
+                GraphFileRole::Topology,
+                GraphFileRole::Properties,
+                GraphFileRole::Index,
+                GraphFileRole::Delta,
+                GraphFileRole::Catalog,
+                GraphFileRole::Other,
+            ] {
+                for bytes in [0, u64::MAX] {
+                    let entry = GraphFileEntry {
+                        relative_path: path.into(),
+                        byte_length: bytes,
+                        content_sha256: "0".repeat(64),
+                        role,
+                    };
+                    let artifact =
+                        crate::graph_construction_encoding::ConstructionEncodedArtifact {
+                            path: path.into(),
+                            bytes,
+                            sha256: entry.content_sha256.clone(),
+                        };
+                    let entry_bytes = serde_json::to_vec(&entry).unwrap().len() as u64;
+                    let artifact_bytes = serde_json::to_vec(&artifact).unwrap().len() as u64;
+                    largest_entry_overhead =
+                        largest_entry_overhead.max(entry_bytes - artifact_bytes);
+                    let digest = hex_digest(logical_path_digest(path));
+                    let leaf = GraphManifestNode {
+                        format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+                        format_version: GRAPH_MANIFEST_NODE_VERSION,
+                        depth: 0,
+                        prefix: digest.clone(),
+                        kind: GraphManifestNodeKind::Leaf {
+                            path_sha256: digest,
+                            entries: vec![entry],
+                        },
+                    };
+                    assert!(
+                        encode_node(&leaf).unwrap().len() as u64
+                            <= GRAPH_MANIFEST_BRANCH_MAX_BYTES
+                                + artifact_bytes
+                                + GRAPH_MANIFEST_ENTRY_ENCODING_OVERHEAD_BYTES
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            largest_entry_overhead,
+            GRAPH_MANIFEST_ENTRY_ENCODING_OVERHEAD_BYTES
+        );
+    }
 
     fn branch(depth: u8, children: BTreeMap<String, String>) -> GraphManifestNode {
         GraphManifestNode {

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -26,15 +26,24 @@ const SHA256_DIR: &str = "sha256";
 const TEMP_DIR: &str = "tmp";
 const ACTIVE_DIR: &str = "active";
 const LIFECYCLE_LOCK: &str = "lifecycle.lock";
-const BUFFER_BYTES: usize = 64 * 1024;
+/// Maximum bytes consumed by one instrumented CAS copy/hash operation.
+pub const GRAPH_OBJECT_IO_BUFFER_BYTES: usize = 64 * 1024;
+const BUFFER_BYTES: usize = GRAPH_OBJECT_IO_BUFFER_BYTES;
 
 #[cfg(test)]
 thread_local! {
     static RETURNED_ERROR_BOUNDARY: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+    static BEFORE_OBJECT_LINK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> = const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(test)]
 fn returned_error_boundary(name: &str) -> Result<(), GfError> {
+    if name == "install:temp-sealed" {
+        let hook = BEFORE_OBJECT_LINK.with(|current| current.borrow_mut().take());
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
     if RETURNED_ERROR_BOUNDARY.with(|boundary| boundary.borrow().as_deref() == Some(name)) {
         return Err(GfError::Storage(format!(
             "injected graph object returned error at {name}"
@@ -563,6 +572,8 @@ pub struct GraphObjectInstallEvidence {
     pub bytes_installed: u64,
     /// Whether an already installed exact object satisfied the request.
     pub reused_existing: bool,
+    /// A temporary object was written and finalized, possibly losing a publication race.
+    pub attempted_install: bool,
     /// Non-empty source or authentication reads completed by the application.
     pub read_calls: u64,
     /// Temporary-object write submissions completed by the application.
@@ -571,6 +582,135 @@ pub struct GraphObjectInstallEvidence {
     pub write_bytes: u64,
     /// File and directory durability barriers completed by this installation.
     pub fsync_calls: u64,
+    /// Completed synchronization of the temporary payload file.
+    pub file_fsync_calls: u64,
+    /// Completed synchronization of object and temporary namespaces.
+    pub directory_fsync_calls: u64,
+}
+
+/// Content-free application work accumulated from actual CAS operations.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GraphObjectIoTotals {
+    /// Bytes consumed by authentication and source reads.
+    pub read_bytes: u64,
+    /// Nonempty application read submissions.
+    pub read_calls: u64,
+    /// Bytes submitted to object writers.
+    pub write_bytes: u64,
+    /// Nonempty application write submissions.
+    pub write_calls: u64,
+    /// Completed file synchronization operations, including cache rollovers.
+    pub file_fsync_calls: u64,
+    /// Completed namespace synchronization operations.
+    pub directory_fsync_calls: u64,
+    /// Objects newly installed; shared objects are charged on first install only.
+    pub installed_objects: u64,
+    /// Completed temporary-object installation attempts, including concurrent losers.
+    pub install_attempts: u64,
+    /// Install requests satisfied by authenticated existing objects.
+    pub reused_objects: u64,
+    /// Logical bytes newly installed.
+    pub installed_bytes: u64,
+}
+
+impl GraphObjectIoTotals {
+    fn add_install(&mut self, evidence: &GraphObjectInstallEvidence) -> Result<(), GfError> {
+        if evidence
+            .file_fsync_calls
+            .checked_add(evidence.directory_fsync_calls)
+            != Some(evidence.fsync_calls)
+        {
+            return Err(validation(
+                "CAS synchronization components do not reconcile",
+            ));
+        }
+        self.checked_add_assign(&Self {
+            read_bytes: evidence.bytes_hashed,
+            read_calls: evidence.read_calls,
+            write_bytes: evidence.write_bytes,
+            write_calls: evidence.write_calls,
+            file_fsync_calls: evidence.file_fsync_calls,
+            directory_fsync_calls: evidence.directory_fsync_calls,
+            installed_objects: u64::from(!evidence.reused_existing),
+            install_attempts: u64::from(evidence.attempted_install),
+            reused_objects: u64::from(evidence.reused_existing),
+            installed_bytes: evidence.bytes_installed,
+        })
+    }
+
+    fn add_read(&mut self, io: ReadIoEvidence) -> Result<(), GfError> {
+        self.checked_add_assign(&Self {
+            read_bytes: io.bytes,
+            read_calls: io.calls,
+            ..Self::default()
+        })
+    }
+
+    fn checked_add_assign(&mut self, other: &Self) -> Result<(), GfError> {
+        for (counter, value) in [
+            (&mut self.read_bytes, other.read_bytes),
+            (&mut self.read_calls, other.read_calls),
+            (&mut self.write_bytes, other.write_bytes),
+            (&mut self.write_calls, other.write_calls),
+            (&mut self.file_fsync_calls, other.file_fsync_calls),
+            (&mut self.directory_fsync_calls, other.directory_fsync_calls),
+            (&mut self.installed_objects, other.installed_objects),
+            (&mut self.install_attempts, other.install_attempts),
+            (&mut self.reused_objects, other.reused_objects),
+            (&mut self.installed_bytes, other.installed_bytes),
+        ] {
+            *counter = counter
+                .checked_add(value)
+                .ok_or_else(|| validation("CAS component counter overflows"))?;
+        }
+        Ok(())
+    }
+}
+
+/// Measured CAS work separated by the authority that performed it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GraphPublicationIo {
+    /// Completed append invocations represented by these components.
+    pub publications: u64,
+    /// Authenticated prior logical entries across those invocations.
+    pub initial_entries: u64,
+    /// Sealed and tombstoned paths submitted to path-copy updates.
+    pub changed_paths: u64,
+    /// Canonical payload installation and source authentication.
+    pub payload: GraphObjectIoTotals,
+    /// Immutable manifest-node installation and reuse authentication.
+    pub manifest: GraphObjectIoTotals,
+    /// Existing manifest nodes read during path-copy updates.
+    pub manifest_reads: GraphObjectIoTotals,
+}
+
+impl GraphPublicationIo {
+    /// Add one completed invocation without replaying earlier receipt work.
+    pub fn checked_add_assign(&mut self, other: &Self) -> Result<(), GfError> {
+        for (counter, value) in [
+            (&mut self.publications, other.publications),
+            (&mut self.initial_entries, other.initial_entries),
+            (&mut self.changed_paths, other.changed_paths),
+        ] {
+            *counter = counter
+                .checked_add(value)
+                .ok_or_else(|| validation("CAS publication inventory overflows"))?;
+        }
+        self.payload.checked_add_assign(&other.payload)?;
+        self.manifest.checked_add_assign(&other.manifest)?;
+        self.manifest_reads
+            .checked_add_assign(&other.manifest_reads)
+    }
+
+    /// Reconcile the independently accumulated operation components.
+    pub fn totals(&self) -> Result<GraphObjectIoTotals, GfError> {
+        let mut totals = self.payload.clone();
+        totals.checked_add_assign(&self.manifest)?;
+        totals.checked_add_assign(&self.manifest_reads)?;
+        Ok(totals)
+    }
 }
 
 /// One-time v1 expanded-tree to v2 object-store migration evidence.
@@ -595,14 +735,16 @@ pub struct GraphFilesAppendEvidence {
     pub payload_bytes_hashed: u64,
     /// Logical object bytes newly installed.
     pub bytes_installed: u64,
-    /// Actual non-empty payload reads performed by object installation.
+    /// Actual nonempty payload, manifest-install and path-authentication reads.
     pub read_calls: u64,
-    /// Actual payload write submissions performed by object installation.
+    /// Actual payload and manifest write submissions performed by object installation.
     pub write_calls: u64,
     /// Payload bytes submitted to object writers.
     pub write_bytes: u64,
     /// File and directory durability barriers completed by object installation.
     pub fsync_calls: u64,
+    /// Independent payload, manifest install and manifest path-read components.
+    pub publication_io: GraphPublicationIo,
 }
 
 /// A graph file whose content identity was established by an upstream durable
@@ -644,9 +786,20 @@ impl GraphManifestState {
         limits: crate::GraphManifestLimits,
     ) -> Result<(Self, crate::GraphManifestResolveEvidence), GfError> {
         validate_publication_identity(lease)?;
-        let (entries, evidence) = crate::resolve_graph_manifest(&root, limits, |digest| {
-            read_graph_object_by_digest_from_cas(&lease.cas, digest, 64 * 1024 * 1024)
+        let mut read_calls = 0_u64;
+        let (entries, mut evidence) = crate::resolve_graph_manifest(&root, limits, |digest| {
+            let (bytes, io) = read_graph_object_by_digest_file_counted(
+                lease.cas.open_digest(digest)?,
+                digest,
+                64 * 1024 * 1024,
+                &lease.cas.diagnostic_root,
+            )?;
+            read_calls = read_calls
+                .checked_add(io.calls)
+                .ok_or_else(|| validation("manifest open read calls overflow"))?;
+            Ok(bytes)
         })?;
+        evidence.application_read_calls = read_calls;
         Ok((
             Self {
                 project_identity: Some(lease.cas.project.identity()),
@@ -984,7 +1137,8 @@ pub(crate) fn gc_graph_objects_guarded(
         }
     }
     let mut evidence = GraphObjectGcEvidence {
-        objects_marked: u64::try_from(marked.len()).unwrap_or(u64::MAX),
+        objects_marked: u64::try_from(marked.len())
+            .map_err(|_| validation("CAS marked object count exceeds u64"))?,
         ..GraphObjectGcEvidence::default()
     };
     for (prefix, object, identity, bytes, allocated) in candidates {
@@ -1015,8 +1169,14 @@ pub(crate) fn gc_graph_objects_guarded(
                 error,
             )
         })?;
-        evidence.objects_removed = evidence.objects_removed.saturating_add(1);
-        evidence.bytes_removed = evidence.bytes_removed.saturating_add(bytes);
+        evidence.objects_removed = evidence
+            .objects_removed
+            .checked_add(1)
+            .ok_or_else(|| validation("CAS removed object count overflows"))?;
+        evidence.bytes_removed = evidence
+            .bytes_removed
+            .checked_add(bytes)
+            .ok_or_else(|| validation("CAS removed byte count overflows"))?;
         evidence
             .removed_identity_allocated_bytes
             .insert(retained_identity_key(identity), allocated);
@@ -1105,7 +1265,7 @@ fn append_graph_files_v2_inner(
         .map_or(0, |root| root.logical_byte_length);
     for (index, relative) in sealed_paths.iter().enumerate() {
         let source = workspace.join(relative);
-        let (digest, expected_length, prehashed_bytes) = if let Some(files) = authenticated {
+        let (digest, expected_length, prehash_io) = if let Some(files) = authenticated {
             let expected = files
                 .get(index)
                 .ok_or_else(|| validation("authenticated graph inventory is incomplete"))?;
@@ -1113,32 +1273,24 @@ fn append_graph_files_v2_inner(
                 return Err(validation("authenticated graph file metadata changed"));
             }
             validate_digest(&expected.content_sha256)?;
-            (expected.content_sha256.clone(), expected.byte_length, 0)
+            (
+                expected.content_sha256.clone(),
+                expected.byte_length,
+                ReadIoEvidence::default(),
+            )
         } else {
             let metadata = fs::symlink_metadata(&source)
                 .map_err(|error| storage("inspect sealed graph file", &source, error))?;
             if !metadata.is_file() || metadata.file_type().is_symlink() {
                 return Err(validation("sealed graph path is not a regular file"));
             }
-            (
-                hex_digest(hash_regular_file(&source)?),
-                metadata.len(),
-                metadata.len(),
-            )
+            let (digest, io) = hash_regular_file(&source)?;
+            (hex_digest(digest), metadata.len(), io)
         };
         let installed =
             install_graph_object_file_with_lease(lease, &source, &digest, expected_length)?;
-        evidence.payload_bytes_hashed = evidence
-            .payload_bytes_hashed
-            .saturating_add(prehashed_bytes)
-            .saturating_add(installed.bytes_hashed);
-        evidence.bytes_installed = evidence
-            .bytes_installed
-            .saturating_add(installed.bytes_installed);
-        evidence.read_calls = evidence.read_calls.saturating_add(installed.read_calls);
-        evidence.write_calls = evidence.write_calls.saturating_add(installed.write_calls);
-        evidence.write_bytes = evidence.write_bytes.saturating_add(installed.write_bytes);
-        evidence.fsync_calls = evidence.fsync_calls.saturating_add(installed.fsync_calls);
+        evidence.publication_io.payload.add_install(&installed)?;
+        evidence.publication_io.payload.add_read(prehash_io)?;
         let relative_path = relative
             .to_str()
             .ok_or_else(|| validation("sealed graph path is not UTF-8"))?
@@ -1150,7 +1302,9 @@ fn append_graph_files_v2_inner(
             role: crate::graph_files::infer_role(relative),
         };
         if let Some(previous) = state.entries.get(&relative_path) {
-            logical_byte_length = logical_byte_length.saturating_sub(previous.byte_length);
+            logical_byte_length = logical_byte_length
+                .checked_sub(previous.byte_length)
+                .ok_or_else(|| validation("graph files v2 logical byte total underflows"))?;
         }
         logical_byte_length = logical_byte_length
             .checked_add(entry.byte_length)
@@ -1162,18 +1316,29 @@ fn append_graph_files_v2_inner(
     tombstones.sort();
     for path in &tombstones {
         if let Some(previous) = state.entries.get(path) {
-            logical_byte_length = logical_byte_length.saturating_sub(previous.byte_length);
+            logical_byte_length = logical_byte_length
+                .checked_sub(previous.byte_length)
+                .ok_or_else(|| validation("graph files v2 logical byte total underflows"))?;
         }
     }
     // All payload objects are authenticated before any manifest node can
     // reference them. A returned error here therefore leaves only unreferenced,
     // retry-safe CAS state.
     returned_error_boundary("append:before-manifest-reference")?;
-    evidence.changed_entries_examined =
-        u64::try_from(additions.len().saturating_add(tombstones.len())).unwrap_or(u64::MAX);
+    evidence.changed_entries_examined = u64::try_from(
+        additions
+            .len()
+            .checked_add(tombstones.len())
+            .ok_or_else(|| validation("graph files v2 changed-entry count overflow"))?,
+    )
+    .map_err(|_| validation("graph files v2 changed-entry count exceeds u64"))?;
+    evidence.publication_io.publications = 1;
+    evidence.publication_io.initial_entries = u64::try_from(state.entries.len())
+        .map_err(|_| validation("graph files v2 prior-entry count exceeds u64"))?;
+    evidence.publication_io.changed_paths = evidence.changed_entries_examined;
     let mut root_digest = match state.root.as_ref() {
         Some(previous) => previous.root_node_sha256.clone(),
-        None => install_manifest_node(lease, &empty_branch(0), &mut evidence.bytes_installed)?,
+        None => install_manifest_node(lease, &empty_branch(0), &mut evidence.publication_io)?,
     };
     for entry in &additions {
         let relative_path = entry.relative_path.clone();
@@ -1183,7 +1348,7 @@ fn append_graph_files_v2_inner(
             0,
             &relative_path,
             Some(entry.clone()),
-            &mut evidence.bytes_installed,
+            &mut evidence.publication_io,
         )?
         .ok_or_else(|| validation("radix update unexpectedly removed the root"))?;
     }
@@ -1194,12 +1359,12 @@ fn append_graph_files_v2_inner(
             0,
             path,
             None,
-            &mut evidence.bytes_installed,
+            &mut evidence.publication_io,
         )?
         .unwrap_or(install_manifest_node(
             lease,
             &empty_branch(0),
-            &mut evidence.bytes_installed,
+            &mut evidence.publication_io,
         )?);
     }
     let added_new = additions
@@ -1220,9 +1385,20 @@ fn append_graph_files_v2_inner(
         format: GRAPH_FILES_V2_FORMAT.into(),
         format_version: GRAPH_FILES_V2_VERSION,
         root_node_sha256: root_digest,
-        logical_file_count: u64::try_from(logical_file_count).unwrap_or(u64::MAX),
+        logical_file_count: u64::try_from(logical_file_count)
+            .map_err(|_| validation("graph files v2 logical file count exceeds u64"))?,
         logical_byte_length,
     };
+    let totals = evidence.publication_io.totals()?;
+    evidence.payload_bytes_hashed = evidence.publication_io.payload.read_bytes;
+    evidence.bytes_installed = totals.installed_bytes;
+    evidence.read_calls = totals.read_calls;
+    evidence.write_calls = totals.write_calls;
+    evidence.write_bytes = totals.write_bytes;
+    evidence.fsync_calls = totals
+        .file_fsync_calls
+        .checked_add(totals.directory_fsync_calls)
+        .ok_or_else(|| validation("CAS synchronization total overflows"))?;
     // Commit the root-bound cache only after every payload and Patricia node
     // operation succeeded. An error above leaves both fields unchanged.
     for entry in additions {
@@ -1255,16 +1431,21 @@ pub fn migrate_graph_files_v1_to_v2(
             &entry.content_sha256,
             entry.byte_length,
         )?;
-        evidence.payload_objects = evidence.payload_objects.saturating_add(1);
+        evidence.payload_objects = evidence
+            .payload_objects
+            .checked_add(1)
+            .ok_or_else(|| validation("CAS payload object count overflows"))?;
         evidence.payload_bytes_hashed = evidence
             .payload_bytes_hashed
-            .saturating_add(installed.bytes_hashed);
+            .checked_add(installed.bytes_hashed)
+            .ok_or_else(|| validation("CAS payload byte count overflows"))?;
         evidence.bytes_installed = evidence
             .bytes_installed
-            .saturating_add(installed.bytes_installed);
+            .checked_add(installed.bytes_installed)
+            .ok_or_else(|| validation("CAS installed byte count overflows"))?;
     }
-    let mut root_digest =
-        install_manifest_node(lease, &empty_branch(0), &mut evidence.bytes_installed)?;
+    let mut publication_io = GraphPublicationIo::default();
+    let mut root_digest = install_manifest_node(lease, &empty_branch(0), &mut publication_io)?;
     for entry in &inventory.files {
         let mut canonical_entry = entry.clone();
         canonical_entry.relative_path =
@@ -1276,10 +1457,14 @@ pub fn migrate_graph_files_v1_to_v2(
             0,
             &canonical_path,
             Some(canonical_entry),
-            &mut evidence.bytes_installed,
+            &mut publication_io,
         )?
         .ok_or_else(|| validation("radix migration unexpectedly removed the root"))?;
     }
+    evidence.bytes_installed = evidence
+        .bytes_installed
+        .checked_add(publication_io.manifest.installed_bytes)
+        .ok_or_else(|| validation("migration manifest bytes overflow"))?;
     Ok((
         GraphFilesRootV2 {
             format: GRAPH_FILES_V2_FORMAT.into(),
@@ -1307,11 +1492,11 @@ fn empty_branch(depth: u8) -> GraphManifestNode {
 fn install_manifest_node(
     lease: &GraphObjectPublicationLease,
     node: &GraphManifestNode,
-    bytes_installed: &mut u64,
+    publication_io: &mut GraphPublicationIo,
 ) -> Result<String, GfError> {
     let bytes = crate::encode_graph_manifest_node(node)?;
     let (digest, evidence) = install_graph_object_bytes_with_lease(lease, &bytes)?;
-    *bytes_installed = bytes_installed.saturating_add(evidence.bytes_installed);
+    publication_io.manifest.add_install(&evidence)?;
     Ok(digest)
 }
 
@@ -1319,8 +1504,15 @@ fn load_manifest_node(
     lease: &GraphObjectPublicationLease,
     digest: &str,
     expected_depth: u8,
+    publication_io: &mut GraphPublicationIo,
 ) -> Result<GraphManifestNode, GfError> {
-    let bytes = read_graph_object_by_digest_from_cas(&lease.cas, digest, 64 * 1024 * 1024)?;
+    let (bytes, io) = read_graph_object_by_digest_file_counted(
+        lease.cas.open_digest(digest)?,
+        digest,
+        64 * 1024 * 1024,
+        &lease.cas.diagnostic_root,
+    )?;
+    publication_io.manifest_reads.add_read(io)?;
     let node = crate::decode_graph_manifest_node(&bytes)?;
     if node.depth != expected_depth {
         return Err(validation(
@@ -1336,7 +1528,7 @@ fn update_manifest_path(
     depth: u8,
     path: &str,
     replacement: Option<crate::GraphFileEntry>,
-    bytes_installed: &mut u64,
+    publication_io: &mut GraphPublicationIo,
 ) -> Result<Option<String>, GfError> {
     let path_digest = hex_digest(crate::graph_manifest::logical_path_digest(path));
     update_manifest_digest(
@@ -1346,7 +1538,7 @@ fn update_manifest_path(
         path,
         &path_digest,
         replacement,
-        bytes_installed,
+        publication_io,
     )
 }
 
@@ -1358,7 +1550,7 @@ fn update_manifest_digest(
     path: &str,
     path_digest: &str,
     replacement: Option<crate::GraphFileEntry>,
-    bytes_installed: &mut u64,
+    publication_io: &mut GraphPublicationIo,
 ) -> Result<Option<String>, GfError> {
     let Some(current_digest) = current_digest else {
         return replacement
@@ -1371,12 +1563,12 @@ fn update_manifest_digest(
                         path_digest,
                         vec![entry],
                     ),
-                    bytes_installed,
+                    publication_io,
                 )
             })
             .transpose();
     };
-    let mut node = load_manifest_node(lease, current_digest, depth)?;
+    let mut node = load_manifest_node(lease, current_digest, depth, publication_io)?;
     let start = usize::from(depth);
     let common = node
         .prefix
@@ -1394,7 +1586,7 @@ fn update_manifest_digest(
         let old_edge = node.prefix[common..=common].to_owned();
         node.depth = split_depth + 1;
         node.prefix = node.prefix[common + 1..].to_owned();
-        let old_digest = install_manifest_node(lease, &node, bytes_installed)?;
+        let old_digest = install_manifest_node(lease, &node, publication_io)?;
         let new_edge = path_digest[usize::from(split_depth)..=usize::from(split_depth)].to_owned();
         if old_edge == new_edge {
             return Err(validation("Patricia split did not diverge"));
@@ -1407,13 +1599,13 @@ fn update_manifest_digest(
                 path_digest,
                 vec![entry],
             ),
-            bytes_installed,
+            publication_io,
         )?;
         let children = BTreeMap::from([(old_edge, old_digest), (new_edge, new_digest)]);
         return install_manifest_node(
             lease,
             &branch_node(depth, &path_digest[start..start + common], children),
-            bytes_installed,
+            publication_io,
         )
         .map(Some);
     }
@@ -1451,7 +1643,7 @@ fn update_manifest_digest(
                 install_manifest_node(
                     lease,
                     &leaf_node(depth, &node.prefix, path_digest, entries),
-                    bytes_installed,
+                    publication_io,
                 )
                 .map(Some)
             }
@@ -1469,7 +1661,7 @@ fn update_manifest_digest(
                 path,
                 path_digest,
                 replacement,
-                bytes_installed,
+                publication_io,
             )?;
             match child {
                 Some(digest) => {
@@ -1483,15 +1675,20 @@ fn update_manifest_digest(
                 0 => Ok(None),
                 1 => {
                     let (edge, child_digest) = children.into_iter().next().expect("one child");
-                    let mut child = load_manifest_node(lease, &child_digest, payload_depth + 1)?;
+                    let mut child = load_manifest_node(
+                        lease,
+                        &child_digest,
+                        payload_depth + 1,
+                        publication_io,
+                    )?;
                     child.depth = depth;
                     child.prefix = format!("{}{}{}", node.prefix, edge, child.prefix);
-                    install_manifest_node(lease, &child, bytes_installed).map(Some)
+                    install_manifest_node(lease, &child, publication_io).map(Some)
                 }
                 _ => install_manifest_node(
                     lease,
                     &branch_node(depth, &node.prefix, children),
-                    bytes_installed,
+                    publication_io,
                 )
                 .map(Some),
             }
@@ -1571,7 +1768,8 @@ fn install_graph_object_bytes_with_lease(
     bytes: &[u8],
 ) -> Result<(String, GraphObjectInstallEvidence), GfError> {
     let digest = hex_digest(Sha256::digest(bytes).into());
-    let expected_length = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    let expected_length =
+        u64::try_from(bytes.len()).map_err(|_| validation("graph object bytes exceed u64"))?;
     install_object(&lease.cas, &digest, expected_length, false, |file| {
         file.write_all(bytes).map_err(|error| {
             storage(
@@ -1591,13 +1789,17 @@ fn install_graph_object_bytes_with_lease(
         // file verification below is an application-observed payload read.
         Ok(0)
     })
-    .map(|mut evidence| {
-        if !evidence.reused_existing {
+    .and_then(|mut evidence| {
+        if evidence.attempted_install {
             evidence.write_bytes = expected_length;
             evidence.write_calls = u64::from(!bytes.is_empty());
-            evidence.fsync_calls = evidence.fsync_calls.saturating_add(1);
+            evidence.file_fsync_calls = 1;
+            evidence.fsync_calls = evidence
+                .fsync_calls
+                .checked_add(1)
+                .ok_or_else(|| validation("CAS fsync count overflows"))?;
         }
-        (digest, evidence)
+        Ok((digest, evidence))
     })
 }
 
@@ -1631,136 +1833,161 @@ fn install_graph_object_file_with_lease(
     let read_calls = std::cell::Cell::new(0_u64);
     let write_calls = std::cell::Cell::new(0_u64);
     let file_sync_calls = std::cell::Cell::new(0_u64);
-    let result = install_object(
-        &lease.cas,
-        expected_digest,
-        expected_length,
-        true,
-        |output| {
-            let cache_window =
-                graphforge_filesystem::cache_release_window_for_streams(2).map_err(|error| {
-                    storage(
-                        "derive graph object cache budget",
-                        &lease.cas.diagnostic_root,
-                        error,
-                    )
-                })?;
-            let input = File::open(source)
-                .map_err(|error| storage("open graph object source", source, error))?;
-            let mut input = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
-                input,
-                cache_window,
-                graphforge_filesystem::FileCacheReleaseTracker::default(),
-            )
-            .map_err(|error| storage("open bounded graph object source", source, error))?;
-            #[cfg(unix)]
-            let mut bounded_output =
-                graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(
-                    output.try_clone().map_err(|error| {
+    let result =
+        install_object(
+            &lease.cas,
+            expected_digest,
+            expected_length,
+            true,
+            |output| {
+                let cache_window = graphforge_filesystem::cache_release_window_for_streams(2)
+                    .map_err(|error| {
                         storage(
-                            "clone temporary graph object",
+                            "derive graph object cache budget",
                             &lease.cas.diagnostic_root,
                             error,
                         )
-                    })?,
+                    })?;
+                let input = File::open(source)
+                    .map_err(|error| storage("open graph object source", source, error))?;
+                let mut input = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                    input,
                     cache_window,
+                    graphforge_filesystem::FileCacheReleaseTracker::default(),
                 )
-                .map_err(|error| {
-                    storage(
-                        "open bounded temporary graph object",
-                        &lease.cas.diagnostic_root,
-                        error,
+                .map_err(|error| storage("open bounded graph object source", source, error))?;
+                #[cfg(unix)]
+                let mut bounded_output =
+                    graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(
+                        output.try_clone().map_err(|error| {
+                            storage(
+                                "clone temporary graph object",
+                                &lease.cas.diagnostic_root,
+                                error,
+                            )
+                        })?,
+                        cache_window,
                     )
-                })?;
-            let mut hasher = Sha256::new();
-            let mut total = 0_u64;
-            let mut buffer = vec![0_u8; BUFFER_BYTES];
-            let copied = (|| -> Result<u64, GfError> {
-                loop {
-                    let read = input
-                        .read(&mut buffer)
-                        .map_err(|error| storage("read graph object source", source, error))?;
-                    if read == 0 {
-                        break;
+                    .map_err(|error| {
+                        storage(
+                            "open bounded temporary graph object",
+                            &lease.cas.diagnostic_root,
+                            error,
+                        )
+                    })?;
+                let mut hasher = Sha256::new();
+                let mut total = 0_u64;
+                let mut buffer = vec![0_u8; BUFFER_BYTES];
+                let copied =
+                    (|| -> Result<u64, GfError> {
+                        loop {
+                            let read = input.read(&mut buffer).map_err(|error| {
+                                storage("read graph object source", source, error)
+                            })?;
+                            if read == 0 {
+                                break;
+                            }
+                            read_calls.set(
+                                read_calls.get().checked_add(1).ok_or_else(|| {
+                                    validation("object install read calls overflow")
+                                })?,
+                            );
+                            #[cfg(unix)]
+                            bounded_output.write_all(&buffer[..read]).map_err(|error| {
+                                storage(
+                                    "write temporary graph object",
+                                    &lease.cas.diagnostic_root,
+                                    error,
+                                )
+                            })?;
+                            #[cfg(windows)]
+                            output.write_all(&buffer[..read]).map_err(|error| {
+                                storage(
+                                    "write temporary graph object",
+                                    &lease.cas.diagnostic_root,
+                                    error,
+                                )
+                            })?;
+                            write_calls.set(write_calls.get().checked_add(1).ok_or_else(|| {
+                                validation("object install write calls overflow")
+                            })?);
+                            hasher.update(&buffer[..read]);
+                            total = total
+                                .checked_add(u64::try_from(read).map_err(|_| {
+                                    validation("object install read length exceeds u64")
+                                })?)
+                                .ok_or_else(|| validation("object install byte count overflows"))?;
+                        }
+                        if total != expected_length
+                            || hex_digest(hasher.finalize().into()) != expected_digest
+                        {
+                            return Err(validation(
+                                "graph object source digest or length changed during install",
+                            ));
+                        }
+                        Ok(total)
+                    })();
+                let released = input
+                    .finish()
+                    .map_err(|error| storage("release graph object source cache", source, error));
+                let total = match (copied, released) {
+                    (Ok(total), Ok(_)) => total,
+                    (Ok(_), Err(release)) => return Err(release),
+                    (Err(primary), Ok(_)) => return Err(primary),
+                    (Err(primary), Err(release)) => {
+                        return Err(storage(
+                            "copy and release graph object source",
+                            source,
+                            format!("{primary}; cache release also failed: {release}"),
+                        ));
                     }
-                    read_calls.set(read_calls.get().saturating_add(1));
-                    #[cfg(unix)]
-                    bounded_output.write_all(&buffer[..read]).map_err(|error| {
-                        storage(
-                            "write temporary graph object",
-                            &lease.cas.diagnostic_root,
-                            error,
-                        )
-                    })?;
-                    #[cfg(windows)]
-                    output.write_all(&buffer[..read]).map_err(|error| {
-                        storage(
-                            "write temporary graph object",
-                            &lease.cas.diagnostic_root,
-                            error,
-                        )
-                    })?;
-                    write_calls.set(write_calls.get().saturating_add(1));
-                    hasher.update(&buffer[..read]);
-                    total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
-                }
-                if total != expected_length
-                    || hex_digest(hasher.finalize().into()) != expected_digest
+                };
+                #[cfg(unix)]
                 {
-                    return Err(validation(
-                        "graph object source digest or length changed during install",
-                    ));
+                    bounded_output.sync_all_and_release().map_err(|error| {
+                        storage(
+                            "fsync temporary graph object",
+                            &lease.cas.diagnostic_root,
+                            error,
+                        )
+                    })?;
+                    file_sync_calls.set(bounded_output.evidence().sync_operations);
+                }
+                #[cfg(windows)]
+                {
+                    output.sync_all().map_err(|error| {
+                        storage(
+                            "fsync temporary graph object",
+                            &lease.cas.diagnostic_root,
+                            error,
+                        )
+                    })?;
+                    file_sync_calls.set(1);
                 }
                 Ok(total)
-            })();
-            let released = input
-                .finish()
-                .map_err(|error| storage("release graph object source cache", source, error));
-            let total = match (copied, released) {
-                (Ok(total), Ok(_)) => total,
-                (Ok(_), Err(release)) => return Err(release),
-                (Err(primary), Ok(_)) => return Err(primary),
-                (Err(primary), Err(release)) => {
-                    return Err(storage(
-                        "copy and release graph object source",
-                        source,
-                        format!("{primary}; cache release also failed: {release}"),
-                    ));
-                }
-            };
-            #[cfg(unix)]
-            {
-                bounded_output.sync_all_and_release().map_err(|error| {
-                    storage(
-                        "fsync temporary graph object",
-                        &lease.cas.diagnostic_root,
-                        error,
-                    )
-                })?;
-                file_sync_calls.set(bounded_output.evidence().sync_operations);
-            }
-            #[cfg(windows)]
-            {
-                output.sync_all().map_err(|error| {
-                    storage(
-                        "fsync temporary graph object",
-                        &lease.cas.diagnostic_root,
-                        error,
-                    )
-                })?;
-                file_sync_calls.set(1);
-            }
-            Ok(total)
-        },
-    );
-    result.map(|mut evidence| {
-        if !evidence.reused_existing {
-            evidence.read_calls = evidence.read_calls.saturating_add(read_calls.get());
-            evidence.write_calls = evidence.write_calls.saturating_add(write_calls.get());
-            evidence.write_bytes = evidence.write_bytes.saturating_add(expected_length);
-            evidence.fsync_calls = evidence.fsync_calls.saturating_add(file_sync_calls.get());
+            },
+        );
+    result.and_then(|mut evidence| {
+        if evidence.attempted_install {
+            evidence.read_calls = evidence
+                .read_calls
+                .checked_add(read_calls.get())
+                .ok_or_else(|| validation("object install read calls overflow"))?;
+            evidence.write_calls = evidence
+                .write_calls
+                .checked_add(write_calls.get())
+                .ok_or_else(|| validation("object install write calls overflow"))?;
+            evidence.write_bytes = evidence
+                .write_bytes
+                .checked_add(expected_length)
+                .ok_or_else(|| validation("object install write bytes overflow"))?;
+            evidence.file_fsync_calls = file_sync_calls.get();
+            evidence.fsync_calls = evidence
+                .fsync_calls
+                .checked_add(file_sync_calls.get())
+                .ok_or_else(|| validation("CAS file synchronization count overflows"))?;
         }
-        evidence
+        Ok(evidence)
     })
 }
 
@@ -1822,25 +2049,50 @@ pub fn materialize_graph_objects(
         let materialized = materialize_from_cas(&lease.cas, &target_directory, entry)?;
         evidence.application_read_bytes = evidence
             .application_read_bytes
-            .saturating_add(materialized.read_bytes);
+            .checked_add(materialized.read_bytes)
+            .ok_or_else(|| validation("object hydration read byte count overflows"))?;
         evidence.application_read_calls = evidence
             .application_read_calls
-            .saturating_add(materialized.read_calls);
+            .checked_add(materialized.read_calls)
+            .ok_or_else(|| validation("object hydration read call count overflows"))?;
         evidence.application_write_bytes = evidence
             .application_write_bytes
-            .saturating_add(materialized.write_bytes);
+            .checked_add(materialized.write_bytes)
+            .ok_or_else(|| validation("object hydration write byte count overflows"))?;
         evidence.application_write_calls = evidence
             .application_write_calls
-            .saturating_add(materialized.write_calls);
+            .checked_add(materialized.write_calls)
+            .ok_or_else(|| validation("object hydration write call count overflows"))?;
         evidence.fsync_calls = evidence
             .fsync_calls
-            .saturating_add(materialized.fsync_calls);
+            .checked_add(materialized.fsync_calls)
+            .ok_or_else(|| validation("object hydration fsync count overflows"))?;
+        evidence.file_fsync_calls = evidence
+            .file_fsync_calls
+            .checked_add(materialized.file_fsync_calls)
+            .ok_or_else(|| validation("object hydration file barrier count overflows"))?;
+        evidence.directory_fsync_calls = evidence
+            .directory_fsync_calls
+            .checked_add(materialized.directory_fsync_calls)
+            .ok_or_else(|| validation("object hydration directory barrier count overflows"))?;
         if materialized.copied {
-            evidence.files_copied = evidence.files_copied.saturating_add(1);
-            evidence.bytes_copied = evidence.bytes_copied.saturating_add(entry.byte_length);
+            evidence.files_copied = evidence
+                .files_copied
+                .checked_add(1)
+                .ok_or_else(|| validation("object hydration copied-file count overflows"))?;
+            evidence.bytes_copied = evidence
+                .bytes_copied
+                .checked_add(entry.byte_length)
+                .ok_or_else(|| validation("object hydration copied-byte count overflows"))?;
         } else {
-            evidence.files_reused = evidence.files_reused.saturating_add(1);
-            evidence.bytes_reused = evidence.bytes_reused.saturating_add(entry.byte_length);
+            evidence.files_reused = evidence
+                .files_reused
+                .checked_add(1)
+                .ok_or_else(|| validation("object hydration reused-file count overflows"))?;
+            evidence.bytes_reused = evidence
+                .bytes_reused
+                .checked_add(entry.byte_length)
+                .ok_or_else(|| validation("object hydration reused-byte count overflows"))?;
         }
     }
     lease.revalidate_for_publish()?;
@@ -1927,6 +2179,8 @@ struct MaterializeIoEvidence {
     write_bytes: u64,
     write_calls: u64,
     fsync_calls: u64,
+    file_fsync_calls: u64,
+    directory_fsync_calls: u64,
 }
 
 fn requires_single_link_materialization(relative_path: &str) -> bool {
@@ -2039,6 +2293,7 @@ fn copy_single_link_materialized_object(
             )
         })?;
         io.fsync_calls = output.evidence().sync_operations;
+        io.file_fsync_calls = io.fsync_calls;
         drop(output.into_file());
         parent
             .replace_child(&temporary_name, output_identity, name)
@@ -2057,7 +2312,14 @@ fn copy_single_link_materialized_object(
                 error,
             )
         })?;
-        io.fsync_calls = io.fsync_calls.saturating_add(1);
+        io.fsync_calls = io
+            .fsync_calls
+            .checked_add(1)
+            .ok_or_else(|| validation("object hydration fsync count overflows"))?;
+        io.directory_fsync_calls = io
+            .directory_fsync_calls
+            .checked_add(1)
+            .ok_or_else(|| validation("object hydration directory barrier count overflows"))?;
         let installed = parent.open_child_file(name).map_err(|error| {
             storage(
                 "open private materialization file",
@@ -2083,8 +2345,7 @@ fn copy_single_link_materialized_object(
             entry.byte_length,
             &cas.diagnostic_root,
         )?;
-        io.read_bytes = io.read_bytes.saturating_add(verified.bytes);
-        io.read_calls = io.read_calls.saturating_add(verified.calls);
+        add_materialization_verification(&mut io, verified)?;
         io.copied = true;
         Ok(io)
     })();
@@ -2094,6 +2355,21 @@ fn copy_single_link_materialized_object(
         let _ = parent.sync();
     }
     result
+}
+
+fn add_materialization_verification(
+    io: &mut MaterializeIoEvidence,
+    verified: ReadIoEvidence,
+) -> Result<(), GfError> {
+    io.read_bytes = io
+        .read_bytes
+        .checked_add(verified.bytes)
+        .ok_or_else(|| validation("object hydration verification bytes overflow"))?;
+    io.read_calls = io
+        .read_calls
+        .checked_add(verified.calls)
+        .ok_or_else(|| validation("object hydration verification calls overflow"))?;
+    Ok(())
 }
 
 fn copy_and_authenticate_materialized_object(
@@ -2114,11 +2390,15 @@ fn copy_and_authenticate_materialized_object(
         if read == 0 {
             break;
         }
-        read_calls = read_calls.saturating_add(1);
+        read_calls = read_calls
+            .checked_add(1)
+            .ok_or_else(|| validation("object hydration read calls overflow"))?;
         output.write_all(&buffer[..read]).map_err(|error| {
             storage("write private materialization file", diagnostic_root, error)
         })?;
-        write_calls = write_calls.saturating_add(1);
+        write_calls = write_calls
+            .checked_add(1)
+            .ok_or_else(|| validation("object hydration write calls overflow"))?;
         digest.update(&buffer[..read]);
         length = length
             .checked_add(read as u64)
@@ -2136,6 +2416,8 @@ fn copy_and_authenticate_materialized_object(
         write_bytes: length,
         write_calls,
         fsync_calls: 0,
+        file_fsync_calls: 0,
+        directory_fsync_calls: 0,
     })
 }
 
@@ -2718,11 +3000,21 @@ fn read_graph_object_by_digest_from_cas(
 }
 
 fn read_graph_object_by_digest_file(
-    mut file: File,
+    file: File,
     digest: &str,
     max_length: u64,
     diagnostic_root: &Path,
 ) -> Result<Vec<u8>, GfError> {
+    read_graph_object_by_digest_file_counted(file, digest, max_length, diagnostic_root)
+        .map(|(bytes, _)| bytes)
+}
+
+fn read_graph_object_by_digest_file_counted(
+    mut file: File,
+    digest: &str,
+    max_length: u64,
+    diagnostic_root: &Path,
+) -> Result<(Vec<u8>, ReadIoEvidence), GfError> {
     let metadata = file
         .metadata()
         .map_err(|error| storage("inspect stable graph object", diagnostic_root, error))?;
@@ -2732,12 +3024,30 @@ fn read_graph_object_by_digest_file(
         ));
     }
     let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
-    file.read_to_end(&mut bytes)
-        .map_err(|error| storage("read stable graph object", diagnostic_root, error))?;
+    let mut io = ReadIoEvidence::default();
+    let mut buffer = vec![0; BUFFER_BYTES];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| storage("read stable graph object", diagnostic_root, error))?;
+        if read == 0 {
+            break;
+        }
+        io.bytes = io
+            .bytes
+            .checked_add(read as u64)
+            .filter(|total| *total <= max_length)
+            .ok_or_else(|| validation("manifest read exceeds admitted byte bound"))?;
+        io.calls = io
+            .calls
+            .checked_add(1)
+            .ok_or_else(|| validation("manifest read call count overflows"))?;
+        bytes.extend_from_slice(&buffer[..read]);
+    }
     if hex_digest(Sha256::digest(&bytes).into()) != digest {
         return Err(validation("graph object digest does not match its address"));
     }
-    Ok(bytes)
+    Ok((bytes, io))
 }
 
 pub(crate) fn read_graph_object_by_digest_with_lease(
@@ -2817,18 +3127,29 @@ where
         digest,
         expected_length,
     )?;
+    let bytes_hashed = [
+        preseal_io.bytes,
+        sealed_bytes_hashed,
+        if installed { 0 } else { expected_length },
+    ]
+    .into_iter()
+    .try_fold(bytes_hashed, u64::checked_add)
+    .ok_or_else(|| validation("graph object hashed byte count overflows"))?;
+    let read_calls = preseal_io
+        .calls
+        .checked_add(concurrent_io.calls)
+        .ok_or_else(|| validation("graph object read call count overflows"))?;
     Ok(GraphObjectInstallEvidence {
-        bytes_hashed: bytes_hashed
-            .saturating_add(preseal_io.bytes)
-            .saturating_add(sealed_bytes_hashed)
-            .saturating_add(if installed { 0 } else { expected_length }),
+        bytes_hashed,
         bytes_installed: if installed { expected_length } else { 0 },
         reused_existing: !installed,
-        read_calls: preseal_io.calls.saturating_add(concurrent_io.calls),
+        attempted_install: true,
+        read_calls,
         // The source-copy/authentication submissions are added by the caller.
-        // Fresh installation always durably synchronizes the destination bucket
-        // and temporary namespace; reuse performs neither operation here.
-        fsync_calls: if installed { 2 } else { 0 },
+        // Finalization synchronizes both namespaces even if a concurrent winner
+        // supplied the retained object. Early reuse returns before this path.
+        fsync_calls: 2,
+        directory_fsync_calls: 2,
         ..GraphObjectInstallEvidence::default()
     })
 }
@@ -2920,8 +3241,14 @@ fn try_reuse_existing_object(
         &cas.diagnostic_root,
     )?;
     let mut evidence = reused_object_evidence(expected_length, io);
-    evidence.bytes_hashed = adoption_io.bytes.saturating_add(io.bytes);
-    evidence.read_calls = adoption_io.calls.saturating_add(io.calls);
+    evidence.bytes_hashed = adoption_io
+        .bytes
+        .checked_add(io.bytes)
+        .ok_or_else(|| validation("reused object hashed byte count overflows"))?;
+    evidence.read_calls = adoption_io
+        .calls
+        .checked_add(io.calls)
+        .ok_or_else(|| validation("reused object read call count overflows"))?;
     Ok(Some(evidence))
 }
 
@@ -3030,11 +3357,24 @@ fn finalize_temporary_object(
     Ok((
         installed,
         sealed_bytes_hashed,
-        ReadIoEvidence {
-            bytes: sealed_io.bytes.saturating_add(concurrent_io.bytes),
-            calls: sealed_io.calls.saturating_add(concurrent_io.calls),
-        },
+        checked_read_io_sum(sealed_io, concurrent_io)?,
     ))
+}
+
+fn checked_read_io_sum(
+    left: ReadIoEvidence,
+    right: ReadIoEvidence,
+) -> Result<ReadIoEvidence, GfError> {
+    Ok(ReadIoEvidence {
+        bytes: left
+            .bytes
+            .checked_add(right.bytes)
+            .ok_or_else(|| validation("sealed object read byte count overflows"))?,
+        calls: left
+            .calls
+            .checked_add(right.calls)
+            .ok_or_else(|| validation("sealed object read call count overflows"))?,
+    })
 }
 
 fn validate_sealed_temporary(
@@ -3155,8 +3495,17 @@ fn verify_file_counted(
             if read == 0 {
                 break;
             }
-            io.bytes = io.bytes.saturating_add(read as u64);
-            io.calls = io.calls.saturating_add(1);
+            io.bytes = io
+                .bytes
+                .checked_add(
+                    u64::try_from(read)
+                        .map_err(|_| validation("object authentication read length exceeds u64"))?,
+                )
+                .ok_or_else(|| validation("object authentication read bytes overflow"))?;
+            io.calls = io
+                .calls
+                .checked_add(1)
+                .ok_or_else(|| validation("object authentication read calls overflow"))?;
             hasher.update(&buffer[..read]);
         }
         if hex_digest(hasher.finalize().into()) != digest {
@@ -3209,8 +3558,15 @@ fn verify_stream_counted(
         if read == 0 {
             break;
         }
-        total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
-        calls = calls.saturating_add(1);
+        total = total
+            .checked_add(
+                u64::try_from(read)
+                    .map_err(|_| validation("object stream read size exceeds u64"))?,
+            )
+            .ok_or_else(|| validation("object stream byte count overflows"))?;
+        calls = calls
+            .checked_add(1)
+            .ok_or_else(|| validation("object stream call count overflows"))?;
         hasher.update(&buffer[..read]);
     }
     if total != expected_length || hex_digest(hasher.finalize().into()) != digest {
@@ -3290,9 +3646,10 @@ fn seal_graph_object(file: &File, object_path: &Path, diagnostic: &Path) -> Resu
     Ok(())
 }
 
-fn hash_regular_file(path: &Path) -> Result<[u8; 32], GfError> {
+fn hash_regular_file(path: &Path) -> Result<([u8; 32], ReadIoEvidence), GfError> {
     let mut file =
         File::open(path).map_err(|error| storage("open sealed graph file", path, error))?;
+    let mut io = ReadIoEvidence::default();
     let mut hasher = Sha256::new();
     let mut buffer = vec![0_u8; BUFFER_BYTES];
     loop {
@@ -3302,9 +3659,17 @@ fn hash_regular_file(path: &Path) -> Result<[u8; 32], GfError> {
         if read == 0 {
             break;
         }
+        io.bytes = io
+            .bytes
+            .checked_add(read as u64)
+            .ok_or_else(|| validation("source authentication bytes overflow"))?;
+        io.calls = io
+            .calls
+            .checked_add(1)
+            .ok_or_else(|| validation("source authentication calls overflow"))?;
         hasher.update(&buffer[..read]);
     }
-    Ok(hasher.finalize().into())
+    Ok((hasher.finalize().into(), io))
 }
 
 fn validate_logical_path(path: &Path) -> Result<(), GfError> {
@@ -4217,6 +4582,8 @@ mod tests {
         assert_eq!(evidence.application_write_bytes, nonempty_bytes);
         assert_eq!(evidence.application_write_calls, nonempty_files);
         assert_eq!(evidence.fsync_calls, inventory.file_count * 2);
+        assert_eq!(evidence.file_fsync_calls, inventory.file_count);
+        assert_eq!(evidence.directory_fsync_calls, inventory.file_count);
         for entry in &inventory.files {
             let file = File::open(target.join(&entry.relative_path)).unwrap();
             assert_eq!(graphforge_filesystem::file_link_count(&file).unwrap(), 1);
@@ -4256,6 +4623,64 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_winner_reuse_retains_the_losing_install_work() {
+        for file_backed in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let source = tempfile::tempdir().unwrap();
+            let payload = b"concurrent payload";
+            let digest = hex_digest(Sha256::digest(payload).into());
+            let winner_root = root.path().to_path_buf();
+            BEFORE_OBJECT_LINK.with(|hook| {
+                *hook.borrow_mut() = Some(Box::new(move || {
+                    let (_, winner) = install_graph_object_bytes(&winner_root, payload).unwrap();
+                    assert!(!winner.reused_existing);
+                    assert!(winner.attempted_install);
+                    assert_eq!(winner.fsync_calls, 3);
+                }));
+            });
+            let loser = if file_backed {
+                let path = source.path().join("payload");
+                fs::write(&path, payload).unwrap();
+                install_graph_object_file(root.path(), &path, &digest, payload.len() as u64)
+                    .unwrap()
+            } else {
+                install_graph_object_bytes(root.path(), payload).unwrap().1
+            };
+            assert!(loser.reused_existing);
+            assert!(loser.attempted_install);
+            assert_eq!(loser.bytes_installed, 0);
+            assert_eq!(loser.write_bytes, payload.len() as u64);
+            assert_eq!(loser.write_calls, 1);
+            assert_eq!(loser.file_fsync_calls, 1);
+            assert_eq!(loser.directory_fsync_calls, 2);
+            assert_eq!(loser.fsync_calls, 3);
+            // Windows authenticates the protected sealed handle after closing
+            // the writable handle, in addition to a file source-copy pass.
+            let read_passes = 2 + u64::from(cfg!(windows) && file_backed);
+            assert_eq!(loser.read_calls, read_passes);
+            assert_eq!(loser.bytes_hashed, read_passes * payload.len() as u64);
+            assert_eq!(
+                read_graph_object(root.path(), &digest, payload.len() as u64).unwrap(),
+                payload
+            );
+            let (_, early_reuse) = install_graph_object_bytes(root.path(), payload).unwrap();
+            assert!(early_reuse.reused_existing);
+            assert!(!early_reuse.attempted_install);
+            assert_eq!(early_reuse.write_bytes, 0);
+            assert_eq!(early_reuse.fsync_calls, 0);
+            assert!(
+                root.path()
+                    .join(GRAPH_OBJECTS_DIR)
+                    .join(TEMP_DIR)
+                    .read_dir()
+                    .unwrap()
+                    .next()
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
     fn file_install_receipts_count_actual_cache_window_synchronizations() {
         let window = graphforge_filesystem::cache_release_window_for_streams(2)
             .unwrap()
@@ -4278,6 +4703,8 @@ mod tests {
                 "payload bytes {bytes}"
             );
             assert!(!installed.reused_existing);
+            assert_eq!(installed.file_fsync_calls, 1 + rollovers);
+            assert_eq!(installed.directory_fsync_calls, 2);
             assert_eq!(installed.bytes_installed, bytes);
             assert_eq!(
                 read_graph_object(root.path(), &digest, bytes).unwrap(),
@@ -4287,6 +4714,8 @@ mod tests {
             let reused = install_graph_object_file(root.path(), &source, &digest, bytes).unwrap();
             assert!(reused.reused_existing);
             assert_eq!(reused.fsync_calls, 0);
+            assert_eq!(reused.file_fsync_calls, 0);
+            assert_eq!(reused.directory_fsync_calls, 0);
             assert_eq!(reused.write_bytes, 0);
             assert!(
                 root.path()
@@ -4639,6 +5068,13 @@ mod tests {
             GraphManifestState::open(&lease, root.clone(), crate::GraphManifestLimits::default())
                 .unwrap();
         assert_eq!(open_evidence.entries_examined, 1);
+        assert_eq!(open_evidence.application_read_calls, 1);
+        assert_eq!(
+            open_evidence.decoded_bytes,
+            fs::metadata(graph_object_path(container.path(), &root.root_node_sha256).unwrap())
+                .unwrap()
+                .len()
+        );
         let (_, append_evidence) = append_graph_files_v2(
             &lease,
             workspace.path(),
@@ -4697,6 +5133,92 @@ mod tests {
         assert_eq!(resolved.len(), FILES);
         assert!(evidence.segments_examined <= (2 * FILES - 1) as u64);
         assert!(evidence.work_units <= (4 * FILES - 2) as u64);
+    }
+
+    #[test]
+    fn publication_components_measure_fresh_reuse_and_path_copy_work() {
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let relative_path = PathBuf::from("payload.parquet");
+        let sealed = |payload: &[u8]| {
+            fs::write(workspace.path().join(&relative_path), payload).unwrap();
+            vec![AuthenticatedGraphFile {
+                relative_path: relative_path.clone(),
+                byte_length: payload.len() as u64,
+                content_sha256: hex_digest(Sha256::digest(payload).into()),
+            }]
+        };
+        let files = sealed(b"first");
+        let mut state = GraphManifestState::empty();
+        let (first_root, fresh) =
+            append_authenticated_graph_files_v2(&lease, workspace.path(), &mut state, &files, &[])
+                .unwrap();
+        assert_eq!(fresh.publication_io.payload.read_bytes, 5);
+        assert_eq!(fresh.publication_io.payload.write_bytes, 5);
+        assert_eq!(fresh.publication_io.payload.installed_objects, 1);
+        // Empty branch, depth-one leaf, and collapsed root leaf are distinct
+        // immutable objects. Both existing nodes are read during the update.
+        assert_eq!(fresh.publication_io.manifest.installed_objects, 3);
+        assert_eq!(fresh.publication_io.manifest.reused_objects, 0);
+        assert_eq!(fresh.publication_io.manifest_reads.read_calls, 2);
+        assert_eq!(fresh.fsync_calls, 12);
+
+        let (_, replay) = append_authenticated_graph_files_v2(
+            &lease,
+            workspace.path(),
+            &mut GraphManifestState::empty(),
+            &files,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(replay.publication_io.payload.reused_objects, 1);
+        assert_eq!(replay.publication_io.payload.read_bytes, 5);
+        assert_eq!(replay.publication_io.manifest.reused_objects, 3);
+        assert_eq!(replay.publication_io.manifest_reads.read_calls, 2);
+        assert_eq!(replay.write_bytes, 0);
+        assert_eq!(replay.fsync_calls, 0);
+        assert_eq!(replay.bytes_installed, 0);
+
+        let changed = sealed(b"second");
+        let (second_root, update) = append_authenticated_graph_files_v2(
+            &lease,
+            workspace.path(),
+            &mut state,
+            &changed,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(update.publication_io.payload.installed_objects, 1);
+        assert_eq!(update.publication_io.manifest.installed_objects, 1);
+        assert_eq!(update.publication_io.manifest_reads.read_calls, 1);
+        assert_eq!(update.fsync_calls, 6);
+        assert_ne!(first_root, second_root);
+        for (root, expected) in [
+            (first_root, b"first".as_slice()),
+            (second_root, b"second".as_slice()),
+        ] {
+            let (reopened, _) =
+                GraphManifestState::open(&lease, root, crate::GraphManifestLimits::default())
+                    .unwrap();
+            let entry = reopened.entries().next().unwrap();
+            assert_eq!(
+                read_graph_object(container.path(), &entry.content_sha256, entry.byte_length)
+                    .unwrap(),
+                expected
+            );
+        }
+        for evidence in [fresh, replay, update] {
+            let totals = evidence.publication_io.totals().unwrap();
+            assert_eq!(totals.read_calls, evidence.read_calls);
+            assert_eq!(totals.write_calls, evidence.write_calls);
+            assert_eq!(totals.write_bytes, evidence.write_bytes);
+            assert_eq!(totals.installed_bytes, evidence.bytes_installed);
+            assert_eq!(
+                totals.file_fsync_calls + totals.directory_fsync_calls,
+                evidence.fsync_calls
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -26,10 +26,12 @@ pub mod adjacency_delta;
 
 pub mod storage_attribution;
 pub use storage_attribution::{
-    ArtifactCategory, ArtifactStorageTotals, ConstructionPhaseAttribution, PhaseIoTotals,
-    ProjectStorageIdentityUnion, StorageAllocationLifecycle, StorageAllocationTransition,
-    StorageAttributionReceipt, StorageAttributionSnapshot, StorageIoPhase,
-    capture_project_storage_identity_union, capture_storage_attribution, classify_graph_artifact,
+    ArtifactCategory, ArtifactCategoryAuthorityContext, ArtifactStorageTotals,
+    ConstructionPhaseAttribution, PhaseIoTotals, ProjectStorageIdentityUnion,
+    StorageAllocationLifecycle, StorageAllocationTransition, StorageAttributionReceipt,
+    StorageAttributionSnapshot, StorageIoPhase, artifact_category_authority_commitment,
+    artifact_category_peak_authority_commitment, capture_project_storage_identity_union,
+    capture_storage_attribution, classify_graph_artifact,
 };
 
 pub mod generation;
@@ -49,20 +51,22 @@ mod graph_construction_encoding;
 pub use graph_construction::{
     CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, ConstructionChunkKind,
     ConstructionChunkReceipt, ConstructionRetainedArtifact, ConstructionSemanticAuthority,
-    ConstructionShape, GraphConstructionBudgets, GraphConstructionEncoding,
-    GraphConstructionEncodingEvidence, GraphConstructionEncodingInvocationEvidence,
-    GraphConstructionEvidence, GraphConstructionSession, GraphConstructionState,
+    ConstructionShape, GRAPH_CONSTRUCTION_ENCODING_BUFFER_BYTES, GraphConstructionBudgets,
+    GraphConstructionEncoding, GraphConstructionEncodingEvidence,
+    GraphConstructionEncodingInvocationEvidence, GraphConstructionEvidence,
+    GraphConstructionSession, GraphConstructionState,
 };
 
 pub mod graph_files;
 #[cfg(test)]
 pub(crate) use graph_files::graph_files_root_participant;
 pub use graph_files::{
-    GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GRAPH_FILES_FAMILY, GRAPH_FILES_RECORD_VERSION,
-    GRAPH_FILES_V2_RECORD_VERSION, GRAPH_TREE_DIR, GraphFileEntry, GraphFileRole,
-    GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy, capture_graph_files,
-    decode_inventory, encode_inventory, graph_tree_root, inventory_participant,
-    materialize_graph_tree, pinned_open_evidence, stage_graph_tree, verify_graph_tree,
+    GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GRAPH_FILES_FAMILY, GRAPH_FILES_IO_BUFFER_BYTES,
+    GRAPH_FILES_RECORD_VERSION, GRAPH_FILES_V2_RECORD_VERSION, GRAPH_TREE_DIR, GraphFileEntry,
+    GraphFileRole, GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy,
+    capture_graph_files, decode_inventory, encode_inventory, graph_tree_root,
+    inventory_participant, materialize_graph_tree, pinned_open_evidence, stage_graph_tree,
+    verify_graph_tree,
 };
 pub(crate) use graph_files::{GraphFilesParticipant, decode_versioned_graph_files_participant};
 
@@ -80,13 +84,20 @@ pub(crate) use graph_manifest::{
     decode_node as decode_graph_manifest_node, decode_root as decode_graph_files_root_v2,
     encode_node as encode_graph_manifest_node, resolve_manifest as resolve_graph_manifest,
 };
+#[cfg(any(test, feature = "test-support"))]
+pub use graph_manifest::{
+    GRAPH_MANIFEST_BRANCH_MAX_BYTES, GRAPH_MANIFEST_ENTRY_ENCODING_OVERHEAD_BYTES,
+};
 
 #[allow(
     dead_code,
     reason = "private CAS construction is consumed by the staged #932 integration"
 )]
 mod graph_object_store;
-pub use graph_object_store::materialize_graph_objects;
+pub use graph_object_store::{
+    GRAPH_OBJECT_IO_BUFFER_BYTES, GraphObjectIoTotals, GraphPublicationIo,
+    materialize_graph_objects,
+};
 #[cfg(any(test, feature = "test-support"))]
 pub use graph_object_store::{
     GraphManifestState, append_graph_files_v2, install_graph_object_bytes, read_graph_object,
@@ -445,7 +456,7 @@ pub use mutator::{
 };
 
 pub mod staging;
-pub use staging::{RewriteBatch, remove_stale_temps};
+pub use staging::{RewriteBatch, STAGE_FILE_BLOCK_BYTES, remove_stale_temps};
 
 pub use graphforge_core::GfError;
 

--- a/crates/graphforge-storage/src/staging.rs
+++ b/crates/graphforge-storage/src/staging.rs
@@ -37,7 +37,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use tempfile::NamedTempFile;
 
-pub(crate) const STAGE_FILE_BLOCK_BYTES: usize = 1024 * 1024;
+/// Fixed staging block used for bounded construction reads and writes.
+pub const STAGE_FILE_BLOCK_BYTES: usize = 1024 * 1024;
 
 use graphforge_core::GfError;
 

--- a/crates/graphforge-storage/src/storage_attribution.rs
+++ b/crates/graphforge-storage/src/storage_attribution.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use graphforge_core::GfError;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
 
 use crate::{
     GraphConstructionEvidence, GraphFileEntry, GraphFilesParticipant, ResolvedProjectGeneration,
@@ -122,8 +123,7 @@ pub struct ConstructionPhaseAttribution {
 
 impl ConstructionPhaseAttribution {
     /// Derive phase ownership from storage-owned construction counters.
-    #[must_use]
-    pub fn from_construction(evidence: &GraphConstructionEvidence) -> Self {
+    pub fn from_construction(evidence: &GraphConstructionEvidence) -> Result<Self, GfError> {
         let mut phases: BTreeMap<_, _> = StorageIoPhase::ALL
             .into_iter()
             .map(|phase| (phase, PhaseIoTotals::default()))
@@ -149,7 +149,7 @@ impl ConstructionPhaseAttribution {
         );
         phases.insert(
             StorageIoPhase::ShapeConsumeReauthentication,
-            shape_phase_totals(evidence),
+            shape_phase_totals(evidence)?,
         );
         phases.insert(
             StorageIoPhase::EncodeWritePostwriteAuthentication,
@@ -195,9 +195,10 @@ impl ConstructionPhaseAttribution {
         phases.insert(
             StorageIoPhase::FsyncSynchronization,
             PhaseIoTotals {
-                fsync_calls: evidence
-                    .fsync_operations
-                    .saturating_add(evidence.merge_fsync_operations),
+                fsync_calls: checked_add(
+                    evidence.fsync_operations,
+                    evidence.merge_fsync_operations,
+                )?,
                 ..Default::default()
             },
         );
@@ -209,26 +210,29 @@ impl ConstructionPhaseAttribution {
                 ..Default::default()
             },
         );
-        let totals = phases
-            .values()
-            .fold(PhaseIoTotals::default(), |mut total, value| {
-                add_phase_totals_saturating(&mut total, value);
-                total
-            });
-        Self { phases, totals }
+        let mut totals = PhaseIoTotals::default();
+        for value in phases.values() {
+            add_phase_totals(&mut totals, value)?;
+        }
+        Ok(Self { phases, totals })
     }
 
     /// Add writer-reported recovery reauthentication completed outside the
     /// construction session, such as interrupted portable finalization.
-    pub fn add_recovery_reauthentication(&mut self, read_bytes: u64, read_calls: u64) {
+    pub fn add_recovery_reauthentication(
+        &mut self,
+        read_bytes: u64,
+        read_calls: u64,
+    ) -> Result<(), GfError> {
         let recovery = self
             .phases
             .entry(StorageIoPhase::RecoveryReauthentication)
             .or_default();
-        recovery.read_bytes = recovery.read_bytes.saturating_add(read_bytes);
-        recovery.read_calls = recovery.read_calls.saturating_add(read_calls);
-        self.totals.read_bytes = self.totals.read_bytes.saturating_add(read_bytes);
-        self.totals.read_calls = self.totals.read_calls.saturating_add(read_calls);
+        recovery.read_bytes = checked_add(recovery.read_bytes, read_bytes)?;
+        recovery.read_calls = checked_add(recovery.read_calls, read_calls)?;
+        self.totals.read_bytes = checked_add(self.totals.read_bytes, read_bytes)?;
+        self.totals.read_calls = checked_add(self.totals.read_calls, read_calls)?;
+        Ok(())
     }
 
     /// Reject missing phases or totals that do not equal the phase sum.
@@ -271,27 +275,27 @@ impl ConstructionPhaseAttribution {
     }
 }
 
-fn shape_phase_totals(evidence: &GraphConstructionEvidence) -> PhaseIoTotals {
-    PhaseIoTotals {
+fn shape_phase_totals(evidence: &GraphConstructionEvidence) -> Result<PhaseIoTotals, GfError> {
+    Ok(PhaseIoTotals {
         read_bytes: evidence.shape_application_read_bytes,
-        write_bytes: evidence
-            .merge_written_bytes
-            .saturating_add(evidence.parquet_write_bytes),
-        read_calls: evidence
-            .shape_input_validation_read_operations
-            .saturating_add(evidence.merge_read_operations)
-            .saturating_add(evidence.parquet_read_operations)
-            .saturating_add(evidence.shaped_output_authentication_operations)
-            .saturating_add(evidence.parent_catalog_read_operations)
-            .saturating_add(evidence.retained_probe_block_loads),
-        write_calls: evidence
-            .merge_write_operations
-            .saturating_add(evidence.parquet_write_operations),
-        block_count: evidence
-            .merge_read_blocks
-            .saturating_add(evidence.merge_write_blocks),
+        write_bytes: checked_add(evidence.merge_written_bytes, evidence.parquet_write_bytes)?,
+        read_calls: [
+            evidence.shape_input_validation_read_operations,
+            evidence.merge_read_operations,
+            evidence.parquet_read_operations,
+            evidence.shaped_output_authentication_operations,
+            evidence.parent_catalog_read_operations,
+            evidence.retained_probe_block_loads,
+        ]
+        .into_iter()
+        .try_fold(0_u64, checked_add)?,
+        write_calls: checked_add(
+            evidence.merge_write_operations,
+            evidence.parquet_write_operations,
+        )?,
+        block_count: checked_add(evidence.merge_read_blocks, evidence.merge_write_blocks)?,
         ..Default::default()
-    }
+    })
 }
 
 /// Reconciled totals for one artifact category.
@@ -309,6 +313,31 @@ pub struct ArtifactStorageTotals {
     pub allocated_bytes: u64,
 }
 
+/// Safe context binding category evidence to native receipt and identity roots.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactCategoryAuthorityContext {
+    /// Evidence contract domain.
+    pub contract: String,
+    /// Authority format version.
+    pub version: u32,
+    /// Deterministic lifecycle rung.
+    pub rung: u64,
+    /// Authenticated generation-manifest digest.
+    pub generation_sha256: String,
+    /// Storage owner within the lifecycle.
+    pub owner: String,
+    /// Digest of the storage-owned receipt/category ledger.
+    pub receipt_authority_sha256: String,
+    /// Digest of native identity membership and allocation.
+    pub native_identity_authority_sha256: String,
+    /// Per-category native identity-membership roots.
+    pub native_category_identity_authority_sha256: BTreeMap<ArtifactCategory, String>,
+    /// Authoritative reopened node denominator.
+    pub live_nodes: u64,
+    /// Authoritative reopened edge denominator.
+    pub live_edges: u64,
+}
+
 /// Authenticated storage attribution for one lifetime-pinned generation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageAttributionSnapshot {
@@ -318,6 +347,9 @@ pub struct StorageAttributionSnapshot {
     pub generation_manifest_sha256: [u8; 32],
     /// Every category exactly once, including zero totals.
     pub categories: BTreeMap<ArtifactCategory, ArtifactStorageTotals>,
+    /// Independently accumulated receipt and native-identity category totals.
+    #[serde(skip)]
+    category_authorities: BTreeMap<ArtifactCategory, ArtifactStorageTotals>,
     /// Reconciled logical references across categories.
     pub logical_references: u64,
     /// Reconciled referenced logical bytes across categories.
@@ -332,6 +364,9 @@ pub struct StorageAttributionSnapshot {
     /// union is the cross-owner input to lifecycle peak tracking.
     #[serde(skip)]
     pub physical_identity_allocated_bytes: BTreeMap<String, u64>,
+    /// Native identity allocation partitioned by its authenticated category.
+    #[serde(skip)]
+    category_physical_identity_allocated_bytes: BTreeMap<ArtifactCategory, BTreeMap<String, u64>>,
 }
 
 /// Identity-free, closed storage evidence suitable for ordinary CLI output.
@@ -689,9 +724,111 @@ impl StorageAllocationLifecycle {
     pub const fn peak_allocated_bytes(&self) -> u64 {
         self.peak_allocated_bytes
     }
+
+    /// Exact deduplicated allocation for a closed set of active owners.
+    ///
+    /// Shared native identities are counted once. Missing owners are rejected
+    /// so an emitted aggregate cannot silently omit a lifecycle owner.
+    pub fn owner_union_allocated_bytes<'a>(
+        &self,
+        owners: impl IntoIterator<Item = &'a str>,
+    ) -> Result<u64, GfError> {
+        let mut identities = BTreeSet::new();
+        for owner in owners {
+            let owned = self
+                .owners
+                .get(owner)
+                .ok_or_else(|| validation("allocation union owner is absent"))?;
+            identities.extend(owned.iter());
+        }
+        identities.into_iter().try_fold(0_u64, |total, identity| {
+            let (allocated, _) = self
+                .active
+                .get(identity)
+                .ok_or_else(|| validation("allocation union identity is absent"))?;
+            checked_add(total, *allocated)
+        })
+    }
 }
 
 impl StorageAttributionSnapshot {
+    /// Identity-free category authorities derived from authenticated inventory
+    /// receipts and the per-category native-identity union.
+    pub fn category_authorities(
+        &self,
+    ) -> Result<BTreeMap<ArtifactCategory, ArtifactStorageTotals>, GfError> {
+        self.validate_reconciliation()?;
+        if self.category_authorities.len() != ArtifactCategory::ALL.len()
+            || self.category_authorities != self.categories
+        {
+            return Err(validation(
+                "reported categories differ from independent receipt/identity authorities",
+            ));
+        }
+        Ok(self.category_authorities.clone())
+    }
+
+    /// Sanitized commitments to independently accumulated category authority.
+    pub fn category_authority_commitments(
+        &self,
+        context: &ArtifactCategoryAuthorityContext,
+    ) -> Result<BTreeMap<ArtifactCategory, String>, GfError> {
+        self.category_authorities()?;
+        Ok(self
+            .category_authorities
+            .iter()
+            .map(|(category, totals)| {
+                (
+                    *category,
+                    artifact_category_authority_commitment(context, *category, totals),
+                )
+            })
+            .collect())
+    }
+
+    /// Build safe authority context from hidden receipt and identity membership.
+    pub fn category_authority_context(
+        &self,
+        contract: &str,
+        rung: u64,
+        owner: &str,
+        live_nodes: u64,
+        live_edges: u64,
+    ) -> Result<ArtifactCategoryAuthorityContext, GfError> {
+        self.category_authorities()?;
+        if contract.is_empty()
+            || owner.is_empty()
+            || rung == 0
+            || live_nodes == 0
+            || live_edges == 0
+        {
+            return Err(validation("category authority context is invalid"));
+        }
+        Ok(ArtifactCategoryAuthorityContext {
+            contract: contract.to_owned(),
+            version: 1,
+            rung,
+            generation_sha256: format_sha256(&self.generation_manifest_sha256),
+            owner: owner.to_owned(),
+            receipt_authority_sha256: category_map_authority_sha256(
+                b"graphforge-storage-receipt-authority-v1\0",
+                &self.category_authorities,
+            ),
+            native_identity_authority_sha256: identity_map_authority_sha256(
+                &self.physical_identity_allocated_bytes,
+            ),
+            native_category_identity_authority_sha256: self
+                .category_physical_identity_allocated_bytes
+                .iter()
+                .map(|(category, identities)| {
+                    (*category, identity_map_authority_sha256(identities))
+                })
+                .collect(),
+            live_nodes,
+            live_edges,
+        })
+    }
+
     /// Whether every retained graph artifact was assigned a qualifying category.
     #[must_use]
     pub fn is_fully_classified(&self) -> bool {
@@ -705,8 +842,18 @@ impl StorageAttributionSnapshot {
         if ArtifactCategory::ALL
             .iter()
             .any(|category| !self.categories.contains_key(category))
+            || ArtifactCategory::ALL
+                .iter()
+                .any(|category| !self.category_authorities.contains_key(category))
+            || self.categories.len() != ArtifactCategory::ALL.len()
+            || self.category_authorities.len() != ArtifactCategory::ALL.len()
         {
             return Err(validation("storage attribution is missing a category"));
+        }
+        if self.categories != self.category_authorities {
+            return Err(validation(
+                "storage categories differ from independent receipt/identity authorities",
+            ));
         }
         let mut total = ArtifactStorageTotals::default();
         for category in ArtifactCategory::ALL {
@@ -924,8 +1071,10 @@ struct Accumulator {
     generation_uuid: uuid::Uuid,
     generation_manifest_sha256: [u8; 32],
     categories: BTreeMap<ArtifactCategory, ArtifactStorageTotals>,
+    category_authorities: BTreeMap<ArtifactCategory, ArtifactStorageTotals>,
     physical_seen: BTreeSet<(u64, [u8; 16])>,
     physical_identity_allocated_bytes: BTreeMap<String, u64>,
+    category_physical_identity_allocated_bytes: BTreeMap<ArtifactCategory, BTreeMap<String, u64>>,
 }
 
 impl Accumulator {
@@ -937,8 +1086,16 @@ impl Accumulator {
                 .into_iter()
                 .map(|category| (category, ArtifactStorageTotals::default()))
                 .collect(),
+            category_authorities: ArtifactCategory::ALL
+                .into_iter()
+                .map(|category| (category, ArtifactStorageTotals::default()))
+                .collect(),
             physical_seen: BTreeSet::new(),
             physical_identity_allocated_bytes: BTreeMap::new(),
+            category_physical_identity_allocated_bytes: ArtifactCategory::ALL
+                .into_iter()
+                .map(|category| (category, BTreeMap::new()))
+                .collect(),
         }
     }
 
@@ -949,6 +1106,12 @@ impl Accumulator {
             .expect("complete categories");
         totals.logical_references = checked_add(totals.logical_references, 1)?;
         totals.logical_bytes = checked_add(totals.logical_bytes, bytes)?;
+        let authority = self
+            .category_authorities
+            .get_mut(&category)
+            .expect("complete category authorities");
+        authority.logical_references = checked_add(authority.logical_references, 1)?;
+        authority.logical_bytes = checked_add(authority.logical_bytes, bytes)?;
         Ok(())
     }
 
@@ -969,10 +1132,13 @@ impl Accumulator {
             .physical_seen
             .insert((identity.volume_serial, identity.file_id))
         {
-            self.physical_identity_allocated_bytes.insert(
-                native_identity_key(identity.volume_serial, &identity.file_id),
-                usage.allocated_bytes,
-            );
+            let identity_key = native_identity_key(identity.volume_serial, &identity.file_id);
+            self.physical_identity_allocated_bytes
+                .insert(identity_key.clone(), usage.allocated_bytes);
+            self.category_physical_identity_allocated_bytes
+                .get_mut(&category)
+                .expect("complete category identity authorities")
+                .insert(identity_key, usage.allocated_bytes);
             let totals = self
                 .categories
                 .get_mut(&category)
@@ -981,6 +1147,15 @@ impl Accumulator {
             totals.physical_logical_bytes =
                 checked_add(totals.physical_logical_bytes, usage.logical_bytes)?;
             totals.allocated_bytes = checked_add(totals.allocated_bytes, usage.allocated_bytes)?;
+            let authority = self
+                .category_authorities
+                .get_mut(&category)
+                .expect("complete category authorities");
+            authority.physical_objects = checked_add(authority.physical_objects, 1)?;
+            authority.physical_logical_bytes =
+                checked_add(authority.physical_logical_bytes, usage.logical_bytes)?;
+            authority.allocated_bytes =
+                checked_add(authority.allocated_bytes, usage.allocated_bytes)?;
         }
         Ok(())
     }
@@ -994,12 +1169,15 @@ impl Accumulator {
             generation_uuid: self.generation_uuid,
             generation_manifest_sha256: self.generation_manifest_sha256,
             categories: self.categories,
+            category_authorities: self.category_authorities,
             logical_references: total.logical_references,
             logical_bytes: total.logical_bytes,
             physical_objects: total.physical_objects,
             physical_logical_bytes: total.physical_logical_bytes,
             allocated_bytes: total.allocated_bytes,
             physical_identity_allocated_bytes: self.physical_identity_allocated_bytes,
+            category_physical_identity_allocated_bytes: self
+                .category_physical_identity_allocated_bytes,
         };
         snapshot.validate_reconciliation()?;
         Ok(snapshot)
@@ -1019,6 +1197,127 @@ fn add_totals(
     Ok(())
 }
 
+/// Commit to one independently derived category without exposing identities.
+#[must_use]
+pub fn artifact_category_authority_commitment(
+    context: &ArtifactCategoryAuthorityContext,
+    category: ArtifactCategory,
+    totals: &ArtifactStorageTotals,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-category-authority-v2\0");
+    update_authority_context(&mut digest, context, category);
+    digest.update(artifact_category_name(category));
+    for value in artifact_totals_values(totals) {
+        digest.update(value.to_be_bytes());
+    }
+    format_sha256(&digest.finalize())
+}
+
+/// Commit to one independently derived category allocation high-water mark.
+#[must_use]
+pub fn artifact_category_peak_authority_commitment(
+    context: &ArtifactCategoryAuthorityContext,
+    category: ArtifactCategory,
+    allocated_bytes: u64,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-category-peak-authority-v2\0");
+    update_authority_context(&mut digest, context, category);
+    digest.update(artifact_category_name(category));
+    digest.update(allocated_bytes.to_be_bytes());
+    format_sha256(&digest.finalize())
+}
+
+fn update_authority_context(
+    digest: &mut Sha256,
+    context: &ArtifactCategoryAuthorityContext,
+    category: ArtifactCategory,
+) {
+    for value in [
+        context.contract.as_bytes(),
+        context.generation_sha256.as_bytes(),
+        context.owner.as_bytes(),
+        context.receipt_authority_sha256.as_bytes(),
+        context.native_identity_authority_sha256.as_bytes(),
+    ] {
+        digest.update((value.len() as u128).to_be_bytes());
+        digest.update(value);
+    }
+    digest.update(context.version.to_be_bytes());
+    digest.update(context.rung.to_be_bytes());
+    digest.update(context.live_nodes.to_be_bytes());
+    digest.update(context.live_edges.to_be_bytes());
+    let category_identity = context
+        .native_category_identity_authority_sha256
+        .get(&category)
+        .expect("complete native category identity authority");
+    digest.update((category_identity.len() as u128).to_be_bytes());
+    digest.update(category_identity.as_bytes());
+}
+
+pub(crate) fn category_map_authority_sha256(
+    domain: &[u8],
+    categories: &BTreeMap<ArtifactCategory, ArtifactStorageTotals>,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for category in ArtifactCategory::ALL {
+        digest.update(artifact_category_name(category));
+        for value in artifact_totals_values(&categories[&category]) {
+            digest.update(value.to_be_bytes());
+        }
+    }
+    format_sha256(&digest.finalize())
+}
+
+pub(crate) fn identity_map_authority_sha256(identities: &BTreeMap<String, u64>) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-native-identity-authority-v1\0");
+    for (identity, allocated_bytes) in identities {
+        digest.update((identity.len() as u128).to_be_bytes());
+        digest.update(identity.as_bytes());
+        digest.update(allocated_bytes.to_be_bytes());
+    }
+    format_sha256(&digest.finalize())
+}
+
+fn artifact_category_name(category: ArtifactCategory) -> &'static [u8] {
+    match category {
+        ArtifactCategory::TopologyNodes => b"topology_nodes",
+        ArtifactCategory::TopologyEdges => b"topology_edges",
+        ArtifactCategory::Properties => b"properties",
+        ArtifactCategory::UuidAndSurrogates => b"uuid_and_surrogates",
+        ArtifactCategory::Adjacency => b"adjacency",
+        ArtifactCategory::CatalogAndManifests => b"catalog_and_manifests",
+        ArtifactCategory::ConstructionStaging => b"construction_staging",
+        ArtifactCategory::PortablePackage => b"portable_package",
+        ArtifactCategory::CleanImportedProject => b"clean_imported_project",
+        ArtifactCategory::Other => b"other",
+    }
+}
+
+fn format_sha256(digest: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut value = String::with_capacity(7 + digest.len() * 2);
+    value.push_str("sha256:");
+    for byte in digest {
+        write!(&mut value, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    value
+}
+
+fn artifact_totals_values(totals: &ArtifactStorageTotals) -> [u64; 5] {
+    [
+        totals.logical_references,
+        totals.logical_bytes,
+        totals.physical_objects,
+        totals.physical_logical_bytes,
+        totals.allocated_bytes,
+    ]
+}
+
 fn add_phase_totals(target: &mut PhaseIoTotals, value: &PhaseIoTotals) -> Result<(), GfError> {
     target.read_bytes = checked_add(target.read_bytes, value.read_bytes)?;
     target.write_bytes = checked_add(target.write_bytes, value.write_bytes)?;
@@ -1028,16 +1327,6 @@ fn add_phase_totals(target: &mut PhaseIoTotals, value: &PhaseIoTotals) -> Result
     target.block_count = checked_add(target.block_count, value.block_count)?;
     target.fsync_calls = checked_add(target.fsync_calls, value.fsync_calls)?;
     Ok(())
-}
-
-fn add_phase_totals_saturating(target: &mut PhaseIoTotals, value: &PhaseIoTotals) {
-    target.read_bytes = target.read_bytes.saturating_add(value.read_bytes);
-    target.write_bytes = target.write_bytes.saturating_add(value.write_bytes);
-    target.read_calls = target.read_calls.saturating_add(value.read_calls);
-    target.write_calls = target.write_calls.saturating_add(value.write_calls);
-    target.object_count = target.object_count.saturating_add(value.object_count);
-    target.block_count = target.block_count.saturating_add(value.block_count);
-    target.fsync_calls = target.fsync_calls.saturating_add(value.fsync_calls);
 }
 
 fn checked_add(left: u64, right: u64) -> Result<u64, GfError> {
@@ -1160,6 +1449,7 @@ mod tests {
         let mut snapshot = StorageAttributionSnapshot {
             generation_uuid: uuid::Uuid::nil(),
             generation_manifest_sha256: [0; 32],
+            category_authorities: categories.clone(),
             categories,
             logical_references: 0,
             logical_bytes: 7,
@@ -1167,8 +1457,24 @@ mod tests {
             physical_logical_bytes: 0,
             allocated_bytes: 0,
             physical_identity_allocated_bytes: BTreeMap::new(),
+            category_physical_identity_allocated_bytes: ArtifactCategory::ALL
+                .into_iter()
+                .map(|category| (category, BTreeMap::new()))
+                .collect(),
         };
         snapshot.validate_reconciliation().unwrap();
+        snapshot
+            .categories
+            .get_mut(&ArtifactCategory::TopologyNodes)
+            .unwrap()
+            .logical_bytes = 6;
+        snapshot
+            .categories
+            .get_mut(&ArtifactCategory::TopologyEdges)
+            .unwrap()
+            .logical_bytes = 1;
+        assert!(snapshot.validate_reconciliation().is_err());
+        snapshot.categories = snapshot.category_authorities.clone();
         snapshot.logical_bytes = 8;
         assert!(snapshot.validate_reconciliation().is_err());
         snapshot.categories.remove(&ArtifactCategory::Other);
@@ -1188,6 +1494,7 @@ mod tests {
         let snapshot = StorageAttributionSnapshot {
             generation_uuid: uuid::Uuid::nil(),
             generation_manifest_sha256: [0; 32],
+            category_authorities: categories.clone(),
             categories,
             logical_references: 1,
             logical_bytes: 0,
@@ -1195,6 +1502,10 @@ mod tests {
             physical_logical_bytes: 0,
             allocated_bytes: 0,
             physical_identity_allocated_bytes: BTreeMap::new(),
+            category_physical_identity_allocated_bytes: ArtifactCategory::ALL
+                .into_iter()
+                .map(|category| (category, BTreeMap::new()))
+                .collect(),
         };
         assert!(snapshot.validate_reconciliation().is_ok());
         assert!(snapshot.validate_for_qualification().is_err());
@@ -1217,6 +1528,7 @@ mod tests {
         let snapshot = StorageAttributionSnapshot {
             generation_uuid: uuid::Uuid::nil(),
             generation_manifest_sha256: [0; 32],
+            category_authorities: categories.clone(),
             categories,
             logical_references: 1,
             logical_bytes: 0,
@@ -1227,6 +1539,17 @@ mod tests {
                 ("dev:a".to_owned(), 0),
                 ("dev:b".to_owned(), 0),
             ]),
+            category_physical_identity_allocated_bytes: ArtifactCategory::ALL
+                .into_iter()
+                .map(|category| {
+                    let identities = if category == ArtifactCategory::CatalogAndManifests {
+                        BTreeMap::from([("dev:a".to_owned(), 0), ("dev:b".to_owned(), 0)])
+                    } else {
+                        BTreeMap::new()
+                    };
+                    (category, identities)
+                })
+                .collect(),
         };
         assert!(snapshot.validate_reconciliation().is_ok());
         assert!(snapshot.validate_for_qualification().is_err());
@@ -1280,6 +1603,20 @@ mod tests {
         lifecycle.replace_owner("source", &first).unwrap();
         assert_eq!(lifecycle.current_allocated_bytes(), 12_288);
         lifecycle.replace_owner("import", &alias).unwrap();
+        assert_eq!(lifecycle.current_allocated_bytes(), 16_384);
+        assert_eq!(
+            lifecycle
+                .owner_union_allocated_bytes(["source", "import"])
+                .unwrap(),
+            16_384
+        );
+        assert_eq!(
+            lifecycle.owner_union_allocated_bytes(["source"]).unwrap(),
+            12_288
+        );
+        assert!(lifecycle.owner_union_allocated_bytes(["missing"]).is_err());
+        let contradictory = BTreeMap::from([("dev:b".to_owned(), 16_384)]);
+        assert!(lifecycle.replace_owner("invalid", &contradictory).is_err());
         assert_eq!(lifecycle.current_allocated_bytes(), 16_384);
         assert_eq!(lifecycle.peak_allocated_bytes(), 16_384);
         lifecycle.remove_owner("source").unwrap();
@@ -1488,7 +1825,7 @@ mod tests {
             merge_fsync_operations: 7,
             ..Default::default()
         };
-        let mut attribution = ConstructionPhaseAttribution::from_construction(&evidence);
+        let mut attribution = ConstructionPhaseAttribution::from_construction(&evidence).unwrap();
         attribution.validate_reconciliation().unwrap();
         attribution.validate_for_qualification().unwrap();
         assert_eq!(attribution.phases.len(), StorageIoPhase::ALL.len());
@@ -1507,7 +1844,7 @@ mod tests {
             attribution.phases[&StorageIoPhase::RecoveryReauthentication].read_calls,
             2
         );
-        attribution.add_recovery_reauthentication(9, 1);
+        attribution.add_recovery_reauthentication(9, 1).unwrap();
         attribution.validate_for_qualification().unwrap();
         assert_eq!(
             attribution.phases[&StorageIoPhase::RecoveryReauthentication].read_bytes,
@@ -1527,15 +1864,83 @@ mod tests {
     #[test]
     fn construction_phase_inventory_rejects_double_counted_total() {
         let mut attribution =
-            ConstructionPhaseAttribution::from_construction(&GraphConstructionEvidence::default());
+            ConstructionPhaseAttribution::from_construction(&GraphConstructionEvidence::default())
+                .unwrap();
         attribution.totals.read_bytes = 1;
         assert!(attribution.validate_reconciliation().is_err());
     }
 
     #[test]
+    fn construction_phase_derivation_rejects_counter_overflow() {
+        let evidence = GraphConstructionEvidence {
+            shape_input_validation_read_operations: u64::MAX,
+            merge_read_operations: 1,
+            ..GraphConstructionEvidence::default()
+        };
+        assert!(ConstructionPhaseAttribution::from_construction(&evidence).is_err());
+        let evidence = GraphConstructionEvidence {
+            shape_application_read_bytes: u64::MAX,
+            encode_application_read_bytes: 1,
+            ..GraphConstructionEvidence::default()
+        };
+        assert!(evidence.total_application_read_bytes().is_err());
+    }
+
+    #[test]
+    fn construction_category_authority_is_independent_from_reported_view() {
+        let mut categories: BTreeMap<_, _> = ArtifactCategory::ALL
+            .into_iter()
+            .map(|category| (category, ArtifactStorageTotals::default()))
+            .collect();
+        categories
+            .get_mut(&ArtifactCategory::ConstructionStaging)
+            .unwrap()
+            .allocated_bytes = 4096;
+        let mut peaks: BTreeMap<_, _> = ArtifactCategory::ALL
+            .into_iter()
+            .map(|category| (category, 0))
+            .collect();
+        peaks.insert(ArtifactCategory::ConstructionStaging, 4096);
+        let mut evidence = GraphConstructionEvidence {
+            storage_current: categories.clone(),
+            storage_receipt_category_authorities: categories,
+            storage_transient_peak_allocated_bytes: peaks.clone(),
+            storage_receipt_transient_peak_authorities: peaks,
+            storage_active_identity_allocated_bytes: BTreeMap::from([(
+                "native-identity".to_owned(),
+                4096,
+            )]),
+            ..GraphConstructionEvidence::default()
+        };
+        evidence.storage_category_authorities().unwrap();
+        let context = evidence
+            .storage_category_authority_context(
+                "test-contract",
+                1,
+                "sha256:generation",
+                "construction",
+                1,
+                1,
+            )
+            .unwrap();
+        assert_ne!(
+            context.native_category_identity_authority_sha256
+                [&ArtifactCategory::ConstructionStaging],
+            context.native_category_identity_authority_sha256[&ArtifactCategory::TopologyNodes]
+        );
+        evidence
+            .storage_current
+            .get_mut(&ArtifactCategory::ConstructionStaging)
+            .unwrap()
+            .logical_bytes = 1;
+        assert!(evidence.storage_category_authorities().is_err());
+    }
+
+    #[test]
     fn qualification_preserves_truthful_zero_io_phase_rows() {
         let attribution =
-            ConstructionPhaseAttribution::from_construction(&GraphConstructionEvidence::default());
+            ConstructionPhaseAttribution::from_construction(&GraphConstructionEvidence::default())
+                .unwrap();
         attribution.validate_for_qualification().unwrap();
         assert_eq!(attribution.phases.len(), StorageIoPhase::ALL.len());
         assert!(

--- a/docs/development/evidence/g500-certification.schema.json
+++ b/docs/development/evidence/g500-certification.schema.json
@@ -4,112 +4,1448 @@
   "title": "GraphForge billion-live-edge certification evidence",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema", "git_sha", "profile_sha256", "run", "host", "tools", "counts", "identities", "package", "authority", "equivalence", "storage_attribution", "phases", "envelope", "result", "first_failure"],
+  "required": [
+    "schema",
+    "git_sha",
+    "profile_sha256",
+    "run",
+    "host",
+    "tools",
+    "counts",
+    "identities",
+    "package",
+    "authority",
+    "equivalence",
+    "storage_attribution",
+    "phases",
+    "envelope",
+    "result",
+    "first_failure"
+  ],
   "properties": {
-    "schema": { "const": "graphforge-billion-edge-certification-evidence/1" },
-    "git_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-    "profile_sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
-    "run": { "type": "object", "additionalProperties": false, "required": ["command", "scale", "edgefactor", "seed", "directionality", "self_loops", "duplicates"], "properties": { "command": { "const": "cargo test -p graphforge-api --release --test scale_g500_ladder certification_target_live_full_lifecycle_evidence -- --ignored --exact --nocapture --test-threads=1" }, "scale": { "enum": [20, 22, 24, 26] }, "edgefactor": { "const": 16 }, "seed": { "const": 1 }, "directionality": { "const": "undirected" }, "self_loops": { "const": "drop" }, "duplicates": { "const": "drop" } } },
-    "host": {
-      "type": "object", "additionalProperties": false,
-      "required": ["provider", "region", "sku", "os_image", "os", "kernel", "filesystem", "memory_bytes", "nvme_bytes"],
+    "schema": {
+      "const": "graphforge-billion-edge-certification-evidence/1"
+    },
+    "git_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "profile_sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "scale",
+        "edgefactor",
+        "seed",
+        "directionality",
+        "self_loops",
+        "duplicates"
+      ],
       "properties": {
-        "provider": { "type": "string", "minLength": 1, "maxLength": 64, "description": "Provisioned cloud provider; never local or a mutable resource identifier." },
-        "region": { "type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[A-Za-z0-9._-]+$", "description": "Exact provider region approved for this run." },
-        "sku": { "type": "string", "minLength": 1, "maxLength": 128, "description": "Exact provisioned machine SKU approved for this run." },
-        "os_image": { "type": "string", "minLength": 1, "maxLength": 256, "description": "Immutable Linux image identity including its resolved version; moving aliases are invalid." },
-        "os": { "type": "string", "pattern": "^Linux", "description": "Observed Linux OS family from the provisioned host." },
-        "kernel": { "type": "string", "minLength": 1, "maxLength": 128 },
-        "filesystem": { "enum": ["ext4", "xfs", "btrfs"], "description": "Filesystem of the Rust process temp workspace; provisioning proves it is the same local-NVMe device as RUNNER_TEMP." },
-        "memory_bytes": { "type": "integer", "minimum": 1, "maximum": 137438953472 },
-        "nvme_bytes": { "type": "integer", "minimum": 1 }
+        "command": {
+          "const": "cargo test -p graphforge-api --release --test scale_g500_ladder certification_target_live_full_lifecycle_evidence -- --ignored --exact --nocapture --test-threads=1"
+        },
+        "scale": {
+          "enum": [
+            20,
+            22,
+            24,
+            26
+          ]
+        },
+        "edgefactor": {
+          "const": 16
+        },
+        "seed": {
+          "const": 1
+        },
+        "directionality": {
+          "const": "undirected"
+        },
+        "self_loops": {
+          "const": "drop"
+        },
+        "duplicates": {
+          "const": "drop"
+        }
       }
     },
-    "tools": { "type": "object", "additionalProperties": { "type": "string", "maxLength": 128 } },
-    "counts": {
-      "type": "object", "additionalProperties": false,
-      "required": ["raw_attempts", "self_loops_rejected", "duplicates_rejected", "live_unique_edges", "source_nodes", "source_edges", "imported_nodes", "imported_edges"],
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "region",
+        "sku",
+        "os_image",
+        "os",
+        "kernel",
+        "filesystem",
+        "memory_bytes",
+        "nvme_bytes"
+      ],
       "properties": {
-        "raw_attempts": { "type": "integer", "minimum": 1 },
-        "self_loops_rejected": { "type": "integer", "minimum": 0 },
-        "duplicates_rejected": { "type": "integer", "minimum": 0 },
-        "live_unique_edges": { "type": "integer", "minimum": 1 },
-        "source_nodes": { "type": "integer", "minimum": 1 }, "source_edges": { "type": "integer", "minimum": 1 },
-        "imported_nodes": { "type": "integer", "minimum": 1 }, "imported_edges": { "type": "integer", "minimum": 1 }
+        "provider": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "description": "Provisioned cloud provider; never local or a mutable resource identifier."
+        },
+        "region": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[A-Za-z0-9._-]+$",
+          "description": "Exact provider region approved for this run."
+        },
+        "sku": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Exact provisioned machine SKU approved for this run."
+        },
+        "os_image": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Immutable Linux image identity including its resolved version; moving aliases are invalid."
+        },
+        "os": {
+          "type": "string",
+          "pattern": "^Linux",
+          "description": "Observed Linux OS family from the provisioned host."
+        },
+        "kernel": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "filesystem": {
+          "enum": [
+            "ext4",
+            "xfs",
+            "btrfs"
+          ],
+          "description": "Filesystem of the Rust process temp workspace; provisioning proves it is the same local-NVMe device as RUNNER_TEMP."
+        },
+        "memory_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 137438953472
+        },
+        "nvme_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 18446744073709551615
+        }
+      }
+    },
+    "tools": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "maxLength": 128
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw_attempts",
+        "self_loops_rejected",
+        "duplicates_rejected",
+        "live_unique_edges",
+        "source_nodes",
+        "source_edges",
+        "imported_nodes",
+        "imported_edges"
+      ],
+      "properties": {
+        "raw_attempts": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 18446744073709551615
+        },
+        "self_loops_rejected": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "duplicates_rejected": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "live_unique_edges": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 18446744073709551615
+        },
+        "source_nodes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 18446744073709551615
+        },
+        "source_edges": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 18446744073709551615
+        },
+        "imported_nodes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 18446744073709551615
+        },
+        "imported_edges": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 18446744073709551615
+        }
       }
     },
     "identities": {
-      "type": "object", "additionalProperties": false,
-      "required": ["source_export_generation_authenticated", "import_receipt_reopen_authenticated", "source_import_generations_distinct", "package", "transport"],
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_export_generation_authenticated",
+        "import_receipt_reopen_authenticated",
+        "source_import_generations_distinct",
+        "package",
+        "transport"
+      ],
       "properties": {
-        "source_export_generation_authenticated": { "const": true },
-        "import_receipt_reopen_authenticated": { "const": true },
-        "source_import_generations_distinct": { "const": true },
-        "package": { "$ref": "#/$defs/sha256" }, "transport": { "$ref": "#/$defs/sha256" },
+        "source_export_generation_authenticated": {
+          "const": true
+        },
+        "import_receipt_reopen_authenticated": {
+          "const": true
+        },
+        "source_import_generations_distinct": {
+          "const": true
+        },
+        "package": {
+          "$ref": "#/$defs/sha256"
+        },
+        "transport": {
+          "$ref": "#/$defs/sha256"
+        },
         "generation_uuid": false
       }
     },
-    "package": { "type": "object", "additionalProperties": false, "required": ["contract", "format", "class", "integrity", "compatibility", "policy"], "properties": { "contract": { "const": "graphforge-portable-verify/2" }, "format": { "const": "portable-project-v2-bundle" }, "class": { "const": "complete" }, "integrity": { "const": "verified" }, "compatibility": { "const": "supported" }, "policy": { "const": "complete-current-generation" } } },
-    "authority": { "type": "object", "required": ["source_fingerprint", "imported_fingerprint"], "properties": { "source_fingerprint": { "$ref": "#/$defs/sha256" }, "imported_fingerprint": { "$ref": "#/$defs/sha256" } }, "additionalProperties": false },
-    "equivalence": { "type": "object", "additionalProperties": false, "required": ["source_project_fingerprint", "imported_project_fingerprint"], "properties": { "source_project_fingerprint": { "$ref": "#/$defs/sha256" }, "imported_project_fingerprint": { "$ref": "#/$defs/sha256" } } },
-    "storage_attribution": { "$ref": "#/$defs/storageAttribution" },
-    "phases": { "type": "array", "minItems": 17, "maxItems": 32, "items": { "$ref": "#/$defs/phase" } },
-    "envelope": { "type": "object", "required": ["peak_rss_bytes", "peak_disk_bytes", "peak_disk_source", "wall_time_s"], "properties": { "peak_rss_bytes": { "type": "integer", "maximum": 137438953472 }, "peak_disk_bytes": { "type": "integer", "maximum": 1099511627776 }, "peak_disk_source": { "const": "storage_owned_active_identity_union" }, "wall_time_s": { "type": "number", "maximum": 14400 } }, "additionalProperties": false },
-    "result": { "enum": ["pass", "fail"] },
-    "first_failure": { "type": ["object", "null"] }
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract",
+        "format",
+        "class",
+        "integrity",
+        "compatibility",
+        "policy"
+      ],
+      "properties": {
+        "contract": {
+          "const": "graphforge-portable-verify/2"
+        },
+        "format": {
+          "const": "portable-project-v2-bundle"
+        },
+        "class": {
+          "const": "complete"
+        },
+        "integrity": {
+          "const": "verified"
+        },
+        "compatibility": {
+          "const": "supported"
+        },
+        "policy": {
+          "const": "complete-current-generation"
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "required": [
+        "source_fingerprint",
+        "imported_fingerprint"
+      ],
+      "properties": {
+        "source_fingerprint": {
+          "$ref": "#/$defs/sha256"
+        },
+        "imported_fingerprint": {
+          "$ref": "#/$defs/sha256"
+        }
+      },
+      "additionalProperties": false
+    },
+    "equivalence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_project_fingerprint",
+        "imported_project_fingerprint"
+      ],
+      "properties": {
+        "source_project_fingerprint": {
+          "$ref": "#/$defs/sha256"
+        },
+        "imported_project_fingerprint": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "storage_attribution": {
+      "$ref": "#/$defs/storageAttribution"
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 17,
+      "maxItems": 32,
+      "items": {
+        "$ref": "#/$defs/phase"
+      }
+    },
+    "envelope": {
+      "type": "object",
+      "required": [
+        "peak_rss_bytes",
+        "peak_disk_bytes",
+        "peak_disk_source",
+        "wall_time_s"
+      ],
+      "properties": {
+        "peak_rss_bytes": {
+          "type": "integer",
+          "maximum": 137438953472
+        },
+        "peak_disk_bytes": {
+          "type": "integer",
+          "maximum": 1099511627776
+        },
+        "peak_disk_source": {
+          "const": "storage_owned_active_identity_union"
+        },
+        "wall_time_s": {
+          "type": "number",
+          "maximum": 14400
+        }
+      },
+      "additionalProperties": false
+    },
+    "result": {
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
+    "first_failure": {
+      "type": [
+        "object",
+        "null"
+      ]
+    }
   },
   "$defs": {
-    "sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
-    "nonNegative": { "type": "integer", "minimum": 0 },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "nonNegative": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 18446744073709551615
+    },
     "artifactTotals": {
-      "type": "object", "additionalProperties": false,
-      "required": ["logical_references", "logical_bytes", "physical_objects", "physical_logical_bytes", "allocated_bytes"],
-      "properties": { "logical_references": { "$ref": "#/$defs/nonNegative" }, "logical_bytes": { "$ref": "#/$defs/nonNegative" }, "physical_objects": { "$ref": "#/$defs/nonNegative" }, "physical_logical_bytes": { "$ref": "#/$defs/nonNegative" }, "allocated_bytes": { "$ref": "#/$defs/nonNegative" } }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "logical_references",
+        "logical_bytes",
+        "physical_objects",
+        "physical_logical_bytes",
+        "allocated_bytes"
+      ],
+      "properties": {
+        "logical_references": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "logical_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "physical_objects": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "physical_logical_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "allocated_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        }
+      }
     },
     "artifactCategories": {
-      "type": "object", "additionalProperties": false,
-      "required": ["topology_nodes", "topology_edges", "properties", "uuid_and_surrogates", "adjacency", "catalog_and_manifests", "construction_staging", "portable_package", "clean_imported_project", "other"],
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "topology_nodes",
+        "topology_edges",
+        "properties",
+        "uuid_and_surrogates",
+        "adjacency",
+        "catalog_and_manifests",
+        "construction_staging",
+        "portable_package",
+        "clean_imported_project",
+        "other"
+      ],
       "properties": {
-        "topology_nodes": { "$ref": "#/$defs/artifactTotals" }, "topology_edges": { "$ref": "#/$defs/artifactTotals" }, "properties": { "$ref": "#/$defs/artifactTotals" }, "uuid_and_surrogates": { "$ref": "#/$defs/artifactTotals" }, "adjacency": { "$ref": "#/$defs/artifactTotals" }, "catalog_and_manifests": { "$ref": "#/$defs/artifactTotals" }, "construction_staging": { "$ref": "#/$defs/artifactTotals" }, "portable_package": { "$ref": "#/$defs/artifactTotals" }, "clean_imported_project": { "$ref": "#/$defs/artifactTotals" }, "other": { "$ref": "#/$defs/artifactTotals" }
+        "topology_nodes": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "topology_edges": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "properties": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "uuid_and_surrogates": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "adjacency": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "catalog_and_manifests": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "construction_staging": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "portable_package": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "clean_imported_project": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "other": {
+          "$ref": "#/$defs/artifactTotals"
+        }
       }
     },
     "snapshot": {
-      "type": "object", "additionalProperties": false,
-      "required": ["generation_manifest_sha256", "categories", "logical_references", "logical_bytes", "physical_objects", "physical_logical_bytes", "allocated_bytes"],
-      "properties": { "generation_manifest_sha256": { "type": "array", "minItems": 32, "maxItems": 32, "items": { "type": "integer", "minimum": 0, "maximum": 255 } }, "categories": { "$ref": "#/$defs/artifactCategories" }, "logical_references": { "$ref": "#/$defs/nonNegative" }, "logical_bytes": { "$ref": "#/$defs/nonNegative" }, "physical_objects": { "$ref": "#/$defs/nonNegative" }, "physical_logical_bytes": { "$ref": "#/$defs/nonNegative" }, "allocated_bytes": { "$ref": "#/$defs/nonNegative" } }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "generation_manifest_sha256",
+        "categories",
+        "logical_references",
+        "logical_bytes",
+        "physical_objects",
+        "physical_logical_bytes",
+        "allocated_bytes",
+        "category_authorities",
+        "category_authority_sha256",
+        "category_authority_context"
+      ],
+      "properties": {
+        "generation_manifest_sha256": {
+          "type": "array",
+          "minItems": 32,
+          "maxItems": 32,
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          }
+        },
+        "categories": {
+          "$ref": "#/$defs/artifactCategories"
+        },
+        "logical_references": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "logical_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "physical_objects": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "physical_logical_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "allocated_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "category_authorities": {
+          "$ref": "#/$defs/artifactCategories"
+        },
+        "category_authority_sha256": {
+          "$ref": "#/$defs/categoryCommitments"
+        },
+        "category_authority_context": {
+          "$ref": "#/$defs/categoryAuthorityContext"
+        }
+      }
     },
     "portableAllocation": {
-      "type": "object", "additionalProperties": false,
-      "required": ["category", "logical_bytes", "allocated_bytes", "logical_references", "physical_objects", "source"],
-      "properties": { "category": { "const": "portable_package" }, "logical_bytes": { "$ref": "#/$defs/nonNegative" }, "allocated_bytes": { "$ref": "#/$defs/nonNegative" }, "logical_references": { "$ref": "#/$defs/nonNegative" }, "physical_objects": { "$ref": "#/$defs/nonNegative" }, "source": { "const": "portable_writer_receipt" } }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "category",
+        "logical_bytes",
+        "allocated_bytes",
+        "logical_references",
+        "physical_objects",
+        "source",
+        "category_authority",
+        "category_authority_sha256",
+        "category_authority_context"
+      ],
+      "properties": {
+        "category": {
+          "const": "portable_package"
+        },
+        "logical_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "allocated_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "logical_references": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "physical_objects": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "source": {
+          "const": "portable_writer_receipt"
+        },
+        "category_authority": {
+          "$ref": "#/$defs/artifactTotals"
+        },
+        "category_authority_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "category_authority_context": {
+          "$ref": "#/$defs/categoryAuthorityContext"
+        }
+      }
     },
     "phaseTotals": {
-      "type": "object", "additionalProperties": false,
-      "required": ["read_bytes", "write_bytes", "read_calls", "write_calls", "object_count", "block_count", "fsync_calls"],
-      "properties": { "read_bytes": { "$ref": "#/$defs/nonNegative" }, "write_bytes": { "$ref": "#/$defs/nonNegative" }, "read_calls": { "$ref": "#/$defs/nonNegative" }, "write_calls": { "$ref": "#/$defs/nonNegative" }, "object_count": { "$ref": "#/$defs/nonNegative" }, "block_count": { "$ref": "#/$defs/nonNegative" }, "fsync_calls": { "$ref": "#/$defs/nonNegative" } }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "read_bytes",
+        "write_bytes",
+        "read_calls",
+        "write_calls",
+        "object_count",
+        "block_count",
+        "fsync_calls"
+      ],
+      "properties": {
+        "read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "write_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "read_calls": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "write_calls": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "object_count": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "block_count": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "fsync_calls": {
+          "$ref": "#/$defs/nonNegative"
+        }
+      }
     },
     "phaseMap": {
-      "type": "object", "additionalProperties": false,
-      "required": ["append_merge", "seal_authentication", "shape_consume_reauthentication", "encode_write_postwrite_authentication", "publication_preauthentication", "cas_install_read_write", "hydration_verification", "fsync_synchronization", "recovery_reauthentication"],
-      "properties": { "append_merge": { "$ref": "#/$defs/phaseTotals" }, "seal_authentication": { "$ref": "#/$defs/phaseTotals" }, "shape_consume_reauthentication": { "$ref": "#/$defs/phaseTotals" }, "encode_write_postwrite_authentication": { "$ref": "#/$defs/phaseTotals" }, "publication_preauthentication": { "$ref": "#/$defs/phaseTotals" }, "cas_install_read_write": { "$ref": "#/$defs/phaseTotals" }, "hydration_verification": { "$ref": "#/$defs/phaseTotals" }, "fsync_synchronization": { "$ref": "#/$defs/phaseTotals" }, "recovery_reauthentication": { "$ref": "#/$defs/phaseTotals" } }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "append_merge",
+        "seal_authentication",
+        "shape_consume_reauthentication",
+        "encode_write_postwrite_authentication",
+        "publication_preauthentication",
+        "cas_install_read_write",
+        "hydration_verification",
+        "fsync_synchronization",
+        "recovery_reauthentication"
+      ],
+      "properties": {
+        "append_merge": {
+          "$ref": "#/$defs/phaseTotals"
+        },
+        "seal_authentication": {
+          "$ref": "#/$defs/phaseTotals"
+        },
+        "shape_consume_reauthentication": {
+          "$ref": "#/$defs/phaseTotals"
+        },
+        "encode_write_postwrite_authentication": {
+          "$ref": "#/$defs/phaseTotals"
+        },
+        "publication_preauthentication": {
+          "$ref": "#/$defs/phaseTotals"
+        },
+        "cas_install_read_write": {
+          "$ref": "#/$defs/phaseTotals"
+        },
+        "hydration_verification": {
+          "$ref": "#/$defs/phaseTotals"
+        },
+        "fsync_synchronization": {
+          "$ref": "#/$defs/phaseTotals"
+        },
+        "recovery_reauthentication": {
+          "$ref": "#/$defs/phaseTotals"
+        }
+      }
     },
     "phaseAttribution": {
-      "type": "object", "additionalProperties": false, "required": ["phases", "totals"],
-      "properties": { "phases": { "$ref": "#/$defs/phaseMap" }, "totals": { "$ref": "#/$defs/phaseTotals" } }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "phases",
+        "totals"
+      ],
+      "properties": {
+        "phases": {
+          "$ref": "#/$defs/phaseMap"
+        },
+        "totals": {
+          "$ref": "#/$defs/phaseTotals"
+        }
+      }
     },
     "construction": {
-      "type": "object", "additionalProperties": false,
-      "required": ["seal_application_read_bytes", "shape_application_read_bytes", "encode_application_read_bytes", "encode_application_read_operations", "encode_application_write_bytes", "encode_application_write_operations", "encode_fsync_operations", "publication_application_read_bytes", "publication_application_read_operations", "cas_application_read_bytes", "cas_application_read_operations", "cas_application_write_bytes", "cas_application_write_operations", "cas_fsync_operations", "hydration_application_read_bytes", "hydration_application_read_operations", "hydration_application_write_bytes", "hydration_application_write_operations", "hydration_fsync_operations", "recovery_application_read_bytes", "recovery_application_read_operations", "canonical_output_bytes", "staged_and_retained_disk_bytes", "storage_current", "storage_transient_peak_allocated_bytes", "storage_transient_peak_total_allocated_bytes", "input_rows", "input_batches", "parquet_shards", "write_bytes", "write_operations", "fsync_operations", "authentication_read_bytes", "authentication_read_operations", "parent_catalog_read_bytes", "parent_catalog_read_operations", "retained_probe_read_bytes", "retained_probe_block_loads", "shaped_output_authentication_bytes", "shaped_output_authentication_operations", "replay_validation_read_bytes", "replay_validation_read_operations", "shape_input_validation_read_bytes", "shape_input_validation_read_operations", "run_records", "peak_batch_rows", "peak_batch_bytes", "peak_run_records", "prior_topology_rows_decoded", "current_transitions", "replayed_chunks", "merge_read_records", "merge_read_operations", "merge_written_records", "merge_write_operations", "merge_groups", "peak_merge_inputs", "merge_read_bytes", "merge_written_bytes", "merge_read_blocks", "merge_write_blocks", "merge_passes", "peak_merge_temporary_bytes", "current_merge_temporary_allocated_bytes", "peak_accounted_live_bytes", "peak_merge_name_slots", "peak_resolved_endpoint_name_slots", "peak_catalog_entries", "peak_catalog_identifier_bytes", "peak_catalog_decoded_batch_bytes", "merge_fsync_operations", "parquet_read_bytes", "parquet_read_operations", "parquet_write_bytes", "parquet_write_operations"],
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "seal_application_read_bytes",
+        "shape_application_read_bytes",
+        "encode_application_read_bytes",
+        "encode_application_read_operations",
+        "encode_application_write_bytes",
+        "encode_application_write_operations",
+        "encode_fsync_operations",
+        "publication_application_read_bytes",
+        "publication_application_read_operations",
+        "cas_application_read_bytes",
+        "cas_application_read_operations",
+        "cas_application_write_bytes",
+        "cas_application_write_operations",
+        "cas_fsync_operations",
+        "hydration_application_read_bytes",
+        "hydration_application_read_operations",
+        "hydration_application_write_bytes",
+        "hydration_application_write_operations",
+        "hydration_fsync_operations",
+        "recovery_application_read_bytes",
+        "recovery_application_read_operations",
+        "canonical_output_bytes",
+        "staged_and_retained_disk_bytes",
+        "storage_current",
+        "storage_transient_peak_allocated_bytes",
+        "storage_transient_peak_total_allocated_bytes",
+        "input_rows",
+        "input_batches",
+        "parquet_shards",
+        "write_bytes",
+        "write_operations",
+        "fsync_operations",
+        "authentication_read_bytes",
+        "authentication_read_operations",
+        "parent_catalog_read_bytes",
+        "parent_catalog_read_operations",
+        "retained_probe_read_bytes",
+        "retained_probe_block_loads",
+        "shaped_output_authentication_bytes",
+        "shaped_output_authentication_operations",
+        "replay_validation_read_bytes",
+        "replay_validation_read_operations",
+        "shape_input_validation_read_bytes",
+        "shape_input_validation_read_operations",
+        "run_records",
+        "peak_batch_rows",
+        "peak_batch_bytes",
+        "peak_run_records",
+        "prior_topology_rows_decoded",
+        "current_transitions",
+        "replayed_chunks",
+        "merge_read_records",
+        "merge_read_operations",
+        "merge_written_records",
+        "merge_write_operations",
+        "merge_groups",
+        "peak_merge_inputs",
+        "merge_read_bytes",
+        "merge_written_bytes",
+        "merge_read_blocks",
+        "merge_write_blocks",
+        "merge_passes",
+        "peak_merge_temporary_bytes",
+        "current_merge_temporary_allocated_bytes",
+        "peak_accounted_live_bytes",
+        "peak_merge_name_slots",
+        "peak_resolved_endpoint_name_slots",
+        "peak_catalog_entries",
+        "peak_catalog_identifier_bytes",
+        "peak_catalog_decoded_batch_bytes",
+        "merge_fsync_operations",
+        "parquet_read_bytes",
+        "parquet_read_operations",
+        "parquet_write_bytes",
+        "parquet_write_operations",
+        "canonical_artifact_objects",
+        "encode_output_fsync_operations",
+        "encode_source_spool_fsync_operations",
+        "encode_membership_fsync_operations",
+        "encode_ordinal_fsync_operations",
+        "hydration_files_copied",
+        "hydration_file_fsync_operations",
+        "hydration_directory_fsync_operations",
+        "encode_output_write_operations",
+        "encode_membership_write_operations",
+        "encode_source_spool_write_operations",
+        "encode_ordinal_artifact_write_operations",
+        "encode_ordinal_publication_write_operations",
+        "storage_category_authorities",
+        "storage_transient_peak_authorities",
+        "storage_category_authority_sha256",
+        "storage_transient_peak_authority_sha256",
+        "storage_category_authority_context",
+        "cas_publication_io"
+      ],
       "properties": {
-        "seal_application_read_bytes": { "$ref": "#/$defs/nonNegative" }, "shape_application_read_bytes": { "$ref": "#/$defs/nonNegative" }, "encode_application_read_bytes": { "$ref": "#/$defs/nonNegative" }, "encode_application_read_operations": { "$ref": "#/$defs/nonNegative" }, "encode_application_write_bytes": { "$ref": "#/$defs/nonNegative" }, "encode_application_write_operations": { "$ref": "#/$defs/nonNegative" }, "encode_fsync_operations": { "$ref": "#/$defs/nonNegative" }, "publication_application_read_bytes": { "$ref": "#/$defs/nonNegative" }, "publication_application_read_operations": { "$ref": "#/$defs/nonNegative" }, "cas_application_read_bytes": { "$ref": "#/$defs/nonNegative" }, "cas_application_read_operations": { "$ref": "#/$defs/nonNegative" }, "cas_application_write_bytes": { "$ref": "#/$defs/nonNegative" }, "cas_application_write_operations": { "$ref": "#/$defs/nonNegative" }, "cas_fsync_operations": { "$ref": "#/$defs/nonNegative" }, "hydration_application_read_bytes": { "$ref": "#/$defs/nonNegative" }, "hydration_application_read_operations": { "$ref": "#/$defs/nonNegative" }, "hydration_application_write_bytes": { "$ref": "#/$defs/nonNegative" }, "hydration_application_write_operations": { "$ref": "#/$defs/nonNegative" }, "hydration_fsync_operations": { "$ref": "#/$defs/nonNegative" }, "recovery_application_read_bytes": { "$ref": "#/$defs/nonNegative" }, "recovery_application_read_operations": { "$ref": "#/$defs/nonNegative" }, "canonical_output_bytes": { "$ref": "#/$defs/nonNegative" }, "staged_and_retained_disk_bytes": { "$ref": "#/$defs/nonNegative" }, "storage_current": { "$ref": "#/$defs/artifactCategories" }, "storage_transient_peak_allocated_bytes": { "type": "object", "additionalProperties": false, "required": ["topology_nodes", "topology_edges", "properties", "uuid_and_surrogates", "adjacency", "catalog_and_manifests", "construction_staging", "portable_package", "clean_imported_project", "other"], "properties": { "topology_nodes": { "$ref": "#/$defs/nonNegative" }, "topology_edges": { "$ref": "#/$defs/nonNegative" }, "properties": { "$ref": "#/$defs/nonNegative" }, "uuid_and_surrogates": { "$ref": "#/$defs/nonNegative" }, "adjacency": { "$ref": "#/$defs/nonNegative" }, "catalog_and_manifests": { "$ref": "#/$defs/nonNegative" }, "construction_staging": { "$ref": "#/$defs/nonNegative" }, "portable_package": { "$ref": "#/$defs/nonNegative" }, "clean_imported_project": { "$ref": "#/$defs/nonNegative" }, "other": { "$ref": "#/$defs/nonNegative" } } }, "storage_transient_peak_total_allocated_bytes": { "$ref": "#/$defs/nonNegative" },
-        "input_rows": { "$ref": "#/$defs/nonNegative" }, "input_batches": { "$ref": "#/$defs/nonNegative" }, "parquet_shards": { "$ref": "#/$defs/nonNegative" }, "write_bytes": { "$ref": "#/$defs/nonNegative" }, "write_operations": { "$ref": "#/$defs/nonNegative" }, "fsync_operations": { "$ref": "#/$defs/nonNegative" }, "authentication_read_bytes": { "$ref": "#/$defs/nonNegative" }, "authentication_read_operations": { "$ref": "#/$defs/nonNegative" }, "parent_catalog_read_bytes": { "$ref": "#/$defs/nonNegative" }, "parent_catalog_read_operations": { "$ref": "#/$defs/nonNegative" }, "retained_probe_read_bytes": { "$ref": "#/$defs/nonNegative" }, "retained_probe_block_loads": { "$ref": "#/$defs/nonNegative" }, "shaped_output_authentication_bytes": { "$ref": "#/$defs/nonNegative" }, "shaped_output_authentication_operations": { "$ref": "#/$defs/nonNegative" }, "replay_validation_read_bytes": { "$ref": "#/$defs/nonNegative" }, "replay_validation_read_operations": { "$ref": "#/$defs/nonNegative" }, "shape_input_validation_read_bytes": { "$ref": "#/$defs/nonNegative" }, "shape_input_validation_read_operations": { "$ref": "#/$defs/nonNegative" }, "run_records": { "$ref": "#/$defs/nonNegative" }, "peak_batch_rows": { "$ref": "#/$defs/nonNegative" }, "peak_batch_bytes": { "$ref": "#/$defs/nonNegative" }, "peak_run_records": { "$ref": "#/$defs/nonNegative" }, "prior_topology_rows_decoded": { "$ref": "#/$defs/nonNegative" }, "current_transitions": { "$ref": "#/$defs/nonNegative" }, "replayed_chunks": { "$ref": "#/$defs/nonNegative" }, "merge_read_records": { "$ref": "#/$defs/nonNegative" }, "merge_read_operations": { "$ref": "#/$defs/nonNegative" }, "merge_written_records": { "$ref": "#/$defs/nonNegative" }, "merge_write_operations": { "$ref": "#/$defs/nonNegative" }, "merge_groups": { "$ref": "#/$defs/nonNegative" }, "peak_merge_inputs": { "$ref": "#/$defs/nonNegative" }, "merge_read_bytes": { "$ref": "#/$defs/nonNegative" }, "merge_written_bytes": { "$ref": "#/$defs/nonNegative" }, "merge_read_blocks": { "$ref": "#/$defs/nonNegative" }, "merge_write_blocks": { "$ref": "#/$defs/nonNegative" }, "merge_passes": { "$ref": "#/$defs/nonNegative" }, "peak_merge_temporary_bytes": { "$ref": "#/$defs/nonNegative" }, "current_merge_temporary_allocated_bytes": { "$ref": "#/$defs/nonNegative" }, "peak_accounted_live_bytes": { "$ref": "#/$defs/nonNegative" }, "peak_merge_name_slots": { "$ref": "#/$defs/nonNegative" }, "peak_resolved_endpoint_name_slots": { "$ref": "#/$defs/nonNegative" }, "peak_catalog_entries": { "$ref": "#/$defs/nonNegative" }, "peak_catalog_identifier_bytes": { "$ref": "#/$defs/nonNegative" }, "peak_catalog_decoded_batch_bytes": { "$ref": "#/$defs/nonNegative" }, "merge_fsync_operations": { "$ref": "#/$defs/nonNegative" }, "parquet_read_bytes": { "$ref": "#/$defs/nonNegative" }, "parquet_read_operations": { "$ref": "#/$defs/nonNegative" }, "parquet_write_bytes": { "$ref": "#/$defs/nonNegative" }, "parquet_write_operations": { "$ref": "#/$defs/nonNegative" }
+        "seal_application_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "shape_application_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_application_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_application_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_application_write_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_application_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "publication_application_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "publication_application_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "cas_application_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "cas_application_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "cas_application_write_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "cas_application_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "cas_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "hydration_application_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "hydration_application_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "hydration_application_write_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "hydration_application_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "hydration_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "recovery_application_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "recovery_application_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "canonical_output_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "staged_and_retained_disk_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "storage_current": {
+          "$ref": "#/$defs/artifactCategories"
+        },
+        "storage_transient_peak_allocated_bytes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "topology_nodes",
+            "topology_edges",
+            "properties",
+            "uuid_and_surrogates",
+            "adjacency",
+            "catalog_and_manifests",
+            "construction_staging",
+            "portable_package",
+            "clean_imported_project",
+            "other"
+          ],
+          "properties": {
+            "topology_nodes": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "topology_edges": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "properties": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "uuid_and_surrogates": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "adjacency": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "catalog_and_manifests": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "construction_staging": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "portable_package": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "clean_imported_project": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "other": {
+              "$ref": "#/$defs/nonNegative"
+            }
+          }
+        },
+        "storage_transient_peak_total_allocated_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "input_rows": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "input_batches": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "parquet_shards": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "write_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "authentication_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "authentication_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "parent_catalog_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "parent_catalog_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "retained_probe_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "retained_probe_block_loads": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "shaped_output_authentication_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "shaped_output_authentication_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "replay_validation_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "replay_validation_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "shape_input_validation_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "shape_input_validation_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "run_records": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_batch_rows": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_batch_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_run_records": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "prior_topology_rows_decoded": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "current_transitions": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "replayed_chunks": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_read_records": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_written_records": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_groups": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_merge_inputs": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_written_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_read_blocks": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_write_blocks": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_passes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_merge_temporary_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "current_merge_temporary_allocated_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_accounted_live_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_merge_name_slots": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_resolved_endpoint_name_slots": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_catalog_entries": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_catalog_identifier_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "peak_catalog_decoded_batch_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "merge_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "parquet_read_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "parquet_read_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "parquet_write_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "parquet_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "canonical_artifact_objects": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_output_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_source_spool_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_membership_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_ordinal_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "hydration_files_copied": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "hydration_file_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "hydration_directory_fsync_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_output_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_membership_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_source_spool_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_ordinal_artifact_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "encode_ordinal_publication_write_operations": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "storage_category_authorities": {
+          "$ref": "#/$defs/artifactCategories"
+        },
+        "storage_transient_peak_authorities": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "topology_nodes",
+            "topology_edges",
+            "properties",
+            "uuid_and_surrogates",
+            "adjacency",
+            "catalog_and_manifests",
+            "construction_staging",
+            "portable_package",
+            "clean_imported_project",
+            "other"
+          ],
+          "properties": {
+            "topology_nodes": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "topology_edges": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "properties": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "uuid_and_surrogates": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "adjacency": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "catalog_and_manifests": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "construction_staging": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "portable_package": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "clean_imported_project": {
+              "$ref": "#/$defs/nonNegative"
+            },
+            "other": {
+              "$ref": "#/$defs/nonNegative"
+            }
+          }
+        },
+        "storage_category_authority_sha256": {
+          "$ref": "#/$defs/categoryCommitments"
+        },
+        "storage_transient_peak_authority_sha256": {
+          "$ref": "#/$defs/categoryCommitments"
+        },
+        "storage_category_authority_context": {
+          "$ref": "#/$defs/categoryAuthorityContext"
+        },
+        "cas_publication_io": {
+          "$ref": "#/$defs/casPublicationIo"
+        }
       }
     },
     "storageAttribution": {
-      "type": "object", "additionalProperties": false,
-      "required": ["source", "source_project_current_allocated_bytes", "portable_package", "clean_import", "construction", "application_io_phases", "workspace_current_allocated_bytes"],
-      "properties": { "source": { "$ref": "#/$defs/snapshot" }, "source_project_current_allocated_bytes": { "$ref": "#/$defs/nonNegative" }, "portable_package": { "$ref": "#/$defs/portableAllocation" }, "clean_import": { "$ref": "#/$defs/snapshot" }, "construction": { "$ref": "#/$defs/construction" }, "application_io_phases": { "$ref": "#/$defs/phaseAttribution" }, "workspace_current_allocated_bytes": { "$ref": "#/$defs/nonNegative" } }
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "source_project_current_allocated_bytes",
+        "portable_package",
+        "clean_import",
+        "construction",
+        "application_io_phases",
+        "workspace_current_allocated_bytes",
+        "workspace_peak_allocated_bytes",
+        "workspace_components"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/snapshot"
+        },
+        "source_project_current_allocated_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "portable_package": {
+          "$ref": "#/$defs/portableAllocation"
+        },
+        "clean_import": {
+          "$ref": "#/$defs/snapshot"
+        },
+        "construction": {
+          "$ref": "#/$defs/construction"
+        },
+        "application_io_phases": {
+          "$ref": "#/$defs/phaseAttribution"
+        },
+        "workspace_current_allocated_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "workspace_peak_allocated_bytes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "workspace_components": {
+          "$ref": "#/$defs/workspaceComponents"
+        }
+      }
     },
-    "phase": { "type": "object", "additionalProperties": false, "required": ["id", "status", "elapsed_ms", "rss_peak_bytes", "disk_peak_bytes"], "properties": { "id": { "type": "string", "pattern": "^[a-z0-9_-]+$" }, "status": { "enum": ["pass", "fail", "cancelled"] }, "elapsed_ms": { "type": "integer", "minimum": 0 }, "rss_peak_bytes": { "type": "integer", "minimum": 0 }, "disk_peak_bytes": { "type": "integer", "minimum": 0 }, "fingerprint": { "anyOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] }, "failure_code": { "type": ["string", "null"], "maxLength": 96 } } }
+    "phase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "status",
+        "elapsed_ms",
+        "rss_peak_bytes",
+        "disk_peak_bytes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]+$"
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "fail",
+            "cancelled"
+          ]
+        },
+        "elapsed_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "rss_peak_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "disk_peak_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "fingerprint": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/sha256"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "failure_code": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 96
+        }
+      }
+    },
+    "workspaceComponents": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_project_and_construction",
+        "portable_package",
+        "clean_import_project",
+        "drill_project_and_construction",
+        "drill_package",
+        "corrupt_drill_package"
+      ],
+      "properties": {
+        "source_project_and_construction": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "portable_package": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "clean_import_project": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "drill_project_and_construction": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "drill_package": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "corrupt_drill_package": {
+          "$ref": "#/$defs/nonNegative"
+        }
+      }
+    },
+    "categoryCommitments": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "topology_nodes",
+        "topology_edges",
+        "properties",
+        "uuid_and_surrogates",
+        "adjacency",
+        "catalog_and_manifests",
+        "construction_staging",
+        "portable_package",
+        "clean_imported_project",
+        "other"
+      ],
+      "properties": {
+        "topology_nodes": {
+          "$ref": "#/$defs/sha256"
+        },
+        "topology_edges": {
+          "$ref": "#/$defs/sha256"
+        },
+        "properties": {
+          "$ref": "#/$defs/sha256"
+        },
+        "uuid_and_surrogates": {
+          "$ref": "#/$defs/sha256"
+        },
+        "adjacency": {
+          "$ref": "#/$defs/sha256"
+        },
+        "catalog_and_manifests": {
+          "$ref": "#/$defs/sha256"
+        },
+        "construction_staging": {
+          "$ref": "#/$defs/sha256"
+        },
+        "portable_package": {
+          "$ref": "#/$defs/sha256"
+        },
+        "clean_imported_project": {
+          "$ref": "#/$defs/sha256"
+        },
+        "other": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "categoryAuthorityContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract",
+        "version",
+        "rung",
+        "generation_sha256",
+        "owner",
+        "receipt_authority_sha256",
+        "native_identity_authority_sha256",
+        "native_category_identity_authority_sha256",
+        "live_nodes",
+        "live_edges"
+      ],
+      "properties": {
+        "contract": {
+          "const": "graphforge-lifecycle-category-authority/2"
+        },
+        "version": {
+          "const": 1
+        },
+        "rung": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "generation_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "owner": {
+          "enum": [
+            "source",
+            "clean_import",
+            "construction",
+            "portable_package"
+          ]
+        },
+        "receipt_authority_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "native_identity_authority_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "live_nodes": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "live_edges": {
+          "$ref": "#/$defs/nonNegative"
+        },
+        "native_category_identity_authority_sha256": {
+          "$ref": "#/$defs/categoryCommitments"
+        }
+      },
+      "description": "Sanitized storage-owned context derived while native receipt identities are authenticated. It binds category commitments to receipt and identity-membership roots without exposing identities. These fields provide internal consistency only: certification authority comes from the externally authenticated provider-result SHA-256, whose graphforge_sha256 artifact member binds the exact ordinary evidence bytes."
+    },
+    "casIoTotals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "read_bytes",
+        "read_calls",
+        "write_bytes",
+        "write_calls",
+        "file_fsync_calls",
+        "directory_fsync_calls",
+        "installed_objects",
+        "reused_objects",
+        "installed_bytes",
+        "install_attempts"
+      ],
+      "properties": {
+        "read_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "read_calls": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "write_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "write_calls": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "file_fsync_calls": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "directory_fsync_calls": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "installed_objects": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "reused_objects": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "installed_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "install_attempts": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        }
+      }
+    },
+    "casPublicationIo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "payload",
+        "manifest",
+        "manifest_reads",
+        "publications",
+        "initial_entries",
+        "changed_paths"
+      ],
+      "properties": {
+        "payload": {
+          "$ref": "#/$defs/casIoTotals"
+        },
+        "manifest": {
+          "$ref": "#/$defs/casIoTotals"
+        },
+        "manifest_reads": {
+          "$ref": "#/$defs/casIoTotals"
+        },
+        "publications": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "initial_entries": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        },
+        "changed_paths": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 18446744073709551615
+        }
+      }
+    }
   }
 }

--- a/docs/development/g500-certification.md
+++ b/docs/development/g500-certification.md
@@ -140,6 +140,77 @@ shards, accepted rows/batches, writes, and authentication reads. Adjacent
 1x/2x/4x observations must show bounded resident windows and topology work that
 scales with rows; continued material RSS growth with edge count is a failure.
 
+The deterministic 1x/2x/4x check retains raw, independently reopened node and
+edge denominators. CAS read/write bytes keep the aggregate affine-growth check;
+payload call counts keep the buffered-growth check. The CAS phase is also the
+exact sum of payload installation, immutable manifest installation, and manifest
+path reads. Fresh and reused objects have separate counts. File synchronization
+includes actual cache-window rollovers; each completed temporary installation
+attempt additionally has two namespace barriers. Early reuse performs only
+authentication. A concurrent losing publisher retains its actual temporary
+writes and barriers while reporting zero newly installed bytes and one reused
+object. Opening a prior manifest records its actual read submissions.
+
+Manifest control work is bounded by the native Patricia protocol, rather than
+requiring every content-dependent path length to increase between rungs. This
+qualification accepts exactly one publication from an empty manifest, with its
+measured changed-path count equal to the canonical payload inventory `P`.
+Repeated publications, prior entries, and additional tombstones cannot borrow
+this bound. Each recursive branch consumes at least one of 64 digest nibbles;
+a split installs at most three nodes and a collapse reads at most one extra
+child per level. Thus install requests are at most `67P + 1` (including the
+empty bootstrap root), and update reads at most `130P`.
+The bootstrap and every changed path also require at least `P + 1` manifest
+install-or-reuse requests and at least `P` existing-root reads. A coherent
+omission of all metadata work therefore fails even if its reduced totals agree.
+
+The authenticated encoding-inventory byte count `I` bounds the shared path,
+digest and length values for all entries, including a hash-collision leaf.
+Changing its artifact keys to manifest-entry keys adds 23 bytes; the longest
+role member adds 20, for 43 bytes per entry. JSON escaping of the shared values
+is identical in both encodings. The largest valid branch, with 16 digest
+references and a 63-nibble compressed prefix, is 1319 bytes including its
+newline; this also exceeds the leaf header. A node is therefore bounded by
+`I + 43P + 1319` bytes. Native maximal-encoding tests check every depth, role,
+escaped and Unicode paths, and zero/u64-maximum lengths. Manifest bytes are
+bounded by this node ceiling times the request bounds, and nonempty reads by
+the actual 64 KiB buffer limits. Coherent component overcounts fail even when
+their aggregate totals agree. Metadata remains in the aggregate byte-growth
+check and every synchronization total.
+
+The controlled ladder varies nodes by adding isolated nodes while keeping its
+edge set fixed. Its sparse CSR adjacency therefore bears the edge axis; this is
+a fixture-specific rule, not a claim that arbitrary added nodes never change
+adjacency storage. Hydration authenticates all objects but copies only the
+private ordinal-V4 node maps; other immutable files are hardlinked. Hydration
+write bytes consequently bear the node axis and remain positive and constant
+on this fixture's edge axis. Read, submission, and barrier checks remain tied
+to actual native work. Catalog object counts remain fixed, while decimal
+lengths in their manifests can gain digits. Catalog bytes must remain positive
+and below the existing normalized denominator ceiling; allocated bytes retain
+the filesystem quantization checks. Source/import categories still reconcile
+field-for-field with storage-owned authorities. Coherently changing those
+ledgers to zero or excessive growth does not bypass the policy tests.
+
+Completed construction retains authenticated shape/merge files for replay.
+Their current allocated bytes are measured against the retained native file
+inventory and checked with filesystem allocation quantization, alongside the
+other retained outputs; this counter is not structurally zero. Intermediate
+merge input removals subtract their actual allocations.
+
+Ordered query admission recognizes the explicit `ordered_one_hop` and
+`ordered_two_hop` leaf families alongside the existing Expand/sort paths. The
+leaves report zero Arrow input batches and rows, actual candidate visits,
+positive bounded identity reads, and their own RSS samples. Destination-degree
+probes include empty rows and are bounded by the authoritative reopened node
+count, independently of the output limit. For the fixture's unrestricted
+directed one-hop query, actual result rows and emitted/candidate counts equal
+`min(K, reopened live edges)`: a small graph cannot supply K distinct edge
+matches. The provider ladder still requires its full K-row outcome. One-hop
+emits exactly its counted candidates; two-hop retains the existing candidate-overhead ceiling. Missing
+RSS, fake input work, omitted probes or reads, and materializing scans fail the
+optimized-family regression checks.
+
 Fingerprint reconciliation is explicit: source and imported durable generation
 IDs are distinct; semantic package and transport digests are distinct;
 ontology/capability authority fingerprints match; canonical source/imported
@@ -153,6 +224,19 @@ mismatches, query-fingerprint drift, identity collapse, unsafe paths, sensitive
 fields, insufficient hosts, and envelope overruns. Project payloads, bundles,
 spills, secrets, credentials, absolute host paths, and mutable runner state are
 not evidence and must never be committed.
+
+Category authority follows one closed provenance chain. Storage derives the
+per-category aggregate ledger and identity-membership roots while authenticating
+native receipt identities. The ordinary GraphForge evidence preserves only
+those aggregates, roots, denominators, and domain-separated commitments. The
+provider result records SHA-256 of the exact ordinary evidence bytes in
+`artifacts.graphforge_sha256`; trusted transport or an immutable manifest
+supplies SHA-256 of that provider result independently of the evidence bundle.
+`validate-g500-certification.py` first verifies this external provider-result
+anchor and artifact binding, then validates the sanitized category proof. A
+category map, commitment map, or authority context supplied beside the evidence
+is never an independent trust anchor. Without the externally anchored provider
+result, category certification fails closed.
 
 Local developer runs validate the small lifecycle and hostile fixtures only;
 they are not certification evidence and cannot close #745.

--- a/scripts/ci/test-validate-g500-certification.py
+++ b/scripts/ci/test-validate-g500-certification.py
@@ -5,7 +5,7 @@ import importlib.util
 import json
 from pathlib import Path
 
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, ValidationError
 import pytest
 
 SCRIPT = Path(__file__).with_name("validate-g500-certification.py")
@@ -17,6 +17,32 @@ SPEC.loader.exec_module(VALIDATOR)
 SHA = "a" * 40
 DIGEST_A = "sha256:" + "a" * 64
 DIGEST_B = "sha256:" + "b" * 64
+HEX_A = "a" * 64
+HEX_B = "b" * 64
+CATEGORY_NAMES = (
+    "topology_nodes",
+    "topology_edges",
+    "properties",
+    "uuid_and_surrogates",
+    "adjacency",
+    "catalog_and_manifests",
+    "construction_staging",
+    "portable_package",
+    "clean_imported_project",
+    "other",
+)
+CATEGORY_AUTHORITY_CONTEXT_FIELDS = (
+    "contract",
+    "version",
+    "rung",
+    "generation_sha256",
+    "owner",
+    "receipt_authority_sha256",
+    "native_identity_authority_sha256",
+    "native_category_identity_authority_sha256",
+    "live_nodes",
+    "live_edges",
+)
 
 
 def artifact_totals(unit=1):
@@ -29,35 +55,89 @@ def artifact_totals(unit=1):
     }
 
 
-def storage_attribution(unit=1):
-    category_names = (
-        "topology_nodes",
-        "topology_edges",
-        "properties",
-        "uuid_and_surrogates",
-        "adjacency",
-        "catalog_and_manifests",
-        "construction_staging",
-        "portable_package",
-        "clean_imported_project",
-        "other",
+def authority_context(owner, scale, live):
+    identity_authority = (
+        DIGEST_B if owner in ("source", "construction", "portable_package") else DIGEST_A
     )
+    return {
+        "contract": "graphforge-lifecycle-category-authority/2",
+        "version": 1,
+        "rung": scale,
+        "generation_sha256": DIGEST_A,
+        "owner": owner,
+        "receipt_authority_sha256": (
+            DIGEST_A if owner in ("source", "construction", "portable_package") else DIGEST_B
+        ),
+        "native_identity_authority_sha256": identity_authority,
+        "native_category_identity_authority_sha256": dict.fromkeys(
+            CATEGORY_NAMES, identity_authority
+        ),
+        "live_nodes": 1 << scale,
+        "live_edges": live,
+    }
+
+
+def category_commitment(context, category, totals):
+    return VALIDATOR.category_commitment(context, category, totals)
+
+
+def peak_commitment(context, category, allocated_bytes):
+    return VALIDATOR.peak_commitment(context, category, allocated_bytes)
+
+
+def storage_attribution(scale, live, unit=1):
     categories = {
-        name: artifact_totals(unit if index < 6 else 0) for index, name in enumerate(category_names)
+        name: artifact_totals(unit if index < 6 else 0) for index, name in enumerate(CATEGORY_NAMES)
     }
-    snapshot = {
-        "generation_manifest_sha256": [1] * 32,
-        "categories": categories,
-        "logical_references": 6 * unit,
-        "logical_bytes": 6 * unit,
-        "physical_objects": 6 * unit,
-        "physical_logical_bytes": 6 * unit,
-        "allocated_bytes": 6 * unit,
-    }
+
+    def snapshot(owner):
+        context = authority_context(owner, scale, live)
+        return {
+            "generation_manifest_sha256": [1] * 32,
+            "categories": categories,
+            "category_authorities": categories,
+            "category_authority_context": context,
+            "category_authority_sha256": {
+                name: category_commitment(context, name, totals)
+                for name, totals in categories.items()
+            },
+            "logical_references": 6 * unit,
+            "logical_bytes": 6 * unit,
+            "physical_objects": 6 * unit,
+            "physical_logical_bytes": 6 * unit,
+            "allocated_bytes": 6 * unit,
+        }
+
     contract = json.loads(VALIDATOR.SCHEMA.read_text())
     construction = dict.fromkeys(contract["$defs"]["construction"]["required"], 0)
-    construction["storage_current"] = {name: artifact_totals(unit) for name in category_names}
-    construction["storage_transient_peak_allocated_bytes"] = dict.fromkeys(category_names, unit)
+    construction["cas_publication_io"] = {
+        name: dict.fromkeys(contract["$defs"]["casIoTotals"]["required"], 0)
+        for name in ("payload", "manifest", "manifest_reads")
+    }
+    construction["cas_publication_io"].update(publications=1, initial_entries=0, changed_paths=0)
+    construction["cas_publication_io"]["payload"]["read_bytes"] = unit
+    construction["cas_publication_io"]["payload"]["read_calls"] = unit
+    construction["cas_publication_io"]["manifest"].update(
+        read_bytes=1, read_calls=1, reused_objects=1
+    )
+    construction["cas_application_read_bytes"] = unit + 1
+    construction["cas_application_read_operations"] = unit + 1
+    construction_context = authority_context("construction", scale, live)
+    construction["storage_category_authority_context"] = construction_context
+    construction["storage_current"] = {name: artifact_totals(unit) for name in CATEGORY_NAMES}
+    construction["storage_category_authorities"] = {
+        name: artifact_totals(unit) for name in CATEGORY_NAMES
+    }
+    construction["storage_transient_peak_allocated_bytes"] = dict.fromkeys(CATEGORY_NAMES, unit)
+    construction["storage_transient_peak_authorities"] = dict.fromkeys(CATEGORY_NAMES, unit)
+    construction["storage_category_authority_sha256"] = {
+        name: category_commitment(construction_context, name, totals)
+        for name, totals in construction["storage_category_authorities"].items()
+    }
+    construction["storage_transient_peak_authority_sha256"] = {
+        name: peak_commitment(construction_context, name, value)
+        for name, value in construction["storage_transient_peak_authorities"].items()
+    }
     construction["storage_transient_peak_total_allocated_bytes"] = 10 * unit
     phase_names = contract["$defs"]["phaseMap"]["required"]
     phases = {}
@@ -71,12 +151,14 @@ def storage_attribution(unit=1):
             "block_count": 0,
             "fsync_calls": unit if name == "fsync_synchronization" else 0,
         }
+    phases["cas_install_read_write"]["read_bytes"] += 1
+    phases["cas_install_read_write"]["read_calls"] += 1
     totals = {
         field: sum(values[field] for values in phases.values())
         for field in next(iter(phases.values()))
     }
     return {
-        "source": snapshot,
+        "source": snapshot("source"),
         "source_project_current_allocated_bytes": 7 * unit,
         "portable_package": {
             "category": "portable_package",
@@ -85,11 +167,27 @@ def storage_attribution(unit=1):
             "logical_references": unit,
             "physical_objects": unit,
             "source": "portable_writer_receipt",
+            "category_authority": artifact_totals(unit),
+            "category_authority_context": authority_context("portable_package", scale, live),
+            "category_authority_sha256": category_commitment(
+                authority_context("portable_package", scale, live),
+                "portable_package",
+                artifact_totals(unit),
+            ),
         },
-        "clean_import": snapshot,
+        "clean_import": snapshot("clean_import"),
         "construction": construction,
         "application_io_phases": {"phases": phases, "totals": totals},
         "workspace_current_allocated_bytes": 14 * unit,
+        "workspace_peak_allocated_bytes": 14 * unit,
+        "workspace_components": {
+            "source_project_and_construction": 7 * unit,
+            "portable_package": unit,
+            "clean_import_project": 2 * unit,
+            "drill_project_and_construction": unit,
+            "drill_package": unit,
+            "corrupt_drill_package": 2 * unit,
+        },
     }
 
 
@@ -163,7 +261,7 @@ def evidence(scale=26, unit=1):
             "source_project_fingerprint": DIGEST_A,
             "imported_project_fingerprint": DIGEST_A,
         },
-        "storage_attribution": storage_attribution(unit),
+        "storage_attribution": storage_attribution(scale, live, unit),
         "phases": phases,
         "envelope": {
             "peak_rss_bytes": 1,
@@ -176,12 +274,416 @@ def evidence(scale=26, unit=1):
     }
 
 
+def encoded(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
+def provider_result(evidence_encoded, scale=26):
+    return {
+        "schema": "graphforge-progressive-provider-run-result/1",
+        "rung": f"S{scale}",
+        "status": "passed",
+        "failure": None,
+        "identities": {
+            "commit": SHA,
+            "profile_id": f"graph500-s{scale}-provider",
+            "profile_sha256": HEX_A,
+            "image_digest": f"registry.fly.io/graphforge@sha256:{HEX_A}",
+            "generator": DIGEST_A,
+            "generator_executable_sha256": HEX_A,
+            "gf_sha256": HEX_A,
+            "certify_sha256": HEX_A,
+            "benchexec_python_sha256": HEX_A,
+            "benchexec_version": "3.31",
+            "admitted_plan_sha256": HEX_A,
+            "source_tree_sha256": HEX_A,
+        },
+        "artifacts": {
+            "plan_sha256": HEX_A,
+            "benchexec_sha256": HEX_A,
+            "graphforge_sha256": hashlib.sha256(evidence_encoded).hexdigest(),
+            "rung_sha256": HEX_B,
+        },
+        "claim": "engineering_evidence_only",
+    }
+
+
+def validate(
+    value,
+    expected_sha=SHA,
+    *,
+    evidence_encoded=None,
+    provider=None,
+    expected_provider_result_sha256=None,
+):
+    if evidence_encoded is None:
+        evidence_encoded = encoded(value)
+    if provider is None:
+        provider = provider_result(evidence_encoded, value["run"]["scale"])
+    provider_encoded = encoded(provider)
+    if expected_provider_result_sha256 is None:
+        expected_provider_result_sha256 = hashlib.sha256(provider_encoded).hexdigest()
+    VALIDATOR.validate(
+        evidence_encoded,
+        expected_sha,
+        provider_encoded,
+        expected_provider_result_sha256,
+    )
+
+
 def test_accepts_complete_sanitized_evidence():
     schema = VALIDATOR.ROOT / "docs/development/evidence/g500-certification.schema.json"
     contract = json.loads(schema.read_text())
     Draft202012Validator.check_schema(contract)
     Draft202012Validator(contract).validate(evidence())
-    VALIDATOR.validate(evidence(), SHA)
+    validate(evidence())
+
+
+def test_rejects_missing_external_provider_result_anchor():
+    value = evidence()
+    evidence_encoded = encoded(value)
+    provider_encoded = encoded(provider_result(evidence_encoded))
+    with pytest.raises(
+        VALIDATOR.EvidenceError,
+        match="external provider-result SHA-256 is required",
+    ):
+        VALIDATOR.validate(evidence_encoded, SHA, provider_encoded, None)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "canonical_artifact_objects",
+        "encode_output_fsync_operations",
+        "encode_source_spool_fsync_operations",
+        "encode_membership_fsync_operations",
+        "encode_ordinal_fsync_operations",
+        "hydration_files_copied",
+        "hydration_file_fsync_operations",
+        "hydration_directory_fsync_operations",
+        "encode_output_write_operations",
+        "encode_membership_write_operations",
+        "encode_source_spool_write_operations",
+        "encode_ordinal_artifact_write_operations",
+        "encode_ordinal_publication_write_operations",
+        "storage_category_authorities",
+        "storage_transient_peak_authorities",
+        "storage_category_authority_context",
+        "storage_category_authority_sha256",
+        "storage_transient_peak_authority_sha256",
+    ],
+)
+def test_construction_authority_fields_are_required(field):
+    value = evidence()
+    value["storage_attribution"]["construction"].pop(field)
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing_construction_authority",
+        "extra_construction_authority",
+        "malformed_construction_authority",
+        "missing_workspace_component",
+        "extra_workspace_component",
+        "malformed_workspace_component",
+        "missing_workspace_peak",
+        "malformed_category_commitment",
+        "overflowing_native_counter",
+    ],
+)
+def test_closed_storage_authority_schema_rejects_mutations(mutation):
+    value = evidence()
+    storage = value["storage_attribution"]
+    if mutation == "missing_construction_authority":
+        storage["construction"].pop("canonical_artifact_objects")
+    elif mutation == "extra_construction_authority":
+        storage["construction"]["unknown_authority"] = 1
+    elif mutation == "malformed_construction_authority":
+        storage["construction"]["hydration_file_fsync_operations"] = "1"
+    elif mutation == "missing_workspace_component":
+        storage["workspace_components"].pop("drill_package")
+    elif mutation == "extra_workspace_component":
+        storage["workspace_components"]["other"] = 1
+    elif mutation == "malformed_workspace_component":
+        storage["workspace_components"]["portable_package"] = "1"
+    elif mutation == "missing_workspace_peak":
+        storage.pop("workspace_peak_allocated_bytes")
+    elif mutation == "malformed_category_commitment":
+        storage["source"]["category_authority_sha256"]["topology_nodes"] = "sha256:bad"
+    elif mutation == "overflowing_native_counter":
+        storage["construction"]["canonical_artifact_objects"] = 1 << 64
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize("owner", ("source", "clean_import"))
+@pytest.mark.parametrize(
+    "field",
+    ("category_authorities", "category_authority_context", "category_authority_sha256"),
+)
+def test_snapshot_authority_fields_are_independently_required(owner, field):
+    value = evidence()
+    value["storage_attribution"][owner].pop(field)
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("category_authority", "category_authority_context", "category_authority_sha256"),
+)
+def test_portable_authority_fields_are_independently_required(field):
+    value = evidence()
+    value["storage_attribution"]["portable_package"].pop(field)
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize(
+    ("owner", "field"),
+    (
+        ("source", "category_authority_sha256"),
+        ("clean_import", "category_authority_sha256"),
+        ("construction", "storage_category_authority_sha256"),
+        ("construction", "storage_transient_peak_authority_sha256"),
+    ),
+)
+@pytest.mark.parametrize("category", CATEGORY_NAMES)
+def test_every_commitment_category_member_is_required(owner, field, category):
+    value = evidence()
+    value["storage_attribution"][owner][field].pop(category)
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize(
+    ("owner", "context_field"),
+    (
+        ("source", "category_authority_context"),
+        ("clean_import", "category_authority_context"),
+        ("portable_package", "category_authority_context"),
+        ("construction", "storage_category_authority_context"),
+    ),
+)
+@pytest.mark.parametrize("category", CATEGORY_NAMES)
+def test_every_native_category_identity_commitment_is_required(owner, context_field, category):
+    value = evidence()
+    value["storage_attribution"][owner][context_field][
+        "native_category_identity_authority_sha256"
+    ].pop(category)
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize(
+    ("owner", "context_field"),
+    (
+        ("source", "category_authority_context"),
+        ("clean_import", "category_authority_context"),
+        ("portable_package", "category_authority_context"),
+        ("construction", "storage_category_authority_context"),
+    ),
+)
+@pytest.mark.parametrize("field", CATEGORY_AUTHORITY_CONTEXT_FIELDS)
+def test_every_category_authority_context_member_is_independently_required(
+    owner, context_field, field
+):
+    value = evidence()
+    value["storage_attribution"][owner][context_field].pop(field)
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize("category", CATEGORY_NAMES)
+def test_every_transient_authority_category_is_required(category):
+    value = evidence()
+    value["storage_attribution"]["construction"]["storage_transient_peak_authorities"].pop(category)
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize(
+    "component",
+    (
+        None,
+        "source_project_and_construction",
+        "portable_package",
+        "clean_import_project",
+        "drill_project_and_construction",
+        "drill_package",
+        "corrupt_drill_package",
+    ),
+)
+def test_workspace_component_object_and_members_are_required(component):
+    value = evidence()
+    if component is None:
+        value["storage_attribution"].pop("workspace_components")
+    else:
+        value["storage_attribution"]["workspace_components"].pop(component)
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+@pytest.mark.parametrize(
+    "location",
+    (
+        "host_memory",
+        "raw_attempts",
+        "self_loops_rejected",
+        "envelope_peak",
+        "snapshot_total",
+        "manifest_byte",
+        "artifact_total",
+        "construction_counter",
+        "phase_io_counter",
+        "phase_elapsed",
+        "phase_rss",
+        "phase_disk",
+        "workspace_component",
+    ),
+)
+def test_every_native_u64_schema_shape_rejects_above_u64(location):
+    value = evidence()
+    above_u64 = 1 << 64
+    if location == "host_memory":
+        value["host"]["memory_bytes"] = above_u64
+    elif location in ("raw_attempts", "self_loops_rejected"):
+        value["counts"][location] = above_u64
+    elif location == "envelope_peak":
+        value["envelope"]["peak_rss_bytes"] = above_u64
+    elif location == "snapshot_total":
+        value["storage_attribution"]["source"]["allocated_bytes"] = above_u64
+    elif location == "manifest_byte":
+        value["storage_attribution"]["source"]["generation_manifest_sha256"][0] = 256
+    elif location == "artifact_total":
+        value["storage_attribution"]["source"]["categories"]["topology_nodes"]["logical_bytes"] = (
+            above_u64
+        )
+    elif location == "construction_counter":
+        value["storage_attribution"]["construction"]["canonical_artifact_objects"] = above_u64
+    elif location == "phase_io_counter":
+        value["storage_attribution"]["application_io_phases"]["phases"]["append_merge"][
+            "read_calls"
+        ] = above_u64
+    elif location == "phase_elapsed":
+        value["phases"][0]["elapsed_ms"] = above_u64
+    elif location == "phase_rss":
+        value["phases"][0]["rss_peak_bytes"] = above_u64
+    elif location == "phase_disk":
+        value["phases"][0]["disk_peak_bytes"] = above_u64
+    elif location == "workspace_component":
+        value["storage_attribution"]["workspace_components"]["drill_package"] = above_u64
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(value)
+
+
+def test_every_integer_schema_node_has_an_explicit_native_ceiling():
+    schema = json.loads(VALIDATOR.SCHEMA.read_text())
+    pending = [schema]
+    while pending:
+        item = pending.pop()
+        if isinstance(item, dict):
+            if item.get("type") == "integer":
+                assert "maximum" in item
+                assert item["maximum"] <= (1 << 64) - 1
+            pending.extend(item.values())
+        elif isinstance(item, list):
+            pending.extend(item)
+
+
+def test_rejects_synchronized_category_views_against_fixed_provider_result_anchor():
+    original = evidence()
+    original_encoded = encoded(original)
+    anchored_provider = provider_result(original_encoded)
+    anchored_provider_encoded = encoded(anchored_provider)
+    external_provider_digest = hashlib.sha256(anchored_provider_encoded).hexdigest()
+    value = json.loads(json.dumps(evidence()))
+    for owner in ("source", "clean_import"):
+        for view in ("categories", "category_authorities"):
+            value["storage_attribution"][owner][view]["topology_nodes"]["logical_bytes"] -= 1
+            value["storage_attribution"][owner][view]["topology_edges"]["logical_bytes"] += 1
+        context = value["storage_attribution"][owner]["category_authority_context"]
+        context["receipt_authority_sha256"] = "sha256:" + "f" * 64
+        value["storage_attribution"][owner]["category_authority_sha256"] = {
+            category: category_commitment(
+                context,
+                category,
+                value["storage_attribution"][owner]["category_authorities"][category],
+            )
+            for category in CATEGORY_NAMES
+        }
+    forged_encoded = encoded(value)
+    forged_provider = json.loads(json.dumps(anchored_provider))
+    forged_provider["artifacts"]["graphforge_sha256"] = hashlib.sha256(forged_encoded).hexdigest()
+    with pytest.raises(
+        VALIDATOR.EvidenceError,
+        match="provider result does not match its external anchor",
+    ):
+        validate(
+            value,
+            evidence_encoded=forged_encoded,
+            provider=forged_provider,
+            expected_provider_result_sha256=external_provider_digest,
+        )
+
+
+def test_provider_result_external_digest_authenticates_ordinary_receipt():
+    value = evidence()
+    evidence_encoded = encoded(value)
+    provider = provider_result(evidence_encoded)
+    provider_encoded = encoded(provider)
+    wrong_external_digest = hashlib.sha256(provider_encoded + b"\n").hexdigest()
+    with pytest.raises(
+        VALIDATOR.EvidenceError,
+        match="provider result does not match its external anchor",
+    ):
+        VALIDATOR.validate(
+            evidence_encoded,
+            SHA,
+            provider_encoded,
+            wrong_external_digest,
+        )
+
+
+def test_provider_result_graphforge_digest_binds_exact_ordinary_receipt_bytes():
+    value = evidence()
+    evidence_encoded = encoded(value)
+    provider = provider_result(evidence_encoded)
+    provider["artifacts"]["graphforge_sha256"] = HEX_B
+    provider_encoded = encoded(provider)
+    with pytest.raises(
+        VALIDATOR.EvidenceError,
+        match="ordinary evidence is not bound",
+    ):
+        VALIDATOR.validate(
+            evidence_encoded,
+            SHA,
+            provider_encoded,
+            hashlib.sha256(provider_encoded).hexdigest(),
+        )
+
+
+def test_authenticated_ordinary_receipt_must_match_sanitized_category_proof():
+    value = evidence()
+    value["storage_attribution"]["source"]["categories"]["topology_nodes"]["logical_bytes"] = 0
+    with pytest.raises(
+        VALIDATOR.EvidenceError,
+        match="authority commitment differs",
+    ):
+        validate(value)
 
 
 @pytest.mark.parametrize(
@@ -190,6 +692,11 @@ def test_accepts_complete_sanitized_evidence():
         ("tools", "build", "018f6e45-7f12-7c00-8000-000000000001"),
         ("tools", "build", "00000000-0000-0000-0000-000000000000"),
         ("tools", "build", "/var/lib/graphforge/project"),
+        (
+            "tools",
+            "build",
+            "artifact=0011223344556677:00112233445566778899aabbccddeeff",
+        ),
         ("tools", "machine_id", "redacted"),
         ("tools", "volume-id", "redacted"),
         ("tools", "provider_resource_id", "redacted"),
@@ -199,7 +706,22 @@ def test_recursive_sanitizer_rejects_raw_identity_path_and_sensitive_keys(sectio
     unsafe = evidence()
     unsafe[section][key] = value
     with pytest.raises(VALIDATOR.EvidenceError):
-        VALIDATOR.validate(unsafe, SHA)
+        validate(unsafe)
+
+
+@pytest.mark.parametrize(
+    "tool_value",
+    (
+        "rustc 1.90.0 (1159e78c4 2026-08-01)",
+        "graphforge-certify/0.5.2",
+        "llvm:19.1.7",
+        "sha256:aabbccddeeff00112233445566778899",
+    ),
+)
+def test_recursive_sanitizer_accepts_legitimate_tool_versions(tool_value):
+    value = evidence()
+    value["tools"]["build"] = tool_value
+    validate(value)
 
 
 @pytest.mark.parametrize(
@@ -214,7 +736,7 @@ def test_generation_proofs_are_closed_and_required_true(proof):
     unsafe = evidence()
     unsafe["identities"][proof] = False
     with pytest.raises(VALIDATOR.EvidenceError):
-        VALIDATOR.validate(unsafe, SHA)
+        validate(unsafe)
 
 
 @pytest.mark.parametrize(
@@ -317,11 +839,99 @@ def test_rejects_incomplete_or_unsafe_evidence(mutation):
     if mutation == "malformed_kernel":
         value["host"]["kernel"] = "6.8.0\nforged"
     with pytest.raises(VALIDATOR.EvidenceError):
-        VALIDATOR.validate(value, SHA)
+        validate(value)
 
 
 def test_requires_expected_sha():
     with pytest.raises(VALIDATOR.EvidenceError, match="expected-sha"):
-        VALIDATOR.validate(evidence(), None)
+        validate(evidence(), None)
     with pytest.raises(VALIDATOR.EvidenceError, match="40-hex"):
-        VALIDATOR.validate(evidence(), "A" * 40)
+        validate(evidence(), "A" * 40)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "read_bytes",
+        "read_calls",
+        "write_bytes",
+        "write_calls",
+        "file_fsync_calls",
+        "directory_fsync_calls",
+    ],
+)
+def test_rejects_unreconciled_manifest_operation_component(field):
+    value = evidence()
+    value["storage_attribution"]["construction"]["cas_publication_io"]["manifest"][field] += 1
+    with pytest.raises(VALIDATOR.EvidenceError, match="CAS"):
+        validate(value)
+
+
+def test_rejects_manifest_path_read_misclassified_as_write():
+    value = evidence()
+    storage = value["storage_attribution"]
+    storage["construction"]["cas_publication_io"]["manifest_reads"]["write_bytes"] = 1
+    storage["construction"]["cas_application_write_bytes"] = 1
+    storage["application_io_phases"]["phases"]["cas_install_read_write"]["write_bytes"] = 1
+    with pytest.raises(VALIDATOR.EvidenceError, match="path authentication"):
+        validate(value)
+
+
+def test_rejects_overflowed_cas_component_sum():
+    value = evidence()
+    components = value["storage_attribution"]["construction"]["cas_publication_io"]
+    components["manifest"]["read_bytes"] = (1 << 64) - 1
+    with pytest.raises(VALIDATOR.EvidenceError, match="native u64"):
+        validate(value)
+
+
+@pytest.mark.parametrize("field", ["publications", "initial_entries", "changed_paths"])
+def test_rejects_nonfresh_publication_using_fresh_control_bound(field):
+    value = evidence()
+    value["storage_attribution"]["construction"]["cas_publication_io"][field] += 1
+    with pytest.raises(VALIDATOR.EvidenceError, match="one fresh publication"):
+        validate(value)
+
+
+def test_rejects_coherent_manifest_protocol_overcount():
+    storage = evidence()["storage_attribution"]
+    construction = storage["construction"]
+    manifest = construction["cas_publication_io"]["manifest"]
+    count = 67 * construction["canonical_artifact_objects"] + 2
+    manifest.update(
+        installed_objects=count,
+        install_attempts=count,
+        file_fsync_calls=count,
+        directory_fsync_calls=2 * count,
+    )
+    manifest["read_calls"] = manifest["read_bytes"] = count + manifest["reused_objects"]
+    for field, aggregate in (
+        ("read_bytes", "cas_application_read_bytes"),
+        ("read_calls", "cas_application_read_operations"),
+    ):
+        construction[aggregate] = (
+            construction["cas_publication_io"]["payload"][field] + manifest[field]
+        )
+        storage["application_io_phases"]["phases"]["cas_install_read_write"][field] = construction[
+            aggregate
+        ]
+    construction["cas_fsync_operations"] = 3 * count
+    storage["application_io_phases"]["phases"]["cas_install_read_write"]["fsync_calls"] = 3 * count
+    with pytest.raises(VALIDATOR.EvidenceError, match="native path/object"):
+        VALIDATOR.validate_cas_publication_components(storage)
+
+
+def test_rejects_coherent_omission_of_all_manifest_work():
+    storage = evidence()["storage_attribution"]
+    construction = storage["construction"]
+    components = construction["cas_publication_io"]
+    for name in ("manifest", "manifest_reads"):
+        components[name] = dict.fromkeys(components[name], 0)
+    phase = storage["application_io_phases"]["phases"]["cas_install_read_write"]
+    for field, aggregate in (
+        ("read_bytes", "cas_application_read_bytes"),
+        ("read_calls", "cas_application_read_operations"),
+    ):
+        phase[field] = construction[aggregate] = components["payload"][field]
+    with pytest.raises(VALIDATOR.EvidenceError, match="mandatory bootstrap"):
+        VALIDATOR.validate_cas_publication_components(storage)

--- a/scripts/ci/validate-g500-certification.py
+++ b/scripts/ci/validate-g500-certification.py
@@ -32,6 +32,18 @@ REQUIRED_PHASES = (
     "drill_resource_limit",
     "drill_interrupted_finalization",
 )
+CATEGORY_NAMES = (
+    "topology_nodes",
+    "topology_edges",
+    "properties",
+    "uuid_and_surrogates",
+    "adjacency",
+    "catalog_and_manifests",
+    "construction_staging",
+    "portable_package",
+    "clean_imported_project",
+    "other",
+)
 FORBIDDEN_KEY = re.compile(
     r"(secret|credential|token|password|host_path|absolute_path|machine[_-]?id|volume[_-]?id|provider_resource_id)",
     re.I,
@@ -41,9 +53,14 @@ RAW_UUID = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.I,
 )
+NATIVE_OBJECT_IDENTITY = re.compile(
+    r"(?<![0-9a-f])[0-9a-f]{16}:[0-9a-f]{32}(?![0-9a-f])",
+    re.I,
+)
 ROOT = Path(__file__).resolve().parents[2]
 PROFILE = ROOT / "crates/graphforge-api/tests/fixtures/scale_g500_certification.v1.json"
 SCHEMA = ROOT / "docs/development/evidence/g500-certification.schema.json"
+PROVIDER_RESULT_SCHEMA = ROOT / "benchmarks/schemas/progressive-provider-run-result.json"
 RUN_COMMAND = (
     "cargo test -p graphforge-api --release --test scale_g500_ladder "
     "certification_target_live_full_lifecycle_evidence -- --ignored --exact "
@@ -65,6 +82,238 @@ def validate_schema(evidence: dict[str, Any]) -> None:
     except ValidationError as error:
         location = ".".join(str(item) for item in error.absolute_path) or "$"
         raise EvidenceError(f"evidence schema violation at {location}: {error.message}") from error
+
+
+def update_authority_context(digest: Any, context: dict[str, Any], category: str) -> None:
+    for field in (
+        "contract",
+        "generation_sha256",
+        "owner",
+        "receipt_authority_sha256",
+        "native_identity_authority_sha256",
+    ):
+        value = context[field].encode()
+        digest.update(len(value).to_bytes(16, "big"))
+        digest.update(value)
+    digest.update(context["version"].to_bytes(4, "big"))
+    digest.update(context["rung"].to_bytes(8, "big"))
+    digest.update(context["live_nodes"].to_bytes(8, "big"))
+    digest.update(context["live_edges"].to_bytes(8, "big"))
+    category_identity = context["native_category_identity_authority_sha256"][category].encode()
+    digest.update(len(category_identity).to_bytes(16, "big"))
+    digest.update(category_identity)
+
+
+def category_commitment(context: dict[str, Any], category: str, totals: dict[str, int]) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"graphforge-category-authority-v2\0")
+    update_authority_context(digest, context, category)
+    digest.update(category.encode())
+    for field in (
+        "logical_references",
+        "logical_bytes",
+        "physical_objects",
+        "physical_logical_bytes",
+        "allocated_bytes",
+    ):
+        digest.update(totals[field].to_bytes(8, "big"))
+    return "sha256:" + digest.hexdigest()
+
+
+def peak_commitment(context: dict[str, Any], category: str, allocated_bytes: int) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"graphforge-category-peak-authority-v2\0")
+    update_authority_context(digest, context, category)
+    digest.update(category.encode())
+    digest.update(allocated_bytes.to_bytes(8, "big"))
+    return "sha256:" + digest.hexdigest()
+
+
+def validate_cas_publication_components(storage: dict[str, Any]) -> None:
+    construction = storage["construction"]
+    components = construction["cas_publication_io"]
+    maximum = (1 << 64) - 1
+
+    def total(*values: int) -> int:
+        value = sum(values)
+        if value > maximum:
+            raise EvidenceError("CAS component sum exceeds native u64")
+        return value
+
+    field_projection = {
+        "read_bytes": "cas_application_read_bytes",
+        "read_calls": "cas_application_read_operations",
+        "write_bytes": "cas_application_write_bytes",
+        "write_calls": "cas_application_write_operations",
+    }
+    phase = storage["application_io_phases"]["phases"]["cas_install_read_write"]
+    for field, aggregate in field_projection.items():
+        expected = total(
+            *(
+                component[field]
+                for component in (
+                    components[name] for name in ("payload", "manifest", "manifest_reads")
+                )
+            )
+        )
+        if construction[aggregate] != expected or phase[field] != expected:
+            raise EvidenceError(f"CAS {field} components do not reconcile")
+    synchronization = total(
+        *(
+            component[field]
+            for component in (
+                components[name] for name in ("payload", "manifest", "manifest_reads")
+            )
+            for field in ("file_fsync_calls", "directory_fsync_calls")
+        )
+    )
+    if (
+        construction["cas_fsync_operations"] != synchronization
+        or phase["fsync_calls"] != synchronization
+    ):
+        raise EvidenceError("CAS synchronization components do not reconcile")
+    paths = construction["canonical_artifact_objects"]
+    if (
+        components["publications"] != 1
+        or components["initial_entries"] != 0
+        or components["changed_paths"] != paths
+    ):
+        raise EvidenceError(
+            "CAS growth proof requires one fresh publication of the complete changed inventory"
+        )
+    inventory_bytes = storage["application_io_phases"]["phases"]["publication_preauthentication"][
+        "read_bytes"
+    ]
+    # Native maximal-encoding fixtures establish 1319 branch/header bytes and
+    # 43 additional bytes per GraphFileEntry over ConstructionEncodedArtifact.
+    node_bytes = total(inventory_bytes, 43 * paths, 1319)
+    install_requests = total(67 * paths, 1)
+    read_requests = total(130 * paths)
+    manifest = components["manifest"]
+    requests = total(manifest["installed_objects"], manifest["reused_objects"])
+    if (
+        requests < total(paths, 1)
+        or manifest["read_calls"] < requests
+        or components["manifest_reads"]["read_calls"] < paths
+    ):
+        raise EvidenceError("CAS manifest lacks mandatory bootstrap/update authentication")
+    if (
+        total(manifest["installed_objects"], manifest["reused_objects"]) > install_requests
+        or manifest["read_bytes"] > total(install_requests * node_bytes)
+        or manifest["write_bytes"] > total(install_requests * node_bytes)
+        or manifest["write_bytes"] < manifest["installed_bytes"]
+        or manifest["write_calls"] != manifest["install_attempts"]
+        or components["manifest_reads"]["read_bytes"] > total(read_requests * node_bytes)
+    ):
+        raise EvidenceError("CAS manifest exceeds native path/object/encoded-inventory bounds")
+    for component in (manifest, components["manifest_reads"]):
+        if (
+            not (component["read_bytes"] + 65535) // 65536
+            <= component["read_calls"]
+            <= component["read_bytes"]
+        ):
+            raise EvidenceError("CAS manifest reads violate native buffer bounds")
+    payload = components["payload"]
+    if (
+        total(payload["installed_objects"], payload["reused_objects"])
+        != construction["canonical_artifact_objects"]
+    ):
+        raise EvidenceError("CAS payload requests differ from canonical inventory")
+    for name in ("payload", "manifest"):
+        component = components[name]
+        requests = total(component["installed_objects"], component["reused_objects"])
+        if not component["installed_objects"] <= component["install_attempts"] <= requests:
+            raise EvidenceError(f"CAS {name} install attempts differ from request inventory")
+        if component["directory_fsync_calls"] != total(
+            component["install_attempts"], component["install_attempts"]
+        ):
+            raise EvidenceError(f"CAS {name} namespace synchronization differs from installs")
+        if component["file_fsync_calls"] < component["install_attempts"]:
+            raise EvidenceError(f"CAS {name} lacks mandatory file synchronization")
+        if name == "manifest" and component["file_fsync_calls"] != component["install_attempts"]:
+            raise EvidenceError("CAS manifest file synchronization differs from installs")
+    if any(
+        value
+        for field, value in components["manifest_reads"].items()
+        if field not in ("read_bytes", "read_calls")
+    ):
+        raise EvidenceError("CAS manifest path authentication reports non-read work")
+
+
+def validate_category_authority(
+    storage: dict[str, Any],
+    *,
+    rung: int,
+    live_nodes: int,
+    live_edges: int,
+) -> None:
+    for owner in ("source", "clean_import"):
+        reported = storage[owner]["categories"]
+        authority = storage[owner]["category_authorities"]
+        context = storage[owner]["category_authority_context"]
+        if (
+            context["owner"] != owner
+            or context["rung"] != rung
+            or context["live_nodes"] != live_nodes
+            or context["live_edges"] != live_edges
+        ):
+            raise EvidenceError(f"{owner} category authority context differs")
+        if reported != authority:
+            raise EvidenceError(f"{owner} categories differ from native authority")
+        for category in CATEGORY_NAMES:
+            commitment = category_commitment(context, category, authority[category])
+            if storage[owner]["category_authority_sha256"][category] != commitment:
+                raise EvidenceError(f"{owner}.{category} authority commitment differs")
+
+    construction = storage["construction"]
+    source_context = storage["source"]["category_authority_context"]
+    construction_context = construction["storage_category_authority_context"]
+    if (
+        construction_context["owner"] != "construction"
+        or construction_context["rung"] != rung
+        or construction_context["generation_sha256"] != source_context["generation_sha256"]
+        or construction_context["live_nodes"] != live_nodes
+        or construction_context["live_edges"] != live_edges
+    ):
+        raise EvidenceError("construction category authority context differs")
+    if construction["storage_current"] != construction["storage_category_authorities"]:
+        raise EvidenceError("construction categories differ from native authority")
+    if (
+        construction["storage_transient_peak_allocated_bytes"]
+        != construction["storage_transient_peak_authorities"]
+    ):
+        raise EvidenceError("construction peaks differ from native authority")
+    for category in CATEGORY_NAMES:
+        current = category_commitment(
+            construction_context,
+            category,
+            construction["storage_category_authorities"][category],
+        )
+        peak = peak_commitment(
+            construction_context,
+            category,
+            construction["storage_transient_peak_authorities"][category],
+        )
+        if construction["storage_category_authority_sha256"][category] != current:
+            raise EvidenceError(f"construction.{category} authority commitment differs")
+        if construction["storage_transient_peak_authority_sha256"][category] != peak:
+            raise EvidenceError(f"construction.{category} peak commitment differs")
+
+    portable = storage["portable_package"]
+    portable_context = portable["category_authority_context"]
+    if (
+        portable_context["owner"] != "portable_package"
+        or portable_context["rung"] != rung
+        or portable_context["generation_sha256"] != source_context["generation_sha256"]
+        or portable_context["live_nodes"] != live_nodes
+        or portable_context["live_edges"] != live_edges
+    ):
+        raise EvidenceError("portable category authority context differs")
+    portable_commitment = category_commitment(
+        portable_context, "portable_package", portable["category_authority"]
+    )
+    if portable["category_authority_sha256"] != portable_commitment:
+        raise EvidenceError("portable package authority commitment differs")
 
 
 def require_mapping(evidence: dict[str, Any], key: str, fields: tuple[str, ...]) -> dict[str, Any]:
@@ -91,9 +340,15 @@ def reject_sensitive(value: Any, trail: str = "$") -> None:
             raise EvidenceError(f"absolute host path at {trail}")
         if RAW_UUID.fullmatch(value):
             raise EvidenceError(f"raw UUID at {trail}")
+        if NATIVE_OBJECT_IDENTITY.search(value):
+            raise EvidenceError(f"raw native object identity at {trail}")
 
 
-def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
+def validate_semantics(
+    evidence: dict[str, Any],
+    expected_sha: str | None,
+) -> None:
+    """Validate content after an external provider-result binding is established."""
     validate_schema(evidence)
     reject_sensitive(evidence)
     if evidence.get("schema") != "graphforge-billion-edge-certification-evidence/1":
@@ -154,6 +409,13 @@ def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
         raise EvidenceError("source/imported node count does not match the declared scale")
 
     storage = evidence.get("storage_attribution", {})
+    validate_cas_publication_components(storage)
+    validate_category_authority(
+        storage,
+        rung=scale,
+        live_nodes=counts["source_nodes"],
+        live_edges=counts["source_edges"],
+    )
     selected_source = storage.get("source", {}).get("allocated_bytes")
     source_project = storage.get("source_project_current_allocated_bytes")
     workspace = storage.get("workspace_current_allocated_bytes")
@@ -278,15 +540,74 @@ def validate(evidence: dict[str, Any], expected_sha: str | None) -> None:
         raise EvidenceError("certification evidence is not a pass")
 
 
+def _decode_object(encoded: bytes, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(encoded)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise EvidenceError(f"{label} is malformed") from error
+    if not isinstance(value, dict):
+        raise EvidenceError(f"{label} root must be an object")
+    return value
+
+
+def validate(
+    evidence_encoded: bytes,
+    expected_sha: str | None,
+    provider_result_encoded: bytes,
+    expected_provider_result_sha256: str | None,
+) -> None:
+    """Validate evidence rooted in an externally authenticated provider result.
+
+    The expected provider-result digest must come from trusted transport or an
+    immutable manifest outside both documents. The provider result then binds
+    the exact ordinary GraphForge evidence bytes through ``graphforge_sha256``.
+    """
+    if not expected_sha:
+        raise EvidenceError("--expected-sha is required to pin the dispatched commit")
+    if re.fullmatch(r"[0-9a-f]{40}", expected_sha) is None:
+        raise EvidenceError("--expected-sha must be an exact lowercase 40-hex commit")
+    if (
+        expected_provider_result_sha256 is None
+        or re.fullmatch(r"[0-9a-f]{64}", expected_provider_result_sha256) is None
+    ):
+        raise EvidenceError("external provider-result SHA-256 is required")
+    actual_provider_result_sha256 = hashlib.sha256(provider_result_encoded).hexdigest()
+    if actual_provider_result_sha256 != expected_provider_result_sha256:
+        raise EvidenceError("provider result does not match its external anchor")
+    provider_result = _decode_object(provider_result_encoded, "provider result")
+    try:
+        provider_schema = json.loads(PROVIDER_RESULT_SCHEMA.read_text(encoding="utf-8"))
+        Draft202012Validator(provider_schema).validate(provider_result)
+    except (OSError, json.JSONDecodeError, SchemaError, ValidationError) as error:
+        raise EvidenceError(f"provider result schema is invalid: {error}") from error
+    evidence = _decode_object(evidence_encoded, "evidence")
+    scale = evidence.get("run", {}).get("scale")
+    identities = provider_result.get("identities", {})
+    artifacts = provider_result.get("artifacts", {})
+    if (
+        provider_result.get("status") != "passed"
+        or provider_result.get("rung") != f"S{scale}"
+        or identities.get("commit") != expected_sha
+        or not isinstance(artifacts, dict)
+        or artifacts.get("graphforge_sha256") != hashlib.sha256(evidence_encoded).hexdigest()
+    ):
+        raise EvidenceError("ordinary evidence is not bound by the authenticated provider result")
+    validate_semantics(evidence, expected_sha)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("evidence", type=Path)
     parser.add_argument("--expected-sha", required=True)
+    parser.add_argument("--provider-result", required=True, type=Path)
+    parser.add_argument("--provider-result-sha256", required=True)
     args = parser.parse_args()
-    value = json.loads(args.evidence.read_text(encoding="utf-8"))
-    if not isinstance(value, dict):
-        raise EvidenceError("evidence root must be an object")
-    validate(value, args.expected_sha)
+    validate(
+        args.evidence.read_bytes(),
+        args.expected_sha,
+        args.provider_result.read_bytes(),
+        args.provider_result_sha256,
+    )
     print(f"valid #745 evidence: {args.evidence}")
     return 0
 


### PR DESCRIPTION
Publication evidence previously omitted manifest installation and path-copy reads, while lifecycle admission assumed fixed CAS synchronization counts. This change carries measured payload, manifest and authentication components through the ordinary facade and reconciles their exact totals across both controlled 1×/2×/4× lifecycle axes.

Closes #1116
Refs #951

The implementation records actual file and directory barriers, preserves synchronized cache-window eviction, and accounts for a concurrent losing publisher's temporary work without counting reused objects as newly retained bytes. Retained shape allocation includes the runtime catalog. Checked arithmetic and protocol-derived Patricia bounds reject omitted, misclassified, duplicated, overflowed or excessive work; source/imported storage inventories remain authoritative.

Historical fixture readability is separate from authenticated certification. The parity gate checks the preserved lifecycle and complete phase mapping; certification still requires an externally anchored provider result. Regressions reject malformed/incomplete history and failed unmapped drills without fabricating provider evidence.

Validation on OVHC-AGENCY's ext4 filesystem:

- `cargo test --locked -p graphforge-storage --lib -- --test-threads=4`: 953 passed, two unchanged existing ignores; private mount namespace supplies ext4 `/tmp` for durable tests.
- `cargo test --locked -p graphforge-api --lib -- --test-threads=4`: all 681 passed, including exact payload/manifest/path-read reconciliation with unchanged growth ceilings.
- `cargo test --locked -p graphforge-api --test scale_g500_ladder -- --test-threads=1 --nocapture`: all 29 passed, including both 1×/2×/4× axes, publication, reopen, export, clean import, recovery and the million-edge sink.
- `PYTHONPATH=benchmarks/harness uv run pytest -q scripts/ci/test-validate-g500-certification.py benchmarks/tests/test_scale_parity.py`: 258 passed, plus 14 adversarial subtests.
- `make -C benchmarks smoke-python`: 389 passed.
- `make -C benchmarks smoke-rust`: all Rust benchmark tests, Clippy, formatting and the public-facade dependency boundary passed.
- Fresh CLI and all benchmark binaries built from this tree; `benchmarks/scripts/test-tiny-lifecycle-certification.py` passed all ten real phases, including source/imported count and query receipts, matching result hashes and retained/peak storage checks.
- Workspace Clippy, formatting, `make pre-push-fast` and `make gate-registry-check`: passed on the final tree.

#951 remains open for S20 and conditional S22 host outcomes using #900's ladder. This PR supplies deterministic implementation and admission proof and does not claim host-scale qualification.

Exact-head CI: [Test Suite 33954226141](https://github.com/CurateLabs/graphforge/actions/runs/33954226141) passed at `de630749b9b19e99bbdbd38f10bc732727a51105`; CI Gate was SUCCESS, merge state CLEAN, and no review threads were unresolved. Squash-merged as `417b6466c027730c0bcbcabb56ac87194585b4fd`; #1116 closure verified.
