### PR TITLE
fix(bench): classify BenchExec authority failures

### DIFF
--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -43,6 +43,10 @@ class ControllerError(ValueError):
     """The requested run is unsafe, out of order, or lacks valid evidence."""
 
 
+class BenchExecRunError(ControllerError):
+    """BenchExec authority reports that the benchmark execution did not pass."""
+
+
 @dataclass(frozen=True)
 class Executables:
     gf: Path
@@ -785,6 +789,10 @@ def ingest_benchexec_result(
     )
     _validate(root, "certification-evidence.json", graphforge)
     _validate(root, "benchexec-run-evidence.json", benchexec)
+    if benchexec.get("outcome") != "passed":
+        raise BenchExecRunError(
+            f"BenchExec authority did not pass: {benchexec.get('outcome', 'unknown')}"
+        )
     rung = assemble_rung_evidence(
         root=root,
         scale=scale,
@@ -853,6 +861,19 @@ def run(
             benchexec, graphforge, rung = ingest_benchexec_result(
                 root=root, stage=stage, scale=scale, plan=plan
             )
+        except BenchExecRunError as error:
+            _preserve_failure_artifacts(stage, output_dir, scale)
+            result = {
+                "schema": RESULT_SCHEMA,
+                "rung": f"S{scale}",
+                "status": "failed",
+                "failure": "benchexec_failed",
+                "identities": plan["identities"],
+                "claim": "engineering_evidence_only",
+            }
+            _validate(root, "progressive-run-result.json", result)
+            _write_json(output_dir / f"s{scale}-result.json", result)
+            raise ControllerError("benchexec_failed") from error
         except (ControllerError, ValueError) as error:
             _preserve_failure_artifacts(stage, output_dir, scale)
             result = {

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -26,6 +26,7 @@ from graphforge_bench.progressive_run import (
     require_bulk_ingest_capability,
     require_order,
     resolve_executables,
+    run,
     validate_fixture_bundle,
     write_plan,
     write_s20_projection,
@@ -629,6 +630,38 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         self.executables.benchexec_python.write_bytes(b"changed-after-planning")
         with self.assertRaisesRegex(ControllerError, "identity changed after planning"):
             _run_benchexec(stage, self.executables, plan["identities"])
+
+    def test_benchexec_authority_failure_is_not_mislabeled_as_missing_receipt(self) -> None:
+        plan = build_plan(
+            root=ROOT,
+            output_dir=self.output,
+            scale=18,
+            commit=COMMIT,
+            executables=self.executables,
+        )
+        stage = self.base / "failed-stage"
+        (stage / "raw").mkdir(parents=True)
+        (stage / "raw" / "result.xml").write_text("<result />")
+        with (
+            patch("graphforge_bench.progressive_run._native_authority"),
+            patch("graphforge_bench.progressive_run._safe_stage", return_value=stage),
+            patch("graphforge_bench.progressive_run._run_benchexec", return_value=0),
+            patch(
+                "graphforge_bench.progressive_run.ingest_benchexec_result",
+                side_effect=BenchExecRunError("BenchExec authority did not pass: oom"),
+            ),
+            self.assertRaisesRegex(ControllerError, "benchexec_failed"),
+        ):
+            run(
+                root=ROOT,
+                output_dir=self.output,
+                scale=18,
+                plan=plan,
+                executables=self.executables,
+            )
+        result = json.loads((self.output / "s18-result.json").read_text())
+        self.assertEqual(result["failure"], "benchexec_failed")
+        self.assertTrue((self.output / "s18-failure-raw" / "result.xml").is_file())
 
     def test_benchexec_sanitized_environment_keeps_only_the_tool_module_path(self) -> None:
         plan = build_plan(

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import patch
 
 from graphforge_bench.progressive_run import (
+    BenchExecRunError,
     ControllerError,
     Executables,
     _authority_staging_parent,
@@ -518,6 +519,23 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         self.assertEqual(normalized["authority"]["read_bytes"], 1024)
         self.assertEqual(rung["metrics"]["wall_seconds"], 2)
 
+        oom_columns = {
+            **columns,
+            "status": "OUT OF MEMORY",
+            "terminationreason": "memory",
+        }
+        oom_xml = (
+            "<result><run>"
+            + "".join(
+                f'<column title="{name}" value="{value}" />' for name, value in oom_columns.items()
+            )
+            + "</run></result>"
+        )
+        (raw / "result.xml").write_text(oom_xml)
+        with self.assertRaisesRegex(BenchExecRunError, "BenchExec authority did not pass: oom"):
+            ingest_benchexec_result(root=ROOT, stage=stage, scale=18, plan=plan)
+
+        (raw / "result.xml").write_text(xml)
         changed = {**gf, "profile_id": "graph500-s19-local"}
         (raw / "run.log").write_text(json.dumps(changed) + "\n")
         with self.assertRaisesRegex(ControllerError, "contradicts the run plan"):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Preserve the true BenchExec terminal outcome when progressive qualification fails before receipt assembly. An S18 OOM was incorrectly emitted as `ordinary_receipt_missing` because the controller handled all ingest failures through one broad receipt-error path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Tests (adding or updating tests)

## Related Issues

Relates to #952

## Changes Made

- Detect validated non-passing BenchExec outcomes before rung assembly.
- Emit `failure=benchexec_failed` while preserving raw failure artifacts.
- Keep receipt validation and phase-binding behavior unchanged.
- Add OOM normalization and terminal-result regressions.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] All existing focused tests pass
- [x] Coverage maintained or improved

### Test Commands Run

```bash
PYTHONPATH=benchmarks/harness uv run pytest benchmarks/tests/test_progressive_run.py
uv run ruff check benchmarks/harness/graphforge_bench/progressive_run.py benchmarks/tests/test_progressive_run.py
```

Result: 24 tests passed; Ruff passed.

## Checklist

### PR Size and Quality

- [x] This PR is small and focused
- [x] This PR addresses one logical bug
- [x] No skips, retries, fallback evidence, or weakened assertions
- [ ] All CI checks pass

### Code Quality

- [x] Changes generate no new warnings
- [x] Self-review completed

### Testing

- [x] Tests prove OOM is not mislabeled as missing receipts
- [x] Failure artifacts remain preserved

## Performance Impact

- [x] No performance impact

## Breaking Changes

- [x] No breaking changes

## Reviewer Notes

The real Fly S18 reproduction reached BenchExec `OUT OF MEMORY` at 4,000,079,872 bytes. This PR corrects only failure classification; the memory limit/root cause is being investigated separately.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b007c81-7eea-4b44-a7a6-8971e17d5258?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b007c81-7eea-4b44-a7a6-8971e17d5258&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790935697&installation_model_id=20486&pr_number=1080&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1080&signature=79e97b9e7ad9db33f60a37dd95024d3148b3c707a3a1e947a6ea4798bc2e0d5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify non-passing BenchExec results as `benchexec_failed` instead of missing receipt
> - Adds `BenchExecRunError` (a `ControllerError` subtype) so callers can distinguish BenchExec execution failures from other controller or receipt-validation errors
> - `ingest_benchexec_result` now requires the normalized BenchExec outcome to be `passed`; any other outcome raises `BenchExecRunError` with the reported outcome, preventing rung evidence assembly for a failed authority result
> - The run authority entrypoint catches `BenchExecRunError`, writes a failed `s{scale}-result.json` with `failure` set to `benchexec_failed`, preserves raw failure artifacts, and re-raises `ControllerError` with the original exception chained
> - Tests in [test_progressive_run.py](https://github.com/CurateLabs/graphforge/pull/1080/files#diff-5e9a27caeaa2704f89fdf519fb8dc0fd2ce0840480f34afa5e5c4371ea6c407d) cover an out-of-memory BenchExec XML receipt and a controller-level authority-failure scenario
> - Behavioral Change: a non-passing BenchExec result after a successful tool-process exit is now classified as `benchexec_failed` rather than falling through to the ordinary receipt-failure path in `run`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4394567.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->