### PR TITLE
fix(storage): evict construction cache at durable boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1047,6 +1047,14 @@ jobs:
           cargo test -p graphforge-storage --features test-failpoints
           project_certification --lib --no-fail-fast
 
+      - name: Run Windows read-only certifier cache cleanup regression
+        shell: bash
+        run: >-
+          cargo test --locked --manifest-path benchmarks/Cargo.toml --target-dir target
+          -p graphforge-benchmark-certify --lib
+          tests::command_owned_cache_direct_files_preserve_read_only_inputs
+          -- --exact --nocapture
+
   macos-graphforge-storage-durability:
     name: macOS graphforge-storage Durability
     runs-on: blacksmith-12vcpu-macos-15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,6 +2157,7 @@ name = "graphforge-api"
 version = "0.5.2"
 dependencies = [
  "arrow",
+ "bytes",
  "cucumber",
  "datafusion",
  "fs4 1.1.0",

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1597,6 +1597,7 @@ dependencies = [
  "graphforge-storage",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -1616,7 +1617,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphforge-benchmark-gdc-snb-interactive"
+name = "graphforge-benchmark-gdc-snb-bi"
 version = "0.0.0"
 dependencies = [
  "serde",
@@ -1624,7 +1625,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphforge-benchmark-gdc-snb-bi"
+name = "graphforge-benchmark-gdc-snb-interactive"
 version = "0.0.0"
 dependencies = [
  "serde",
@@ -1636,7 +1637,9 @@ name = "graphforge-benchmark-graph500-generator"
 version = "0.0.0"
 dependencies = [
  "arrow",
+ "graphforge-filesystem",
  "parquet",
+ "tempfile",
 ]
 
 [[package]]

--- a/benchmarks/fixtures/progressive/tiny-executable.json
+++ b/benchmarks/fixtures/progressive/tiny-executable.json
@@ -22,7 +22,7 @@
       "phase": "generate",
       "action": {
         "interface": "benchmark_generator",
-        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
         "executable": "graphforge-benchmark-graph500-generator",
         "args": [
           "--scale",

--- a/benchmarks/profiles/graph500/s18-local.json
+++ b/benchmarks/profiles/graph500/s18-local.json
@@ -18,7 +18,7 @@
       "phase": "generate",
       "action": {
         "interface": "benchmark_generator",
-        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
         "executable": "graphforge-benchmark-graph500-generator",
         "args": [
           "--scale",
@@ -273,7 +273,7 @@
     }
   ],
   "generator": {
-    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
     "edge_factor": 16,
     "seed": 13907095936298285200
   },

--- a/benchmarks/profiles/graph500/s19-local.json
+++ b/benchmarks/profiles/graph500/s19-local.json
@@ -18,7 +18,7 @@
       "phase": "generate",
       "action": {
         "interface": "benchmark_generator",
-        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
         "executable": "graphforge-benchmark-graph500-generator",
         "args": [
           "--scale",
@@ -273,7 +273,7 @@
     }
   ],
   "generator": {
-    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
     "edge_factor": 16,
     "seed": 13907095936298285200
   },

--- a/benchmarks/profiles/graph500/s20-provider.json
+++ b/benchmarks/profiles/graph500/s20-provider.json
@@ -18,7 +18,7 @@
       "phase": "generate",
       "action": {
         "interface": "benchmark_generator",
-        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
         "executable": "graphforge-benchmark-graph500-generator",
         "args": [
           "--scale",
@@ -273,7 +273,7 @@
     }
   ],
   "generator": {
-    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
     "edge_factor": 16,
     "seed": 13907095936298285200
   },

--- a/benchmarks/profiles/graph500/s22-provider.json
+++ b/benchmarks/profiles/graph500/s22-provider.json
@@ -18,7 +18,7 @@
       "phase": "generate",
       "action": {
         "interface": "benchmark_generator",
-        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
         "executable": "graphforge-benchmark-graph500-generator",
         "args": [
           "--scale",
@@ -273,7 +273,7 @@
     }
   ],
   "generator": {
-    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
     "edge_factor": 16,
     "seed": 13907095936298285200
   },

--- a/benchmarks/profiles/graph500/s24-provider.json
+++ b/benchmarks/profiles/graph500/s24-provider.json
@@ -18,7 +18,7 @@
       "phase": "generate",
       "action": {
         "interface": "benchmark_generator",
-        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
         "executable": "graphforge-benchmark-graph500-generator",
         "args": [
           "--scale",
@@ -273,7 +273,7 @@
     }
   ],
   "generator": {
-    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
     "edge_factor": 16,
     "seed": 13907095936298285200
   },

--- a/benchmarks/profiles/graph500/s25-provider.json
+++ b/benchmarks/profiles/graph500/s25-provider.json
@@ -18,7 +18,7 @@
       "phase": "generate",
       "action": {
         "interface": "benchmark_generator",
-        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
         "executable": "graphforge-benchmark-graph500-generator",
         "args": [
           "--scale",
@@ -273,7 +273,7 @@
     }
   ],
   "generator": {
-    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
     "edge_factor": 16,
     "seed": 13907095936298285200
   },

--- a/benchmarks/profiles/graph500/s26-provider.json
+++ b/benchmarks/profiles/graph500/s26-provider.json
@@ -18,7 +18,7 @@
       "phase": "generate",
       "action": {
         "interface": "benchmark_generator",
-        "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+        "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
         "executable": "graphforge-benchmark-graph500-generator",
         "args": [
           "--scale",
@@ -273,7 +273,7 @@
     }
   ],
   "generator": {
-    "identity": "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2",
+    "identity": "sha256:0ffb58a6c80c0c83fc728ab3f930156cd2c99c1935031e1ac31c52a1dc38abae",
     "edge_factor": 16,
     "seed": 13907095936298285200
   },

--- a/benchmarks/runners/certify/Cargo.toml
+++ b/benchmarks/runners/certify/Cargo.toml
@@ -11,3 +11,6 @@ serde.workspace = true
 serde_json.workspace = true
 graphforge-filesystem = { path = "../../../crates/graphforge-filesystem" }
 graphforge-storage = { path = "../../../crates/graphforge-storage" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
 use std::io::Read;
@@ -266,6 +266,7 @@ pub struct Execution {
     pub duration_ms: u64,
     pub peak_rss_bytes: Option<u64>,
     pub failure: Option<FailureKind>,
+    pub cleanup_failure: Option<String>,
     pub receipts: Vec<serde_json::Value>,
 }
 
@@ -403,8 +404,10 @@ impl LifecycleStorageSession {
             || !self.imported_project_observed
             || self.source_project_current_allocated_bytes.is_none()
         {
-            return Err("lifecycle storage session is missing an authenticated owner or transient phase"
-                .to_owned());
+            return Err(
+                "lifecycle storage session is missing an authenticated owner or transient phase"
+                    .to_owned(),
+            );
         }
         let source_project_current_allocated_bytes = self
             .source_project_current_allocated_bytes
@@ -517,6 +520,7 @@ impl PhaseExecutor for PublicProcessExecutor {
                             duration_ms: millis(started.elapsed()),
                             peak_rss_bytes,
                             failure: Some(FailureKind::CommandUnavailable),
+                            cleanup_failure: None,
                             receipts,
                         });
                     }
@@ -529,6 +533,7 @@ impl PhaseExecutor for PublicProcessExecutor {
                         duration_ms: millis(started.elapsed()),
                         peak_rss_bytes,
                         failure: execution.failure,
+                        cleanup_failure: execution.cleanup_failure,
                         receipts,
                     });
                 }
@@ -538,6 +543,7 @@ impl PhaseExecutor for PublicProcessExecutor {
                 duration_ms: millis(started.elapsed()),
                 peak_rss_bytes,
                 failure: None,
+                cleanup_failure: None,
                 receipts,
             };
             if produce_lifecycle_storage {
@@ -598,32 +604,57 @@ fn execute_process(executable: &str, args: &[String]) -> Result<Execution, Strin
             let stdout = stdout_reader
                 .join()
                 .map_err(|_| "public command stdout reader failed".to_owned())??;
-            let receipts = match parse_receipts(
+            let receipts = parse_receipts(
                 &stdout,
                 status.success() && args.iter().any(|argument| argument == "--json"),
-            ) {
-                Ok(receipts) => receipts,
-                Err(_) if status.success() => {
-                    release_cgroup_page_cache();
+            );
+            let released = release_command_owned_file_cache(args);
+            if !status.success() {
+                let cleanup_failure = match (receipts.as_ref().err(), released.as_ref().err()) {
+                    (None, None) => None,
+                    (Some(receipts), None) => Some(format!(
+                        "child exit preserved; receipt cleanup also failed: {receipts}"
+                    )),
+                    (None, Some(release)) => Some(format!(
+                        "child exit preserved; command-owned cache release also failed: {release}"
+                    )),
+                    (Some(receipts), Some(release)) => Some(format!(
+                        "child exit preserved; receipt cleanup also failed: {receipts}; command-owned cache release also failed: {release}"
+                    )),
+                };
+                return Ok(Execution {
+                    exit_code: status.code(),
+                    duration_ms: millis(started.elapsed()),
+                    peak_rss_bytes,
+                    failure: Some(FailureKind::CommandFailed),
+                    cleanup_failure,
+                    receipts: receipts.unwrap_or_default(),
+                });
+            }
+            let receipts = match (receipts, released) {
+                (Ok(receipts), Ok(_)) => receipts,
+                (Ok(_), Err(error)) => return Err(error),
+                (Err(_), Ok(_)) if status.success() => {
                     return Ok(Execution {
                         exit_code: status.code(),
                         duration_ms: millis(started.elapsed()),
                         peak_rss_bytes,
                         failure: Some(FailureKind::EvidenceInvalid),
+                        cleanup_failure: None,
                         receipts: Vec::new(),
                     });
                 }
-                Err(error) => {
-                    release_cgroup_page_cache();
-                    return Err(error);
+                (Err(primary), Err(release)) => {
+                    return Err(format!("{primary}; {release}"));
                 }
+                (Err(error), Ok(_)) => return Err(error),
             };
-            release_cgroup_page_cache();
             return Ok(Execution {
                 exit_code: status.code(),
                 duration_ms: millis(started.elapsed()),
                 peak_rss_bytes,
                 failure: None,
+                cleanup_failure: None,
                 receipts,
             });
         }
@@ -631,22 +662,134 @@ fn execute_process(executable: &str, args: &[String]) -> Result<Execution, Strin
     }
 }
 
-/// Drop Linux page-cache pressure attributed to the BenchExec cgroup between
-/// sequential public-command invocations. Without this, file-backed cache from
-/// prior `gf` subprocesses accumulates until the 4 GiB memlimit even though
-/// each invocation's anonymous RSS stays bounded (#904).
-#[cfg(target_os = "linux")]
-fn release_cgroup_page_cache() {
-    use std::io::Write;
-
-    let _ = std::process::Command::new("sync").status();
-    if let Ok(mut drop_caches) = fs::File::create("/proc/sys/vm/drop_caches") {
-        let _ = drop_caches.write_all(b"3");
-    }
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CommandCacheReleaseEvidence {
+    files: u64,
+    sync_operations: u64,
+    release_operations: u64,
+    unsupported_operations: u64,
+    unsupported_traversals: u64,
+    released_bytes: u64,
+    peak_window_bytes: u64,
 }
 
-#[cfg(not(target_os = "linux"))]
-fn release_cgroup_page_cache() {}
+#[cfg(test)]
+thread_local! {
+    static INJECT_COMMAND_CACHE_RELEASE_FAILURE: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+fn inject_command_cache_release_failure() {
+    INJECT_COMMAND_CACHE_RELEASE_FAILURE.with(|failure| failure.set(true));
+}
+
+/// Release only regular files explicitly owned or consumed by one command.
+///
+/// This fallback uses retained, no-follow file capabilities. It synchronizes
+/// each owned file before advice, never invokes global sync or privileged cache
+/// controls, and never submits a known-dirty range to `POSIX_FADV_DONTNEED`.
+fn release_command_owned_file_cache(
+    args: &[String],
+) -> Result<CommandCacheReleaseEvidence, String> {
+    #[cfg(test)]
+    INJECT_COMMAND_CACHE_RELEASE_FAILURE.with(|failure| {
+        if failure.replace(false) {
+            return Err("injected command-owned cache release failure".to_owned());
+        }
+        Ok(())
+    })?;
+    let mut roots = BTreeSet::new();
+    for flag in [
+        "--project",
+        "--input",
+        "--output",
+        "--nodes",
+        "--edges",
+        "--path",
+    ] {
+        if let Some(path) = argument_path(args, flag)
+            && path.exists()
+        {
+            roots.insert(path.to_path_buf());
+        }
+    }
+    let mut remaining = 1_000_000_usize;
+    let mut evidence = CommandCacheReleaseEvidence::default();
+    for root in roots {
+        let metadata = fs::symlink_metadata(&root)
+            .map_err(|_| "command-owned cache root could not be inspected".to_owned())?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_file() {
+            let parent = root
+                .parent()
+                .ok_or_else(|| "command-owned cache file has no parent".to_owned())?;
+            let name = root
+                .file_name()
+                .ok_or_else(|| "command-owned cache file has no name".to_owned())?;
+            let directory = graphforge_filesystem::StableDirectory::open(parent)
+                .map_err(|_| "command-owned cache parent could not be retained".to_owned())?;
+            let file = directory
+                .open_child_file(name)
+                .map_err(|_| "command-owned cache file is not a stable regular file".to_owned())?;
+            release_open_file_cache(&file, &mut evidence)?;
+        } else if metadata.is_dir() {
+            let directory = graphforge_filesystem::StableDirectory::open(&root)
+                .map_err(|_| "command-owned cache directory could not be retained".to_owned())?;
+            let traversal = directory.visit_regular_files(&mut remaining, &mut |file| {
+                release_open_file_cache(file, &mut evidence).map_err(std::io::Error::other)
+            });
+            match traversal {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::Unsupported => {
+                    evidence.unsupported_traversals =
+                        evidence.unsupported_traversals.saturating_add(1);
+                }
+                Err(_) => {
+                    return Err("command-owned descriptor traversal failed".to_owned());
+                }
+            }
+        }
+    }
+    Ok(evidence)
+}
+
+fn release_open_file_cache(
+    file: &fs::File,
+    evidence: &mut CommandCacheReleaseEvidence,
+) -> Result<(), String> {
+    let bytes = file
+        .metadata()
+        .map_err(|_| "command-owned cache file could not be inspected".to_owned())?
+        .len();
+    file.sync_all()
+        .map_err(|_| "command-owned cache file synchronization failed".to_owned())?;
+    evidence.sync_operations = evidence.sync_operations.saturating_add(1);
+    evidence.files = evidence.files.saturating_add(1);
+    let mut offset = 0_u64;
+    while offset < bytes {
+        let window =
+            (bytes - offset).min(graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES);
+        let outcome = graphforge_filesystem::release_file_cache(file, offset, window)
+            .map_err(|_| "command-owned file cache release failed".to_owned())?;
+        evidence.peak_window_bytes = evidence.peak_window_bytes.max(window);
+        match outcome {
+            graphforge_filesystem::FileCacheReleaseOutcome::Released => {
+                evidence.release_operations = evidence.release_operations.saturating_add(1);
+                evidence.released_bytes = evidence.released_bytes.saturating_add(window);
+            }
+            graphforge_filesystem::FileCacheReleaseOutcome::Unsupported => {
+                evidence.unsupported_operations = evidence.unsupported_operations.saturating_add(1);
+            }
+        }
+        offset = offset
+            .checked_add(window)
+            .ok_or_else(|| "command-owned cache release offset overflow".to_owned())?;
+    }
+    Ok(())
+}
 
 fn read_bounded(mut input: impl Read, limit: usize) -> Result<Vec<u8>, String> {
     let mut kept = Vec::new();
@@ -805,9 +948,7 @@ fn sanitize_receipt(value: &serde_json::Value) -> Option<serde_json::Value> {
                 "transient_peak_allocated_bytes",
             ],
         )
-        .filter(|receipt| {
-            sanitized_numeric_fields(receipt, &["transient_peak_allocated_bytes"])
-        }),
+        .filter(|receipt| sanitized_numeric_fields(receipt, &["transient_peak_allocated_bytes"])),
         Some(contract) if contract.starts_with("graphforge-portable-") => copy_selected_receipt(
             object,
             &[
@@ -1225,6 +1366,28 @@ pub enum FailureKind {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CleanupFailureKind {
+    ReceiptCleanupFailed,
+    CommandOwnedCacheReleaseFailed,
+    MultipleCleanupFailures,
+    CleanupFailed,
+}
+
+fn sanitize_cleanup_failure(value: Option<&str>) -> Option<CleanupFailureKind> {
+    value.map(|value| {
+        let receipt = value.contains("receipt cleanup");
+        let cache = value.contains("command-owned cache release");
+        match (receipt, cache) {
+            (true, true) => CleanupFailureKind::MultipleCleanupFailures,
+            (true, false) => CleanupFailureKind::ReceiptCleanupFailed,
+            (false, true) => CleanupFailureKind::CommandOwnedCacheReleaseFailed,
+            (false, false) => CleanupFailureKind::CleanupFailed,
+        }
+    })
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PhaseOutcome {
     pub phase: Phase,
@@ -1234,6 +1397,8 @@ pub struct PhaseOutcome {
     pub exit_code: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<FailureKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_failure: Option<CleanupFailureKind>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub receipts: Vec<serde_json::Value>,
 }
@@ -1289,6 +1454,9 @@ pub fn certify_with_events(
                     } else {
                         execution.failure.or(Some(FailureKind::CommandFailed))
                     },
+                    cleanup_failure: sanitize_cleanup_failure(
+                        execution.cleanup_failure.as_deref(),
+                    ),
                     receipts: execution.receipts,
                 }
             }
@@ -1299,6 +1467,7 @@ pub fn certify_with_events(
                 peak_rss_bytes: None,
                 exit_code: None,
                 failure: Some(FailureKind::CommandUnavailable),
+                cleanup_failure: None,
                 receipts: Vec::new(),
             },
         };
@@ -1377,6 +1546,7 @@ pub fn normalize_evidence(input: &[u8]) -> Result<Evidence, RunnerError> {
                     peak_rss_bytes: phase.max_rss_kib.and_then(|value| value.checked_mul(1_024)),
                     exit_code: phase.exit_code,
                     failure: (!phase.ok).then_some(FailureKind::CommandFailed),
+                    cleanup_failure: None,
                     receipts: Vec::new(),
                 });
                 if !phase.ok {
@@ -1421,7 +1591,9 @@ fn validate_evidence(evidence: Evidence) -> Result<Evidence, RunnerError> {
         .map(|outcome| outcome.phase);
     let statuses_are_consistent = evidence.phases.iter().enumerate().all(|(index, outcome)| {
         let failed = outcome.status == OutcomeStatus::Failed;
-        failed == outcome.failure.is_some() && (!failed || index + 1 == evidence.phases.len())
+        failed == outcome.failure.is_some()
+            && (failed || outcome.cleanup_failure.is_none())
+            && (!failed || index + 1 == evidence.phases.len())
     });
     if observed_failure != evidence.failed_phase
         || (observed_failure.is_some()) != (evidence.status == OutcomeStatus::Failed)
@@ -1742,10 +1914,7 @@ mod tests {
         });
         let encoded = serde_json::to_vec(&lifecycle).expect("lifecycle receipt JSON");
         let sanitized = parse_receipts(&encoded, true).expect("closed lifecycle receipt");
-        assert_eq!(
-            sanitized[0]["source_project_current_allocated_bytes"],
-            256
-        );
+        assert_eq!(sanitized[0]["source_project_current_allocated_bytes"], 256);
         for invalid in [
             serde_json::Value::Null,
             serde_json::json!(true),
@@ -1754,8 +1923,7 @@ mod tests {
         ] {
             let mut malformed = lifecycle.clone();
             malformed["source_project_current_allocated_bytes"] = invalid;
-            let encoded =
-                serde_json::to_vec(&malformed).expect("malformed lifecycle receipt JSON");
+            let encoded = serde_json::to_vec(&malformed).expect("malformed lifecycle receipt JSON");
             assert!(parse_receipts(&encoded, true).is_err());
         }
         let mut missing = lifecycle;
@@ -1990,6 +2158,7 @@ mod tests {
             duration_ms: index + 1,
             peak_rss_bytes: Some((index + 1) * 1_024),
             failure: None,
+            cleanup_failure: None,
             receipts: Vec::new(),
         })
     }
@@ -2024,6 +2193,7 @@ mod tests {
             duration_ms: 4,
             peak_rss_bytes: Some(4_096),
             failure: None,
+            cleanup_failure: None,
             receipts: Vec::new(),
         }));
         executions.extend((4..10).map(passed_execution));
@@ -2042,6 +2212,45 @@ mod tests {
         assert_eq!(evidence.phases.len(), 4);
         assert_eq!(events.len(), 4);
         assert_eq!(events.last().unwrap().outcome.status, OutcomeStatus::Failed);
+    }
+
+    #[test]
+    fn cleanup_failure_is_closed_sanitized_and_emitted_with_primary_child_failure() {
+        let mut executor = FakeExecutor {
+            executions: VecDeque::from([Ok(Execution {
+                exit_code: Some(7),
+                duration_ms: 4,
+                peak_rss_bytes: Some(4_096),
+                failure: Some(FailureKind::CommandFailed),
+                cleanup_failure: Some(
+                    "child exit preserved; command-owned cache release also failed: /secret/project"
+                        .to_owned(),
+                ),
+                receipts: Vec::new(),
+            })]),
+            calls: Vec::new(),
+        };
+        let mut events = Vec::new();
+        let evidence = certify_with_events(&tiny_profile(), &mut executor, |event| {
+            events.push(event.clone());
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(evidence.failed_phase, Some(Phase::Admission));
+        assert_eq!(
+            evidence.phases[0].failure,
+            Some(FailureKind::CommandFailed)
+        );
+        assert_eq!(
+            evidence.phases[0].cleanup_failure,
+            Some(CleanupFailureKind::CommandOwnedCacheReleaseFailed)
+        );
+        assert_eq!(events[0].outcome, evidence.phases[0]);
+        let encoded = serde_json::to_string(&(events, evidence)).unwrap();
+        assert!(encoded.contains("\"cleanup_failure\":\"command_owned_cache_release_failed\""));
+        assert!(!encoded.contains("/secret"));
+        assert!(!encoded.contains("project"));
     }
 
     #[test]
@@ -2189,10 +2398,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn public_executor_classifies_invalid_success_receipt_as_evidence_invalid() {
-        let root = std::env::temp_dir().join(format!(
-            "gf-certify-invalid-receipt-{}",
-            std::process::id()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("gf-certify-invalid-receipt-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&root).unwrap();
         let executable = root.join("gf");
@@ -2202,11 +2409,7 @@ mod tests {
         )
         .unwrap();
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
-        let result = execute_process(
-            executable.to_str().unwrap(),
-            &["--json".to_owned()],
-        )
-        .unwrap();
+        let result = execute_process(executable.to_str().unwrap(), &["--json".to_owned()]).unwrap();
         assert_eq!(result.exit_code, Some(0));
         assert_eq!(result.failure, Some(FailureKind::EvidenceInvalid));
         fs::remove_dir_all(root).unwrap();
@@ -2214,18 +2417,14 @@ mod tests {
 
     #[test]
     fn reopen_emits_authoritative_source_project_union_allocation() {
-        let root = std::env::temp_dir().join(format!(
-            "gf-certify-source-union-{}",
-            std::process::id()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("gf-certify-source-union-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&root).unwrap();
         let project = root.join("project");
-        let current =
-            graphforge_storage::open_or_initialize_ephemeral_project(&project).unwrap();
+        let current = graphforge_storage::open_or_initialize_ephemeral_project(&project).unwrap();
         let selected = graphforge_storage::capture_storage_attribution(&current).unwrap();
-        let union =
-            graphforge_storage::capture_project_storage_identity_union(&current).unwrap();
+        let union = graphforge_storage::capture_project_storage_identity_union(&current).unwrap();
         assert!(
             union
                 .retained_generation_uuids
@@ -2244,7 +2443,12 @@ mod tests {
                 ],
             },
         };
-        assert!(session.observe(Phase::Reopen, &reopen, &[]).unwrap().is_none());
+        assert!(
+            session
+                .observe(Phase::Reopen, &reopen, &[])
+                .unwrap()
+                .is_none()
+        );
         session.generator_observed = true;
         session.construction_peak_observed = true;
         session.portable_package_observed = true;
@@ -2379,4 +2583,138 @@ mod tests {
         assert!(error.contains("missing an authenticated owner or transient phase"));
     }
 
+    #[test]
+    fn command_owned_cache_fallback_covers_complete_lifecycle() {
+        let root =
+            std::env::temp_dir().join(format!("gf-certify-cache-lifecycle-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+
+        for phase in Phase::ALL {
+            let owned = root.join(phase.to_string());
+            fs::create_dir_all(owned.join("nested")).unwrap();
+            fs::write(owned.join("nested").join("payload"), vec![7_u8; 1 << 20]).unwrap();
+            let evidence = release_command_owned_file_cache(&[
+                "--project".to_owned(),
+                owned.to_string_lossy().into_owned(),
+            ])
+            .unwrap();
+            #[cfg(unix)]
+            {
+                assert_eq!(evidence.files, 1, "{phase}");
+                assert_eq!(evidence.sync_operations, 1, "{phase}");
+                assert!(
+                    evidence.peak_window_bytes
+                        <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES,
+                    "{phase}"
+                );
+                #[cfg(target_os = "linux")]
+                {
+                    assert_eq!(evidence.release_operations, 1, "{phase}");
+                    assert_eq!(evidence.released_bytes, 1 << 20, "{phase}");
+                }
+                #[cfg(not(target_os = "linux"))]
+                assert_eq!(evidence.unsupported_operations, 1, "{phase}");
+            }
+            #[cfg(not(unix))]
+            {
+                assert_eq!(evidence.files, 0, "{phase}");
+                assert_eq!(evidence.unsupported_traversals, 1, "{phase}");
+            }
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn command_owned_cache_fallback_covers_s18_generator_and_register_shapes() {
+        let root = tempfile::tempdir().unwrap();
+        let nodes = root.path().join("nodes.parquet");
+        let edges = root.path().join("edges.parquet");
+        fs::write(&nodes, vec![1_u8; 1 << 20]).unwrap();
+        fs::write(&edges, vec![2_u8; 1 << 20]).unwrap();
+
+        let generated = release_command_owned_file_cache(&[
+            "--scale".to_owned(),
+            "18".to_owned(),
+            "--edge-factor".to_owned(),
+            "16".to_owned(),
+            "--nodes".to_owned(),
+            nodes.to_string_lossy().into_owned(),
+            "--edges".to_owned(),
+            edges.to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+        assert_eq!(generated.files, 2);
+        assert_eq!(generated.sync_operations, 2);
+
+        let project = root.path().join("project");
+        fs::create_dir(&project).unwrap();
+        fs::write(project.join("manifest.json"), b"durable").unwrap();
+        let registered = release_command_owned_file_cache(&[
+            "--project".to_owned(),
+            project.to_string_lossy().into_owned(),
+            "import-session".to_owned(),
+            "register-parquet".to_owned(),
+            "--path".to_owned(),
+            nodes.to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+        assert_eq!(registered.files, 2);
+        assert_eq!(registered.sync_operations, 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn command_owned_cache_fallback_never_follows_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let owned = root.path().join("owned");
+        let outside = root.path().join("outside");
+        fs::create_dir(&owned).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(owned.join("inside"), b"inside").unwrap();
+        fs::write(outside.join("secret"), b"outside").unwrap();
+        symlink(&outside, owned.join("escape")).unwrap();
+        symlink(outside.join("secret"), root.path().join("root-alias")).unwrap();
+
+        let nested = release_command_owned_file_cache(&[
+            "--project".to_owned(),
+            owned.to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+        assert_eq!(nested.files, 1);
+        assert_eq!(nested.sync_operations, 1);
+
+        let alias = release_command_owned_file_cache(&[
+            "--path".to_owned(),
+            root.path()
+                .join("root-alias")
+                .to_string_lossy()
+                .into_owned(),
+        ])
+        .unwrap();
+        assert_eq!(alias, CommandCacheReleaseEvidence::default());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unsuccessful_child_remains_primary_when_cache_release_fails() {
+        let root = tempfile::tempdir().unwrap();
+        let executable = root.path().join("fails");
+        fs::write(&executable, "#!/bin/sh\nexit 7\n").unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        inject_command_cache_release_failure();
+
+        let execution = execute_process(executable.to_str().unwrap(), &[]).unwrap();
+        assert_eq!(execution.exit_code, Some(7));
+        assert_eq!(execution.failure, Some(FailureKind::CommandFailed));
+        assert_eq!(
+            execution.cleanup_failure.as_deref(),
+            Some(
+                "child exit preserved; command-owned cache release also failed: injected command-owned cache release failure"
+            )
+        );
+    }
 }

--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -764,9 +764,15 @@ fn release_open_file_cache(
         .metadata()
         .map_err(|_| "command-owned cache file could not be inspected".to_owned())?
         .len();
-    file.sync_all()
-        .map_err(|_| "command-owned cache file synchronization failed".to_owned())?;
-    evidence.sync_operations = evidence.sync_operations.saturating_add(1);
+    // Unix synchronizes before attempting cache advice. Windows does not support
+    // this advice, and these retained input handles are read-only: attempting
+    // FlushFileBuffers would require write access and fail a completed command.
+    #[cfg(unix)]
+    {
+        file.sync_all()
+            .map_err(|_| "command-owned cache file synchronization failed".to_owned())?;
+        evidence.sync_operations = evidence.sync_operations.saturating_add(1);
+    }
     evidence.files = evidence.files.saturating_add(1);
     let mut offset = 0_u64;
     while offset < bytes {
@@ -1454,9 +1460,7 @@ pub fn certify_with_events(
                     } else {
                         execution.failure.or(Some(FailureKind::CommandFailed))
                     },
-                    cleanup_failure: sanitize_cleanup_failure(
-                        execution.cleanup_failure.as_deref(),
-                    ),
+                    cleanup_failure: sanitize_cleanup_failure(execution.cleanup_failure.as_deref()),
                     receipts: execution.receipts,
                 }
             }
@@ -1782,8 +1786,6 @@ fn resident_bytes(_pid: u32) -> Option<u64> {
 mod tests {
     use super::*;
     use std::collections::VecDeque;
-    #[cfg(unix)]
-    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn child_receipts_are_bounded_allowlisted_and_strip_content_bearing_paths() {
@@ -2238,10 +2240,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(evidence.failed_phase, Some(Phase::Admission));
-        assert_eq!(
-            evidence.phases[0].failure,
-            Some(FailureKind::CommandFailed)
-        );
+        assert_eq!(evidence.phases[0].failure, Some(FailureKind::CommandFailed));
         assert_eq!(
             evidence.phases[0].cleanup_failure,
             Some(CleanupFailureKind::CommandOwnedCacheReleaseFailed)
@@ -2341,6 +2340,19 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn shell_ingest_profile(script: &Path) -> Profile {
+        let mut profile = tiny_profile();
+        profile.executable = "/bin/sh".to_owned();
+        let PhaseAction::GraphForgeCliWorkflow { commands } = &mut profile.phases[2].action else {
+            panic!("ingest fixture must be a command workflow");
+        };
+        for args in commands {
+            args.insert(0, script.to_string_lossy().into_owned());
+        }
+        profile
+    }
+
+    #[cfg(unix)]
     #[test]
     fn public_executor_runs_ingest_transaction_in_order() {
         let root = std::env::temp_dir().join(format!("gf-certify-{}", std::process::id()));
@@ -2356,13 +2368,19 @@ mod tests {
             ),
         )
         .unwrap();
-        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
-        let mut profile = tiny_profile();
-        profile.executable = executable.to_string_lossy().into_owned();
+        // Model a write descriptor inherited by another concurrent child until
+        // its exec closes the descriptor. The stable shell reads the fixture;
+        // executing this newly written inode directly would be ETXTBSY.
+        let fixture_writer = fs::OpenOptions::new()
+            .write(true)
+            .open(&executable)
+            .unwrap();
+        let profile = shell_ingest_profile(&executable);
         let mut executor = PublicProcessExecutor::default();
         let result = executor.execute(&profile, &profile.phases[2]).unwrap();
         assert_eq!(result.exit_code, Some(0));
         assert_eq!(fs::read_to_string(state).unwrap().trim(), "5");
+        drop(fixture_writer);
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -2382,9 +2400,7 @@ mod tests {
             ),
         )
         .unwrap();
-        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
-        let mut profile = tiny_profile();
-        profile.executable = executable.to_string_lossy().into_owned();
+        let profile = shell_ingest_profile(&executable);
         let result = PublicProcessExecutor::default()
             .execute(&profile, &profile.phases[2])
             .unwrap();
@@ -2408,8 +2424,14 @@ mod tests {
             "#!/bin/sh\nprintf '%s\\n' '{\"contract\":\"graphforge-portable-import/2\"}'\n",
         )
         .unwrap();
-        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
-        let result = execute_process(executable.to_str().unwrap(), &["--json".to_owned()]).unwrap();
+        let result = execute_process(
+            "/bin/sh",
+            &[
+                executable.to_string_lossy().into_owned(),
+                "--json".to_owned(),
+            ],
+        )
+        .unwrap();
         assert_eq!(result.exit_code, Some(0));
         assert_eq!(result.failure, Some(FailureKind::EvidenceInvalid));
         fs::remove_dir_all(root).unwrap();
@@ -2625,6 +2647,41 @@ mod tests {
         fs::remove_dir_all(root).unwrap();
     }
 
+    #[test]
+    fn command_owned_cache_direct_files_preserve_read_only_inputs() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("input.parquet");
+        let payload = b"completed command input";
+        fs::write(&path, payload).unwrap();
+        for flag in ["--input", "--nodes", "--edges", "--path", "--output"] {
+            // StableDirectory opens the existing regular file with read access
+            // only, including on Windows. Each public flag must finish cleanup
+            // without requiring write authority over that input.
+            let evidence = release_command_owned_file_cache(&[
+                flag.to_owned(),
+                path.to_string_lossy().into_owned(),
+            ])
+            .unwrap();
+            assert_eq!(evidence.files, 1, "{flag}");
+            assert_eq!(evidence.sync_operations, u64::from(cfg!(unix)), "{flag}");
+            assert_eq!(evidence.unsupported_traversals, 0, "{flag}");
+            let supported = cfg!(target_os = "linux");
+            assert_eq!(evidence.release_operations, u64::from(supported), "{flag}");
+            assert_eq!(
+                evidence.unsupported_operations,
+                u64::from(!supported),
+                "{flag}"
+            );
+            assert_eq!(
+                evidence.released_bytes,
+                u64::from(supported) * payload.len() as u64,
+                "{flag}"
+            );
+            assert_eq!(evidence.peak_window_bytes, payload.len() as u64, "{flag}");
+            assert_eq!(fs::read(&path).unwrap(), payload, "{flag}");
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn command_owned_cache_fallback_covers_s18_generator_and_register_shapes() {
@@ -2704,10 +2761,10 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let executable = root.path().join("fails");
         fs::write(&executable, "#!/bin/sh\nexit 7\n").unwrap();
-        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
         inject_command_cache_release_failure();
 
-        let execution = execute_process(executable.to_str().unwrap(), &[]).unwrap();
+        let execution =
+            execute_process("/bin/sh", &[executable.to_string_lossy().into_owned()]).unwrap();
         assert_eq!(execution.exit_code, Some(7));
         assert_eq!(execution.failure, Some(FailureKind::CommandFailed));
         assert_eq!(

--- a/benchmarks/runners/graph500-generator/Cargo.toml
+++ b/benchmarks/runners/graph500-generator/Cargo.toml
@@ -12,4 +12,8 @@ path = "src/main.rs"
 
 [dependencies]
 arrow.workspace = true
+graphforge-filesystem = { path = "../../../crates/graphforge-filesystem" }
 parquet.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/benchmarks/runners/graph500-generator/src/main.rs
+++ b/benchmarks/runners/graph500-generator/src/main.rs
@@ -31,8 +31,8 @@ fn main() -> Result<(), String> {
         return Err("scale must be 1..26 and edge factor must be 16".to_owned());
     }
     let node_count = 1_u64 << config.scale;
-    write_nodes(&config.nodes, node_count)?;
-    write_edges(
+    let _node_cache_release = write_nodes(&config.nodes, node_count)?;
+    let _edge_cache_release = write_edges(
         &config.edges,
         config.scale,
         node_count.saturating_mul(config.edge_factor),
@@ -94,19 +94,35 @@ fn binary(values: impl Iterator<Item = [u8; 16]>) -> Result<FixedSizeBinaryArray
         .map_err(|error| error.to_string())
 }
 
-fn writer(path: &Path, schema: Arc<Schema>) -> Result<ArrowWriter<File>, String> {
+type DurableArrowWriter = ArrowWriter<graphforge_filesystem::DurableFileCacheWriter>;
+
+fn writer(path: &Path, schema: Arc<Schema>) -> Result<DurableArrowWriter, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
     }
-    ArrowWriter::try_new(
+    let output = graphforge_filesystem::DurableFileCacheWriter::new(
         File::create(path).map_err(|error| error.to_string())?,
-        schema,
-        None,
     )
-    .map_err(|error| error.to_string())
+    .map_err(|error| error.to_string())?;
+    ArrowWriter::try_new(output, schema, None).map_err(|error| error.to_string())
 }
 
-fn write_nodes(path: &Path, count: u64) -> Result<(), String> {
+fn finish_writer(
+    output: DurableArrowWriter,
+) -> Result<graphforge_filesystem::FileCacheReleaseEvidence, String> {
+    // `into_inner` finalizes and flushes the Parquet footer before the durable
+    // writer synchronizes and releases the final clean cache window.
+    let mut output = output.into_inner().map_err(|error| error.to_string())?;
+    output
+        .sync_all_and_release()
+        .map_err(|error| error.to_string())?;
+    Ok(output.evidence())
+}
+
+fn write_nodes(
+    path: &Path,
+    count: u64,
+) -> Result<graphforge_filesystem::FileCacheReleaseEvidence, String> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("node_uuid", DataType::FixedSizeBinary(16), true),
         Field::new("label", DataType::Utf8, false),
@@ -125,11 +141,15 @@ fn write_nodes(path: &Path, count: u64) -> Result<(), String> {
         .map_err(|error| error.to_string())?;
         output.write(&batch).map_err(|error| error.to_string())?;
     }
-    output.close().map_err(|error| error.to_string())?;
-    Ok(())
+    finish_writer(output)
 }
 
-fn write_edges(path: &Path, scale: u32, count: u64, seed: u64) -> Result<(), String> {
+fn write_edges(
+    path: &Path,
+    scale: u32,
+    count: u64,
+    seed: u64,
+) -> Result<graphforge_filesystem::FileCacheReleaseEvidence, String> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("edge_uuid", DataType::FixedSizeBinary(16), true),
         Field::new("rel_type", DataType::Utf8, false),
@@ -160,8 +180,7 @@ fn write_edges(path: &Path, scale: u32, count: u64, seed: u64) -> Result<(), Str
         .map_err(|error| error.to_string())?;
         output.write(&batch).map_err(|error| error.to_string())?;
     }
-    output.close().map_err(|error| error.to_string())?;
-    Ok(())
+    finish_writer(output)
 }
 
 fn rmat_edge(scale: u32, random: &mut SplitMix64) -> (u64, u64) {
@@ -212,5 +231,44 @@ mod tests {
                 .iter()
                 .all(|(source, target)| *source < 64 && *target < 64)
         );
+    }
+
+    #[test]
+    fn generator_outputs_are_finalized_before_bounded_durable_release() {
+        let root = tempfile::tempdir().unwrap();
+        let nodes = root.path().join("nodes.parquet");
+        let edges = root.path().join("edges.parquet");
+        let node_evidence = write_nodes(&nodes, 128).unwrap();
+        let edge_evidence = write_edges(&edges, 7, 256, 13_907_095_936_298_285_200).unwrap();
+
+        for (path, evidence) in [(&nodes, node_evidence), (&edges, edge_evidence)] {
+            assert!(path.metadata().unwrap().len() > 0);
+            assert!(
+                evidence.peak_window_bytes
+                    <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+            );
+            assert!(evidence.sync_operations > 0);
+            #[cfg(target_os = "linux")]
+            {
+                assert!(evidence.release_operations > 0);
+                assert_eq!(evidence.unsupported_operations, 0);
+            }
+            #[cfg(not(target_os = "linux"))]
+            assert!(evidence.unsupported_operations > 0);
+
+            let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+                File::open(path).unwrap(),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+            assert!(
+                reader
+                    .map(Result::unwrap)
+                    .map(|batch| batch.num_rows())
+                    .sum::<usize>()
+                    > 0
+            );
+        }
     }
 }

--- a/benchmarks/schemas/certification-evidence.json
+++ b/benchmarks/schemas/certification-evidence.json
@@ -57,6 +57,9 @@
         "failure": {
           "enum": ["command_failed", "command_unavailable", "evidence_invalid"]
         },
+        "cleanup_failure": {
+          "enum": ["receipt_cleanup_failed", "command_owned_cache_release_failed", "multiple_cleanup_failures", "cleanup_failed"]
+        },
         "receipts": {
           "type": "array",
           "maxItems": 8,
@@ -111,6 +114,14 @@
           },
           "then": { "required": ["failure"] },
           "else": { "not": { "required": ["failure"] } }
+        },
+        {
+          "if": {
+            "required": ["cleanup_failure"]
+          },
+          "then": {
+            "properties": { "status": { "const": "failed" } }
+          }
         }
       ],
       "additionalProperties": false

--- a/benchmarks/tests/test_progressive_qualification.py
+++ b/benchmarks/tests/test_progressive_qualification.py
@@ -4,6 +4,9 @@ import copy
 import hashlib
 import json
 from pathlib import Path
+import runpy
+import shutil
+import tempfile
 import unittest
 
 from graphforge_bench.progressive_qualification import (
@@ -362,6 +365,35 @@ class ProgressiveQualificationTests(unittest.TestCase):
         profile = json.loads((ROOT / "profiles/graph500/s18-local.json").read_text())
         profile["generator"]["identity"] = 42
         self.assertFalse(self.profile_schema.is_valid(profile))
+
+    def test_identity_regeneration_never_rewrites_commit_bound_evidence(self) -> None:
+        tool = runpy.run_path(str(ROOT.parent / "scripts/ci/graph500-generator-identity.py"))
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for relative in (
+                "benchmarks/profiles/graph500",
+                "benchmarks/fixtures/progressive",
+                "benchmarks/fixtures/parity/ladder-bundle",
+                "benchmarks/runners/graph500-generator/src",
+            ):
+                source = ROOT.parent / relative
+                shutil.copytree(source, root / relative)
+            generator = root / "benchmarks/runners/graph500-generator/src/main.rs"
+            generator.write_bytes(generator.read_bytes() + b"\n// changed\n")
+            historical = root / "benchmarks/fixtures/parity/ladder-bundle/manifest.json"
+            before = historical.read_bytes()
+
+            self.assertEqual(tool["main"](["--root", str(root), "--write"]), 0)
+
+            expected = "sha256:" + hashlib.sha256(generator.read_bytes()).hexdigest()
+            profile = json.loads((root / "benchmarks/profiles/graph500/s18-local.json").read_text())
+            tiny = json.loads(
+                (root / "benchmarks/fixtures/progressive/tiny-executable.json").read_text()
+            )
+            self.assertEqual(profile["generator"]["identity"], expected)
+            self.assertEqual(profile["phases"][1]["action"]["identity"], expected)
+            self.assertEqual(tiny["phases"][1]["action"]["identity"], expected)
+            self.assertEqual(historical.read_bytes(), before)
 
     def test_each_capacity_dimension_refuses_independently(self) -> None:
         cases = {

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -22,9 +22,11 @@ _API_COMPILE_DATA = [
 ]
 
 _API_DEPS = [
+    "@crates//:bytes",
     "//crates/graphforge-core:graphforge_core",
     "//crates/graphforge-cypher:graphforge_cypher",
     "//crates/graphforge-exec:graphforge_exec",
+    "//crates/graphforge-filesystem:graphforge_filesystem",
     "//crates/graphforge-ir:graphforge_ir",
     "//crates/graphforge-io:graphforge_io",
     "//crates/graphforge-knowledge:graphforge_knowledge",
@@ -210,7 +212,7 @@ gf_rust_integration_test(
     data = _API_TEST_DATA,
     size = "large",
     timeout = "long",
-    deps = _API_DEPS + ["//crates/graphforge-filesystem:graphforge_filesystem"],
+    deps = _API_DEPS,
 )
 
 gf_rust_integration_test(

--- a/crates/graphforge-api/Cargo.toml
+++ b/crates/graphforge-api/Cargo.toml
@@ -20,7 +20,9 @@ graphforge-exec = { version = "0.5.2", path = "../graphforge-exec" }
 graphforge-io = { version = "0.5.2", path = "../graphforge-io" }
 graphforge-observability = { version = "0.5.2", path = "../graphforge-observability" }
 graphforge-search = { version = "0.5.2", path = "../graphforge-search" }
+graphforge-filesystem = { version = "0.5.2", path = "../graphforge-filesystem" }
 arrow = { workspace = true }
+bytes = "1"
 datafusion = { workspace = true }
 futures = { workspace = true }
 parquet = { workspace = true }
@@ -39,7 +41,6 @@ cucumber = { workspace = true }
 tokio = { workspace = true }
 graphforge-cypher = { path = "../graphforge-cypher" }
 graphforge-storage = { path = "../graphforge-storage", features = ["test-failpoints", "test-support"] }
-graphforge-filesystem = { path = "../graphforge-filesystem" }
 
 # BDD runner for the public-API + TCK feature files (tests/features/).
 # A custom-harness target (cucumber drives its own main).

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -1,15 +1,17 @@
 //! Durable, bounded staged graph-import sessions (#738).
 
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Write};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use arrow::ipc::reader::FileReader as ArrowFileReader;
 use arrow::ipc::writer::FileWriter as ArrowFileWriter;
 use arrow::record_batch::RecordBatch;
+use bytes::Bytes;
 use graphforge_core::GfError;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::file::reader::{ChunkReader, Length};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -19,6 +21,31 @@ use crate::{BulkInputKind, CancellationToken, GraphConstructionBudgets, GraphFor
 const FORMAT_VERSION: u32 = 1;
 const SESSION_DIR: &str = "import-sessions";
 const MANIFEST: &str = "manifest.json";
+
+#[cfg(test)]
+thread_local! {
+    static COPY_PARQUET_FAILURES: std::cell::RefCell<Vec<&'static str>> = const {
+        std::cell::RefCell::new(Vec::new())
+    };
+}
+
+#[cfg(test)]
+fn inject_copy_parquet_failures(points: &[&'static str]) {
+    COPY_PARQUET_FAILURES.with(|failures| failures.borrow_mut().extend_from_slice(points));
+}
+
+#[cfg(test)]
+fn copy_parquet_failure(point: &str) -> Result<(), GfError> {
+    COPY_PARQUET_FAILURES.with(|failures| {
+        let mut failures = failures.borrow_mut();
+        if let Some(index) = failures.iter().position(|candidate| *candidate == point) {
+            failures.remove(index);
+            return Err(storage(format!("injected Parquet copy {point} failure")));
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
 
 /// Explicit resource envelope for one staged import.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -153,6 +180,18 @@ pub struct ImportConstructionEvidence {
     pub write_operations: u64,
     /// File and directory durability barriers completed by construction.
     pub fsync_operations: u64,
+    /// Successful file-level page-cache release boundaries.
+    #[serde(default)]
+    pub cache_release_operations: u64,
+    /// Page-cache release boundaries unsupported by the target platform.
+    #[serde(default)]
+    pub cache_release_unsupported_operations: u64,
+    /// Clean file bytes covered by successful page-cache release requests.
+    #[serde(default)]
+    pub cache_released_bytes: u64,
+    /// Largest synchronized file-cache window between release boundaries.
+    #[serde(default)]
+    pub peak_cache_release_window_bytes: u64,
     /// Largest retained Arrow row window.
     pub peak_batch_rows: u64,
     /// Largest retained Arrow byte window.
@@ -441,8 +480,11 @@ impl GraphImportSession {
         let destination = self.root.join("sources").join(&name);
         let temporary = self.root.join("sources").join(format!(".{name}.tmp"));
         let file = File::create(&temporary).map_err(storage)?;
-        let mut writer = ArrowFileWriter::try_new(BufWriter::new(file), &batches[0].schema())
-            .map_err(storage)?;
+        let cache_writer =
+            graphforge_filesystem::DurableFileCacheWriter::new(file).map_err(storage)?;
+        let mut writer =
+            ArrowFileWriter::try_new(BufWriter::new(cache_writer), &batches[0].schema())
+                .map_err(storage)?;
         let mut rows = 0_u64;
         for batch in batches {
             if batch.num_rows() > self.manifest.limits.batch_rows {
@@ -457,8 +499,13 @@ impl GraphImportSession {
                 .max(batch.num_rows() as u64);
         }
         writer.finish().map_err(storage)?;
+        writer.flush().map_err(storage)?;
+        writer
+            .get_mut()
+            .get_mut()
+            .sync_all_and_release()
+            .map_err(storage)?;
         fs::rename(&temporary, &destination).map_err(storage)?;
-        sync_file(&destination)?;
         let result = self.register_record(
             source_kind,
             name,
@@ -493,17 +540,41 @@ impl GraphImportSession {
         let sequence = self.next_sequence()?;
         let name = format!("{sequence:020}.parquet");
         let destination = self.root.join("sources").join(&name);
-        fs::copy(source, &destination).map_err(storage)?;
-        sync_file(&destination)?;
-        self.register_record(
+        let temporary = self.root.join("sources").join(format!(".{name}.tmp"));
+        let (bytes, cache_release) = copy_parquet_source(source, &temporary)?;
+        let writer_release = cache_release.writer;
+        debug_assert!(writer_release.sync_operations > 0);
+        #[cfg(target_os = "linux")]
+        {
+            let operation_window = graphforge_filesystem::cache_release_window_for_streams(2)
+                .expect("two-stream cache budget is valid");
+            debug_assert!(cache_release.reader.peak_window_bytes <= operation_window.get());
+            debug_assert!(cache_release.writer.peak_window_bytes <= operation_window.get());
+            debug_assert!(
+                cache_release.peak_combined_window_bytes
+                    <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+            );
+        }
+        #[cfg(not(target_os = "linux"))]
+        let _ = cache_release.peak_combined_window_bytes;
+        if bytes != metadata.len() {
+            let _ = fs::remove_file(&temporary);
+            return Err(storage("Parquet source length changed while copying"));
+        }
+        fs::rename(&temporary, &destination).map_err(storage)?;
+        let result = self.register_record(
             match kind {
                 BulkInputKind::Node => ImportSourceKind::ParquetNodes,
                 BulkInputKind::Edge => ImportSourceKind::ParquetEdges,
             },
             name,
-            metadata.len(),
+            bytes,
             0,
-        )
+        );
+        if result.is_err() {
+            let _ = fs::remove_file(destination);
+        }
+        result
     }
 
     /// Persist counters and source ordering without publishing graph state.
@@ -758,6 +829,12 @@ impl GraphImportSession {
             write_bytes: progress.evidence.write_bytes,
             write_operations: progress.evidence.write_operations,
             fsync_operations: progress.evidence.fsync_operations,
+            cache_release_operations: progress.evidence.cache_release_operations,
+            cache_release_unsupported_operations: progress
+                .evidence
+                .cache_release_unsupported_operations,
+            cache_released_bytes: progress.evidence.cache_released_bytes,
+            peak_cache_release_window_bytes: progress.evidence.peak_cache_release_window_bytes,
             peak_batch_rows: progress.evidence.peak_batch_rows,
             peak_batch_bytes: progress.evidence.peak_batch_bytes,
             transient_peak_allocated_bytes: progress
@@ -822,31 +899,224 @@ fn for_each_source_batch(
     mut consume: impl FnMut(RecordBatch) -> Result<(), GfError>,
 ) -> Result<(), GfError> {
     let path = root.join("sources").join(&source.name);
+    let tracker = graphforge_filesystem::FileCacheReleaseTracker::default();
     match source.kind {
         ImportSourceKind::ArrowNodes | ImportSourceKind::ArrowEdges => {
-            for batch in
-                ArrowFileReader::try_new(BufReader::new(File::open(path).map_err(storage)?), None)
-                    .map_err(storage)?
-            {
-                consume(batch.map_err(storage)?)?;
-            }
+            let result = (|| {
+                let file = File::open(path).map_err(storage)?;
+                let reader = graphforge_filesystem::FileCacheReleasingReader::with_tracker(
+                    file,
+                    tracker.clone(),
+                )
+                .map_err(storage)?;
+                for batch in
+                    ArrowFileReader::try_new(BufReader::new(reader), None).map_err(storage)?
+                {
+                    consume(batch.map_err(storage)?)?;
+                }
+                Ok(())
+            })();
+            finish_source_cache_release(result, &tracker, "Arrow source")?;
         }
         ImportSourceKind::ParquetNodes | ImportSourceKind::ParquetEdges => {
-            let reader =
-                ParquetRecordBatchReaderBuilder::try_new(File::open(path).map_err(storage)?)
+            let result = (|| {
+                let file = File::open(path).map_err(storage)?;
+                let chunk_reader = ImportChunkReader::new(file, tracker.clone())?;
+                let reader = ParquetRecordBatchReaderBuilder::try_new(chunk_reader)
                     .map_err(storage)?
                     .with_batch_size(batch_rows)
                     .build()
                     .map_err(storage)?;
-            for batch in reader {
-                consume(canonicalize_parquet_batch(
-                    source.kind.input_kind(),
-                    &batch.map_err(storage)?,
-                )?)?;
-            }
+                for batch in reader {
+                    consume(canonicalize_parquet_batch(
+                        source.kind.input_kind(),
+                        &batch.map_err(storage)?,
+                    )?)?;
+                }
+                Ok(())
+            })();
+            finish_source_cache_release(result, &tracker, "Parquet source")?;
         }
     }
     Ok(())
+}
+
+#[derive(Clone)]
+struct ImportChunkReader {
+    file: std::sync::Arc<File>,
+    length: u64,
+    tracker: graphforge_filesystem::FileCacheReleaseTracker,
+}
+
+impl ImportChunkReader {
+    fn new(
+        file: File,
+        tracker: graphforge_filesystem::FileCacheReleaseTracker,
+    ) -> Result<Self, GfError> {
+        let length = file.metadata().map_err(storage)?.len();
+        Ok(Self {
+            file: std::sync::Arc::new(file),
+            length,
+            tracker,
+        })
+    }
+}
+
+impl Length for ImportChunkReader {
+    fn len(&self) -> u64 {
+        self.length
+    }
+}
+
+impl ChunkReader for ImportChunkReader {
+    type T = BufReader<graphforge_filesystem::FileCacheReleasingReader>;
+
+    fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
+        let file = self.file.try_clone()?;
+        let mut reader = graphforge_filesystem::FileCacheReleasingReader::with_tracker(
+            file,
+            self.tracker.clone(),
+        )?;
+        reader.seek(SeekFrom::Start(start))?;
+        Ok(BufReader::new(reader))
+    }
+
+    fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<Bytes> {
+        let file = self.file.try_clone()?;
+        let mut reader = graphforge_filesystem::FileCacheReleasingReader::with_tracker(
+            file,
+            self.tracker.clone(),
+        )?;
+        reader.seek(SeekFrom::Start(start))?;
+        let mut bytes = vec![0_u8; length];
+        reader.read_exact(&mut bytes)?;
+        reader.finish()?;
+        Ok(Bytes::from(bytes))
+    }
+}
+
+fn finish_source_cache_release<T>(
+    primary: Result<T, GfError>,
+    tracker: &graphforge_filesystem::FileCacheReleaseTracker,
+    source_kind: &str,
+) -> Result<T, GfError> {
+    match (primary, tracker.check_error()) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(release)) => Err(storage(release)),
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(release)) => Err(storage(format!(
+            "{primary}; {source_kind} cache release also failed: {release}"
+        ))),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct CopyCacheReleaseEvidence {
+    reader: graphforge_filesystem::FileCacheReleaseEvidence,
+    writer: graphforge_filesystem::FileCacheReleaseEvidence,
+    peak_combined_window_bytes: u64,
+}
+
+fn finish_parquet_copy_source(
+    reader: &mut graphforge_filesystem::FileCacheReleasingReader,
+) -> Result<graphforge_filesystem::FileCacheReleaseEvidence, GfError> {
+    let evidence = reader.finish().map_err(storage)?;
+    #[cfg(test)]
+    copy_parquet_failure("source release")?;
+    Ok(evidence)
+}
+
+fn synchronize_parquet_copy_output(
+    writer: &mut graphforge_filesystem::DurableFileCacheWriter,
+) -> Result<(), GfError> {
+    writer.sync_all_and_release().map_err(storage)?;
+    #[cfg(test)]
+    copy_parquet_failure("writer release")?;
+    Ok(())
+}
+
+fn copy_parquet_source(
+    source: &Path,
+    temporary: &Path,
+) -> Result<(u64, CopyCacheReleaseEvidence), GfError> {
+    let parent = source
+        .parent()
+        .ok_or_else(|| validation("Parquet source must have a parent directory"))?;
+    let name = source
+        .file_name()
+        .ok_or_else(|| validation("Parquet source must have a file name"))?;
+    let directory = graphforge_filesystem::StableDirectory::open(parent).map_err(storage)?;
+    let source_file = directory.open_child_file(name).map_err(storage)?;
+    let tracker = graphforge_filesystem::FileCacheReleaseTracker::default();
+    let window = graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage)?;
+    let mut reader = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+        source_file,
+        window,
+        tracker.clone(),
+    )
+    .map_err(storage)?;
+    let mut writer = graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(
+        File::create(temporary).map_err(storage)?,
+        window,
+    )
+    .map_err(storage)?;
+    let mut copied = 0_u64;
+    let copied_result = (|| -> Result<(), GfError> {
+        let mut buffer = vec![0_u8; 1024 * 1024];
+        loop {
+            let read = reader.read(&mut buffer).map_err(storage)?;
+            if read == 0 {
+                break;
+            }
+            writer.write_all(&buffer[..read]).map_err(storage)?;
+            copied = copied
+                .checked_add(u64::try_from(read).map_err(storage)?)
+                .ok_or_else(|| storage("Parquet copy byte count overflow"))?;
+            #[cfg(test)]
+            copy_parquet_failure("copy")?;
+        }
+        Ok(())
+    })();
+    let reader_release = finish_parquet_copy_source(&mut reader);
+    let writer_release = synchronize_parquet_copy_output(&mut writer);
+    let mut result =
+        append_copy_cleanup(copied_result, reader_release.map(|_| ()), "source release");
+    result = append_copy_cleanup(result, writer_release, "writer synchronization/release");
+    let reader_evidence = tracker.evidence();
+    let writer_evidence = writer.evidence();
+    let peak_combined_window_bytes = reader_evidence
+        .peak_window_bytes
+        .checked_add(writer_evidence.peak_window_bytes)
+        .ok_or_else(|| storage("Parquet copy cache-window evidence overflow"))?;
+    drop(writer);
+    drop(reader);
+    if let Err(primary) = result {
+        let removed = fs::remove_file(temporary).map_err(storage);
+        return append_copy_cleanup(Err(primary), removed, "partial output removal");
+    }
+    Ok((
+        copied,
+        CopyCacheReleaseEvidence {
+            reader: reader_evidence,
+            writer: writer_evidence,
+            peak_combined_window_bytes,
+        },
+    ))
+}
+
+fn append_copy_cleanup<T>(
+    primary: Result<T, GfError>,
+    cleanup: Result<(), GfError>,
+    context: &str,
+) -> Result<T, GfError> {
+    match (primary, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup)) => Err(cleanup),
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(cleanup)) => Err(storage(format!(
+            "{primary}; Parquet copy {context} also failed: {cleanup}"
+        ))),
+    }
 }
 
 fn canonicalize_parquet_batch(
@@ -931,12 +1201,6 @@ fn import_batch_operation(base: Uuid, source: u64, batch: u64) -> OperationId {
     bytes[6] = (bytes[6] & 0x0f) | 0x70;
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
     OperationId(Uuid::from_bytes(bytes))
-}
-
-fn sync_file(path: &Path) -> Result<(), GfError> {
-    File::open(path)
-        .and_then(|file| file.sync_all())
-        .map_err(storage)
 }
 
 fn validation(message: impl Into<String>) -> GfError {
@@ -1049,12 +1313,38 @@ mod tests {
             .unwrap();
         let progress = resumed.validate(&graph).unwrap();
         assert_eq!((progress.rows_accepted, progress.files_pending), (3, 0));
+        let construction = progress.construction.as_ref().unwrap();
+        assert!(
+            construction.peak_cache_release_window_bytes
+                <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        );
+        #[cfg(target_os = "linux")]
+        {
+            assert!(construction.cache_release_operations > 0);
+            assert!(construction.cache_released_bytes > 0);
+            assert_eq!(construction.cache_release_unsupported_operations, 0);
+        }
+        #[cfg(not(target_os = "linux"))]
+        assert!(construction.cache_release_unsupported_operations > 0);
         assert_eq!(*graph.current_generation_uuid.lock().unwrap(), before);
         let committed = resumed.commit(&graph, None).unwrap();
         assert_ne!(committed, before);
+        let expected_inventory = graphforge_storage::resolve_project_generation(
+            &graph.resolved_generation.container_root(),
+        )
+        .unwrap()
+        .graph_files_inventory()
+        .unwrap();
 
         drop(graph);
         let reopened = GraphForge::new(project.to_str()).unwrap();
+        let reopened_inventory = graphforge_storage::resolve_project_generation(
+            reopened.resolved_generation.container_root(),
+        )
+        .unwrap()
+        .graph_files_inventory()
+        .unwrap();
+        assert_eq!(reopened_inventory, expected_inventory);
         assert_eq!(reopened.node_count("Person").unwrap(), 2);
         assert_eq!(
             reopened
@@ -1066,6 +1356,132 @@ mod tests {
                 .sum::<usize>(),
             1
         );
+    }
+
+    #[test]
+    fn in_memory_import_reports_bounded_cache_release_evidence() {
+        let graph = GraphForge::new(None).unwrap();
+        let node_ids = [Uuid::now_v7(), Uuid::now_v7()];
+        let mut session = graph
+            .begin_import_session(OperationId(Uuid::now_v7()), ImportSessionLimits::default())
+            .unwrap();
+        session
+            .append_arrow(BulkInputKind::Node, &[nodes(&node_ids)])
+            .unwrap();
+        let validated = session.validate(&graph).unwrap();
+        let evidence = validated.construction.unwrap();
+        assert!(
+            evidence.peak_cache_release_window_bytes
+                <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        );
+        #[cfg(target_os = "linux")]
+        {
+            assert!(evidence.cache_release_operations > 0);
+            assert!(evidence.cache_released_bytes > 0);
+            assert_eq!(evidence.cache_release_unsupported_operations, 0);
+        }
+        #[cfg(not(target_os = "linux"))]
+        assert!(evidence.cache_release_unsupported_operations > 0);
+
+        session.commit(&graph, None).unwrap();
+        assert_eq!(graph.node_count("Person").unwrap(), 2);
+    }
+
+    #[test]
+    fn parquet_registration_copy_bounds_combined_non_sparse_cache_and_preserves_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source.parquet");
+        let destination = root.path().join("destination.tmp");
+        let chunk = (0_u32..(1 << 18))
+            .flat_map(u32::to_le_bytes)
+            .collect::<Vec<_>>();
+        let length = 129_u64 * 1024 * 1024 + 17;
+        let mut output = File::create(&source).unwrap();
+        let mut remaining = length;
+        while remaining > 0 {
+            let bytes = usize::try_from(remaining.min(chunk.len() as u64)).unwrap();
+            output.write_all(&chunk[..bytes]).unwrap();
+            remaining -= bytes as u64;
+        }
+        output.sync_all().unwrap();
+        drop(output);
+
+        let (copied, evidence) = copy_parquet_source(&source, &destination).unwrap();
+        assert_eq!(copied, length);
+        assert_eq!(destination.metadata().unwrap().len(), length);
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(evidence.reader.release_operations, 5);
+            assert_eq!(evidence.writer.release_operations, 5);
+            assert_eq!(evidence.reader.released_bytes, length);
+            assert_eq!(evidence.writer.released_bytes, length);
+            assert_eq!(
+                evidence.peak_combined_window_bytes,
+                graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+            );
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(evidence.reader.unsupported_operations, 1);
+            assert_eq!(evidence.writer.unsupported_operations, 1);
+            assert_eq!(evidence.peak_combined_window_bytes, length * 2);
+        }
+
+        let mut expected = BufReader::new(File::open(source).unwrap());
+        let mut actual = BufReader::new(File::open(destination).unwrap());
+        let mut expected_chunk = vec![0_u8; 1 << 20];
+        let mut actual_chunk = vec![0_u8; 1 << 20];
+        loop {
+            let expected_read = expected.read(&mut expected_chunk).unwrap();
+            let actual_read = actual.read(&mut actual_chunk).unwrap();
+            assert_eq!(actual_read, expected_read);
+            assert_eq!(
+                &actual_chunk[..actual_read],
+                &expected_chunk[..expected_read]
+            );
+            if expected_read == 0 {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn parquet_copy_failure_syncs_and_removes_partial_output() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source.parquet");
+        let destination = root.path().join("destination.tmp");
+        std::fs::write(&source, vec![7_u8; 2 * 1024 * 1024]).unwrap();
+        inject_copy_parquet_failures(&["copy"]);
+
+        let error = copy_parquet_source(&source, &destination).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("injected Parquet copy copy failure")
+        );
+        assert!(!destination.exists());
+    }
+
+    #[test]
+    fn parquet_copy_preserves_primary_and_appends_every_cleanup_failure() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source.parquet");
+        let destination = root.path().join("destination.tmp");
+        std::fs::write(&source, vec![9_u8; 2 * 1024 * 1024]).unwrap();
+        inject_copy_parquet_failures(&["copy", "source release", "writer release"]);
+
+        let error = copy_parquet_source(&source, &destination)
+            .unwrap_err()
+            .to_string();
+        let copy = error.find("injected Parquet copy copy failure").unwrap();
+        let source_release = error
+            .find("Parquet copy source release also failed")
+            .unwrap();
+        let writer_release = error
+            .find("Parquet copy writer synchronization/release also failed")
+            .unwrap();
+        assert!(copy < source_release && source_release < writer_release);
+        assert!(!destination.exists());
     }
 
     #[test]

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -3769,7 +3769,17 @@ fn tiny_construction_ladder_resumes_and_scales_bounded_work_linearly() {
             progress.evidence.input_batches
         );
         assert_eq!(progress.evidence.immutable_artifacts, 7 * factor + 4);
-        assert_eq!(progress.evidence.fsync_operations, 23 * factor + 13);
+        // Each full node-detail run (272 * 65,536 bytes = 17 MiB) and
+        // edge-detail run (304 * 65,536 bytes = 19 MiB) crosses the 16 MiB
+        // per-stream cache window once. The final edge chunk is two rows
+        // short and still crosses once; the separately acknowledged one-edge
+        // chunk does not. These synchronized rollovers add two real barriers
+        // per factor to the original artifact publication protocol on Linux.
+        let rollover_fsyncs = u64::from(cfg!(target_os = "linux")) * 2 * factor;
+        assert_eq!(
+            progress.evidence.fsync_operations,
+            23 * factor + 13 + rollover_fsyncs
+        );
         assert!(progress.evidence.peak_batch_rows <= CONSTRUCTION_BATCH_ROWS as u64);
         assert!(progress.evidence.peak_accounted_live_bytes <= 64 * 1024 * 1024);
         assert!(progress.evidence.peak_run_records <= budgets.max_run_records as u64);

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -3,10 +3,591 @@
 
 #![deny(unsafe_code)]
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs::File;
-use std::io;
+use std::io::{self, Read, Seek, Write};
+use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+/// Default maximum dirty/file-cache window retained by one durable writer.
+pub const DEFAULT_CACHE_RELEASE_WINDOW_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Derive one non-zero per-stream window from the shared 64 MiB operation budget.
+///
+/// # Errors
+/// Returns an error for zero streams, an unrepresentable stream count, or when
+/// the stream count is too large to receive even one byte.
+pub fn cache_release_window_for_streams(active_streams: usize) -> io::Result<NonZeroU64> {
+    let active_streams = u64::try_from(active_streams)
+        .map_err(|_| io::Error::other("cache-release stream count overflow"))?;
+    if active_streams == 0 {
+        return Err(io::Error::other("cache-release stream count is zero"));
+    }
+    let window = DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        .checked_div(active_streams)
+        .and_then(NonZeroU64::new)
+        .ok_or_else(|| io::Error::other("cache-release operation budget is exhausted"))?;
+    let aggregate = window
+        .get()
+        .checked_mul(active_streams)
+        .ok_or_else(|| io::Error::other("cache-release aggregate window overflow"))?;
+    if aggregate > DEFAULT_CACHE_RELEASE_WINDOW_BYTES {
+        return Err(io::Error::other(
+            "cache-release aggregate window exceeds operation budget",
+        ));
+    }
+    Ok(window)
+}
+
+/// Validate the aggregate configured windows of the streams actually opened
+/// by one operation.
+///
+/// # Errors
+/// Returns an error on arithmetic overflow, an empty stream set, or an
+/// aggregate above the shared 64 MiB operation budget.
+pub fn validate_cache_release_operation_windows(windows: &[NonZeroU64]) -> io::Result<u64> {
+    if windows.is_empty() {
+        return Err(io::Error::other(
+            "cache-release operation has no active streams",
+        ));
+    }
+    let aggregate = windows.iter().try_fold(0_u64, |sum, window| {
+        sum.checked_add(window.get())
+            .ok_or_else(|| io::Error::other("cache-release aggregate window overflow"))
+    })?;
+    if aggregate > DEFAULT_CACHE_RELEASE_WINDOW_BYTES {
+        return Err(io::Error::other(
+            "cache-release aggregate window exceeds operation budget",
+        ));
+    }
+    Ok(aggregate)
+}
+
+/// Result of one file-level page-cache release request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileCacheReleaseOutcome {
+    /// The operating system accepted the release request.
+    Released,
+    /// This target has no supported file-level cache-release primitive.
+    Unsupported,
+}
+
+/// Content-free evidence emitted by a durable cache-bounded writer.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FileCacheReleaseEvidence {
+    /// Synchronization barriers completed by the writer.
+    pub sync_operations: u64,
+    /// File-level cache-release requests accepted by the operating system.
+    pub release_operations: u64,
+    /// File-level cache-release requests not supported on this target.
+    pub unsupported_operations: u64,
+    /// Bytes covered by accepted release requests.
+    pub released_bytes: u64,
+    /// Largest byte window synchronized before a release request.
+    pub peak_window_bytes: u64,
+}
+
+/// Shared evidence and deferred-error channel for cache-releasing readers.
+#[derive(Clone, Debug, Default)]
+pub struct FileCacheReleaseTracker {
+    state: Arc<Mutex<FileCacheReleaseTrackerState>>,
+}
+
+#[derive(Debug, Default)]
+struct FileCacheReleaseTrackerState {
+    evidence: FileCacheReleaseEvidence,
+    deferred_error: Option<(io::ErrorKind, String)>,
+}
+
+impl FileCacheReleaseTracker {
+    /// Return aggregate evidence from every reader attached to this tracker.
+    #[must_use]
+    pub fn evidence(&self) -> FileCacheReleaseEvidence {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .evidence
+    }
+
+    /// Surface an advisory failure captured while a reader was being dropped.
+    ///
+    /// # Errors
+    /// Returns the first deferred cache-release error.
+    pub fn check_error(&self) -> io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match state.deferred_error.take() {
+            Some((kind, message)) => Err(io::Error::new(kind, message)),
+            None => Ok(()),
+        }
+    }
+
+    fn account(&self, outcome: FileCacheReleaseOutcome, bytes: u64) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.evidence.peak_window_bytes = state.evidence.peak_window_bytes.max(bytes);
+        match outcome {
+            FileCacheReleaseOutcome::Released => {
+                state.evidence.release_operations =
+                    state.evidence.release_operations.saturating_add(1);
+                state.evidence.released_bytes = state.evidence.released_bytes.saturating_add(bytes);
+            }
+            FileCacheReleaseOutcome::Unsupported => {
+                state.evidence.unsupported_operations =
+                    state.evidence.unsupported_operations.saturating_add(1);
+            }
+        }
+    }
+
+    fn defer(&self, error: &io::Error) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.deferred_error.is_none() {
+            state.deferred_error = Some((error.kind(), error.to_string()));
+        }
+    }
+}
+
+/// Owned sequential reader that releases completed, already-consumed windows.
+#[derive(Debug)]
+pub struct FileCacheReleasingReader {
+    file: File,
+    window_bytes: NonZeroU64,
+    pending_offset: u64,
+    pending_bytes: u64,
+    tracker: FileCacheReleaseTracker,
+    finished: bool,
+}
+
+impl FileCacheReleasingReader {
+    /// Wrap `file` at its current descriptor offset with the default window.
+    ///
+    /// # Errors
+    /// Returns an error when the current descriptor offset cannot be observed.
+    pub fn new(file: File) -> io::Result<Self> {
+        Self::with_window_bytes(
+            file,
+            NonZeroU64::new(DEFAULT_CACHE_RELEASE_WINDOW_BYTES)
+                .expect("default cache-release window is non-zero"),
+            FileCacheReleaseTracker::default(),
+        )
+    }
+
+    /// Wrap `file` at its current descriptor offset and attach shared evidence.
+    ///
+    /// # Errors
+    /// Returns an error when the current descriptor offset cannot be observed.
+    pub fn with_tracker(file: File, tracker: FileCacheReleaseTracker) -> io::Result<Self> {
+        Self::with_window_bytes(
+            file,
+            NonZeroU64::new(DEFAULT_CACHE_RELEASE_WINDOW_BYTES)
+                .expect("default cache-release window is non-zero"),
+            tracker,
+        )
+    }
+
+    /// Wrap `file` with an explicit non-zero window and evidence tracker.
+    ///
+    /// # Errors
+    /// Returns an error when the current descriptor offset cannot be observed.
+    pub fn with_window_bytes(
+        mut file: File,
+        window_bytes: NonZeroU64,
+        tracker: FileCacheReleaseTracker,
+    ) -> io::Result<Self> {
+        let pending_offset = file.stream_position()?;
+        Ok(Self {
+            file,
+            window_bytes,
+            pending_offset,
+            pending_bytes: 0,
+            tracker,
+            finished: false,
+        })
+    }
+
+    /// Release the final consumed partial window and surface deferred failures.
+    ///
+    /// # Errors
+    /// Returns an error when a supported release request fails.
+    pub fn finish(&mut self) -> io::Result<FileCacheReleaseEvidence> {
+        self.release_pending()?;
+        self.finished = true;
+        self.tracker.check_error()?;
+        Ok(self.tracker.evidence())
+    }
+
+    /// Borrow the shared aggregate evidence tracker.
+    #[must_use]
+    pub fn tracker(&self) -> FileCacheReleaseTracker {
+        self.tracker.clone()
+    }
+
+    /// Return this reader's configured release window.
+    #[must_use]
+    pub const fn window_bytes(&self) -> NonZeroU64 {
+        self.window_bytes
+    }
+
+    /// Borrow the underlying file.
+    #[must_use]
+    pub const fn file(&self) -> &File {
+        &self.file
+    }
+
+    fn release_pending(&mut self) -> io::Result<()> {
+        if self.pending_bytes == 0 {
+            return Ok(());
+        }
+        let bytes = self.pending_bytes;
+        let end = self
+            .pending_offset
+            .checked_add(bytes)
+            .ok_or_else(|| io::Error::other("cache-release reader offset overflow"))?;
+        let outcome = release_file_cache(&self.file, self.pending_offset, bytes)?;
+        self.tracker.account(outcome, bytes);
+        self.pending_offset = end;
+        self.pending_bytes = 0;
+        Ok(())
+    }
+}
+
+impl Read for FileCacheReleasingReader {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() || self.finished {
+            return Ok(0);
+        }
+        if file_cache_release_supported() && self.pending_bytes == self.window_bytes.get() {
+            self.release_pending()?;
+        }
+        let limit = if file_cache_release_supported() {
+            usize::try_from(self.window_bytes.get() - self.pending_bytes)
+                .unwrap_or(usize::MAX)
+                .min(buffer.len())
+        } else {
+            buffer.len()
+        };
+        self.pending_offset
+            .checked_add(self.pending_bytes)
+            .and_then(|offset| offset.checked_add(u64::try_from(limit).ok()?))
+            .ok_or_else(|| io::Error::other("cache-release reader offset overflow"))?;
+        let read = self.file.read(&mut buffer[..limit])?;
+        self.pending_bytes = self
+            .pending_bytes
+            .checked_add(u64::try_from(read).map_err(io::Error::other)?)
+            .ok_or_else(|| io::Error::other("cache-release reader byte count overflow"))?;
+        if read == 0 {
+            self.release_pending()?;
+            self.finished = true;
+        }
+        Ok(read)
+    }
+}
+
+impl Seek for FileCacheReleasingReader {
+    fn seek(&mut self, position: io::SeekFrom) -> io::Result<u64> {
+        self.release_pending()?;
+        let offset = self.file.seek(position)?;
+        self.pending_offset = offset;
+        self.finished = false;
+        Ok(offset)
+    }
+}
+
+impl Drop for FileCacheReleasingReader {
+    fn drop(&mut self) {
+        if !self.finished
+            && let Err(error) = self.release_pending()
+        {
+            self.tracker.defer(&error);
+        }
+    }
+}
+
+/// File writer that synchronizes and releases completed page-cache windows.
+#[derive(Debug)]
+pub struct DurableFileCacheWriter {
+    file: File,
+    window_bytes: NonZeroU64,
+    pending_offset: u64,
+    pending_bytes: u64,
+    evidence: FileCacheReleaseEvidence,
+}
+
+impl DurableFileCacheWriter {
+    /// Wrap `file` with the default 64 MiB durable cache window.
+    ///
+    /// # Errors
+    /// Returns an error when the current descriptor offset cannot be observed.
+    pub fn new(file: File) -> io::Result<Self> {
+        Self::with_window_bytes(
+            file,
+            NonZeroU64::new(DEFAULT_CACHE_RELEASE_WINDOW_BYTES)
+                .expect("default cache-release window is non-zero"),
+        )
+    }
+
+    /// Wrap `file` with an explicit non-zero durable cache window.
+    ///
+    /// # Errors
+    /// Returns an error when the current descriptor offset cannot be observed.
+    pub fn with_window_bytes(file: File, window_bytes: NonZeroU64) -> io::Result<Self> {
+        Self::with_window_bytes_checked(file, window_bytes, || Ok(()))
+    }
+
+    /// Wrap `file` and run one caller-supplied setup check after observing the
+    /// real descriptor offset but before constructing the writer.
+    ///
+    /// This exists so higher layers can deterministically exercise constructor
+    /// failure without bypassing the actual descriptor setup path.
+    ///
+    /// # Errors
+    /// Returns an error when offset observation or `setup_check` fails.
+    pub fn with_window_bytes_checked(
+        mut file: File,
+        window_bytes: NonZeroU64,
+        setup_check: impl FnOnce() -> io::Result<()>,
+    ) -> io::Result<Self> {
+        let pending_offset = file.stream_position()?;
+        setup_check()?;
+        Ok(Self {
+            file,
+            window_bytes,
+            pending_offset,
+            pending_bytes: 0,
+            evidence: FileCacheReleaseEvidence::default(),
+        })
+    }
+
+    /// Complete the final durability barrier and release its remaining cache window.
+    ///
+    /// # Errors
+    /// Returns an error if synchronization or a supported cache-release request fails.
+    pub fn sync_all_and_release(&mut self) -> io::Result<()> {
+        self.synchronize_pending(true)
+    }
+
+    /// Borrow the underlying file.
+    #[must_use]
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    /// Return content-free synchronization and cache-release evidence.
+    #[must_use]
+    pub const fn evidence(&self) -> FileCacheReleaseEvidence {
+        self.evidence
+    }
+
+    /// Return this writer's configured synchronization/release window.
+    #[must_use]
+    pub const fn window_bytes(&self) -> NonZeroU64 {
+        self.window_bytes
+    }
+
+    /// Consume the writer and return its underlying file.
+    #[must_use]
+    pub fn into_file(self) -> File {
+        self.file
+    }
+
+    fn synchronize_pending(&mut self, final_barrier: bool) -> io::Result<()> {
+        if self.pending_bytes == 0 && !final_barrier {
+            return Ok(());
+        }
+        if self.pending_bytes == 0 {
+            synchronize_file(&self.file)?;
+            self.evidence.sync_operations = self
+                .evidence
+                .sync_operations
+                .checked_add(1)
+                .ok_or_else(|| io::Error::other("cache-release sync count overflow"))?;
+            return Ok(());
+        }
+        let bytes = self.pending_bytes;
+        let end = self
+            .pending_offset
+            .checked_add(bytes)
+            .ok_or_else(|| io::Error::other("cache-release writer offset overflow"))?;
+        let outcome = synchronize_before_release(
+            || synchronize_file(&self.file),
+            || release_file_cache(&self.file, self.pending_offset, bytes),
+        )?;
+        self.evidence.sync_operations = self
+            .evidence
+            .sync_operations
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("cache-release sync count overflow"))?;
+        self.evidence.peak_window_bytes = self.evidence.peak_window_bytes.max(bytes);
+        match outcome {
+            FileCacheReleaseOutcome::Released => {
+                self.evidence.release_operations = self
+                    .evidence
+                    .release_operations
+                    .checked_add(1)
+                    .ok_or_else(|| io::Error::other("cache-release operation count overflow"))?;
+                self.evidence.released_bytes = self
+                    .evidence
+                    .released_bytes
+                    .checked_add(bytes)
+                    .ok_or_else(|| io::Error::other("cache-release byte count overflow"))?;
+            }
+            FileCacheReleaseOutcome::Unsupported => {
+                self.evidence.unsupported_operations = self
+                    .evidence
+                    .unsupported_operations
+                    .checked_add(1)
+                    .ok_or_else(|| io::Error::other("unsupported cache-release count overflow"))?;
+            }
+        }
+        self.pending_offset = end;
+        self.pending_bytes = 0;
+        Ok(())
+    }
+}
+
+fn synchronize_before_release<T>(
+    synchronize: impl FnOnce() -> io::Result<()>,
+    release: impl FnOnce() -> io::Result<T>,
+) -> io::Result<T> {
+    synchronize()?;
+    release()
+}
+
+impl Write for DurableFileCacheWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if file_cache_release_supported() && self.pending_bytes == self.window_bytes.get() {
+            // Synchronize before consuming any bytes from this call. A failure
+            // therefore obeys `Write::write`: callers may safely retry.
+            self.synchronize_pending(false)?;
+        }
+        let limit = if file_cache_release_supported() {
+            let remaining = self.window_bytes.get() - self.pending_bytes;
+            buffer
+                .len()
+                .min(usize::try_from(remaining).unwrap_or(usize::MAX))
+        } else {
+            buffer.len()
+        };
+        self.pending_offset
+            .checked_add(self.pending_bytes)
+            .and_then(|offset| offset.checked_add(u64::try_from(limit).ok()?))
+            .ok_or_else(|| io::Error::other("cache-release writer offset overflow"))?;
+        let written = self.file.write(&buffer[..limit])?;
+        self.pending_bytes = self
+            .pending_bytes
+            .checked_add(u64::try_from(written).map_err(io::Error::other)?)
+            .ok_or_else(|| io::Error::other("cache-release writer byte count overflow"))?;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()
+    }
+}
+
+/// Release one clean file range from the operating-system page cache.
+///
+/// Callers writing the file must synchronize the range before calling this
+/// primitive. Prefer [`DurableFileCacheWriter`] for write paths because it
+/// structurally enforces synchronization before release.
+///
+/// # Errors
+/// Returns an error when a supported operating-system release request fails.
+pub fn release_file_cache(
+    file: &File,
+    offset: u64,
+    bytes: u64,
+) -> io::Result<FileCacheReleaseOutcome> {
+    #[cfg(test)]
+    CACHE_RELEASE_FAILURE.with(|failure| {
+        if failure.replace(false) {
+            return Err(io::Error::other("injected cache-release failure"));
+        }
+        Ok(())
+    })?;
+    if bytes == 0 {
+        return Ok(if file_cache_release_supported() {
+            FileCacheReleaseOutcome::Released
+        } else {
+            FileCacheReleaseOutcome::Unsupported
+        });
+    }
+    release_file_cache_inner(file, offset, bytes)
+}
+
+fn synchronize_file(file: &File) -> io::Result<()> {
+    #[cfg(test)]
+    CACHE_SYNC_FAILURE.with(|failure| {
+        if failure.replace(false) {
+            return Err(io::Error::other("injected cache-sync failure"));
+        }
+        Ok(())
+    })?;
+    file.sync_all()
+}
+
+#[cfg(test)]
+thread_local! {
+    static CACHE_RELEASE_FAILURE: std::cell::Cell<bool> = const {
+        std::cell::Cell::new(false)
+    };
+    static CACHE_SYNC_FAILURE: std::cell::Cell<bool> = const {
+        std::cell::Cell::new(false)
+    };
+}
+
+#[cfg(test)]
+fn inject_cache_release_failure() {
+    CACHE_RELEASE_FAILURE.with(|failure| failure.set(true));
+}
+
+#[cfg(test)]
+fn inject_cache_sync_failure() {
+    CACHE_SYNC_FAILURE.with(|failure| failure.set(true));
+}
+
+#[cfg(target_os = "linux")]
+const fn file_cache_release_supported() -> bool {
+    true
+}
+
+#[cfg(not(target_os = "linux"))]
+const fn file_cache_release_supported() -> bool {
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn release_file_cache_inner(
+    file: &File,
+    offset: u64,
+    bytes: u64,
+) -> io::Result<FileCacheReleaseOutcome> {
+    rustix::fs::fadvise(
+        file,
+        offset,
+        NonZeroU64::new(bytes),
+        rustix::fs::Advice::DontNeed,
+    )
+    .map_err(io::Error::from)?;
+    Ok(FileCacheReleaseOutcome::Released)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn release_file_cache_inner(
+    _file: &File,
+    _offset: u64,
+    _bytes: u64,
+) -> io::Result<FileCacheReleaseOutcome> {
+    Ok(FileCacheReleaseOutcome::Unsupported)
+}
 
 /// Stable filesystem identity suitable for Windows and Unix filesystems.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -192,6 +773,240 @@ pub struct StableDirectory {
     identity: FileIdentity,
 }
 
+/// Single-owner capability for one exclusively created, unpublished child.
+///
+/// The guard follows the owned inode across an atomic rename and removes any
+/// still-uncommitted name on explicit cleanup or drop. Callers must retain the
+/// guard until every higher-level publication invariant, including parent
+/// directory synchronization and manifest/receipt inclusion, is complete.
+#[derive(Debug)]
+pub struct UnpublishedArtifactGuard {
+    directory: StableDirectory,
+    candidate_names: Vec<OsString>,
+    identity: Option<FileIdentity>,
+    file: Option<File>,
+    published: bool,
+    parent_synced: bool,
+    armed: bool,
+}
+
+impl UnpublishedArtifactGuard {
+    /// Return the immutable identity captured during descriptor setup.
+    ///
+    /// # Errors
+    /// Returns an error before descriptor identity has been initialized.
+    pub fn identity(&self) -> io::Result<FileIdentity> {
+        self.identity
+            .ok_or_else(|| io::Error::other("unpublished artifact identity is not initialized"))
+    }
+
+    /// Re-read the retained descriptor identity and run a setup check before
+    /// the descriptor is transferred to a writer.
+    ///
+    /// # Errors
+    /// Returns an error when identity observation, `setup_check`, or the
+    /// identity comparison fails.
+    pub fn verify_identity_with(
+        &mut self,
+        setup_check: impl FnOnce() -> io::Result<()>,
+    ) -> io::Result<FileIdentity> {
+        let file = self
+            .file
+            .as_ref()
+            .ok_or_else(|| io::Error::other("unpublished artifact descriptor was transferred"))?;
+        let observed = file_identity(file)?;
+        self.identity = Some(observed);
+        setup_check()?;
+        Ok(observed)
+    }
+
+    /// Open one sibling through the retained no-follow parent capability.
+    ///
+    /// # Errors
+    /// Returns an error when the child is absent, special, linked, or the
+    /// retained directory authority changed.
+    pub fn open_sibling(&self, name: &OsStr) -> io::Result<File> {
+        self.directory.open_child_file(name)
+    }
+
+    /// Transfer the retained data descriptor into its durable writer.
+    ///
+    /// # Errors
+    /// Returns an error if identity observation fails or the descriptor was
+    /// already transferred.
+    pub fn take_file(&mut self) -> io::Result<File> {
+        if self.identity.is_none() {
+            let file = self
+                .file
+                .as_ref()
+                .ok_or_else(|| io::Error::other("unpublished artifact file already transferred"))?;
+            self.identity = Some(file_identity(file)?);
+        }
+        self.file
+            .take()
+            .ok_or_else(|| io::Error::other("unpublished artifact file already transferred"))
+    }
+
+    /// Atomically install `target` while retaining cleanup ownership.
+    ///
+    /// # Errors
+    /// Returns an error when identity-safe installation fails.
+    pub fn install_child(&mut self, target: &OsStr) -> io::Result<()> {
+        validate_child_name(target)?;
+        let temporary = self
+            .candidate_names
+            .first()
+            .ok_or_else(|| io::Error::other("unpublished artifact has no temporary name"))?
+            .clone();
+        if !self.candidate_names.iter().any(|name| name == target) {
+            self.candidate_names.push(target.to_owned());
+        }
+        self.directory
+            .install_child(&temporary, self.identity()?, target)?;
+        self.published = true;
+        self.parent_synced = false;
+        Ok(())
+    }
+
+    /// Synchronize the retained parent directory while remaining armed.
+    ///
+    /// # Errors
+    /// Returns an error when the directory durability barrier fails.
+    pub fn sync_parent(&mut self) -> io::Result<()> {
+        self.directory.sync()?;
+        self.parent_synced = true;
+        Ok(())
+    }
+
+    /// Disarm cleanup after every publication invariant is complete.
+    ///
+    /// # Errors
+    /// Returns an error if the descriptor is still held by the guard or the
+    /// atomic publication and parent barrier have not both completed.
+    pub fn commit(mut self) -> io::Result<()> {
+        if self.file.is_some() || !self.published || !self.parent_synced {
+            return Err(io::Error::other(
+                "unpublished artifact commit invariants are incomplete",
+            ));
+        }
+        self.armed = false;
+        Ok(())
+    }
+
+    /// Remove every possible uncommitted name and synchronize the parent.
+    ///
+    /// Names that are absent or no longer identify the exclusively created
+    /// inode are left untouched.
+    ///
+    /// # Errors
+    /// Returns sanitized cleanup failure context after attempting every unlink
+    /// and the final parent-directory barrier.
+    pub fn cleanup(&mut self) -> io::Result<()> {
+        if !self.armed {
+            return Ok(());
+        }
+        let mut cleanup = Ok(());
+        let identity = match self.identity {
+            Some(identity) => Some(identity),
+            None => match self
+                .file
+                .as_ref()
+                .ok_or_else(|| io::Error::other("unpublished artifact descriptor is unavailable"))
+                .and_then(file_identity)
+            {
+                Ok(identity) => {
+                    self.identity = Some(identity);
+                    Some(identity)
+                }
+                Err(error) => {
+                    cleanup = append_sanitized_cleanup(
+                        cleanup,
+                        &error,
+                        "unpublished artifact identity recovery failed",
+                    );
+                    None
+                }
+            },
+        };
+        self.file.take();
+        for name in &self.candidate_names {
+            let Some(identity) = identity else {
+                break;
+            };
+            let removed = self.directory.open_child_file(name).and_then(|file| {
+                if file_identity(&file)? == identity {
+                    drop(file);
+                    self.directory.unlink_child_if_identity(name, identity)?;
+                }
+                Ok(())
+            });
+            match removed {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    cleanup = append_sanitized_cleanup(
+                        cleanup,
+                        &error,
+                        "unpublished artifact unlink failed",
+                    );
+                }
+            }
+        }
+        cleanup = match self.directory.sync() {
+            Ok(()) => cleanup,
+            Err(error) => append_sanitized_cleanup(
+                cleanup,
+                &error,
+                "unpublished artifact directory synchronization failed",
+            ),
+        };
+        self.armed = false;
+        cleanup
+    }
+
+    /// Perform full identity-safe cleanup and its parent barrier, then run one
+    /// caller-supplied finalization check.
+    ///
+    /// # Errors
+    /// Returns sanitized cleanup or finalization context after both have been
+    /// attempted.
+    pub fn cleanup_checked(
+        &mut self,
+        finalization_check: impl FnOnce() -> io::Result<()>,
+    ) -> io::Result<()> {
+        let cleanup = self.cleanup();
+        match finalization_check() {
+            Ok(()) => cleanup,
+            Err(error) => append_sanitized_cleanup(
+                cleanup,
+                &error,
+                "unpublished artifact cleanup finalization failed",
+            ),
+        }
+    }
+}
+
+impl Drop for UnpublishedArtifactGuard {
+    fn drop(&mut self) {
+        let _ = self.cleanup();
+    }
+}
+
+fn append_sanitized_cleanup(
+    primary: io::Result<()>,
+    cleanup: &io::Error,
+    context: &'static str,
+) -> io::Result<()> {
+    let cleanup = io::Error::new(cleanup.kind(), context);
+    match primary {
+        Ok(()) => Err(cleanup),
+        Err(primary) => Err(io::Error::new(
+            primary.kind(),
+            format!("{primary}; {cleanup}"),
+        )),
+    }
+}
+
 impl StableDirectory {
     /// Duplicate this retained directory capability without resolving its path again.
     ///
@@ -364,6 +1179,25 @@ impl StableDirectory {
         Ok(file)
     }
 
+    /// Visit regular descendants through retained, no-follow directory handles.
+    ///
+    /// Every child is opened relative to its retained parent and revalidated
+    /// before it reaches `visit`. Links and non-regular objects are skipped.
+    ///
+    /// # Errors
+    /// Returns an error if traversal exceeds `remaining`, a retained identity
+    /// changes, directory enumeration fails, or `visit` fails. Targets without
+    /// descriptor-relative directory enumeration return `Unsupported`.
+    pub fn visit_regular_files(
+        &self,
+        remaining: &mut usize,
+        visit: &mut impl FnMut(&File) -> io::Result<()>,
+    ) -> io::Result<()> {
+        self.revalidate_named()?;
+        visit_regular_files_platform(self, remaining, visit)?;
+        self.revalidate_named()
+    }
+
     /// Create one new regular child without following links or reparse points.
     pub fn create_child_file(&self, name: &OsStr) -> io::Result<File> {
         validate_child_name(name)?;
@@ -511,6 +1345,32 @@ impl StableDirectory {
         validate_stable_child_file(&file, &path)?;
         self.revalidate_named()?;
         Ok(file)
+    }
+
+    /// Exclusively create one replaceable child and immediately bind cleanup
+    /// ownership to its retained descriptor identity.
+    ///
+    /// # Errors
+    /// Returns an error when creation, identity capture, or directory-capability
+    /// cloning fails. Setup failure removes the exact created inode when safe.
+    pub fn create_unpublished_replaceable_child(
+        &self,
+        name: &OsStr,
+    ) -> io::Result<UnpublishedArtifactGuard> {
+        // Clone the parent authority before creating the child. From the
+        // instant exclusive creation succeeds, no fallible setup remains
+        // outside the armed guard.
+        let directory = self.try_clone()?;
+        let file = self.create_replaceable_child_file(name)?;
+        Ok(UnpublishedArtifactGuard {
+            directory,
+            candidate_names: vec![name.to_owned()],
+            identity: None,
+            file: Some(file),
+            published: false,
+            parent_synced: false,
+            armed: true,
+        })
     }
 
     /// Open an existing regular child for read/write, or create it once.
@@ -741,6 +1601,59 @@ fn stable_open_directory(path: &Path) -> io::Result<File> {
     )
     .map(File::from)
     .map_err(io::Error::from)
+}
+
+#[cfg(unix)]
+fn visit_regular_files_platform(
+    directory: &StableDirectory,
+    remaining: &mut usize,
+    visit: &mut impl FnMut(&File) -> io::Result<()>,
+) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    use rustix::fs::{AtFlags, Dir, FileType};
+
+    let mut entries = Dir::read_from(&directory.file).map_err(io::Error::from)?;
+    while let Some(entry) = entries.read() {
+        let entry = entry.map_err(io::Error::from)?;
+        let raw_name = entry.file_name().to_bytes();
+        if matches!(raw_name, b"." | b"..") {
+            continue;
+        }
+        if *remaining == 0 {
+            return Err(io::Error::other(
+                "descriptor-relative traversal exceeds entry bound",
+            ));
+        }
+        *remaining -= 1;
+        let name = OsStr::from_bytes(raw_name);
+        let mut file_type = entry.file_type();
+        if file_type == FileType::Unknown {
+            let stat = rustix::fs::statat(&directory.file, name, AtFlags::SYMLINK_NOFOLLOW)
+                .map_err(io::Error::from)?;
+            file_type = FileType::from_raw_mode(stat.st_mode);
+        }
+        if file_type.is_file() {
+            let file = directory.open_child_file(name)?;
+            visit(&file)?;
+        } else if file_type.is_dir() {
+            let child = directory.open_child_directory(name)?;
+            visit_regular_files_platform(&child, remaining, visit)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn visit_regular_files_platform(
+    _directory: &StableDirectory,
+    _remaining: &mut usize,
+    _visit: &mut impl FnMut(&File) -> io::Result<()>,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "descriptor-relative directory traversal is unsupported",
+    ))
 }
 
 #[cfg(unix)]
@@ -3466,6 +4379,45 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn descriptor_relative_visit_skips_symlinks_and_rejects_root_replacement() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().unwrap();
+        let owned = parent.path().join("owned");
+        let outside = parent.path().join("outside");
+        std::fs::create_dir(&owned).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(owned.join("inside"), b"inside").unwrap();
+        std::fs::write(outside.join("secret"), b"secret").unwrap();
+        symlink(&outside, owned.join("escape")).unwrap();
+        let stable = StableDirectory::open(&owned).unwrap();
+        let mut remaining = 16;
+        let mut lengths = Vec::new();
+        stable
+            .visit_regular_files(&mut remaining, &mut |file| {
+                lengths.push(file.metadata()?.len());
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(lengths, [6]);
+
+        std::fs::rename(&owned, parent.path().join("displaced")).unwrap();
+        std::fs::create_dir(&owned).unwrap();
+        std::fs::write(owned.join("replacement"), b"replacement").unwrap();
+        let mut visited = 0;
+        assert!(
+            stable
+                .visit_regular_files(&mut remaining, &mut |_| {
+                    visited += 1;
+                    Ok(())
+                })
+                .is_err()
+        );
+        assert_eq!(visited, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn stable_directory_enumerates_and_links_only_retained_regular_source() {
         use std::io::Write as _;
 
@@ -3661,6 +4613,467 @@ mod tests {
             b"authenticated"
         );
         assert!(!root.path().join("CURRENT").exists());
+    }
+
+    #[test]
+    fn cache_release_never_runs_before_successful_synchronization() {
+        use std::cell::RefCell;
+
+        let calls = RefCell::new(Vec::new());
+        synchronize_before_release(
+            || {
+                calls.borrow_mut().push("sync");
+                Ok(())
+            },
+            || {
+                calls.borrow_mut().push("release");
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(*calls.borrow(), ["sync", "release"]);
+
+        calls.borrow_mut().clear();
+        let error = synchronize_before_release(
+            || {
+                calls.borrow_mut().push("sync");
+                Err(io::Error::other("sync failed"))
+            },
+            || {
+                calls.borrow_mut().push("release");
+                Ok(())
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "sync failed");
+        assert_eq!(*calls.borrow(), ["sync"]);
+    }
+
+    #[test]
+    fn durable_cache_writer_preserves_bytes_and_reports_platform_semantics() {
+        use std::io::Read as _;
+        use std::num::NonZeroU64;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("bounded");
+        let file = File::create(&path).unwrap();
+        let mut writer =
+            DurableFileCacheWriter::with_window_bytes(file, NonZeroU64::new(8).unwrap()).unwrap();
+        writer.write_all(b"0123456789abcdefghij").unwrap();
+
+        #[cfg(target_os = "linux")]
+        {
+            let evidence = writer.evidence();
+            assert_eq!(evidence.sync_operations, 2);
+            assert_eq!(evidence.release_operations, 2);
+            assert_eq!(evidence.released_bytes, 16);
+            assert_eq!(evidence.peak_window_bytes, 8);
+        }
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(writer.evidence(), FileCacheReleaseEvidence::default());
+
+        writer.sync_all_and_release().unwrap();
+        let evidence = writer.evidence();
+        assert_eq!(
+            evidence.sync_operations,
+            if cfg!(target_os = "linux") { 3 } else { 1 }
+        );
+        assert!(evidence.peak_window_bytes <= 8 || !cfg!(target_os = "linux"));
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(evidence.release_operations, 3);
+            assert_eq!(evidence.unsupported_operations, 0);
+            assert_eq!(evidence.released_bytes, 20);
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(evidence.release_operations, 0);
+            assert_eq!(evidence.unsupported_operations, 1);
+            assert_eq!(evidence.released_bytes, 0);
+            assert_eq!(evidence.peak_window_bytes, 20);
+        }
+
+        drop(writer);
+        let mut bytes = Vec::new();
+        File::open(path).unwrap().read_to_end(&mut bytes).unwrap();
+        assert_eq!(bytes, b"0123456789abcdefghij");
+    }
+
+    #[test]
+    fn shared_cache_budget_covers_every_construction_operation_topology() {
+        for (operation, active_streams) in [
+            ("copy", 2_usize),
+            ("v3-index", 3),
+            ("v4-projections", 2),
+            ("node-encoding", 5),
+            ("edge-encoding", 4),
+            ("merge-two-way", 3),
+            ("merge-fan-in", 33),
+        ] {
+            let window = cache_release_window_for_streams(active_streams).unwrap();
+            let aggregate = window
+                .get()
+                .checked_mul(u64::try_from(active_streams).unwrap())
+                .unwrap();
+            assert!(window.get() > 0, "{operation}");
+            assert!(
+                aggregate <= DEFAULT_CACHE_RELEASE_WINDOW_BYTES,
+                "{operation}: {aggregate}"
+            );
+        }
+        assert!(cache_release_window_for_streams(0).is_err());
+        assert!(
+            cache_release_window_for_streams(
+                usize::try_from(DEFAULT_CACHE_RELEASE_WINDOW_BYTES).unwrap() + 1
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn operation_budget_validation_uses_opened_reader_and_writer_configuration() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let output = root.path().join("output");
+        std::fs::write(&source, b"source").unwrap();
+        let window = cache_release_window_for_streams(2).unwrap();
+        let reader = FileCacheReleasingReader::with_window_bytes(
+            File::open(source).unwrap(),
+            window,
+            FileCacheReleaseTracker::default(),
+        )
+        .unwrap();
+        let writer =
+            DurableFileCacheWriter::with_window_bytes(File::create(output).unwrap(), window)
+                .unwrap();
+
+        assert_eq!(
+            validate_cache_release_operation_windows(&[
+                reader.window_bytes(),
+                writer.window_bytes(),
+            ])
+            .unwrap(),
+            DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        );
+        assert!(
+            validate_cache_release_operation_windows(&[
+                NonZeroU64::new(DEFAULT_CACHE_RELEASE_WINDOW_BYTES).unwrap(),
+                writer.window_bytes(),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn unpublished_artifact_guard_tracks_rename_commit_and_safe_cleanup() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = StableDirectory::open(root.path()).unwrap();
+
+        {
+            let mut guard = directory
+                .create_unpublished_replaceable_child(OsStr::new("drop-temp"))
+                .unwrap();
+            let mut file = guard.take_file().unwrap();
+            file.write_all(b"temporary").unwrap();
+            file.sync_all().unwrap();
+            drop(file);
+        }
+        assert!(!root.path().join("drop-temp").exists());
+
+        {
+            let mut guard = directory
+                .create_unpublished_replaceable_child(OsStr::new("rename-temp"))
+                .unwrap();
+            let mut file = guard.take_file().unwrap();
+            file.write_all(b"renamed").unwrap();
+            file.sync_all().unwrap();
+            drop(file);
+            guard.install_child(OsStr::new("renamed-final")).unwrap();
+            guard.sync_parent().unwrap();
+        }
+        assert!(!root.path().join("rename-temp").exists());
+        assert!(!root.path().join("renamed-final").exists());
+
+        {
+            let mut guard = directory
+                .create_unpublished_replaceable_child(OsStr::new("commit-temp"))
+                .unwrap();
+            let mut file = guard.take_file().unwrap();
+            file.write_all(b"committed").unwrap();
+            file.sync_all().unwrap();
+            drop(file);
+            guard.install_child(OsStr::new("committed-final")).unwrap();
+            guard.sync_parent().unwrap();
+            guard.commit().unwrap();
+        }
+        assert_eq!(
+            std::fs::read(root.path().join("committed-final")).unwrap(),
+            b"committed"
+        );
+
+        std::fs::write(root.path().join("occupied"), b"original").unwrap();
+        {
+            let mut guard = directory
+                .create_unpublished_replaceable_child(OsStr::new("failed-install-temp"))
+                .unwrap();
+            let file = guard.take_file().unwrap();
+            drop(file);
+            assert!(guard.install_child(OsStr::new("occupied")).is_err());
+        }
+        assert_eq!(
+            std::fs::read(root.path().join("occupied")).unwrap(),
+            b"original"
+        );
+        assert!(!root.path().join("failed-install-temp").exists());
+    }
+
+    #[test]
+    fn durable_cache_writer_respects_current_offset() {
+        use std::io::{Read as _, Seek as _, SeekFrom};
+        use std::num::NonZeroU64;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("offset");
+        std::fs::write(&path, b"prefix-xxxxxxx").unwrap();
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        file.seek(SeekFrom::Start(7)).unwrap();
+        let mut writer =
+            DurableFileCacheWriter::with_window_bytes(file, NonZeroU64::new(3).unwrap()).unwrap();
+        writer.write_all(b"changed").unwrap();
+        writer.sync_all_and_release().unwrap();
+        drop(writer);
+
+        let mut actual = Vec::new();
+        File::open(path).unwrap().read_to_end(&mut actual).unwrap();
+        assert_eq!(actual, b"prefix-changed");
+    }
+
+    #[test]
+    fn durable_cache_writer_sync_failure_precedes_next_write_consumption() {
+        use std::io::Read as _;
+        use std::num::NonZeroU64;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("sync-failure");
+        let mut writer = DurableFileCacheWriter::with_window_bytes(
+            File::create(&path).unwrap(),
+            NonZeroU64::new(8).unwrap(),
+        )
+        .unwrap();
+        writer.write_all(b"12345678").unwrap();
+        inject_cache_sync_failure();
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(
+                writer.write(b"9").unwrap_err().to_string(),
+                "injected cache-sync failure"
+            );
+            assert_eq!(writer.write(b"9").unwrap(), 1);
+            writer.sync_all_and_release().unwrap();
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(writer.write(b"9").unwrap(), 1);
+            assert_eq!(
+                writer.sync_all_and_release().unwrap_err().to_string(),
+                "injected cache-sync failure"
+            );
+            writer.sync_all_and_release().unwrap();
+        }
+        drop(writer);
+
+        let mut actual = Vec::new();
+        File::open(path).unwrap().read_to_end(&mut actual).unwrap();
+        assert_eq!(actual, b"123456789");
+    }
+
+    #[test]
+    fn durable_cache_writer_surfaces_advice_failure_after_durability() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("writer-advice-failure");
+        let mut writer = DurableFileCacheWriter::new(File::create(&path).unwrap()).unwrap();
+        writer.write_all(b"durable").unwrap();
+        inject_cache_release_failure();
+        assert_eq!(
+            writer.sync_all_and_release().unwrap_err().to_string(),
+            "injected cache-release failure"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), b"durable");
+        writer.sync_all_and_release().unwrap();
+    }
+
+    #[test]
+    fn cache_releasing_reader_releases_completed_and_partial_windows_on_drop() {
+        use std::io::Read as _;
+        use std::num::NonZeroU64;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("drop-reader");
+        std::fs::write(&path, b"0123456789abcdefghij").unwrap();
+        let tracker = FileCacheReleaseTracker::default();
+        let mut reader = FileCacheReleasingReader::with_window_bytes(
+            File::open(path).unwrap(),
+            NonZeroU64::new(8).unwrap(),
+            tracker.clone(),
+        )
+        .unwrap();
+        let mut bytes = [0_u8; 9];
+        reader.read_exact(&mut bytes).unwrap();
+        drop(reader);
+        tracker.check_error().unwrap();
+
+        let evidence = tracker.evidence();
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(evidence.release_operations, 2);
+            assert_eq!(evidence.released_bytes, 9);
+            assert_eq!(evidence.peak_window_bytes, 8);
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(evidence.unsupported_operations, 1);
+            assert_eq!(evidence.peak_window_bytes, 9);
+        }
+    }
+
+    #[test]
+    fn cache_releasing_reader_empty_reads_preserve_remaining_data_and_evidence() {
+        use std::io::Read as _;
+        use std::num::NonZeroU64;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("empty-read");
+        let expected = b"0123456789abcdef";
+        std::fs::write(&path, expected).unwrap();
+
+        for prefix_length in [0, 3, 8] {
+            let tracker = FileCacheReleaseTracker::default();
+            let mut reader = FileCacheReleasingReader::with_window_bytes(
+                File::open(&path).unwrap(),
+                NonZeroU64::new(8).unwrap(),
+                tracker.clone(),
+            )
+            .unwrap();
+            let mut actual = vec![0; prefix_length];
+            reader.read_exact(&mut actual).unwrap();
+            let before_empty_read = tracker.evidence();
+            assert_eq!(reader.read(&mut []).unwrap(), 0);
+            assert_eq!(tracker.evidence(), before_empty_read);
+            reader.read_to_end(&mut actual).unwrap();
+            assert_eq!(actual, expected, "prefix length {prefix_length}");
+            reader.finish().unwrap();
+        }
+    }
+
+    #[test]
+    fn cache_releasing_reader_real_syscalls_cover_two_windows_and_partial_tail() {
+        use std::io::Read as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("large-sparse-reader");
+        let length = DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+            .checked_mul(2)
+            .unwrap()
+            .checked_add(1_048_593)
+            .unwrap();
+        let file = File::create(&path).unwrap();
+        file.set_len(length).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        let mut reader = FileCacheReleasingReader::new(File::open(path).unwrap()).unwrap();
+        let mut buffer = vec![0_u8; 1 << 20];
+        let mut read = 0_u64;
+        loop {
+            let count = reader.read(&mut buffer).unwrap();
+            if count == 0 {
+                break;
+            }
+            read += count as u64;
+        }
+        let evidence = reader.finish().unwrap();
+        assert_eq!(read, length);
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(evidence.release_operations, 3);
+            assert_eq!(evidence.released_bytes, length);
+            assert_eq!(
+                evidence.peak_window_bytes,
+                DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+            );
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(evidence.unsupported_operations, 1);
+            assert_eq!(evidence.peak_window_bytes, length);
+        }
+    }
+
+    #[test]
+    fn cache_releasing_reader_surfaces_injected_advice_failure() {
+        use std::io::Read as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("advice-failure");
+        std::fs::write(&path, b"consumed").unwrap();
+        let mut reader = FileCacheReleasingReader::new(File::open(path).unwrap()).unwrap();
+        let mut bytes = [0_u8; 8];
+        assert_eq!(reader.read(&mut bytes).unwrap(), 8);
+        inject_cache_release_failure();
+        assert_eq!(
+            reader.finish().unwrap_err().to_string(),
+            "injected cache-release failure"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn injected_advice_failures_after_completed_windows_preserve_prior_evidence() {
+        use std::io::{Read as _, Write as _};
+        use std::num::NonZeroU64;
+
+        let root = tempfile::tempdir().unwrap();
+        let written_path = root.path().join("writer-spanning-failure");
+        let mut writer = DurableFileCacheWriter::with_window_bytes(
+            File::create(&written_path).unwrap(),
+            NonZeroU64::new(8).unwrap(),
+        )
+        .unwrap();
+        writer.write_all(b"0123456789abcdef").unwrap();
+        assert_eq!(writer.evidence().release_operations, 1);
+        inject_cache_release_failure();
+        assert_eq!(
+            writer.write(b"x").unwrap_err().to_string(),
+            "injected cache-release failure"
+        );
+        assert_eq!(writer.evidence().released_bytes, 8);
+        writer.write_all(b"x").unwrap();
+        writer.sync_all_and_release().unwrap();
+        assert_eq!(std::fs::read(&written_path).unwrap(), b"0123456789abcdefx");
+
+        let read_path = root.path().join("reader-spanning-failure");
+        std::fs::write(&read_path, b"0123456789abcdefghijklmnop").unwrap();
+        let tracker = FileCacheReleaseTracker::default();
+        let mut reader = FileCacheReleasingReader::with_window_bytes(
+            File::open(read_path).unwrap(),
+            NonZeroU64::new(8).unwrap(),
+            tracker.clone(),
+        )
+        .unwrap();
+        let mut prefix = [0_u8; 16];
+        reader.read_exact(&mut prefix).unwrap();
+        assert_eq!(tracker.evidence().release_operations, 1);
+        inject_cache_release_failure();
+        assert_eq!(
+            reader.read(&mut [0_u8; 1]).unwrap_err().to_string(),
+            "injected cache-release failure"
+        );
+        assert_eq!(tracker.evidence().released_bytes, 8);
+        reader.finish().unwrap();
     }
 
     #[cfg(windows)]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -416,8 +416,21 @@ pub struct GraphConstructionEvidence {
     pub write_bytes: u64,
     /// Actual submissions by measured immutable-artifact writers.
     pub write_operations: u64,
-    /// File and directory durability barriers completed for accepted artifacts.
+    /// File and directory durability barriers completed for accepted artifacts,
+    /// including synchronized cache-window rollovers before publication.
     pub fsync_operations: u64,
+    /// Successful file-level page-cache release boundaries.
+    #[serde(default)]
+    pub cache_release_operations: u64,
+    /// Page-cache release boundaries unsupported by the target platform.
+    #[serde(default)]
+    pub cache_release_unsupported_operations: u64,
+    /// Clean file bytes covered by successful page-cache release requests.
+    #[serde(default)]
+    pub cache_released_bytes: u64,
+    /// Largest synchronized file-cache window between release boundaries.
+    #[serde(default)]
+    pub peak_cache_release_window_bytes: u64,
     /// Bytes read for independent authentication.
     pub authentication_read_bytes: u64,
     /// Actual bounded authentication reads.
@@ -620,6 +633,7 @@ impl ConstructionSemanticAuthority {
 
 pub use crate::graph_construction_encoding::{
     ConstructionRetainedArtifact, GraphConstructionEncoding, GraphConstructionEncodingEvidence,
+    GraphConstructionEncodingInvocationEvidence,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -1032,45 +1046,47 @@ impl GraphConstructionSession {
             &mut cancelled,
         )?;
         record_encoded_active_artifacts(&self.root, &encoded, &mut self.checkpoint.evidence)?;
+        let invocation = &encoded.invocation.evidence;
         self.checkpoint.evidence.encode_application_read_bytes = self
             .checkpoint
             .evidence
             .encode_application_read_bytes
-            .saturating_add(encoded.evidence.input_read_bytes)
-            .saturating_add(encoded.evidence.membership_read_bytes);
+            .saturating_add(invocation.input_read_bytes)
+            .saturating_add(invocation.membership_read_bytes);
         self.checkpoint.evidence.encode_application_read_operations = self
             .checkpoint
             .evidence
             .encode_application_read_operations
-            .saturating_add(encoded.evidence.input_read_operations)
-            .saturating_add(encoded.evidence.membership_read_operations)
-            .saturating_add(encoded.evidence.source_spool_read_operations);
+            .saturating_add(invocation.input_read_operations)
+            .saturating_add(invocation.membership_read_operations)
+            .saturating_add(invocation.source_spool_read_operations);
         self.checkpoint.evidence.encode_application_write_bytes = self
             .checkpoint
             .evidence
             .encode_application_write_bytes
-            .saturating_add(encoded.evidence.output_write_bytes)
-            .saturating_add(encoded.evidence.membership_total_write_bytes)
-            .saturating_add(encoded.evidence.source_spool_write_bytes)
-            .saturating_add(encoded.evidence.ordinal_artifact_write_bytes)
-            .saturating_add(encoded.evidence.ordinal_publication_write_bytes);
+            .saturating_add(invocation.output_write_bytes)
+            .saturating_add(invocation.membership_total_write_bytes)
+            .saturating_add(invocation.source_spool_write_bytes)
+            .saturating_add(invocation.ordinal_artifact_write_bytes)
+            .saturating_add(invocation.ordinal_publication_write_bytes);
         self.checkpoint.evidence.encode_application_write_operations = self
             .checkpoint
             .evidence
             .encode_application_write_operations
-            .saturating_add(encoded.evidence.output_write_operations)
-            .saturating_add(encoded.evidence.membership_write_operations)
-            .saturating_add(encoded.evidence.source_spool_write_operations)
-            .saturating_add(encoded.evidence.ordinal_artifact_write_operations)
-            .saturating_add(encoded.evidence.ordinal_publication_write_operations);
+            .saturating_add(invocation.output_write_operations)
+            .saturating_add(invocation.membership_write_operations)
+            .saturating_add(invocation.source_spool_write_operations)
+            .saturating_add(invocation.ordinal_artifact_write_operations)
+            .saturating_add(invocation.ordinal_publication_write_operations);
         self.checkpoint.evidence.encode_fsync_operations = self
             .checkpoint
             .evidence
             .encode_fsync_operations
-            .saturating_add(encoded.evidence.fsync_operations)
-            .saturating_add(encoded.evidence.membership_fsync_operations)
-            .saturating_add(encoded.evidence.source_spool_fsync_operations)
-            .saturating_add(encoded.evidence.ordinal_fsync_operations);
+            .saturating_add(invocation.fsync_operations)
+            .saturating_add(invocation.membership_fsync_operations)
+            .saturating_add(invocation.source_spool_fsync_operations)
+            .saturating_add(invocation.ordinal_fsync_operations);
+        account_encoding_cache_release(invocation, &mut self.checkpoint.evidence);
         self.checkpoint.evidence.canonical_output_bytes = encoded
             .artifacts
             .iter()
@@ -2210,6 +2226,7 @@ impl GraphConstructionSession {
             &self.root,
             &format!("{stem}.parquet"),
             &sorted_batch,
+            &mut self.checkpoint.evidence,
         )?);
         replace_control(&self.root, INTENT, &intent)?;
         reject_cancelled(&mut cancelled)?;
@@ -2217,6 +2234,7 @@ impl GraphConstructionSession {
             &self.root,
             &format!("{stem}.identities.run"),
             &arrays.identities,
+            &mut self.checkpoint.evidence,
         )?);
         replace_control(&self.root, INTENT, &intent)?;
         reject_cancelled(&mut cancelled)?;
@@ -2225,17 +2243,24 @@ impl GraphConstructionSession {
                 &self.root,
                 &format!("{stem}.endpoints.run"),
                 &arrays.endpoints,
+                &mut self.checkpoint.evidence,
             )?);
             replace_control(&self.root, INTENT, &intent)?;
             reject_cancelled(&mut cancelled)?;
         }
         intent.details = Some(match &arrays.details {
-            DetailRuns::Node(records) => {
-                write_fixed_run(&self.root, &format!("{stem}.node-details.run"), records)?
-            }
-            DetailRuns::Edge(records) => {
-                write_fixed_run(&self.root, &format!("{stem}.edge-details.run"), records)?
-            }
+            DetailRuns::Node(records) => write_fixed_run(
+                &self.root,
+                &format!("{stem}.node-details.run"),
+                records,
+                &mut self.checkpoint.evidence,
+            )?,
+            DetailRuns::Edge(records) => write_fixed_run(
+                &self.root,
+                &format!("{stem}.edge-details.run"),
+                records,
+                &mut self.checkpoint.evidence,
+            )?,
         });
         replace_control(&self.root, INTENT, &intent)?;
         reject_cancelled(&mut cancelled)?;
@@ -2284,6 +2309,7 @@ impl GraphConstructionSession {
             }
             if authenticate_artifacts {
                 let work = validate_receipt_artifacts(&self.root, &receipt)?;
+                account_cache_release(work.cache_release, &mut self.checkpoint.evidence);
                 read_bytes = read_bytes.saturating_add(work.bytes);
                 read_operations = read_operations.saturating_add(work.operations);
             }
@@ -2380,7 +2406,9 @@ impl GraphConstructionSession {
             // decoder cannot establish a whole-file digest, so retain exactly
             // one explicit whole-file authentication pass for that artifact.
             let mut work = authenticate_artifact(&self.root, &receipt.parquet)?;
+            account_cache_release(work.cache_release, &mut self.checkpoint.evidence);
             let metadata_work = validate_parquet_metadata(&self.root, &receipt)?;
+            account_cache_release(metadata_work.cache_release, &mut self.checkpoint.evidence);
             work.bytes = work.bytes.saturating_add(metadata_work.bytes);
             work.operations = work.operations.saturating_add(metadata_work.operations);
             self.checkpoint.evidence.shape_input_validation_read_bytes = self
@@ -2413,7 +2441,13 @@ impl GraphConstructionSession {
                     &mut self.checkpoint.evidence,
                 )?;
             let name = format!("merge-unified-{sequence:020}.run");
-            convert_identity_run(&self.root, &receipt, &name, &mut self.checkpoint.evidence)?;
+            convert_identity_run(
+                &self.root,
+                &receipt,
+                &name,
+                &mut cancelled,
+                &mut self.checkpoint.evidence,
+            )?;
             unified.push::<BASE_IDENTITY_WIDTH>(
                 &self.root,
                 name,
@@ -2427,6 +2461,7 @@ impl GraphConstructionSession {
                         &self.root,
                         &receipt.details,
                         &name,
+                        &mut cancelled,
                         &mut self.checkpoint.evidence,
                     )?;
                     node_details.push::<NODE_DETAIL_WIDTH>(
@@ -2442,6 +2477,7 @@ impl GraphConstructionSession {
                         &self.root,
                         &receipt.details,
                         &detail,
+                        &mut cancelled,
                         &mut self.checkpoint.evidence,
                     )?;
                     edge_details.push::<EDGE_DETAIL_WIDTH>(
@@ -2458,6 +2494,7 @@ impl GraphConstructionSession {
                             .as_ref()
                             .ok_or_else(|| storage("edge receipt lacks endpoint run"))?,
                         &endpoint,
+                        &mut cancelled,
                         &mut self.checkpoint.evidence,
                     )?;
                     endpoints.push::<ENDPOINT_WIDTH>(
@@ -2826,6 +2863,10 @@ impl GraphConstructionSession {
                 .flatten()
                 {
                     let recovery_work = authenticate_artifact(&self.root, &artifact)?;
+                    account_cache_release(
+                        recovery_work.cache_release,
+                        &mut self.checkpoint.evidence,
+                    );
                     self.checkpoint.evidence.recovery_application_read_bytes = self
                         .checkpoint
                         .evidence
@@ -3406,8 +3447,8 @@ fn uuid_value(array: &FixedSizeBinaryArray, row: usize) -> Result<[u8; 16], GfEr
         .map_err(|_| storage("UUID width changed"))
 }
 
-struct HashingWriter<W> {
-    inner: W,
+struct HashingWriter {
+    inner: graphforge_filesystem::DurableFileCacheWriter,
     digest: Sha256,
     bytes: u64,
     operations: u64,
@@ -3460,6 +3501,36 @@ impl<R: Read> Read for CountingRead<R> {
 pub(crate) struct CountingChunkReader<R = File> {
     pub(crate) file: R,
     pub(crate) counter: IoCounter,
+    cache_release: graphforge_filesystem::FileCacheReleaseTracker,
+    cache_window_bytes: std::num::NonZeroU64,
+}
+
+impl<R> CountingChunkReader<R> {
+    pub(crate) fn new(file: R, counter: IoCounter) -> Self {
+        Self::with_cache_window(
+            file,
+            counter,
+            std::num::NonZeroU64::new(graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES)
+                .expect("default cache window is non-zero"),
+        )
+    }
+
+    pub(crate) fn with_cache_window(
+        file: R,
+        counter: IoCounter,
+        cache_window_bytes: std::num::NonZeroU64,
+    ) -> Self {
+        Self {
+            file,
+            counter,
+            cache_release: graphforge_filesystem::FileCacheReleaseTracker::default(),
+            cache_window_bytes,
+        }
+    }
+
+    pub(crate) fn cache_release_tracker(&self) -> graphforge_filesystem::FileCacheReleaseTracker {
+        self.cache_release.clone()
+    }
 }
 
 pub(crate) trait ConstructionFileHandle: Send + Sync {
@@ -3494,12 +3565,17 @@ impl<R: ConstructionFileHandle> Length for CountingChunkReader<R> {
 }
 
 impl<R: ConstructionFileHandle> ChunkReader for CountingChunkReader<R> {
-    type T = CountingRead<BufReader<File>>;
+    type T = CountingRead<BufReader<graphforge_filesystem::FileCacheReleasingReader>>;
 
     fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
         use std::io::{Seek, SeekFrom};
 
-        let mut file = self.file.descriptor().try_clone()?;
+        let file = self.file.descriptor().try_clone()?;
+        let mut file = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+            file,
+            self.cache_window_bytes,
+            self.cache_release.clone(),
+        )?;
         file.seek(SeekFrom::Start(start))?;
         Ok(CountingRead {
             inner: BufReader::with_capacity(BLOCK_BYTES, file),
@@ -3510,27 +3586,44 @@ impl<R: ConstructionFileHandle> ChunkReader for CountingChunkReader<R> {
     fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<bytes::Bytes> {
         use std::io::{Seek, SeekFrom};
 
-        let mut file = self.file.descriptor().try_clone()?;
+        let file = self.file.descriptor().try_clone()?;
+        let mut file = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+            file,
+            self.cache_window_bytes,
+            self.cache_release.clone(),
+        )?;
         file.seek(SeekFrom::Start(start))?;
         let mut value = vec![0_u8; length];
         file.read_exact(&mut value)?;
+        file.finish()?;
         self.counter.account(length);
         Ok(bytes::Bytes::from(value))
     }
 }
 
-impl<W> HashingWriter<W> {
-    fn new(inner: W) -> Self {
-        Self {
-            inner,
+impl HashingWriter {
+    fn new(inner: File) -> Result<Self, GfError> {
+        let cache_window =
+            graphforge_filesystem::cache_release_window_for_streams(4).map_err(storage)?;
+        Self::with_cache_window(inner, cache_window)
+    }
+
+    fn with_cache_window(inner: File, cache_window: std::num::NonZeroU64) -> Result<Self, GfError> {
+        Ok(Self {
+            inner: graphforge_filesystem::DurableFileCacheWriter::with_window_bytes_checked(
+                inner,
+                cache_window,
+                || shape_publication_io_failure("writer_construction"),
+            )
+            .map_err(storage)?,
             digest: Sha256::new(),
             bytes: 0,
             operations: 0,
-        }
+        })
     }
 }
 
-impl<W: Write> Write for HashingWriter<W> {
+impl Write for HashingWriter {
     fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
         let written = self.inner.write(bytes)?;
         self.digest.update(&bytes[..written]);
@@ -3544,35 +3637,74 @@ impl<W: Write> Write for HashingWriter<W> {
     }
 }
 
+fn account_cache_release(
+    released: graphforge_filesystem::FileCacheReleaseEvidence,
+    evidence: &mut GraphConstructionEvidence,
+) {
+    evidence.cache_release_operations = evidence
+        .cache_release_operations
+        .saturating_add(released.release_operations);
+    evidence.cache_release_unsupported_operations = evidence
+        .cache_release_unsupported_operations
+        .saturating_add(released.unsupported_operations);
+    evidence.cache_released_bytes = evidence
+        .cache_released_bytes
+        .saturating_add(released.released_bytes);
+    evidence.peak_cache_release_window_bytes = evidence
+        .peak_cache_release_window_bytes
+        .max(released.peak_window_bytes);
+}
+
+fn account_encoding_cache_release(
+    released: &GraphConstructionEncodingEvidence,
+    evidence: &mut GraphConstructionEvidence,
+) {
+    evidence.cache_release_operations = evidence
+        .cache_release_operations
+        .saturating_add(released.cache_release_operations);
+    evidence.cache_release_unsupported_operations = evidence
+        .cache_release_unsupported_operations
+        .saturating_add(released.cache_release_unsupported_operations);
+    evidence.cache_released_bytes = evidence
+        .cache_released_bytes
+        .saturating_add(released.cache_released_bytes);
+    evidence.peak_cache_release_window_bytes = evidence
+        .peak_cache_release_window_bytes
+        .max(released.peak_cache_release_window_bytes);
+}
+
 fn write_parquet(
     root: &StableDirectory,
     name: &str,
     batch: &RecordBatch,
+    evidence: &mut GraphConstructionEvidence,
 ) -> Result<ArtifactReceipt, GfError> {
     let temporary = artifact_temp(name);
     let file = root
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
-    let hashing = HashingWriter::new(file);
+    let hashing = HashingWriter::new(file)?;
     let buffered = BufWriter::with_capacity(BLOCK_BYTES, hashing);
     let mut parquet = ArrowWriter::try_new(buffered, batch.schema(), None).map_err(storage)?;
     parquet.write(batch).map_err(storage)?;
     parquet.finish().map_err(storage)?;
     parquet.sync().map_err(storage)?;
-    let hashing = parquet.inner().get_ref();
-    hashing.inner.sync_all().map_err(storage)?;
+    let hashing = parquet.inner_mut().get_mut();
+    hashing.inner.sync_all_and_release().map_err(storage)?;
+    let cache_release = hashing.inner.evidence();
+    account_cache_release(cache_release, evidence);
     construction_failpoint(&format!("artifact.after_temp_fsync.{name}"));
     let receipt = ArtifactReceipt {
         name: name.to_owned(),
         bytes: hashing.bytes,
-        allocated_bytes: graphforge_filesystem::file_space_usage(&hashing.inner)
+        allocated_bytes: graphforge_filesystem::file_space_usage(hashing.inner.file())
             .map_err(storage)?
             .allocated_bytes,
         sha256: hex(&hashing.digest.clone().finalize()),
         identity: identity.into(),
         write_operations: hashing.operations,
-        fsync_operations: 4,
+        fsync_operations: 4_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(name))
@@ -3587,13 +3719,14 @@ fn write_fixed_run<const N: usize>(
     root: &StableDirectory,
     name: &str,
     records: &[[u8; N]],
+    evidence: &mut GraphConstructionEvidence,
 ) -> Result<ArtifactReceipt, GfError> {
     let temporary = artifact_temp(name);
     let file = root
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
-    let mut writer = HashingWriter::new(file);
+    let mut writer = HashingWriter::new(file)?;
     let records_per_block = (BLOCK_BYTES / N).max(1);
     let mut block = Vec::with_capacity(records_per_block * N);
     for group in records.chunks(records_per_block) {
@@ -3604,18 +3737,20 @@ fn write_fixed_run<const N: usize>(
         writer.write_all(&block).map_err(storage)?;
     }
     writer.flush().map_err(storage)?;
-    writer.inner.sync_all().map_err(storage)?;
+    writer.inner.sync_all_and_release().map_err(storage)?;
+    let cache_release = writer.inner.evidence();
+    account_cache_release(cache_release, evidence);
     construction_failpoint(&format!("artifact.after_temp_fsync.{name}"));
     let receipt = ArtifactReceipt {
         name: name.to_owned(),
         bytes: writer.bytes,
-        allocated_bytes: graphforge_filesystem::file_space_usage(&writer.inner)
+        allocated_bytes: graphforge_filesystem::file_space_usage(writer.inner.file())
             .map_err(storage)?
             .allocated_bytes,
         sha256: hex(&writer.digest.finalize()),
         identity: identity.into(),
         write_operations: writer.operations,
-        fsync_operations: 3,
+        fsync_operations: 3_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(name))
@@ -3766,6 +3901,10 @@ fn copy_post_shape_io(target: &mut GraphConstructionEvidence, source: &GraphCons
         .clone_from(&source.storage_allocation_transitions);
     target.current_merge_temporary_allocated_bytes = source.current_merge_temporary_allocated_bytes;
     target.peak_merge_temporary_bytes = source.peak_merge_temporary_bytes;
+    target.cache_release_operations = source.cache_release_operations;
+    target.cache_release_unsupported_operations = source.cache_release_unsupported_operations;
+    target.cache_released_bytes = source.cache_released_bytes;
+    target.peak_cache_release_window_bytes = source.peak_cache_release_window_bytes;
     target.encode_application_read_bytes = source.encode_application_read_bytes;
     target.encode_application_read_operations = source.encode_application_read_operations;
     target.encode_application_write_bytes = source.encode_application_write_bytes;
@@ -4136,41 +4275,61 @@ fn receipt_for_existing_with_work(
             ReadWork {
                 bytes: control_bytes,
                 operations: 1,
+                ..Default::default()
             },
         ));
     }
-    let mut file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
+    let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
     if file_link_count(&file).map_err(storage)? != 1 {
         return Err(storage("shaped output has extra links"));
     }
     let identity = file_identity(&file).map_err(storage)?;
+    let mut file = graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(storage)?;
     let mut digest = Sha256::new();
     let mut bytes = 0_u64;
     let mut operations = 0_u64;
     let mut block = vec![0_u8; BLOCK_BYTES];
-    loop {
-        let count = file.read(&mut block).map_err(storage)?;
-        if count == 0 {
-            break;
+    let authenticated = (|| -> Result<(ArtifactReceipt, ReadWork), GfError> {
+        loop {
+            let count = file.read(&mut block).map_err(storage)?;
+            if count == 0 {
+                break;
+            }
+            digest.update(&block[..count]);
+            bytes = bytes.saturating_add(count as u64);
+            operations = operations.saturating_add(1);
         }
-        digest.update(&block[..count]);
-        bytes = bytes.saturating_add(count as u64);
-        operations = operations.saturating_add(1);
+        Ok((
+            ArtifactReceipt {
+                name: name.to_owned(),
+                bytes,
+                allocated_bytes: graphforge_filesystem::file_space_usage(file.file())
+                    .map_err(storage)?
+                    .allocated_bytes,
+                sha256: hex(&digest.finalize()),
+                identity: identity.into(),
+                write_operations: 0,
+                fsync_operations: 0,
+            },
+            ReadWork {
+                bytes,
+                operations,
+                ..Default::default()
+            },
+        ))
+    })();
+    let released = file.finish().map_err(storage);
+    match (authenticated, released) {
+        (Ok((receipt, mut work)), Ok(cache_release)) => {
+            work.cache_release = cache_release;
+            Ok((receipt, work))
+        }
+        (Ok(_), Err(release)) => Err(release),
+        (Err(primary), Ok(_)) => Err(primary),
+        (Err(primary), Err(release)) => Err(storage(format!(
+            "{primary}; shaped artifact cache release also failed: {release}"
+        ))),
     }
-    Ok((
-        ArtifactReceipt {
-            name: name.to_owned(),
-            bytes,
-            allocated_bytes: graphforge_filesystem::file_space_usage(&file)
-                .map_err(storage)?
-                .allocated_bytes,
-            sha256: hex(&digest.finalize()),
-            identity: identity.into(),
-            write_operations: 0,
-            fsync_operations: 0,
-        },
-        ReadWork { bytes, operations },
-    ))
 }
 
 fn shape_receipt_name(name: &str) -> String {
@@ -4568,20 +4727,181 @@ fn open_counted_fixed_reader(
     root: &StableDirectory,
     name: &str,
     evidence: &mut GraphConstructionEvidence,
-) -> Result<(BufReader<CountingRead<File>>, IoCounter), GfError> {
+) -> Result<
+    (
+        BufReader<CountingRead<graphforge_filesystem::FileCacheReleasingReader>>,
+        IoCounter,
+    ),
+    GfError,
+> {
     let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
     account_sequential_read(file.metadata().map_err(storage)?.len(), evidence);
     let counter = IoCounter::default();
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(4).map_err(storage)?;
     Ok((
         BufReader::with_capacity(
             BLOCK_BYTES,
             CountingRead {
-                inner: file,
+                inner: graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                    file,
+                    cache_window,
+                    graphforge_filesystem::FileCacheReleaseTracker::default(),
+                )
+                .map_err(storage)?,
                 counter: counter.clone(),
             },
         ),
         counter,
     ))
+}
+
+fn release_counted_reader_cache(
+    reader: &mut BufReader<CountingRead<graphforge_filesystem::FileCacheReleasingReader>>,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    let released = reader.get_mut().inner.finish().map_err(storage)?;
+    account_cache_release(released, evidence);
+    #[cfg(test)]
+    SHAPE_CLEANUP_FAILURES.with(|failures| {
+        if failures.borrow().input_release {
+            failures.borrow_mut().input_release = false;
+            return Err(storage("injected shape input release failure"));
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
+
+fn combine_cache_cleanup<T>(
+    primary: Result<T, GfError>,
+    cleanup: Result<(), GfError>,
+    source: &str,
+) -> Result<T, GfError> {
+    match (primary, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup)) => Err(cleanup),
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(cleanup)) => Err(storage(format!(
+            "{primary}; {source} cache release also failed: {cleanup}"
+        ))),
+    }
+}
+
+fn combine_secondary_cleanup<T>(
+    primary: Result<T, GfError>,
+    cleanup: Result<(), GfError>,
+    context: &str,
+) -> Result<T, GfError> {
+    match (primary, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup)) => Err(cleanup),
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(cleanup)) => Err(storage(format!(
+            "{primary}; {context} also failed: {cleanup}"
+        ))),
+    }
+}
+
+fn cleanup_failed_shape_output(
+    mut writer: BufWriter<HashingWriter>,
+    publication: &mut graphforge_filesystem::UnpublishedArtifactGuard,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<(), GfError> {
+    let flushed = writer.flush().map_err(storage);
+    let synchronized = writer
+        .get_mut()
+        .inner
+        .sync_all_and_release()
+        .map_err(storage);
+    let cache_release = writer.get_ref().inner.evidence();
+    account_cache_release(cache_release, evidence);
+    let finalized =
+        combine_secondary_cleanup(flushed, synchronized, "shape output synchronization");
+    drop(writer);
+    let guard_cleanup = cleanup_shape_publication(publication);
+    combine_secondary_cleanup(finalized, guard_cleanup, "shape output removal")
+}
+
+fn cleanup_shape_publication(
+    publication: &mut graphforge_filesystem::UnpublishedArtifactGuard,
+) -> Result<(), GfError> {
+    publication
+        .cleanup_checked(|| {
+            take_shape_output_cleanup_failure()
+                .map_err(|_| std::io::Error::other("injected shape output cleanup failure"))
+        })
+        .map_err(storage)
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct ShapeCleanupFailures {
+    input_release: bool,
+    output_cleanup: bool,
+    publication_failure: Option<&'static str>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static SHAPE_CLEANUP_FAILURES: std::cell::RefCell<ShapeCleanupFailures> =
+        std::cell::RefCell::new(ShapeCleanupFailures::default());
+}
+
+#[cfg(test)]
+fn inject_shape_cleanup_failures(input_release: bool, output_cleanup: bool) {
+    SHAPE_CLEANUP_FAILURES.with(|failures| {
+        *failures.borrow_mut() = ShapeCleanupFailures {
+            input_release,
+            output_cleanup,
+            publication_failure: None,
+        };
+    });
+}
+
+#[cfg(test)]
+fn inject_shape_publication_failure(point: &'static str) {
+    SHAPE_CLEANUP_FAILURES.with(|failures| failures.borrow_mut().publication_failure = Some(point));
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn shape_publication_failure(point: &str) -> Result<(), GfError> {
+    #[cfg(test)]
+    SHAPE_CLEANUP_FAILURES.with(|failures| {
+        if failures
+            .borrow()
+            .publication_failure
+            .is_some_and(|configured| configured == point)
+        {
+            failures.borrow_mut().publication_failure.take();
+            return Err(storage(format!(
+                "injected shape publication failure at {point}"
+            )));
+        }
+        Ok(())
+    })?;
+    #[cfg(not(test))]
+    let _ = point;
+    Ok(())
+}
+
+fn shape_publication_io_failure(point: &str) -> std::io::Result<()> {
+    shape_publication_failure(point).map_err(|_| {
+        std::io::Error::other(format!("injected shape publication failure at {point}"))
+    })
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn take_shape_output_cleanup_failure() -> Result<(), GfError> {
+    #[cfg(test)]
+    if SHAPE_CLEANUP_FAILURES.with(|failures| {
+        let output_cleanup = failures.borrow().output_cleanup;
+        failures.borrow_mut().output_cleanup = false;
+        output_cleanup
+    }) {
+        return Err(storage("injected shape output cleanup failure"));
+    }
+    Ok(())
 }
 
 fn account_fixed_write_operations(
@@ -4597,10 +4917,12 @@ fn account_fixed_write_operations(
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 fn convert_identity_run(
     root: &StableDirectory,
     receipt: &ConstructionChunkReceipt,
     output: &str,
+    cancelled: &mut impl FnMut() -> bool,
     evidence: &mut GraphConstructionEvidence,
 ) -> Result<(), GfError> {
     let input = root
@@ -4616,66 +4938,183 @@ fn convert_identity_run(
         return Err(storage("identity source authority changed before merge"));
     }
     let temporary = artifact_temp(output);
-    let file = root
-        .create_replaceable_child_file(OsStr::new(&temporary))
+    let mut publication = root
+        .create_unpublished_replaceable_child(OsStr::new(&temporary))
         .map_err(storage)?;
-    let identity = file_identity(&file).map_err(storage)?;
+    let identity = match publication
+        .verify_identity_with(|| shape_publication_io_failure("initial_file_identity"))
+        .map_err(storage)
+    {
+        Ok(identity) => identity,
+        Err(primary) => {
+            let cleanup = cleanup_shape_publication(&mut publication);
+            return combine_secondary_cleanup(Err(primary), cleanup, "identity setup cleanup");
+        }
+    };
+    let file = publication.take_file().map_err(storage)?;
     let read_counter = IoCounter::default();
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage)?;
     let mut reader = BufReader::with_capacity(
         BLOCK_BYTES,
         CountingRead {
-            inner: input,
+            inner: graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                input,
+                cache_window,
+                graphforge_filesystem::FileCacheReleaseTracker::default(),
+            )
+            .map_err(storage)?,
             counter: read_counter.clone(),
         },
     );
-    let hashing = HashingWriter::new(file);
+    let hashing = match HashingWriter::with_cache_window(file, cache_window) {
+        Ok(hashing) => hashing,
+        Err(primary) => {
+            let cleanup = cleanup_shape_publication(&mut publication);
+            return combine_secondary_cleanup(Err(primary), cleanup, "identity setup cleanup");
+        }
+    };
+    let configured = graphforge_filesystem::validate_cache_release_operation_windows(&[
+        reader.get_ref().inner.window_bytes(),
+        hashing.inner.window_bytes(),
+    ])
+    .map_err(storage)
+    .and_then(|_| shape_publication_failure("window_validation"));
     let mut writer = BufWriter::with_capacity(BLOCK_BYTES, hashing);
+    if let Err(primary) = configured {
+        let released = release_counted_reader_cache(&mut reader, evidence);
+        let primary = combine_cache_cleanup::<()>(Err(primary), released, "identity source")
+            .expect_err("primary cache configuration failure is retained");
+        let cleanup = cleanup_failed_shape_output(writer, &mut publication, evidence);
+        return combine_secondary_cleanup(Err(primary), cleanup, "identity output cleanup");
+    }
     let mut digest = Sha256::new();
     let mut bytes = 0_u64;
-    while let Some(uuid) = read_fixed::<IDENTITY_WIDTH>(&mut reader)? {
-        digest.update(uuid);
-        bytes = bytes.saturating_add(IDENTITY_WIDTH as u64);
-        let mut record = [0_u8; BASE_IDENTITY_WIDTH];
-        record[..16].copy_from_slice(&uuid);
-        record[16] = u8::from(receipt.kind == ConstructionChunkKind::Edge);
-        writer.write_all(&record).map_err(storage)?;
-        account_merge_read::<IDENTITY_WIDTH>(evidence);
-        account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+    let copied = (|| -> Result<(), GfError> {
+        while let Some(uuid) = read_fixed::<IDENTITY_WIDTH>(&mut reader)? {
+            digest.update(uuid);
+            bytes = bytes.saturating_add(IDENTITY_WIDTH as u64);
+            let mut record = [0_u8; BASE_IDENTITY_WIDTH];
+            record[..16].copy_from_slice(&uuid);
+            record[16] = u8::from(receipt.kind == ConstructionChunkKind::Edge);
+            writer.write_all(&record).map_err(storage)?;
+            account_merge_read::<IDENTITY_WIDTH>(evidence);
+            account_merge_write::<BASE_IDENTITY_WIDTH>(evidence);
+            reject_cancelled(cancelled)?;
+        }
+        if bytes != receipt.identities.bytes || hex(&digest.finalize()) != receipt.identities.sha256
+        {
+            return Err(storage("identity source content changed before merge"));
+        }
+        account_fixed_read_operations(&read_counter, evidence)
+    })();
+    let released = release_counted_reader_cache(&mut reader, evidence);
+    let copied = combine_cache_cleanup(copied, released, "identity source");
+    if let Err(primary) = copied {
+        let cleanup = cleanup_failed_shape_output(writer, &mut publication, evidence);
+        return combine_secondary_cleanup(Err(primary), cleanup, "identity output cleanup");
     }
-    if bytes != receipt.identities.bytes || hex(&digest.finalize()) != receipt.identities.sha256 {
-        return Err(storage("identity source content changed before merge"));
+    let finalized = writer.flush().map_err(storage).and_then(|()| {
+        writer
+            .get_mut()
+            .inner
+            .sync_all_and_release()
+            .map_err(storage)
+    });
+    if let Err(primary) = finalized {
+        let cleanup = cleanup_failed_shape_output(writer, &mut publication, evidence);
+        return combine_secondary_cleanup(Err(primary), cleanup, "identity output cleanup");
     }
-    account_fixed_read_operations(&read_counter, evidence)?;
-    writer.flush().map_err(storage)?;
-    writer.get_ref().inner.sync_all().map_err(storage)?;
-    account_sequential_write(writer.get_ref().bytes, evidence);
-    let output_receipt = ArtifactReceipt {
-        name: output.to_owned(),
-        bytes: writer.get_ref().bytes,
-        allocated_bytes: graphforge_filesystem::file_space_usage(&writer.get_ref().inner)
-            .map_err(storage)?
-            .allocated_bytes,
-        sha256: hex(&writer.get_ref().digest.clone().finalize()),
-        identity: identity.into(),
-        write_operations: writer.get_ref().operations,
-        fsync_operations: 2,
+    let cache_release = writer.get_ref().inner.evidence();
+    let prepared = (|| -> Result<(_, _), GfError> {
+        shape_publication_failure("fsync_evidence_overflow")?;
+        let mut committed_evidence = evidence.clone();
+        account_cache_release(cache_release, &mut committed_evidence);
+        let aggregate_peak = reader
+            .get_ref()
+            .inner
+            .tracker()
+            .evidence()
+            .peak_window_bytes
+            .checked_add(cache_release.peak_window_bytes)
+            .ok_or_else(|| storage("identity copy aggregate cache window overflow"))?;
+        committed_evidence.peak_cache_release_window_bytes = committed_evidence
+            .peak_cache_release_window_bytes
+            .max(aggregate_peak);
+        account_sequential_write(writer.get_ref().bytes, &mut committed_evidence);
+        shape_publication_failure("final_file_identity")?;
+        if file_identity(writer.get_ref().inner.file()).map_err(storage)?
+            != publication.identity().map_err(storage)?
+        {
+            return Err(storage(
+                "identity output authority changed before publication",
+            ));
+        }
+        shape_publication_failure("file_space_usage")?;
+        let output_receipt = ArtifactReceipt {
+            name: output.to_owned(),
+            bytes: writer.get_ref().bytes,
+            allocated_bytes: graphforge_filesystem::file_space_usage(writer.get_ref().inner.file())
+                .map_err(storage)?
+                .allocated_bytes,
+            sha256: hex(&writer.get_ref().digest.clone().finalize()),
+            identity: identity.into(),
+            write_operations: writer.get_ref().operations,
+            fsync_operations: 2_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+        };
+        record_shape_artifact_install(&mut committed_evidence, &output_receipt)?;
+        account_fixed_write_operations(&output_receipt, &mut committed_evidence)?;
+        committed_evidence.merge_fsync_operations =
+            committed_evidence.merge_fsync_operations.saturating_add(2);
+        Ok((output_receipt, committed_evidence))
+    })();
+    let (output_receipt, committed_evidence) = match prepared {
+        Ok(prepared) => prepared,
+        Err(primary) => {
+            let cleanup = cleanup_failed_shape_output(writer, &mut publication, evidence);
+            return combine_secondary_cleanup(
+                Err(primary),
+                cleanup,
+                "identity setup publication cleanup",
+            );
+        }
     };
     drop(writer);
-    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
-        .map_err(storage)?;
-    root.sync().map_err(storage)?;
-    construction_failpoint("shape.fixed.after_install");
-    persist_shape_receipt(root, &output_receipt)?;
-    record_shape_artifact_install(evidence, &output_receipt)?;
-    account_fixed_write_operations(&output_receipt, evidence)?;
-    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
+    let published = (|| -> Result<(), GfError> {
+        shape_publication_failure("install_child")?;
+        publication
+            .install_child(OsStr::new(output))
+            .map_err(storage)?;
+        publication.sync_parent().map_err(storage)?;
+        shape_publication_failure("directory_sync")?;
+        shape_publication_failure("post_publication_metric_overflow")?;
+        shape_publication_failure("manifest_update")?;
+        construction_failpoint("shape.fixed.after_install");
+        persist_shape_receipt(root, &output_receipt)
+    })();
+    if let Err(primary) = published {
+        let receipt_cleanup =
+            unlink_writer_capability(root, output, Some(&output_receipt)).map_err(storage);
+        let primary = combine_secondary_cleanup::<()>(
+            Err(primary),
+            receipt_cleanup,
+            "identity receipt cleanup",
+        )
+        .expect_err("primary identity publication failure is retained");
+        let cleanup = cleanup_shape_publication(&mut publication);
+        return combine_secondary_cleanup(Err(primary), cleanup, "identity publication cleanup");
+    }
+    publication.commit().map_err(storage)?;
+    *evidence = committed_evidence;
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 fn copy_authenticated_run<const N: usize>(
     root: &StableDirectory,
     receipt: &ArtifactReceipt,
     output: &str,
+    cancelled: &mut impl FnMut() -> bool,
     evidence: &mut GraphConstructionEvidence,
 ) -> Result<(), GfError> {
     let input = root
@@ -4690,57 +5129,176 @@ fn copy_authenticated_run<const N: usize>(
         return Err(storage("construction merge source authority changed"));
     }
     let temporary = artifact_temp(output);
-    let file = root
-        .create_replaceable_child_file(OsStr::new(&temporary))
+    let mut publication = root
+        .create_unpublished_replaceable_child(OsStr::new(&temporary))
         .map_err(storage)?;
-    let identity = file_identity(&file).map_err(storage)?;
+    let identity = match publication
+        .verify_identity_with(|| shape_publication_io_failure("initial_file_identity"))
+        .map_err(storage)
+    {
+        Ok(identity) => identity,
+        Err(primary) => {
+            let cleanup = cleanup_shape_publication(&mut publication);
+            return combine_secondary_cleanup(Err(primary), cleanup, "authenticated setup cleanup");
+        }
+    };
+    let file = publication.take_file().map_err(storage)?;
     let read_counter = IoCounter::default();
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage)?;
     let mut reader = BufReader::with_capacity(
         BLOCK_BYTES,
         CountingRead {
-            inner: input,
+            inner: graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                input,
+                cache_window,
+                graphforge_filesystem::FileCacheReleaseTracker::default(),
+            )
+            .map_err(storage)?,
             counter: read_counter.clone(),
         },
     );
-    let hashing = HashingWriter::new(file);
+    let hashing = match HashingWriter::with_cache_window(file, cache_window) {
+        Ok(hashing) => hashing,
+        Err(primary) => {
+            let cleanup = cleanup_shape_publication(&mut publication);
+            return combine_secondary_cleanup(Err(primary), cleanup, "authenticated setup cleanup");
+        }
+    };
+    let configured = graphforge_filesystem::validate_cache_release_operation_windows(&[
+        reader.get_ref().inner.window_bytes(),
+        hashing.inner.window_bytes(),
+    ])
+    .map_err(storage)
+    .and_then(|_| shape_publication_failure("window_validation"));
     let mut writer = BufWriter::with_capacity(BLOCK_BYTES, hashing);
+    if let Err(primary) = configured {
+        let released = release_counted_reader_cache(&mut reader, evidence);
+        let primary =
+            combine_cache_cleanup::<()>(Err(primary), released, "construction merge source")
+                .expect_err("primary cache configuration failure is retained");
+        let cleanup = cleanup_failed_shape_output(writer, &mut publication, evidence);
+        return combine_secondary_cleanup(Err(primary), cleanup, "authenticated output cleanup");
+    }
     let mut digest = Sha256::new();
     let mut bytes = 0_u64;
-    while let Some(record) = read_fixed::<N>(&mut reader)? {
-        digest.update(record);
-        bytes = bytes.saturating_add(N as u64);
-        writer.write_all(&record).map_err(storage)?;
-        account_merge_read::<N>(evidence);
-        account_merge_write::<N>(evidence);
+    let copied = (|| -> Result<(), GfError> {
+        while let Some(record) = read_fixed::<N>(&mut reader)? {
+            digest.update(record);
+            bytes = bytes.saturating_add(N as u64);
+            writer.write_all(&record).map_err(storage)?;
+            account_merge_read::<N>(evidence);
+            account_merge_write::<N>(evidence);
+            reject_cancelled(cancelled)?;
+        }
+        if bytes != receipt.bytes || hex(&digest.finalize()) != receipt.sha256 {
+            return Err(storage("construction merge source content changed"));
+        }
+        account_fixed_read_operations(&read_counter, evidence)
+    })();
+    let released = release_counted_reader_cache(&mut reader, evidence);
+    let copied = combine_cache_cleanup(copied, released, "construction merge source");
+    if let Err(primary) = copied {
+        let cleanup = cleanup_failed_shape_output(writer, &mut publication, evidence);
+        return combine_secondary_cleanup(Err(primary), cleanup, "authenticated output cleanup");
     }
-    if bytes != receipt.bytes || hex(&digest.finalize()) != receipt.sha256 {
-        return Err(storage("construction merge source content changed"));
+    let finalized = writer.flush().map_err(storage).and_then(|()| {
+        writer
+            .get_mut()
+            .inner
+            .sync_all_and_release()
+            .map_err(storage)
+    });
+    if let Err(primary) = finalized {
+        let cleanup = cleanup_failed_shape_output(writer, &mut publication, evidence);
+        return combine_secondary_cleanup(Err(primary), cleanup, "authenticated output cleanup");
     }
-    account_fixed_read_operations(&read_counter, evidence)?;
-    writer.flush().map_err(storage)?;
-    writer.get_ref().inner.sync_all().map_err(storage)?;
-    account_sequential_write(bytes, evidence);
-    let allocated_bytes = graphforge_filesystem::file_space_usage(&writer.get_ref().inner)
-        .map_err(storage)?
-        .allocated_bytes;
-    let write_operations = writer.get_ref().operations;
-    drop(writer);
-    root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
-        .map_err(storage)?;
-    root.sync().map_err(storage)?;
-    let output_receipt = ArtifactReceipt {
-        name: output.to_owned(),
-        bytes,
-        allocated_bytes,
-        sha256: receipt.sha256.clone(),
-        identity: identity.into(),
-        write_operations,
-        fsync_operations: 2,
+    let cache_release = writer.get_ref().inner.evidence();
+    let prepared = (|| -> Result<(_, _), GfError> {
+        shape_publication_failure("fsync_evidence_overflow")?;
+        let mut committed_evidence = evidence.clone();
+        account_cache_release(cache_release, &mut committed_evidence);
+        let aggregate_peak = reader
+            .get_ref()
+            .inner
+            .tracker()
+            .evidence()
+            .peak_window_bytes
+            .checked_add(cache_release.peak_window_bytes)
+            .ok_or_else(|| storage("authenticated copy aggregate cache window overflow"))?;
+        committed_evidence.peak_cache_release_window_bytes = committed_evidence
+            .peak_cache_release_window_bytes
+            .max(aggregate_peak);
+        account_sequential_write(bytes, &mut committed_evidence);
+        shape_publication_failure("final_file_identity")?;
+        if file_identity(writer.get_ref().inner.file()).map_err(storage)?
+            != publication.identity().map_err(storage)?
+        {
+            return Err(storage(
+                "authenticated output authority changed before publication",
+            ));
+        }
+        shape_publication_failure("file_space_usage")?;
+        let allocated_bytes =
+            graphforge_filesystem::file_space_usage(writer.get_ref().inner.file())
+                .map_err(storage)?
+                .allocated_bytes;
+        let output_receipt = ArtifactReceipt {
+            name: output.to_owned(),
+            bytes,
+            allocated_bytes,
+            sha256: receipt.sha256.clone(),
+            identity: identity.into(),
+            write_operations: writer.get_ref().operations,
+            fsync_operations: 2_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
+        };
+        record_shape_artifact_install(&mut committed_evidence, &output_receipt)?;
+        account_fixed_write_operations(&output_receipt, &mut committed_evidence)?;
+        committed_evidence.merge_fsync_operations =
+            committed_evidence.merge_fsync_operations.saturating_add(2);
+        Ok((output_receipt, committed_evidence))
+    })();
+    let (output_receipt, committed_evidence) = match prepared {
+        Ok(prepared) => prepared,
+        Err(primary) => {
+            let cleanup = cleanup_failed_shape_output(writer, &mut publication, evidence);
+            return combine_secondary_cleanup(
+                Err(primary),
+                cleanup,
+                "authenticated setup publication cleanup",
+            );
+        }
     };
-    persist_shape_receipt(root, &output_receipt)?;
-    record_shape_artifact_install(evidence, &output_receipt)?;
-    account_fixed_write_operations(&output_receipt, evidence)?;
-    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
+    drop(writer);
+    let published = (|| -> Result<(), GfError> {
+        shape_publication_failure("install_child")?;
+        publication
+            .install_child(OsStr::new(output))
+            .map_err(storage)?;
+        publication.sync_parent().map_err(storage)?;
+        shape_publication_failure("directory_sync")?;
+        shape_publication_failure("post_publication_metric_overflow")?;
+        shape_publication_failure("manifest_update")?;
+        persist_shape_receipt(root, &output_receipt)
+    })();
+    if let Err(primary) = published {
+        let receipt_cleanup =
+            unlink_writer_capability(root, output, Some(&output_receipt)).map_err(storage);
+        let primary = combine_secondary_cleanup::<()>(
+            Err(primary),
+            receipt_cleanup,
+            "authenticated receipt cleanup",
+        )
+        .expect_err("primary authenticated publication failure is retained");
+        let cleanup = cleanup_shape_publication(&mut publication);
+        return combine_secondary_cleanup(
+            Err(primary),
+            cleanup,
+            "authenticated publication cleanup",
+        );
+    }
+    publication.commit().map_err(storage)?;
+    *evidence = committed_evidence;
     Ok(())
 }
 
@@ -4889,6 +5447,7 @@ impl FixedMergeAccumulator {
     }
 }
 
+#[allow(clippy::too_many_lines)] // One streamed merge keeps reader release and output durability coupled.
 fn merge_fixed_group<const N: usize>(
     root: &StableDirectory,
     inputs: &[String],
@@ -4898,21 +5457,32 @@ fn merge_fixed_group<const N: usize>(
     evidence: &mut GraphConstructionEvidence,
 ) -> Result<ArtifactReceipt, GfError> {
     let read_counter = IoCounter::default();
+    let active_streams = inputs
+        .len()
+        .checked_add(1)
+        .ok_or_else(|| storage("fixed merge stream count overflow"))?;
+    let reader_cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(active_streams).map_err(storage)?;
     let mut readers = inputs
         .iter()
         .map(|name| {
             root.open_child_file(OsStr::new(name))
-                .map(|file| {
+                .and_then(|file| {
                     if let Ok(metadata) = file.metadata() {
                         account_sequential_read(metadata.len(), evidence);
                     }
-                    BufReader::with_capacity(
+                    Ok(BufReader::with_capacity(
                         BLOCK_BYTES,
                         CountingRead {
-                            inner: file,
+                            inner:
+                                graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                                    file,
+                                    reader_cache_window,
+                                    graphforge_filesystem::FileCacheReleaseTracker::default(),
+                                )?,
                             counter: read_counter.clone(),
                         },
-                    )
+                    ))
                 })
                 .map_err(storage)
         })
@@ -4923,7 +5493,7 @@ fn merge_fixed_group<const N: usize>(
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
-    let hashing = HashingWriter::new(file);
+    let hashing = HashingWriter::with_cache_window(file, reader_cache_window)?;
     let mut writer = BufWriter::with_capacity(BLOCK_BYTES, hashing);
     let mut heap = BinaryHeap::new();
     for (index, reader) in readers.iter_mut().enumerate() {
@@ -4954,18 +5524,43 @@ fn merge_fixed_group<const N: usize>(
     }
     writer.flush().map_err(storage)?;
     account_fixed_read_operations(&read_counter, evidence)?;
-    writer.get_ref().inner.sync_all().map_err(storage)?;
+    for reader in &mut readers {
+        release_counted_reader_cache(reader, evidence)?;
+    }
+    writer
+        .get_mut()
+        .inner
+        .sync_all_and_release()
+        .map_err(storage)?;
+    let cache_release = writer.get_ref().inner.evidence();
+    account_cache_release(cache_release, evidence);
+    let aggregate_peak =
+        readers
+            .iter()
+            .try_fold(cache_release.peak_window_bytes, |peak, reader| {
+                peak.checked_add(
+                    reader
+                        .get_ref()
+                        .inner
+                        .tracker()
+                        .evidence()
+                        .peak_window_bytes,
+                )
+                .ok_or_else(|| storage("fixed merge aggregate cache window overflow"))
+            })?;
+    evidence.peak_cache_release_window_bytes =
+        evidence.peak_cache_release_window_bytes.max(aggregate_peak);
     account_sequential_write(writer.get_ref().bytes, evidence);
     let receipt = ArtifactReceipt {
         name: output.to_owned(),
         bytes: writer.get_ref().bytes,
-        allocated_bytes: graphforge_filesystem::file_space_usage(&writer.get_ref().inner)
+        allocated_bytes: graphforge_filesystem::file_space_usage(writer.get_ref().inner.file())
             .map_err(storage)?
             .allocated_bytes,
         sha256: hex(&writer.get_ref().digest.clone().finalize()),
         identity: identity.into(),
         write_operations: writer.get_ref().operations,
-        fsync_operations: 2,
+        fsync_operations: 2_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
     };
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
@@ -4975,7 +5570,9 @@ fn merge_fixed_group<const N: usize>(
     persist_shape_receipt(root, &receipt)?;
     record_shape_artifact_install(evidence, &receipt)?;
     account_fixed_write_operations(&receipt, evidence)?;
-    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
+    evidence.merge_fsync_operations = evidence
+        .merge_fsync_operations
+        .saturating_add(receipt.fsync_operations);
     evidence.merge_groups = evidence.merge_groups.saturating_add(1);
     Ok(receipt)
 }
@@ -5047,33 +5644,60 @@ fn merge_row_group(
     evidence.peak_merge_inputs = evidence.peak_merge_inputs.max(inputs.len() as u64);
     let mut cursors = Vec::with_capacity(inputs.len());
     let mut counters = Vec::with_capacity(inputs.len());
+    let mut cache_release_trackers = Vec::with_capacity(inputs.len());
+    let active_streams = inputs
+        .len()
+        .checked_add(1)
+        .ok_or_else(|| storage("row merge stream count overflow"))?;
+    let reader_cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(active_streams).map_err(storage)?;
     let mut schema: Option<SchemaRef> = None;
-    for input in inputs {
-        let file = root.open_child_file(OsStr::new(input)).map_err(storage)?;
-        let counter = IoCounter::default();
-        let builder = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-            file,
-            counter: counter.clone(),
-        })
-        .map_err(storage)?;
-        if schema
-            .as_ref()
-            .is_some_and(|known| known.as_ref() != builder.schema().as_ref())
-        {
-            return Err(storage("row merge schemas differ"));
+    let initialized = (|| -> Result<(), GfError> {
+        for input in inputs {
+            let file = root.open_child_file(OsStr::new(input)).map_err(storage)?;
+            let counter = IoCounter::default();
+            let chunk_reader =
+                CountingChunkReader::with_cache_window(file, counter.clone(), reader_cache_window);
+            let cache_release = chunk_reader.cache_release_tracker();
+            counters.push(counter);
+            cache_release_trackers.push(cache_release);
+            let builder =
+                ParquetRecordBatchReaderBuilder::try_new(chunk_reader).map_err(storage)?;
+            if schema
+                .as_ref()
+                .is_some_and(|known| known.as_ref() != builder.schema().as_ref())
+            {
+                return Err(storage("row merge schemas differ"));
+            }
+            schema.get_or_insert_with(|| builder.schema().clone());
+            cursors.push(RowCursor {
+                reader: Box::new(
+                    builder
+                        .with_batch_size(output_rows.min(4096))
+                        .build()
+                        .map_err(storage)?,
+                ),
+                batch: None,
+                row: 0,
+            });
         }
-        schema.get_or_insert_with(|| builder.schema().clone());
-        cursors.push(RowCursor {
-            reader: Box::new(
-                builder
-                    .with_batch_size(output_rows.min(4096))
-                    .build()
-                    .map_err(storage)?,
-            ),
-            batch: None,
-            row: 0,
-        });
-        counters.push(counter);
+        Ok(())
+    })();
+    if let Err(primary) = initialized {
+        drop(cursors);
+        let mut result = Err(primary);
+        for tracker in &cache_release_trackers {
+            result = combine_cache_cleanup(
+                result,
+                tracker.check_error().map_err(storage),
+                "row merge source",
+            );
+            account_cache_release(tracker.evidence(), evidence);
+        }
+        for counter in counters {
+            counter.add_to(evidence);
+        }
+        return result;
     }
     let schema = schema.ok_or_else(|| storage("row merge lacks schema"))?;
     let temporary = artifact_temp(output);
@@ -5081,88 +5705,121 @@ fn merge_row_group(
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
-    let hashing = HashingWriter::new(file);
+    let hashing = HashingWriter::with_cache_window(file, reader_cache_window)?;
     let buffered = BufWriter::with_capacity(BLOCK_BYTES, hashing);
     let mut writer = ArrowWriter::try_new(buffered, schema.clone(), None).map_err(storage)?;
-    let mut heap = BinaryHeap::new();
-    for (source, cursor) in cursors.iter_mut().enumerate() {
-        if let Some(uuid) = cursor.advance()? {
-            heap.push((Reverse(uuid), Reverse(source)));
+    let merged = (|| -> Result<(), GfError> {
+        let mut heap = BinaryHeap::new();
+        for (source, cursor) in cursors.iter_mut().enumerate() {
+            if let Some(uuid) = cursor.advance()? {
+                heap.push((Reverse(uuid), Reverse(source)));
+            }
         }
+        let mut selected = Vec::with_capacity(output_rows);
+        let mut selected_bytes = 0_usize;
+        let mut previous = None;
+        while let Some((Reverse(uuid), Reverse(source))) = heap.pop() {
+            reject_cancelled(cancelled)?;
+            if previous.is_some_and(|prior| prior >= uuid) {
+                return Err(storage("duplicate or unordered UUID in row merge"));
+            }
+            previous = Some(uuid);
+            let cursor = &mut cursors[source];
+            let batch = cursor
+                .batch
+                .as_ref()
+                .ok_or_else(|| storage("row cursor lacks batch"))?;
+            let row_bytes = batch.columns().iter().try_fold(0_usize, |total, column| {
+                column
+                    .slice(cursor.row, 1)
+                    .to_data()
+                    .get_slice_memory_size()
+                    .map(|bytes| total.saturating_add(bytes))
+                    .map_err(storage)
+            })?;
+            if row_bytes > output_bytes {
+                return Err(storage("one normalized row exceeds merge byte window"));
+            }
+            if !selected.is_empty()
+                && (selected.len() == output_rows
+                    || selected_bytes.saturating_add(row_bytes) > output_bytes)
+            {
+                let output_batch = materialize_selected_rows(schema.clone(), &selected)?;
+                evidence.merge_read_records = evidence
+                    .merge_read_records
+                    .saturating_add(output_batch.num_rows() as u64);
+                writer.write(&output_batch).map_err(storage)?;
+                evidence.merge_written_records = evidence
+                    .merge_written_records
+                    .saturating_add(output_batch.num_rows() as u64);
+                selected.clear();
+                selected_bytes = 0;
+            }
+            selected.push((batch.clone(), cursor.row));
+            selected_bytes = selected_bytes.saturating_add(row_bytes);
+            cursor.row = cursor.row.saturating_add(1);
+            if let Some(next) = cursor.advance()? {
+                heap.push((Reverse(next), Reverse(source)));
+            }
+            if heap.is_empty() {
+                let batch = materialize_selected_rows(schema.clone(), &selected)?;
+                evidence.merge_read_records = evidence
+                    .merge_read_records
+                    .saturating_add(batch.num_rows() as u64);
+                writer.write(&batch).map_err(storage)?;
+                evidence.merge_written_records = evidence
+                    .merge_written_records
+                    .saturating_add(batch.num_rows() as u64);
+                selected.clear();
+                selected_bytes = 0;
+            }
+        }
+        writer.finish().map_err(storage)?;
+        writer.sync().map_err(storage)
+    })();
+    drop(cursors);
+    let mut merged = merged;
+    let mut reader_cache_peak = 0_u64;
+    for tracker in &cache_release_trackers {
+        merged = combine_cache_cleanup(
+            merged,
+            tracker.check_error().map_err(storage),
+            "row merge source",
+        );
+        let cache_release = tracker.evidence();
+        reader_cache_peak = reader_cache_peak
+            .checked_add(cache_release.peak_window_bytes)
+            .ok_or_else(|| storage("row merge reader cache window overflow"))?;
+        account_cache_release(cache_release, evidence);
     }
-    let mut selected = Vec::with_capacity(output_rows);
-    let mut selected_bytes = 0_usize;
-    let mut previous = None;
-    while let Some((Reverse(uuid), Reverse(source))) = heap.pop() {
-        reject_cancelled(cancelled)?;
-        if previous.is_some_and(|prior| prior >= uuid) {
-            return Err(storage("duplicate or unordered UUID in row merge"));
-        }
-        previous = Some(uuid);
-        let cursor = &mut cursors[source];
-        let batch = cursor
-            .batch
-            .as_ref()
-            .ok_or_else(|| storage("row cursor lacks batch"))?;
-        let row_bytes = batch.columns().iter().try_fold(0_usize, |total, column| {
-            column
-                .slice(cursor.row, 1)
-                .to_data()
-                .get_slice_memory_size()
-                .map(|bytes| total.saturating_add(bytes))
-                .map_err(storage)
-        })?;
-        if row_bytes > output_bytes {
-            return Err(storage("one normalized row exceeds merge byte window"));
-        }
-        if !selected.is_empty()
-            && (selected.len() == output_rows
-                || selected_bytes.saturating_add(row_bytes) > output_bytes)
-        {
-            let output_batch = materialize_selected_rows(schema.clone(), &selected)?;
-            evidence.merge_read_records = evidence
-                .merge_read_records
-                .saturating_add(output_batch.num_rows() as u64);
-            writer.write(&output_batch).map_err(storage)?;
-            evidence.merge_written_records = evidence
-                .merge_written_records
-                .saturating_add(output_batch.num_rows() as u64);
-            selected.clear();
-            selected_bytes = 0;
-        }
-        selected.push((batch.clone(), cursor.row));
-        selected_bytes = selected_bytes.saturating_add(row_bytes);
-        cursor.row = cursor.row.saturating_add(1);
-        if let Some(next) = cursor.advance()? {
-            heap.push((Reverse(next), Reverse(source)));
-        }
-        if heap.is_empty() {
-            let batch = materialize_selected_rows(schema.clone(), &selected)?;
-            evidence.merge_read_records = evidence
-                .merge_read_records
-                .saturating_add(batch.num_rows() as u64);
-            writer.write(&batch).map_err(storage)?;
-            evidence.merge_written_records = evidence
-                .merge_written_records
-                .saturating_add(batch.num_rows() as u64);
-            selected.clear();
-            selected_bytes = 0;
-        }
+    for counter in counters {
+        counter.add_to(evidence);
     }
-    writer.finish().map_err(storage)?;
-    writer.sync().map_err(storage)?;
+    merged?;
+    writer
+        .inner_mut()
+        .get_mut()
+        .inner
+        .sync_all_and_release()
+        .map_err(storage)?;
     let hashing = writer.inner().get_ref();
-    hashing.inner.sync_all().map_err(storage)?;
+    let cache_release = hashing.inner.evidence();
+    account_cache_release(cache_release, evidence);
+    let aggregate_peak = reader_cache_peak
+        .checked_add(cache_release.peak_window_bytes)
+        .ok_or_else(|| storage("row merge aggregate cache window overflow"))?;
+    evidence.peak_cache_release_window_bytes =
+        evidence.peak_cache_release_window_bytes.max(aggregate_peak);
     let receipt = ArtifactReceipt {
         name: output.to_owned(),
         bytes: hashing.bytes,
-        allocated_bytes: graphforge_filesystem::file_space_usage(&hashing.inner)
+        allocated_bytes: graphforge_filesystem::file_space_usage(hashing.inner.file())
             .map_err(storage)?
             .allocated_bytes,
         sha256: hex(&hashing.digest.clone().finalize()),
         identity: identity.into(),
         write_operations: hashing.operations,
-        fsync_operations: 4,
+        fsync_operations: 4_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
     };
     root.sync().map_err(storage)?;
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
@@ -5171,15 +5828,14 @@ fn merge_row_group(
     construction_failpoint("shape.row_merge.after_install");
     persist_shape_receipt(root, &receipt)?;
     record_shape_artifact_install(evidence, &receipt)?;
-    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(4);
+    evidence.merge_fsync_operations = evidence
+        .merge_fsync_operations
+        .saturating_add(receipt.fsync_operations);
     evidence.merge_groups = evidence.merge_groups.saturating_add(1);
     evidence.parquet_write_bytes = evidence.parquet_write_bytes.saturating_add(receipt.bytes);
     evidence.parquet_write_operations = evidence
         .parquet_write_operations
         .saturating_add(receipt.write_operations);
-    for counter in counters {
-        counter.add_to(evidence);
-    }
     Ok(receipt)
 }
 
@@ -5363,80 +6019,100 @@ fn build_runtime_catalog(
         for name in names {
             let file = root.open_child_file(OsStr::new(name)).map_err(storage)?;
             let counter = IoCounter::default();
-            let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-                file,
-                counter: counter.clone(),
-            })
-            .map_err(storage)?
-            .with_batch_size(4096)
-            .build()
-            .map_err(storage)?;
-            for batch in reader {
-                reject_cancelled(cancelled)?;
-                let batch = batch.map_err(storage)?;
-                let decoded_bytes = batch.get_array_memory_size();
-                if decoded_bytes > budgets.max_catalog_decoded_bytes {
-                    return Err(storage("runtime catalog decoded batch budget exhausted"));
+            let chunk_reader = CountingChunkReader::new(file, counter.clone());
+            let cache_release = chunk_reader.cache_release_tracker();
+            let scan = (|| -> Result<(), GfError> {
+                let reader = ParquetRecordBatchReaderBuilder::try_new(chunk_reader)
+                    .map_err(storage)?
+                    .with_batch_size(4096)
+                    .build()
+                    .map_err(storage)?;
+                for batch in reader {
+                    reject_cancelled(cancelled)?;
+                    let batch = batch.map_err(storage)?;
+                    let decoded_bytes = batch.get_array_memory_size();
+                    if decoded_bytes > budgets.max_catalog_decoded_bytes {
+                        return Err(storage("runtime catalog decoded batch budget exhausted"));
+                    }
+                    evidence.peak_catalog_decoded_batch_bytes = evidence
+                        .peak_catalog_decoded_batch_bytes
+                        .max(decoded_bytes as u64);
+                    let owner = batch
+                        .column(1)
+                        .as_any()
+                        .downcast_ref::<StringArray>()
+                        .ok_or_else(|| storage("catalog owner column is not Utf8"))?;
+                    let required = if kind == ConstructionChunkKind::Node {
+                        2
+                    } else {
+                        4
+                    };
+                    for row in 0..batch.num_rows() {
+                        let owner_name = owner.value(row);
+                        match kind {
+                            ConstructionChunkKind::Node => {
+                                admit_catalog_identifier(
+                                    !catalog.contains_entity_type(owner_name),
+                                    owner_name.len(),
+                                    &mut catalog_entries,
+                                    &mut identifier_bytes,
+                                    budgets,
+                                    evidence,
+                                )?;
+                                catalog.intern_label_at(owner_name, now_micros);
+                            }
+                            ConstructionChunkKind::Edge => {
+                                admit_catalog_identifier(
+                                    !catalog.contains_relation_type(owner_name),
+                                    owner_name.len(),
+                                    &mut catalog_entries,
+                                    &mut identifier_bytes,
+                                    budgets,
+                                    evidence,
+                                )?;
+                                catalog.intern_relation_type_at(owner_name, now_micros);
+                            }
+                        }
+                        for (offset, field) in
+                            batch.schema().fields()[required..].iter().enumerate()
+                        {
+                            if !batch.column(required + offset).is_null(row) {
+                                admit_catalog_identifier(
+                                    !catalog.contains_property(field.name(), Some(owner_name)),
+                                    field.name().len().saturating_add(owner_name.len()),
+                                    &mut catalog_entries,
+                                    &mut identifier_bytes,
+                                    budgets,
+                                    evidence,
+                                )?;
+                                catalog.intern_property_at(
+                                    field.name(),
+                                    Some(owner_name),
+                                    now_micros,
+                                );
+                            }
+                        }
+                    }
                 }
-                evidence.peak_catalog_decoded_batch_bytes = evidence
-                    .peak_catalog_decoded_batch_bytes
-                    .max(decoded_bytes as u64);
-                let owner = batch
-                    .column(1)
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .ok_or_else(|| storage("catalog owner column is not Utf8"))?;
-                let required = if kind == ConstructionChunkKind::Node {
-                    2
-                } else {
-                    4
-                };
-                for row in 0..batch.num_rows() {
-                    let owner_name = owner.value(row);
-                    match kind {
-                        ConstructionChunkKind::Node => {
-                            admit_catalog_identifier(
-                                !catalog.contains_entity_type(owner_name),
-                                owner_name.len(),
-                                &mut catalog_entries,
-                                &mut identifier_bytes,
-                                budgets,
-                                evidence,
-                            )?;
-                            catalog.intern_label_at(owner_name, now_micros);
-                        }
-                        ConstructionChunkKind::Edge => {
-                            admit_catalog_identifier(
-                                !catalog.contains_relation_type(owner_name),
-                                owner_name.len(),
-                                &mut catalog_entries,
-                                &mut identifier_bytes,
-                                budgets,
-                                evidence,
-                            )?;
-                            catalog.intern_relation_type_at(owner_name, now_micros);
-                        }
-                    }
-                    for (offset, field) in batch.schema().fields()[required..].iter().enumerate() {
-                        if !batch.column(required + offset).is_null(row) {
-                            admit_catalog_identifier(
-                                !catalog.contains_property(field.name(), Some(owner_name)),
-                                field.name().len().saturating_add(owner_name.len()),
-                                &mut catalog_entries,
-                                &mut identifier_bytes,
-                                budgets,
-                                evidence,
-                            )?;
-                            catalog.intern_property_at(field.name(), Some(owner_name), now_micros);
-                        }
-                    }
+                Ok(())
+            })();
+            let released = cache_release.check_error().map_err(storage);
+            match (scan, released) {
+                (Ok(()), Ok(())) => {}
+                (Ok(()), Err(error)) => return Err(error),
+                (Err(primary), Ok(())) => return Err(primary),
+                (Err(primary), Err(release)) => {
+                    return Err(storage(format!(
+                        "{primary}; runtime catalog cache release also failed: {release}"
+                    )));
                 }
             }
+            account_cache_release(cache_release.evidence(), evidence);
             counter.add_to(evidence);
         }
     }
     let output = "shaped-runtime-catalog.parquet";
-    let receipt = write_parquet(root, output, &catalog.to_record_batch())?;
+    let receipt = write_parquet(root, output, &catalog.to_record_batch(), evidence)?;
     evidence.merge_fsync_operations = evidence
         .merge_fsync_operations
         .saturating_add(receipt.fsync_operations);
@@ -5480,6 +6156,7 @@ fn admit_catalog_identifier(
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)] // One retained-file pass couples digest and Parquet cache cleanup.
 fn load_parent_runtime_catalog(
     project: &StableDirectory,
     parent_generation: u64,
@@ -5506,54 +6183,79 @@ fn load_parent_runtime_catalog(
         return Err(storage("parent runtime catalog has extra links"));
     }
     let identity = file_identity(&file).map_err(storage)?;
+    let mut digest_reader =
+        graphforge_filesystem::FileCacheReleasingReader::new(file.try_clone().map_err(storage)?)
+            .map_err(storage)?;
     let mut digest = Sha256::new();
     let mut work = ReadWork::default();
     let mut block = vec![0_u8; BLOCK_BYTES];
-    loop {
-        let count = file.read(&mut block).map_err(storage)?;
-        if count == 0 {
-            break;
+    let hashed = (|| -> Result<(), GfError> {
+        loop {
+            let count = digest_reader.read(&mut block).map_err(storage)?;
+            if count == 0 {
+                break;
+            }
+            digest.update(&block[..count]);
+            work.bytes = work.bytes.saturating_add(count as u64);
+            work.operations = work.operations.saturating_add(1);
         }
-        digest.update(&block[..count]);
-        work.bytes = work.bytes.saturating_add(count as u64);
-        work.operations = work.operations.saturating_add(1);
-    }
+        Ok(())
+    })();
+    let released = digest_reader.finish().map_err(storage);
+    work.cache_release = match (hashed, released) {
+        (Ok(()), Ok(released)) => released,
+        (Ok(()), Err(release)) => return Err(release),
+        (Err(primary), Ok(_)) => return Err(primary),
+        (Err(primary), Err(release)) => {
+            return Err(storage(format!(
+                "{primary}; parent catalog digest cache release also failed: {release}"
+            )));
+        }
+    };
     file.rewind().map_err(storage)?;
     if file_identity(&file).map_err(storage)? != identity {
         return Err(storage("parent runtime catalog identity changed"));
     }
     let counter = IoCounter::default();
-    let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-        file,
-        counter: counter.clone(),
-    })
-    .map_err(storage)?
-    .with_batch_size(4_096.min(budgets.max_catalog_entries))
-    .build()
-    .map_err(storage)?;
+    let chunk_reader = CountingChunkReader::new(file, counter.clone());
+    let cache_release = chunk_reader.cache_release_tracker();
     let mut catalog = RuntimeCatalog::new();
     let mut entries = 0_usize;
     let mut decoded_bytes = 0_usize;
-    for batch in reader {
-        let batch = batch.map_err(storage)?;
-        entries = entries
-            .checked_add(batch.num_rows())
-            .ok_or_else(|| storage("parent runtime catalog entry count overflow"))?;
-        decoded_bytes = decoded_bytes
-            .checked_add(batch.get_array_memory_size())
-            .ok_or_else(|| storage("parent runtime catalog decoded size overflow"))?;
-        if entries > budgets.max_catalog_entries
-            || decoded_bytes > budgets.max_catalog_decoded_bytes
-        {
-            return Err(storage("parent runtime catalog admission budget exhausted"));
+    let decoded = (|| -> Result<(), GfError> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(chunk_reader)
+            .map_err(storage)?
+            .with_batch_size(4_096.min(budgets.max_catalog_entries))
+            .build()
+            .map_err(storage)?;
+        for batch in reader {
+            let batch = batch.map_err(storage)?;
+            entries = entries
+                .checked_add(batch.num_rows())
+                .ok_or_else(|| storage("parent runtime catalog entry count overflow"))?;
+            decoded_bytes = decoded_bytes
+                .checked_add(batch.get_array_memory_size())
+                .ok_or_else(|| storage("parent runtime catalog decoded size overflow"))?;
+            if entries > budgets.max_catalog_entries
+                || decoded_bytes > budgets.max_catalog_decoded_bytes
+            {
+                return Err(storage("parent runtime catalog admission budget exhausted"));
+            }
+            catalog.extend_from_record_batch(&batch).map_err(storage)?;
+            if catalog.retained_identifier_bytes() > budgets.max_catalog_identifier_bytes {
+                return Err(storage(
+                    "parent runtime catalog identifier budget exhausted",
+                ));
+            }
         }
-        catalog.extend_from_record_batch(&batch).map_err(storage)?;
-        if catalog.retained_identifier_bytes() > budgets.max_catalog_identifier_bytes {
-            return Err(storage(
-                "parent runtime catalog identifier budget exhausted",
-            ));
-        }
-    }
+        Ok(())
+    })();
+    combine_cache_cleanup(
+        decoded,
+        cache_release.check_error().map_err(storage),
+        "parent runtime catalog",
+    )?;
+    merge_cache_release_evidence(&mut work.cache_release, cache_release.evidence());
     work.bytes = work
         .bytes
         .saturating_add(counter.bytes.load(Ordering::Relaxed));
@@ -5606,37 +6308,44 @@ where
     R: ConstructionFileHandle + 'static,
 {
     let counter = IoCounter::default();
-    let reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-        file,
-        counter: counter.clone(),
-    })
-    .map_err(storage)?
-    .with_batch_size(4_096.min(budgets.max_catalog_entries))
-    .build()
-    .map_err(storage)?;
+    let chunk_reader = CountingChunkReader::new(file, counter.clone());
+    let cache_release = chunk_reader.cache_release_tracker();
     let mut catalog = RuntimeCatalog::new();
     let mut entries = 0_usize;
     let mut decoded_bytes = 0_usize;
-    for batch in reader {
-        let batch = batch.map_err(storage)?;
-        entries = entries
-            .checked_add(batch.num_rows())
-            .ok_or_else(|| storage("parent runtime catalog entry count overflow"))?;
-        decoded_bytes = decoded_bytes
-            .checked_add(batch.get_array_memory_size())
-            .ok_or_else(|| storage("parent runtime catalog decoded size overflow"))?;
-        if entries > budgets.max_catalog_entries
-            || decoded_bytes > budgets.max_catalog_decoded_bytes
-        {
-            return Err(storage("parent runtime catalog admission budget exhausted"));
+    let decoded = (|| -> Result<(), GfError> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(chunk_reader)
+            .map_err(storage)?
+            .with_batch_size(4_096.min(budgets.max_catalog_entries))
+            .build()
+            .map_err(storage)?;
+        for batch in reader {
+            let batch = batch.map_err(storage)?;
+            entries = entries
+                .checked_add(batch.num_rows())
+                .ok_or_else(|| storage("parent runtime catalog entry count overflow"))?;
+            decoded_bytes = decoded_bytes
+                .checked_add(batch.get_array_memory_size())
+                .ok_or_else(|| storage("parent runtime catalog decoded size overflow"))?;
+            if entries > budgets.max_catalog_entries
+                || decoded_bytes > budgets.max_catalog_decoded_bytes
+            {
+                return Err(storage("parent runtime catalog admission budget exhausted"));
+            }
+            catalog.extend_from_record_batch(&batch).map_err(storage)?;
+            if catalog.retained_identifier_bytes() > budgets.max_catalog_identifier_bytes {
+                return Err(storage(
+                    "parent runtime catalog identifier budget exhausted",
+                ));
+            }
         }
-        catalog.extend_from_record_batch(&batch).map_err(storage)?;
-        if catalog.retained_identifier_bytes() > budgets.max_catalog_identifier_bytes {
-            return Err(storage(
-                "parent runtime catalog identifier budget exhausted",
-            ));
-        }
-    }
+        Ok(())
+    })();
+    combine_cache_cleanup(
+        decoded,
+        cache_release.check_error().map_err(storage),
+        "compact parent runtime catalog",
+    )?;
     let bytes = counter.bytes.load(Ordering::Relaxed);
     let operations = counter.operations.load(Ordering::Relaxed);
     if !is_canonical_sha256(digest) {
@@ -5645,7 +6354,11 @@ where
     Ok((
         catalog,
         Some(digest.to_owned()),
-        ReadWork { bytes, operations },
+        ReadWork {
+            bytes,
+            operations,
+            cache_release: cache_release.evidence(),
+        },
     ))
 }
 
@@ -5763,6 +6476,7 @@ fn reject_staged_base_conflicts(
         reject_cancelled(cancelled)?;
     }
     account_fixed_read_operations(&reader_counter, evidence)?;
+    release_counted_reader_cache(&mut reader, evidence)?;
     base.revalidate()?;
     Ok(())
 }
@@ -5857,6 +6571,7 @@ fn validate_unified_and_details(
         .checked_add(new_edges)
         .ok_or_else(|| storage("edge surrogate overflow"))?;
     account_fixed_read_operations(&identities_counter, evidence)?;
+    release_counted_reader_cache(&mut identities, evidence)?;
     Ok((node_count, edge_count, max_node, max_edge))
 }
 
@@ -5916,6 +6631,8 @@ fn validate_detail_domain<const N: usize>(
     }
     account_fixed_read_operations(&identities_counter, evidence)?;
     account_fixed_read_operations(&details_counter, evidence)?;
+    release_counted_reader_cache(&mut identities, evidence)?;
+    release_counted_reader_cache(&mut details, evidence)?;
     Ok(())
 }
 
@@ -5973,6 +6690,8 @@ fn validate_endpoints(
     }
     account_fixed_read_operations(&identities_counter, evidence)?;
     account_fixed_read_operations(&endpoints_counter, evidence)?;
+    release_counted_reader_cache(&mut identities, evidence)?;
+    release_counted_reader_cache(&mut endpoints, evidence)?;
     Ok(())
 }
 
@@ -5991,7 +6710,7 @@ fn assign_surrogates(
         .map_err(storage)?;
     let identity = file_identity(&file).map_err(storage)?;
     let (mut reader, reader_counter) = open_counted_fixed_reader(root, input_name, evidence)?;
-    let hashing = HashingWriter::new(file);
+    let hashing = HashingWriter::new(file)?;
     let mut writer = BufWriter::with_capacity(BLOCK_BYTES, hashing);
     let mut count = 0_u64;
     while let Some(mut record) = read_fixed::<BASE_IDENTITY_WIDTH>(&mut reader)? {
@@ -6025,18 +6744,24 @@ fn assign_surrogates(
     }
     account_fixed_read_operations(&reader_counter, evidence)?;
     writer.flush().map_err(storage)?;
-    writer.get_ref().inner.sync_all().map_err(storage)?;
+    writer
+        .get_mut()
+        .inner
+        .sync_all_and_release()
+        .map_err(storage)?;
+    let cache_release = writer.get_ref().inner.evidence();
+    account_cache_release(cache_release, evidence);
     account_sequential_write(writer.get_ref().bytes, evidence);
     let output_receipt = ArtifactReceipt {
         name: output.to_owned(),
         bytes: writer.get_ref().bytes,
-        allocated_bytes: graphforge_filesystem::file_space_usage(&writer.get_ref().inner)
+        allocated_bytes: graphforge_filesystem::file_space_usage(writer.get_ref().inner.file())
             .map_err(storage)?
             .allocated_bytes,
         sha256: hex(&writer.get_ref().digest.clone().finalize()),
         identity: identity.into(),
         write_operations: writer.get_ref().operations,
-        fsync_operations: 2,
+        fsync_operations: 2_u64.saturating_add(cache_release.sync_operations.saturating_sub(1)),
     };
     drop(writer);
     root.install_child(OsStr::new(&temporary), identity, OsStr::new(output))
@@ -6045,7 +6770,9 @@ fn assign_surrogates(
     persist_shape_receipt(root, &output_receipt)?;
     record_shape_artifact_install(evidence, &output_receipt)?;
     account_fixed_write_operations(&output_receipt, evidence)?;
-    evidence.merge_fsync_operations = evidence.merge_fsync_operations.saturating_add(2);
+    evidence.merge_fsync_operations = evidence
+        .merge_fsync_operations
+        .saturating_add(output_receipt.fsync_operations);
     Ok(output.to_owned())
 }
 
@@ -6130,7 +6857,7 @@ fn resolve_endpoint_surrogates(
         if window.len() == window_rows {
             window.sort_unstable();
             let name = format!("merge-resolved-source-{sequence:020}.run");
-            let receipt = write_fixed_run(root, &name, &window)?;
+            let receipt = write_fixed_run(root, &name, &window, evidence)?;
             record_shape_artifact_install(evidence, &receipt)?;
             evidence.merge_written_bytes =
                 evidence.merge_written_bytes.saturating_add(receipt.bytes);
@@ -6154,7 +6881,7 @@ fn resolve_endpoint_surrogates(
     if !window.is_empty() {
         window.sort_unstable();
         let name = format!("merge-resolved-source-{sequence:020}.run");
-        let receipt = write_fixed_run(root, &name, &window)?;
+        let receipt = write_fixed_run(root, &name, &window, evidence)?;
         record_shape_artifact_install(evidence, &receipt)?;
         evidence.merge_written_bytes = evidence.merge_written_bytes.saturating_add(receipt.bytes);
         account_fixed_write_operations(&receipt, evidence)?;
@@ -6193,8 +6920,10 @@ fn account_probe_work(
 struct ReadWork {
     bytes: u64,
     operations: u64,
+    cache_release: graphforge_filesystem::FileCacheReleaseEvidence,
 }
 
+#[allow(clippy::too_many_lines)] // One authentication pass validates format, digest, and cache cleanup together.
 fn authenticate_artifact(
     root: &StableDirectory,
     receipt: &ArtifactReceipt,
@@ -6210,80 +6939,103 @@ fn authenticate_artifact(
     {
         return Err(storage("artifact identity or link count changed"));
     }
-    let mut reader = BufReader::with_capacity(BLOCK_BYTES, file);
-    let mut block = vec![0_u8; BLOCK_BYTES];
-    let mut digest = Sha256::new();
-    let mut bytes = 0_u64;
-    let mut operations = 0_u64;
-    let width = if receipt.name.ends_with(".identities.run") {
-        Some(IDENTITY_WIDTH)
-    } else if receipt.name.ends_with(".endpoints.run") {
-        Some(ENDPOINT_WIDTH)
-    } else if receipt.name.ends_with(".node-details.run") {
-        Some(NODE_DETAIL_WIDTH)
-    } else if receipt.name.ends_with(".edge-details.run") {
-        Some(EDGE_DETAIL_WIDTH)
-    } else {
-        None
-    };
-    let mut pending = Vec::new();
-    let mut previous: Option<Vec<u8>> = None;
-    loop {
-        let count = reader.read(&mut block).map_err(storage)?;
-        if count == 0 {
-            break;
-        }
-        digest.update(&block[..count]);
-        bytes = bytes.saturating_add(count as u64);
-        operations = operations.saturating_add(1);
-        if let Some(width) = width {
-            pending.extend_from_slice(&block[..count]);
-            let complete = pending.len() / width * width;
-            for record in pending[..complete].chunks_exact(width) {
-                if previous
-                    .as_ref()
-                    .is_some_and(|prior| prior.as_slice() >= record)
-                {
-                    return Err(storage("fixed construction run is not strictly sorted"));
-                }
-                if width == ENDPOINT_WIDTH
-                    && (!matches!(record[32], 0 | 1) || record[33..].iter().any(|byte| *byte != 0))
-                {
-                    return Err(storage("endpoint run record is malformed"));
-                }
-                if width == EDGE_DETAIL_WIDTH {
-                    let route_len = record[48] as usize;
-                    if route_len == 0 || record[49 + route_len..].iter().any(|byte| *byte != 0) {
-                        return Err(storage("edge detail run record is malformed"));
-                    }
-                }
-                if width == NODE_DETAIL_WIDTH {
-                    let label_len = record[16] as usize;
-                    if label_len == 0 || record[17 + label_len..].iter().any(|byte| *byte != 0) {
-                        return Err(storage("node detail run record is malformed"));
-                    }
-                }
-                if width == BASE_IDENTITY_WIDTH
-                    && (!matches!(record[16], 0 | 1)
-                        || record[17] != 1
-                        || record[18..24].iter().any(|byte| *byte != 0)
-                        || (record[16] == 0 && record[24..].iter().all(|byte| *byte == 0))
-                        || (record[16] == 1 && record[24..].iter().any(|byte| *byte != 0)))
-                {
-                    return Err(storage("base identity run record is malformed"));
-                }
-                previous = Some(record.to_vec());
+    let releasing = graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(storage)?;
+    let mut reader = BufReader::with_capacity(BLOCK_BYTES, releasing);
+    let result = (|| -> Result<(u64, u64), GfError> {
+        let mut block = vec![0_u8; BLOCK_BYTES];
+        let mut digest = Sha256::new();
+        let mut bytes = 0_u64;
+        let mut operations = 0_u64;
+        let width = if receipt.name.ends_with(".identities.run") {
+            Some(IDENTITY_WIDTH)
+        } else if receipt.name.ends_with(".endpoints.run") {
+            Some(ENDPOINT_WIDTH)
+        } else if receipt.name.ends_with(".node-details.run") {
+            Some(NODE_DETAIL_WIDTH)
+        } else if receipt.name.ends_with(".edge-details.run") {
+            Some(EDGE_DETAIL_WIDTH)
+        } else {
+            None
+        };
+        let mut pending = Vec::new();
+        let mut previous: Option<Vec<u8>> = None;
+        loop {
+            let count = reader.read(&mut block).map_err(storage)?;
+            if count == 0 {
+                break;
             }
-            pending.drain(..complete);
+            digest.update(&block[..count]);
+            bytes = bytes.saturating_add(count as u64);
+            operations = operations.saturating_add(1);
+            if let Some(width) = width {
+                pending.extend_from_slice(&block[..count]);
+                let complete = pending.len() / width * width;
+                for record in pending[..complete].chunks_exact(width) {
+                    if previous
+                        .as_ref()
+                        .is_some_and(|prior| prior.as_slice() >= record)
+                    {
+                        return Err(storage("fixed construction run is not strictly sorted"));
+                    }
+                    if width == ENDPOINT_WIDTH
+                        && (!matches!(record[32], 0 | 1)
+                            || record[33..].iter().any(|byte| *byte != 0))
+                    {
+                        return Err(storage("endpoint run record is malformed"));
+                    }
+                    if width == EDGE_DETAIL_WIDTH {
+                        let route_len = record[48] as usize;
+                        if route_len == 0 || record[49 + route_len..].iter().any(|byte| *byte != 0)
+                        {
+                            return Err(storage("edge detail run record is malformed"));
+                        }
+                    }
+                    if width == NODE_DETAIL_WIDTH {
+                        let label_len = record[16] as usize;
+                        if label_len == 0 || record[17 + label_len..].iter().any(|byte| *byte != 0)
+                        {
+                            return Err(storage("node detail run record is malformed"));
+                        }
+                    }
+                    if width == BASE_IDENTITY_WIDTH
+                        && (!matches!(record[16], 0 | 1)
+                            || record[17] != 1
+                            || record[18..24].iter().any(|byte| *byte != 0)
+                            || (record[16] == 0 && record[24..].iter().all(|byte| *byte == 0))
+                            || (record[16] == 1 && record[24..].iter().any(|byte| *byte != 0)))
+                    {
+                        return Err(storage("base identity run record is malformed"));
+                    }
+                    previous = Some(record.to_vec());
+                }
+                pending.drain(..complete);
+            }
         }
-    }
-    if !pending.is_empty() {
-        return Err(storage("fixed construction run has a truncated tail"));
-    }
-    if bytes != receipt.bytes || hex(&digest.finalize()) != receipt.sha256 {
-        return Err(storage("artifact digest or size changed"));
-    }
-    Ok(ReadWork { bytes, operations })
+        if !pending.is_empty() {
+            return Err(storage("fixed construction run has a truncated tail"));
+        }
+        if bytes != receipt.bytes || hex(&digest.finalize()) != receipt.sha256 {
+            return Err(storage("artifact digest or size changed"));
+        }
+        Ok((bytes, operations))
+    })();
+    let release = reader.get_mut().finish().map_err(storage);
+    let (bytes, operations) = match (result, release) {
+        (Ok(value), Ok(_)) => value,
+        (Ok(_), Err(error)) => return Err(error),
+        (Err(primary), Ok(_)) => return Err(primary),
+        (Err(primary), Err(release)) => {
+            return Err(storage(format!(
+                "{primary}; cache release after failed authentication also failed: {release}"
+            )));
+        }
+    };
+    let cache_release = reader.get_ref().tracker().evidence();
+    Ok(ReadWork {
+        bytes,
+        operations,
+        cache_release,
+    })
 }
 
 fn validate_artifact_name(receipt: &ArtifactReceipt) -> Result<(), GfError> {
@@ -6437,11 +7189,27 @@ fn validate_receipt_artifacts(
         let artifact_work = authenticate_artifact(root, artifact)?;
         work.bytes = work.bytes.saturating_add(artifact_work.bytes);
         work.operations = work.operations.saturating_add(artifact_work.operations);
+        merge_cache_release_evidence(&mut work.cache_release, artifact_work.cache_release);
     }
     let parquet_work = validate_parquet_shape(root, receipt)?;
     work.bytes = work.bytes.saturating_add(parquet_work.bytes);
     work.operations = work.operations.saturating_add(parquet_work.operations);
+    merge_cache_release_evidence(&mut work.cache_release, parquet_work.cache_release);
     Ok(work)
+}
+
+fn merge_cache_release_evidence(
+    target: &mut graphforge_filesystem::FileCacheReleaseEvidence,
+    source: graphforge_filesystem::FileCacheReleaseEvidence,
+) {
+    target.release_operations = target
+        .release_operations
+        .saturating_add(source.release_operations);
+    target.unsupported_operations = target
+        .unsupported_operations
+        .saturating_add(source.unsupported_operations);
+    target.released_bytes = target.released_bytes.saturating_add(source.released_bytes);
+    target.peak_window_bytes = target.peak_window_bytes.max(source.peak_window_bytes);
 }
 
 fn validate_parquet_shape(
@@ -6459,45 +7227,53 @@ fn validate_parquet_shape(
         return Err(storage("Parquet identity changed during schema reopen"));
     }
     let counter = IoCounter::default();
-    let builder = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-        file,
-        counter: counter.clone(),
-    })
-    .map_err(storage)?;
-    let expected_prefix = match receipt.kind {
-        ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
-        ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
-    };
-    let schema = builder.schema();
-    if schema.fields().len() < expected_prefix.fields().len()
-        || schema.fields()[..expected_prefix.fields().len()] != expected_prefix.fields()[..]
-        || normalized_schema_digest(schema.as_ref()) != receipt.schema_sha256
-        || builder.metadata().file_metadata().num_rows()
-            != i64::try_from(receipt.rows).map_err(|_| storage("receipt row count exceeds i64"))?
-    {
-        return Err(storage("Parquet schema or row count differs from receipt"));
-    }
-    let mut reader = builder.with_batch_size(4096).build().map_err(storage)?;
-    let identity_name = if receipt.kind == ConstructionChunkKind::Node {
-        "node_uuid"
-    } else {
-        "edge_uuid"
-    };
-    let mut previous: Option<[u8; 16]> = None;
-    for batch in &mut reader {
-        let batch = batch.map_err(storage)?;
-        let identities = uuid_column(&batch, identity_name)?;
-        for row in 0..batch.num_rows() {
-            let value = uuid_value(identities, row)?;
-            if previous.is_some_and(|prior| prior >= value) {
-                return Err(storage("row artifact is not strictly UUID sorted"));
-            }
-            previous = Some(value);
+    let chunk_reader = CountingChunkReader::new(file, counter.clone());
+    let cache_release = chunk_reader.cache_release_tracker();
+    let validated = (|| -> Result<(), GfError> {
+        let builder = ParquetRecordBatchReaderBuilder::try_new(chunk_reader).map_err(storage)?;
+        let expected_prefix = match receipt.kind {
+            ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
+            ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
+        };
+        let schema = builder.schema();
+        if schema.fields().len() < expected_prefix.fields().len()
+            || schema.fields()[..expected_prefix.fields().len()] != expected_prefix.fields()[..]
+            || normalized_schema_digest(schema.as_ref()) != receipt.schema_sha256
+            || builder.metadata().file_metadata().num_rows()
+                != i64::try_from(receipt.rows)
+                    .map_err(|_| storage("receipt row count exceeds i64"))?
+        {
+            return Err(storage("Parquet schema or row count differs from receipt"));
         }
-    }
+        let reader = builder.with_batch_size(4096).build().map_err(storage)?;
+        let identity_name = if receipt.kind == ConstructionChunkKind::Node {
+            "node_uuid"
+        } else {
+            "edge_uuid"
+        };
+        let mut previous: Option<[u8; 16]> = None;
+        for batch in reader {
+            let batch = batch.map_err(storage)?;
+            let identities = uuid_column(&batch, identity_name)?;
+            for row in 0..batch.num_rows() {
+                let value = uuid_value(identities, row)?;
+                if previous.is_some_and(|prior| prior >= value) {
+                    return Err(storage("row artifact is not strictly UUID sorted"));
+                }
+                previous = Some(value);
+            }
+        }
+        Ok(())
+    })();
+    combine_cache_cleanup(
+        validated,
+        cache_release.check_error().map_err(storage),
+        "Parquet shape",
+    )?;
     Ok(ReadWork {
         bytes: counter.bytes.load(Ordering::Relaxed),
         operations: counter.operations.load(Ordering::Relaxed),
+        cache_release: cache_release.evidence(),
     })
 }
 
@@ -6516,27 +7292,35 @@ fn validate_parquet_metadata(
         return Err(storage("Parquet identity changed during metadata reopen"));
     }
     let counter = IoCounter::default();
-    let builder = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-        file,
-        counter: counter.clone(),
-    })
-    .map_err(storage)?;
-    let expected_prefix = match receipt.kind {
-        ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
-        ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
-    };
-    let schema = builder.schema();
-    if schema.fields().len() < expected_prefix.fields().len()
-        || schema.fields()[..expected_prefix.fields().len()] != expected_prefix.fields()[..]
-        || normalized_schema_digest(schema.as_ref()) != receipt.schema_sha256
-        || builder.metadata().file_metadata().num_rows()
-            != i64::try_from(receipt.rows).map_err(|_| storage("receipt row count exceeds i64"))?
-    {
-        return Err(storage("Parquet schema or row count differs from receipt"));
-    }
+    let chunk_reader = CountingChunkReader::new(file, counter.clone());
+    let cache_release = chunk_reader.cache_release_tracker();
+    let validated = (|| -> Result<(), GfError> {
+        let builder = ParquetRecordBatchReaderBuilder::try_new(chunk_reader).map_err(storage)?;
+        let expected_prefix = match receipt.kind {
+            ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
+            ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
+        };
+        let schema = builder.schema();
+        if schema.fields().len() < expected_prefix.fields().len()
+            || schema.fields()[..expected_prefix.fields().len()] != expected_prefix.fields()[..]
+            || normalized_schema_digest(schema.as_ref()) != receipt.schema_sha256
+            || builder.metadata().file_metadata().num_rows()
+                != i64::try_from(receipt.rows)
+                    .map_err(|_| storage("receipt row count exceeds i64"))?
+        {
+            return Err(storage("Parquet schema or row count differs from receipt"));
+        }
+        Ok(())
+    })();
+    combine_cache_cleanup(
+        validated,
+        cache_release.check_error().map_err(storage),
+        "Parquet metadata",
+    )?;
     Ok(ReadWork {
         bytes: counter.bytes.load(Ordering::Relaxed),
         operations: counter.operations.load(Ordering::Relaxed),
+        cache_release: cache_release.evidence(),
     })
 }
 
@@ -6998,7 +7782,7 @@ fn remove_unrecorded_artifact(
     kind: ConstructionChunkKind,
     rows: u64,
 ) -> Result<(), GfError> {
-    let mut file = match root.open_child_file(OsStr::new(name)) {
+    let file = match root.open_child_file(OsStr::new(name)) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(storage(error)),
@@ -7008,18 +7792,29 @@ fn remove_unrecorded_artifact(
         return Err(storage("unrecorded artifact has unexpected links"));
     }
     if name.ends_with(".parquet") {
-        let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(storage)?;
-        let expected = match kind {
-            ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
-            ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
-        };
-        if builder.schema().fields().len() < expected.fields().len()
-            || builder.schema().fields()[..expected.fields().len()] != expected.fields()[..]
-            || builder.metadata().file_metadata().num_rows()
-                != i64::try_from(rows).map_err(|_| storage("artifact row count exceeds i64"))?
-        {
-            return Err(storage("unrecorded Parquet artifact is not session-owned"));
-        }
+        let chunk_reader = CountingChunkReader::new(file, IoCounter::default());
+        let cache_release = chunk_reader.cache_release_tracker();
+        let validated = (|| -> Result<(), GfError> {
+            let builder =
+                ParquetRecordBatchReaderBuilder::try_new(chunk_reader).map_err(storage)?;
+            let expected = match kind {
+                ConstructionChunkKind::Node => &*CONSTRUCTION_NODE_SCHEMA,
+                ConstructionChunkKind::Edge => &*CONSTRUCTION_EDGE_SCHEMA,
+            };
+            if builder.schema().fields().len() < expected.fields().len()
+                || builder.schema().fields()[..expected.fields().len()] != expected.fields()[..]
+                || builder.metadata().file_metadata().num_rows()
+                    != i64::try_from(rows).map_err(|_| storage("artifact row count exceeds i64"))?
+            {
+                return Err(storage("unrecorded Parquet artifact is not session-owned"));
+            }
+            Ok(())
+        })();
+        combine_cache_cleanup(
+            validated,
+            cache_release.check_error().map_err(storage),
+            "unrecorded Parquet artifact",
+        )?;
     } else {
         let width = if name.ends_with(".identities.run") {
             IDENTITY_WIDTH
@@ -7041,7 +7836,7 @@ fn remove_unrecorded_artifact(
         {
             return Err(storage("unrecorded fixed run row count changed"));
         }
-        validate_sorted_run(&mut file, width)?;
+        validate_sorted_run(file, width)?;
     }
     unlink_writer_capability(root, name, None)?;
     root.unlink_child_if_identity(OsStr::new(name), identity)
@@ -7049,51 +7844,57 @@ fn remove_unrecorded_artifact(
     root.sync().map_err(storage)
 }
 
-fn validate_sorted_run(file: &mut File, width: usize) -> Result<(), GfError> {
-    let mut reader = BufReader::with_capacity(BLOCK_BYTES, file);
+fn validate_sorted_run(file: File, width: usize) -> Result<(), GfError> {
+    let releasing = graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(storage)?;
+    let mut reader = BufReader::with_capacity(BLOCK_BYTES, releasing);
     let mut block = vec![0_u8; BLOCK_BYTES];
     let mut pending = Vec::new();
     let mut previous: Option<Vec<u8>> = None;
-    loop {
-        let count = reader.read(&mut block).map_err(storage)?;
-        if count == 0 {
-            break;
-        }
-        pending.extend_from_slice(&block[..count]);
-        let complete = pending.len() / width * width;
-        for record in pending[..complete].chunks_exact(width) {
-            if previous
-                .as_ref()
-                .is_some_and(|prior| prior.as_slice() >= record)
-                || (width == ENDPOINT_WIDTH
-                    && (!matches!(record[32], 0 | 1) || record[33..].iter().any(|byte| *byte != 0)))
-                || (width == EDGE_DETAIL_WIDTH
-                    && (record[48] == 0
-                        || record[49 + record[48] as usize..]
-                            .iter()
-                            .any(|byte| *byte != 0)))
-                || (width == NODE_DETAIL_WIDTH
-                    && (record[16] == 0
-                        || record[17 + record[16] as usize..]
-                            .iter()
-                            .any(|byte| *byte != 0)))
-                || (width == BASE_IDENTITY_WIDTH
-                    && (!matches!(record[16], 0 | 1)
-                        || record[17] != 1
-                        || record[18..24].iter().any(|byte| *byte != 0)
-                        || (record[16] == 0 && record[24..].iter().all(|byte| *byte == 0))
-                        || (record[16] == 1 && record[24..].iter().any(|byte| *byte != 0))))
-            {
-                return Err(storage("unrecorded fixed run is malformed"));
+    let validated = (|| -> Result<(), GfError> {
+        loop {
+            let count = reader.read(&mut block).map_err(storage)?;
+            if count == 0 {
+                break;
             }
-            previous = Some(record.to_vec());
+            pending.extend_from_slice(&block[..count]);
+            let complete = pending.len() / width * width;
+            for record in pending[..complete].chunks_exact(width) {
+                if previous
+                    .as_ref()
+                    .is_some_and(|prior| prior.as_slice() >= record)
+                    || (width == ENDPOINT_WIDTH
+                        && (!matches!(record[32], 0 | 1)
+                            || record[33..].iter().any(|byte| *byte != 0)))
+                    || (width == EDGE_DETAIL_WIDTH
+                        && (record[48] == 0
+                            || record[49 + record[48] as usize..]
+                                .iter()
+                                .any(|byte| *byte != 0)))
+                    || (width == NODE_DETAIL_WIDTH
+                        && (record[16] == 0
+                            || record[17 + record[16] as usize..]
+                                .iter()
+                                .any(|byte| *byte != 0)))
+                    || (width == BASE_IDENTITY_WIDTH
+                        && (!matches!(record[16], 0 | 1)
+                            || record[17] != 1
+                            || record[18..24].iter().any(|byte| *byte != 0)
+                            || (record[16] == 0 && record[24..].iter().all(|byte| *byte == 0))
+                            || (record[16] == 1 && record[24..].iter().any(|byte| *byte != 0))))
+                {
+                    return Err(storage("unrecorded fixed run is malformed"));
+                }
+                previous = Some(record.to_vec());
+            }
+            pending.drain(..complete);
         }
-        pending.drain(..complete);
-    }
-    if !pending.is_empty() {
-        return Err(storage("unrecorded fixed run has truncated tail"));
-    }
-    Ok(())
+        if !pending.is_empty() {
+            return Err(storage("unrecorded fixed run has truncated tail"));
+        }
+        Ok(())
+    })();
+    let released = reader.get_mut().finish().map_err(storage);
+    combine_cache_cleanup(validated, released.map(|_| ()), "unrecorded fixed run")
 }
 
 fn artifact_stem(sequence: u64, kind: ConstructionChunkKind) -> String {
@@ -7252,6 +8053,51 @@ mod tests {
                 !entry.file_name().to_string_lossy().ends_with(".tmp")
             }
         })
+    }
+
+    #[test]
+    fn fixed_run_receipts_count_cache_rollovers_and_preserve_reopened_bytes() {
+        let window = graphforge_filesystem::cache_release_window_for_streams(4)
+            .unwrap()
+            .get();
+        assert_eq!(window, 16 * 1024 * 1024);
+        let supported = cfg!(target_os = "linux");
+        for bytes in [window - 1, window, window + 1] {
+            let temporary = TempDir::new().unwrap();
+            let root = StableDirectory::open(temporary.path()).unwrap();
+            let records = vec![[0x5a_u8]; usize::try_from(bytes).unwrap()];
+            let mut evidence = GraphConstructionEvidence::default();
+            let receipt = write_fixed_run(&root, "window.run", &records, &mut evidence).unwrap();
+            // The existing protocol has one final file barrier and two
+            // namespace barriers. Only a supported full-window rollover adds
+            // another file barrier; an exact final window is not charged twice.
+            let rollovers = u64::from(supported && bytes > window);
+            assert_eq!(receipt.fsync_operations, 3 + rollovers);
+            assert_eq!(receipt.bytes, bytes);
+            assert_eq!(
+                evidence.cache_release_operations,
+                u64::from(supported) * (1 + rollovers)
+            );
+            assert_eq!(
+                evidence.cache_release_unsupported_operations,
+                u64::from(!supported)
+            );
+            assert_eq!(evidence.cache_released_bytes, u64::from(supported) * bytes);
+            assert_eq!(
+                evidence.peak_cache_release_window_bytes,
+                if supported { bytes.min(window) } else { bytes }
+            );
+            drop(root);
+
+            let reopened = StableDirectory::open(temporary.path()).unwrap();
+            let mut file = reopened.open_child_file(OsStr::new("window.run")).unwrap();
+            let mut actual = Vec::new();
+            file.read_to_end(&mut actual).unwrap();
+            assert_eq!(u64::try_from(actual.len()).unwrap(), bytes);
+            assert!(actual.iter().all(|byte| *byte == 0x5a));
+            assert_eq!(hex(&Sha256::digest(&actual)), receipt.sha256);
+            assert!(tree_has_no_temps(temporary.path()));
+        }
     }
 
     #[test]
@@ -8005,8 +8851,8 @@ mod tests {
             ],
         )
         .unwrap();
-        write_parquet(&private, "nodes.parquet", &rows).unwrap();
         let mut evidence = GraphConstructionEvidence::default();
+        write_parquet(&private, "nodes.parquet", &rows, &mut evidence).unwrap();
         let project_root = StableDirectory::open(project.path()).unwrap();
         let (parent_catalog, parent_catalog_sha256, _) =
             load_parent_runtime_catalog(&project_root, 1, GraphConstructionBudgets::default())
@@ -8319,10 +9165,12 @@ mod tests {
         for index in 0..5_000 {
             source.intern_label_at(&format!("Label{index:05}"), 42);
         }
+        let mut evidence = GraphConstructionEvidence::default();
         write_parquet(
             &topology,
             "runtime_catalog.parquet",
             &source.to_record_batch(),
+            &mut evidence,
         )
         .unwrap();
 
@@ -8788,6 +9636,163 @@ mod tests {
         resumed.shape_canonical_with_cancellation(|| false).unwrap();
     }
 
+    fn shape_temporary_names(root: &StableDirectory) -> Vec<String> {
+        root.child_names()
+            .unwrap()
+            .into_iter()
+            .filter_map(|name| name.into_string().ok())
+            .filter(|name| is_owned_artifact_temp(name))
+            .collect()
+    }
+
+    #[test]
+    fn shaping_copy_failures_finalize_release_and_remove_unpublished_outputs() {
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 8_031);
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let receipt = session.read_receipt(0).unwrap();
+
+        let mut cancelled = || true;
+        let error = convert_identity_run(
+            &session.root,
+            &receipt,
+            "cancelled-identities.run",
+            &mut cancelled,
+            &mut session.checkpoint.evidence,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("construction cancelled"), "{error}");
+        assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+        assert!(shape_temporary_names(&session.root).is_empty());
+        assert!(
+            session
+                .root
+                .open_child_file(OsStr::new("cancelled-identities.run"))
+                .is_err()
+        );
+
+        inject_shape_cleanup_failures(true, true);
+        let mut never_cancelled = || false;
+        let error = copy_authenticated_run::<NODE_DETAIL_WIDTH>(
+            &session.root,
+            &receipt.details,
+            "failed-details.run",
+            &mut never_cancelled,
+            &mut session.checkpoint.evidence,
+        )
+        .unwrap_err()
+        .to_string();
+        let primary = error.find("injected shape input release failure").unwrap();
+        let cleanup = error
+            .find("authenticated output cleanup also failed")
+            .unwrap();
+        assert!(primary < cleanup, "{error}");
+        assert!(
+            error.contains("authenticated output cleanup also failed"),
+            "{error}"
+        );
+        assert!(
+            error.contains("unpublished artifact cleanup finalization failed"),
+            "{error}"
+        );
+        assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+        assert!(shape_temporary_names(&session.root).is_empty());
+        assert!(
+            session
+                .root
+                .open_child_file(OsStr::new("failed-details.run"))
+                .is_err()
+        );
+        #[cfg(target_os = "linux")]
+        assert!(session.checkpoint.evidence.cache_release_operations >= 4);
+    }
+
+    #[test]
+    fn shaping_publication_guard_covers_setup_and_post_rename_failures() {
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 8_032);
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 2))
+            .unwrap();
+        session.seal().unwrap();
+        let receipt = session.read_receipt(0).unwrap();
+        let points = [
+            "initial_file_identity",
+            "writer_construction",
+            "window_validation",
+            "fsync_evidence_overflow",
+            "final_file_identity",
+            "file_space_usage",
+            "install_child",
+            "directory_sync",
+            "post_publication_metric_overflow",
+            "manifest_update",
+        ];
+        for point in points {
+            let output = format!("guard-identity-{point}.run");
+            if matches!(point, "initial_file_identity" | "writer_construction") {
+                inject_shape_cleanup_failures(false, true);
+            }
+            inject_shape_publication_failure(point);
+            let error = convert_identity_run(
+                &session.root,
+                &receipt,
+                &output,
+                &mut || false,
+                &mut session.checkpoint.evidence,
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(
+                error.contains(&format!("injected shape publication failure at {point}")),
+                "{error}"
+            );
+            if matches!(point, "initial_file_identity" | "writer_construction") {
+                let primary = error.find("injected shape publication failure").unwrap();
+                let cleanup = error
+                    .find("unpublished artifact cleanup finalization failed")
+                    .unwrap();
+                assert!(primary < cleanup, "{error}");
+            }
+            assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+            assert!(shape_temporary_names(&session.root).is_empty());
+            assert!(session.root.open_child_file(OsStr::new(&output)).is_err());
+
+            let output = format!("guard-authenticated-{point}.run");
+            if matches!(point, "initial_file_identity" | "writer_construction") {
+                inject_shape_cleanup_failures(false, true);
+            }
+            inject_shape_publication_failure(point);
+            let error = copy_authenticated_run::<NODE_DETAIL_WIDTH>(
+                &session.root,
+                &receipt.details,
+                &output,
+                &mut || false,
+                &mut session.checkpoint.evidence,
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(
+                error.contains(&format!("injected shape publication failure at {point}")),
+                "{error}"
+            );
+            if matches!(point, "initial_file_identity" | "writer_construction") {
+                let primary = error.find("injected shape publication failure").unwrap();
+                let cleanup = error
+                    .find("unpublished artifact cleanup finalization failed")
+                    .unwrap();
+                assert!(primary < cleanup, "{error}");
+            }
+            assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+            assert!(shape_temporary_names(&session.root).is_empty());
+            assert!(session.root.open_child_file(OsStr::new(&output)).is_err());
+        }
+    }
+
     #[test]
     fn fixed_merge_reader_rejects_truncation_and_self_loop_is_valid() {
         assert!(read_fixed::<16>(&mut std::io::Cursor::new(vec![0_u8; 15])).is_err());
@@ -9063,10 +10068,7 @@ mod tests {
             payload.len() as u64,
         )
         .unwrap();
-        let reader = CountingChunkReader {
-            file,
-            counter: IoCounter::default(),
-        };
+        let reader = CountingChunkReader::new(file, IoCounter::default());
         assert_eq!(Length::len(&reader), payload.len() as u64);
     }
 
@@ -9447,7 +10449,7 @@ mod tests {
             root.path(),
             operation,
             0,
-            authority,
+            authority.clone(),
             GraphConstructionBudgets::default(),
         )
         .unwrap();
@@ -9486,6 +10488,18 @@ mod tests {
         assert_eq!(encoding.evidence.ordinal_work_operations, 3);
         assert_eq!(encoding.evidence.ordinal_peak_buffer_bytes, 3 * 64 * 1024);
         assert_eq!(encoding.evidence.ordinal_publication_write_operations, 3);
+        assert!(
+            session.evidence().peak_cache_release_window_bytes
+                <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        );
+        #[cfg(target_os = "linux")]
+        {
+            assert!(session.evidence().cache_release_operations > 0);
+            assert!(session.evidence().cache_released_bytes > 0);
+            assert_eq!(session.evidence().cache_release_unsupported_operations, 0);
+        }
+        #[cfg(not(target_os = "linux"))]
+        assert!(session.evidence().cache_release_unsupported_operations > 0);
         // Three artifact file syncs, one artifact-directory barrier, two
         // barriers for each of receipt/manifest/lock, and four ancestor
         // directory barriers after the complete facet is installed.
@@ -9551,8 +10565,110 @@ mod tests {
                 .unwrap();
         assert!(!adjacency.is_empty());
 
-        let resumed = session.encode_canonical(&shape, 1).unwrap();
+        drop(session);
+        let mut resumed_session = GraphConstructionSession::open_with_semantic_authority(
+            root.path(),
+            operation,
+            0,
+            authority,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap();
+        let resumed = resumed_session
+            .prepare_canonical_encoding_with_cancellation(1, || false)
+            .unwrap();
+        assert!(encoding.invocation.performed);
+        assert!(!encoding.invocation.reused);
+        let mut encoding = encoding;
+        encoding.invocation = Default::default();
         assert_eq!(resumed, encoding);
+    }
+
+    #[test]
+    fn fresh_v4_authority_transaction_failure_matrix_cleans_and_retries() {
+        for (ordinal, point) in [
+            "after_artifacts",
+            "receipt_install",
+            "manifest_install",
+            "lock_install",
+            "directory_sync",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let root = TempDir::new().unwrap();
+            let operation = Uuid::from_u128(9_600 + ordinal as u128);
+            let mut session = open(&root, 9_600 + ordinal as u128);
+            session
+                .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 3))
+                .unwrap();
+            session.seal().unwrap();
+            let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+            if point == "after_artifacts" {
+                crate::uuid_membership::inject_v4_output_cleanup_failure();
+            }
+            crate::uuid_membership::inject_v4_authority_failure(point);
+            let error = session.encode_canonical(&shape, 1).unwrap_err().to_string();
+            assert!(
+                error.contains(&format!("injected v4 authority failure at {point}")),
+                "{error}"
+            );
+            if point == "after_artifacts" {
+                let primary = error.find("injected v4 authority failure").unwrap();
+                let cleanup = error
+                    .find("unpublished artifact cleanup finalization failed")
+                    .unwrap();
+                assert!(primary < cleanup, "{error}");
+            }
+            assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+            let membership = root
+                .path()
+                .join(PRIVATE_ROOT)
+                .join(operation.simple().to_string())
+                .join("encoded-v1/graph/topology/uuid-membership");
+            if membership.exists() {
+                let names = std::fs::read_dir(&membership)
+                    .unwrap()
+                    .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+                    .collect::<Vec<_>>();
+                assert!(
+                    names.iter().all(|name| {
+                        !crate::uuid_membership::is_exact_private_v4_name(name)
+                            && name != "ordinal-v4-receipt.json"
+                            && name != "ordinal-v4-manifest.json"
+                            && name != "ordinal-v4.lock"
+                    }),
+                    "{point}: {names:?}"
+                );
+            }
+
+            let encoding = session.encode_canonical(&shape, 1).unwrap();
+            let manifest_path = root
+                .path()
+                .join(PRIVATE_ROOT)
+                .join(operation.simple().to_string())
+                .join(&encoding.root)
+                .join("graph/topology/uuid-membership/ordinal-v4-manifest.json");
+            let manifest_bytes = std::fs::read(&manifest_path).unwrap();
+            let manifest: crate::V4OrdinalIdentityManifest =
+                serde_json::from_slice(&manifest_bytes).unwrap();
+            for artifact in manifest
+                .forward_identities
+                .iter()
+                .chain(manifest.ordinal_ranges.iter().map(|range| &range.artifact))
+                .chain(manifest.tombstones.iter().map(|run| &run.artifact))
+            {
+                assert_eq!(
+                    sha256(
+                        &std::fs::read(manifest_path.parent().unwrap().join(&artifact.name))
+                            .unwrap()
+                    ),
+                    artifact.sha256
+                );
+            }
+            let reopened = session.encode_canonical(&shape, 1).unwrap();
+            assert_eq!(reopened.artifacts, encoding.artifacts);
+        }
     }
 
     #[test]
@@ -9886,6 +11002,45 @@ mod tests {
                 .map(RecordBatch::num_rows)
                 .sum::<usize>(),
             256
+        );
+    }
+
+    #[test]
+    fn canonical_encoder_reuse_accounts_only_second_invocation_io() {
+        let root = TempDir::new().unwrap();
+        let mut session = open(&root, 9_481);
+        session
+            .append(ConstructionChunkKind::Node, "nodes", &node_batch(1, 4))
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+
+        let first = session.encode_canonical(&shape, 1).unwrap();
+        assert!(first.invocation.performed);
+        assert!(!first.invocation.reused);
+        assert!(first.invocation.evidence.output_write_bytes > 0);
+        assert!(
+            first.invocation.evidence.peak_cache_release_window_bytes
+                <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        );
+        let cache_after_first = session.evidence().cache_release_operations;
+        let writes_after_first = session.evidence().encode_application_write_bytes;
+
+        let second = session.encode_canonical(&shape, 1).unwrap();
+        assert!(!second.invocation.performed);
+        assert!(second.invocation.reused);
+        assert_eq!(second.invocation.evidence.output_write_bytes, 0);
+        assert_eq!(second.invocation.evidence.membership_total_write_bytes, 0);
+        assert_eq!(
+            session.evidence().encode_application_write_bytes,
+            writes_after_first
+        );
+        assert_eq!(
+            session
+                .evidence()
+                .cache_release_operations
+                .saturating_sub(cache_after_first),
+            second.invocation.evidence.cache_release_operations
         );
     }
 

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -84,7 +84,7 @@ fn run_source_spool_hook(phase: &str) {
 fn run_source_spool_hook(_phase: &str) {}
 
 struct CountingWriter {
-    inner: File,
+    inner: graphforge_filesystem::DurableFileCacheWriter,
     counter: IoCounter,
     digest: Sha256,
 }
@@ -132,12 +132,26 @@ fn authenticated_source_spool<'a>(
     output: &'a StableDirectory,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<(File, EncodingTempGuard<'a>), GfError> {
-    let mut authenticated = open_authenticated_shape_source(source, outputs, name)?;
+    let authenticated = open_authenticated_shape_source(source, outputs, name)?;
+    let expected_identity = authenticated.identity;
+    let expected_bytes = authenticated.bytes;
+    let expected_sha256 = authenticated.sha256;
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage)?;
+    let mut authenticated = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+        authenticated.file,
+        cache_window,
+        graphforge_filesystem::FileCacheReleaseTracker::default(),
+    )
+    .map_err(storage)?;
     let temporary = format!(".authenticated-source-{}.tmp", Uuid::new_v4().simple());
-    let mut spool = output
+    let spool = output
         .create_replaceable_child_file(OsStr::new(&temporary))
         .map_err(storage)?;
     let spool_identity = file_identity(&spool).map_err(storage)?;
+    let mut spool =
+        graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(spool, cache_window)
+            .map_err(storage)?;
     let guard = EncodingTempGuard {
         directory: output,
         name: temporary,
@@ -147,39 +161,64 @@ fn authenticated_source_spool<'a>(
     let mut digest = Sha256::new();
     let mut bytes = 0_u64;
     let mut buffer = vec![0_u8; COPY_BUFFER_BYTES];
-    loop {
-        run_source_spool_hook("before_read");
-        let read = authenticated.file.read(&mut buffer).map_err(storage)?;
-        run_source_spool_hook("after_read");
-        if read == 0 {
-            break;
+    let authentication = (|| -> Result<(), GfError> {
+        loop {
+            run_source_spool_hook("before_read");
+            let read = authenticated.read(&mut buffer).map_err(storage)?;
+            run_source_spool_hook("after_read");
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+            spool.write_all(&buffer[..read]).map_err(storage)?;
+            bytes = bytes.saturating_add(read as u64);
+            evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(read as u64);
+            evidence.input_read_operations = evidence.input_read_operations.saturating_add(1);
+            evidence.source_spool_write_bytes = evidence
+                .source_spool_write_bytes
+                .saturating_add(read as u64);
+            evidence.source_spool_write_operations =
+                evidence.source_spool_write_operations.saturating_add(1);
         }
-        digest.update(&buffer[..read]);
-        spool.write_all(&buffer[..read]).map_err(storage)?;
-        bytes = bytes.saturating_add(read as u64);
-        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(read as u64);
-        evidence.input_read_operations = evidence.input_read_operations.saturating_add(1);
-        evidence.source_spool_write_bytes = evidence
-            .source_spool_write_bytes
-            .saturating_add(read as u64);
-        evidence.source_spool_write_operations =
-            evidence.source_spool_write_operations.saturating_add(1);
-    }
-    if file_identity(&authenticated.file).map_err(storage)? != authenticated.identity
-        || file_link_count(&authenticated.file).map_err(storage)? != 1
-        || bytes != authenticated.bytes
-        || hex(&digest.finalize()) != authenticated.sha256
-    {
-        return Err(storage(
-            "shaped source changed during authenticated spooling",
-        ));
-    }
+        if file_identity(authenticated.file()).map_err(storage)? != expected_identity
+            || file_link_count(authenticated.file()).map_err(storage)? != 1
+            || bytes != expected_bytes
+            || hex(&digest.finalize()) != expected_sha256
+        {
+            return Err(storage(
+                "shaped source changed during authenticated spooling",
+            ));
+        }
+        Ok(())
+    })();
+    let source_release = authenticated.finish().map_err(storage);
+    let source_release = match (authentication, source_release) {
+        (Ok(()), Ok(released)) => released,
+        (Ok(()), Err(error)) => return Err(error),
+        (Err(primary), Ok(_)) => return Err(primary),
+        (Err(primary), Err(release)) => {
+            return Err(storage(format!(
+                "{primary}; source cache release also failed: {release}"
+            )));
+        }
+    };
+    account_cache_release(source_release, evidence);
     spool.flush().map_err(storage)?;
-    spool.sync_all().map_err(storage)?;
-    evidence.source_spool_fsync_operations =
-        evidence.source_spool_fsync_operations.saturating_add(1);
+    spool.sync_all_and_release().map_err(storage)?;
+    evidence.source_spool_fsync_operations = evidence
+        .source_spool_fsync_operations
+        .saturating_add(spool.evidence().sync_operations);
+    let spool_release = spool.evidence();
+    account_cache_release(spool_release, evidence);
+    let aggregate_peak = source_release
+        .peak_window_bytes
+        .checked_add(spool_release.peak_window_bytes)
+        .ok_or_else(|| storage("source spool aggregate cache window overflow"))?;
+    evidence.peak_cache_release_window_bytes =
+        evidence.peak_cache_release_window_bytes.max(aggregate_peak);
     evidence.source_spool_peak_temporary_bytes =
         evidence.source_spool_peak_temporary_bytes.max(bytes);
+    let mut spool = spool.into_file();
     spool.rewind().map_err(storage)?;
     Ok((spool, guard))
 }
@@ -203,6 +242,48 @@ impl Write for CountingWriter {
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
     }
+}
+
+fn account_cache_release(
+    released: graphforge_filesystem::FileCacheReleaseEvidence,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) {
+    evidence.cache_release_operations = evidence
+        .cache_release_operations
+        .saturating_add(released.release_operations);
+    evidence.cache_release_unsupported_operations = evidence
+        .cache_release_unsupported_operations
+        .saturating_add(released.unsupported_operations);
+    evidence.cache_released_bytes = evidence
+        .cache_released_bytes
+        .saturating_add(released.released_bytes);
+    evidence.peak_cache_release_window_bytes = evidence
+        .peak_cache_release_window_bytes
+        .max(released.peak_window_bytes);
+}
+
+fn merge_encoding_evidence(
+    target: &mut GraphConstructionEncodingEvidence,
+    source: &GraphConstructionEncodingEvidence,
+) {
+    target.input_read_bytes = target
+        .input_read_bytes
+        .saturating_add(source.input_read_bytes);
+    target.input_read_operations = target
+        .input_read_operations
+        .saturating_add(source.input_read_operations);
+    target.cache_release_operations = target
+        .cache_release_operations
+        .saturating_add(source.cache_release_operations);
+    target.cache_release_unsupported_operations = target
+        .cache_release_unsupported_operations
+        .saturating_add(source.cache_release_unsupported_operations);
+    target.cache_released_bytes = target
+        .cache_released_bytes
+        .saturating_add(source.cache_released_bytes);
+    target.peak_cache_release_window_bytes = target
+        .peak_cache_release_window_bytes
+        .max(source.peak_cache_release_window_bytes);
 }
 
 fn storage(error: impl std::fmt::Display) -> GfError {
@@ -258,6 +339,18 @@ pub struct GraphConstructionEncodingEvidence {
     pub output_write_operations: u64,
     /// Completed file and directory durability barriers.
     pub fsync_operations: u64,
+    /// Successful file-level page-cache release boundaries.
+    #[serde(default)]
+    pub cache_release_operations: u64,
+    /// Page-cache release boundaries unsupported by the target platform.
+    #[serde(default)]
+    pub cache_release_unsupported_operations: u64,
+    /// Clean file bytes covered by successful page-cache release requests.
+    #[serde(default)]
+    pub cache_released_bytes: u64,
+    /// Largest synchronized file-cache window between release boundaries.
+    #[serde(default)]
+    pub peak_cache_release_window_bytes: u64,
     /// Topology rows decoded from the retained parent. Always zero.
     pub prior_topology_rows_decoded: u64,
     /// Retained topology bytes copied. Always zero.
@@ -359,6 +452,22 @@ pub struct GraphConstructionEncoding {
     pub retained_artifacts: Vec<ConstructionRetainedArtifact>,
     /// Measured bounded work.
     pub evidence: GraphConstructionEncodingEvidence,
+    /// Work performed by the invocation that returned this inventory.
+    ///
+    /// This delta is not part of durable inventory authority.
+    #[serde(skip)]
+    pub invocation: GraphConstructionEncodingInvocationEvidence,
+}
+
+/// Per-invocation encoding work, distinct from durable cumulative evidence.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GraphConstructionEncodingInvocationEvidence {
+    /// This invocation generated and installed a new inventory.
+    pub performed: bool,
+    /// This invocation reused an already-authoritative inventory.
+    pub reused: bool,
+    /// Actual I/O and cache-release work performed by this invocation.
+    pub evidence: GraphConstructionEncodingEvidence,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -417,8 +526,8 @@ pub(crate) fn encode(
         .create_child_directory(OsStr::new(ENCODED_ROOT))
         .map_err(storage)?;
     cleanup_encoding_temps(&output, budgets)?;
-    if let Some(existing) = read_inventory(&output)? {
-        authenticate_inventory(&output, &existing, parent_index)?;
+    if let Some(mut existing) = read_inventory(&output)? {
+        let authentication = authenticate_inventory(&output, &existing, parent_index)?;
         if existing.generation != generation
             || existing.ontology_mode != shape.ontology_mode
             || existing.semantic_authority_sha256 != shape.semantic_authority_sha256
@@ -431,6 +540,11 @@ pub(crate) fn encode(
         match expected_inventory_sha256 {
             Some(expected) if expected == actual_authority => {
                 remove_encoding_intent(&output)?;
+                existing.invocation = GraphConstructionEncodingInvocationEvidence {
+                    performed: false,
+                    reused: true,
+                    evidence: authentication,
+                };
                 return Ok(existing);
             }
             Some(_) => {
@@ -483,7 +597,7 @@ pub(crate) fn encode(
             budgets,
             &mut evidence,
         )?;
-        copy_artifact(
+        copy_file_artifact(
             catalog_spool.try_clone().map_err(storage)?,
             &output,
             "topology/runtime_catalog.parquet",
@@ -526,7 +640,8 @@ pub(crate) fn encode(
         &mut artifacts,
         &mut evidence,
     )?;
-    if let Some((manifest, metrics)) = v4 {
+    if let Some(bundle) = v4 {
+        let metrics = &bundle.metrics;
         if metrics.input_records != shape.node_count {
             return Err(storage("v4 construction count differs from shaped nodes"));
         }
@@ -537,10 +652,10 @@ pub(crate) fn encode(
         evidence.ordinal_work_operations = metrics.cancellation_polls;
         evidence.ordinal_peak_buffer_bytes =
             u64::try_from(metrics.peak_buffer_bytes).map_err(storage)?;
-        let (v4_artifacts, publication) =
+        let (v4_artifacts, publication, metrics) =
             crate::uuid_membership::publish_v4_construction_artifacts(
                 &output,
-                &manifest,
+                bundle,
                 generation,
                 identities_sha256,
             )?;
@@ -552,6 +667,7 @@ pub(crate) fn encode(
         evidence.ordinal_peak_temporary_bytes = metrics
             .peak_temporary_bytes
             .max(publication.peak_temporary_bytes);
+        account_cache_release(metrics.cache_release, &mut evidence);
         crate::graph_construction::construction_failpoint("encode.after_v4_before_inventory");
         index.artifacts.extend(v4_artifacts);
     }
@@ -596,6 +712,7 @@ pub(crate) fn encode(
     evidence.membership_created_runs = index.created_runs;
     evidence.membership_peak_buffer_bytes = index.peak_buffer_bytes;
     evidence.membership_peak_temporary_bytes = index.peak_temporary_bytes;
+    account_cache_release(index.cache_release, &mut evidence);
     evidence.retained_index_runs = index.retained_runs;
     evidence.retained_index_payload_bytes = index.retained_payload_bytes;
     let retained_artifacts = index
@@ -612,7 +729,7 @@ pub(crate) fn encode(
     {
         return Err(storage("canonical encoding contains duplicate paths"));
     }
-    let completed = GraphConstructionEncoding {
+    let mut completed = GraphConstructionEncoding {
         root: ENCODED_ROOT.to_owned(),
         generation,
         ontology_mode: shape.ontology_mode,
@@ -622,10 +739,18 @@ pub(crate) fn encode(
         artifacts,
         retained_artifacts,
         evidence,
+        invocation: GraphConstructionEncodingInvocationEvidence::default(),
     };
     install_json(&output, INVENTORY, &completed)?;
-    authenticate_inventory(&output, &completed, parent_index)?;
+    let authentication = authenticate_inventory(&output, &completed, parent_index)?;
     remove_encoding_intent(&output)?;
+    let mut invocation = completed.evidence.clone();
+    merge_encoding_evidence(&mut invocation, &authentication);
+    completed.invocation = GraphConstructionEncodingInvocationEvidence {
+        performed: true,
+        reused: false,
+        evidence: invocation,
+    };
     Ok(completed)
 }
 
@@ -767,13 +892,7 @@ fn encode_nodes(
     cancelled: &mut impl FnMut() -> bool,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
-) -> Result<
-    Option<(
-        crate::V4OrdinalIdentityManifest,
-        crate::uuid_membership::V4OrdinalBuildMetrics,
-    )>,
-    GfError,
-> {
+) -> Result<Option<crate::uuid_membership::V4ConstructionArtifactBundle>, GfError> {
     if shape.node_rows.is_empty() {
         if !build_v4 {
             return Ok(None);
@@ -795,8 +914,14 @@ fn encode_nodes(
         .node_details
         .as_deref()
         .ok_or_else(|| storage("node rows lack canonical details"))?;
-    let mut identities =
-        FixedReader::<IDENTITY_WIDTH>::open(source, shape_outputs, &shape.identities)?;
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(5).map_err(storage)?;
+    let mut identities = FixedReader::<IDENTITY_WIDTH>::open(
+        source,
+        shape_outputs,
+        &shape.identities,
+        cache_window,
+    )?;
     let v4_index = if build_v4 {
         let graph = output
             .open_child_directory(OsStr::new("graph"))
@@ -814,88 +939,114 @@ fn encode_nodes(
     };
     let mut v4 = v4_index
         .as_ref()
-        .map(|index| crate::uuid_membership::V4OrdinalConstructionWriter::start(generation, index))
+        .map(|index| {
+            crate::uuid_membership::V4OrdinalConstructionWriter::start_with_cache_window(
+                generation,
+                index,
+                cache_window,
+            )
+        })
         .transpose()?;
-    let mut details = FixedReader::<NODE_DETAIL_WIDTH>::open(source, shape_outputs, details_name)?;
+    let mut details =
+        FixedReader::<NODE_DETAIL_WIDTH>::open(source, shape_outputs, details_name, cache_window)?;
     let rows_per_window = budgets
         .max_batch_rows
         .min((budgets.max_batch_bytes / 128).max(1));
-    loop {
-        if cancelled() {
-            return Err(storage("construction encoding cancelled"));
-        }
-        let mut out_uuid = Vec::with_capacity(rows_per_window);
-        let mut out_id = Vec::with_capacity(rows_per_window);
-        let mut out_type = Vec::with_capacity(rows_per_window);
-        let mut owners = BTreeMap::<String, ResolvedOwner>::new();
-        while out_uuid.len() < rows_per_window {
-            let (identity, detail) = match (next_kind(&mut identities, 0)?, details.next()?) {
-                (Some(identity), Some(detail)) => (identity, detail),
-                (None, None) => break,
-                _ => return Err(storage("node detail and identity stream lengths differ")),
-            };
-            if identity[..16] != detail[..16] || identity[17] != 0 {
-                return Err(storage("node detail and identity streams differ"));
-            }
-            let uuid: [u8; 16] = detail[..16].try_into().expect("fixed UUID");
-            let label_len = usize::from(detail[16]);
-            let label = std::str::from_utf8(&detail[17..17 + label_len]).map_err(storage)?;
-            let runtime_route = if ontology_mode == OntologyMode::Exploratory {
-                "_untyped"
-            } else {
-                label
-            };
-            let owner = if let Some(owner) = owners.get(label) {
-                owner.clone()
-            } else {
-                let owner = resolve_owner(
-                    semantic_context,
-                    semantic_bindings,
-                    SymbolKind::Entity,
-                    SemanticRouteKind::Entity,
-                    label,
-                    runtime_route,
-                )?;
-                owners.insert(label.to_owned(), owner.clone());
-                owner
-            };
-            let type_id = match owner.storage_id {
-                Some(storage_id) => storage_id,
-                None => *label_ids
-                    .get(label)
-                    .ok_or_else(|| storage("node label is absent from runtime catalog"))?,
-            };
-            let node_id = u64::from_be_bytes(identity[24..32].try_into().expect("fixed"));
-            if let Some(v4) = v4.as_mut() {
-                v4.push_pair(Uuid::from_bytes(uuid), node_id, cancelled)?;
-            }
-            out_uuid.push(uuid);
-            out_id.push(node_id);
-            out_type.push(type_id);
-            if out_uuid.len().is_multiple_of(4096) && cancelled() {
+    let encoded = (|| -> Result<(), GfError> {
+        loop {
+            if cancelled() {
                 return Err(storage("construction encoding cancelled"));
             }
+            let mut out_uuid = Vec::with_capacity(rows_per_window);
+            let mut out_id = Vec::with_capacity(rows_per_window);
+            let mut out_type = Vec::with_capacity(rows_per_window);
+            let mut owners = BTreeMap::<String, ResolvedOwner>::new();
+            while out_uuid.len() < rows_per_window {
+                let (identity, detail) = match (next_kind(&mut identities, 0)?, details.next()?) {
+                    (Some(identity), Some(detail)) => (identity, detail),
+                    (None, None) => break,
+                    _ => return Err(storage("node detail and identity stream lengths differ")),
+                };
+                if identity[..16] != detail[..16] || identity[17] != 0 {
+                    return Err(storage("node detail and identity streams differ"));
+                }
+                let uuid: [u8; 16] = detail[..16].try_into().expect("fixed UUID");
+                let label_len = usize::from(detail[16]);
+                let label = std::str::from_utf8(&detail[17..17 + label_len]).map_err(storage)?;
+                let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                    "_untyped"
+                } else {
+                    label
+                };
+                let owner = if let Some(owner) = owners.get(label) {
+                    owner.clone()
+                } else {
+                    let owner = resolve_owner(
+                        semantic_context,
+                        semantic_bindings,
+                        SymbolKind::Entity,
+                        SemanticRouteKind::Entity,
+                        label,
+                        runtime_route,
+                    )?;
+                    owners.insert(label.to_owned(), owner.clone());
+                    owner
+                };
+                let type_id = match owner.storage_id {
+                    Some(storage_id) => storage_id,
+                    None => *label_ids
+                        .get(label)
+                        .ok_or_else(|| storage("node label is absent from runtime catalog"))?,
+                };
+                let node_id = u64::from_be_bytes(identity[24..32].try_into().expect("fixed"));
+                if let Some(v4) = v4.as_mut() {
+                    v4.push_pair(Uuid::from_bytes(uuid), node_id, cancelled)?;
+                }
+                out_uuid.push(uuid);
+                out_id.push(node_id);
+                out_type.push(type_id);
+                if out_uuid.len().is_multiple_of(4096) && cancelled() {
+                    return Err(storage("construction encoding cancelled"));
+                }
+            }
+            if out_id.is_empty() {
+                break;
+            }
+            let canonical = node_batch(
+                &out_uuid,
+                &out_id,
+                &out_type,
+                shape.runtime_catalog_now_micros,
+            )?;
+            account_batch(&canonical, budgets, evidence)?;
+            let first = *out_id.first().expect("nonempty");
+            let last = *out_id.last().expect("nonempty");
+            let path = format!("topology/nodes/{first:020}-{last:020}.parquet");
+            artifacts.push(write_parquet(
+                output,
+                &path,
+                &canonical,
+                cache_window,
+                evidence,
+            )?);
         }
-        if out_id.is_empty() {
-            break;
+        if details.next()?.is_some() || next_kind(&mut identities, 0)?.is_some() {
+            return Err(storage("node streams contain unconsumed rows"));
         }
-        let canonical = node_batch(
-            &out_uuid,
-            &out_id,
-            &out_type,
-            shape.runtime_catalog_now_micros,
-        )?;
-        account_batch(&canonical, budgets, evidence)?;
-        let first = *out_id.first().expect("nonempty");
-        let last = *out_id.last().expect("nonempty");
-        let path = format!("topology/nodes/{first:020}-{last:020}.parquet");
-        artifacts.push(write_parquet(output, &path, &canonical, evidence)?);
-    }
-    if details.next()?.is_some() || next_kind(&mut identities, 0)?.is_some() {
-        return Err(storage("node streams contain unconsumed rows"));
-    }
-    identities.authenticate_and_account(evidence)?;
-    details.authenticate_and_account(evidence)?;
+        Ok(())
+    })();
+    let authenticate = encoded.is_ok();
+    let encoded = combine_reader_cleanup(
+        encoded,
+        identities.finish_and_account(authenticate, evidence),
+        "node identity",
+    );
+    let encoded = combine_reader_cleanup(
+        encoded,
+        details.finish_and_account(authenticate, evidence),
+        "node detail",
+    );
+    encoded?;
     encode_node_properties(
         source,
         output,
@@ -934,88 +1085,119 @@ fn encode_node_properties(
         }
         let (file, _spool_guard) =
             authenticated_source_spool(source, shape_outputs, name, output, evidence)?;
+        let cache_window =
+            graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage)?;
         let counter = IoCounter::default();
-        let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-            file,
-            counter: counter.clone(),
-        })
-        .map_err(storage)?
-        .with_batch_size(budgets.max_batch_rows)
-        .build()
-        .map_err(storage)?;
+        let chunk_reader =
+            CountingChunkReader::with_cache_window(file, counter.clone(), cache_window);
+        let cache_release = chunk_reader.cache_release_tracker();
+        let reader = (|| {
+            ParquetRecordBatchReaderBuilder::try_new(chunk_reader)
+                .map_err(storage)?
+                .with_batch_size(budgets.max_batch_rows)
+                .build()
+                .map_err(storage)
+        })();
+        let mut reader = match reader {
+            Ok(reader) => reader,
+            Err(primary) => {
+                combine_reader_cleanup(
+                    Err(primary),
+                    cache_release.check_error().map_err(storage),
+                    "node property",
+                )?;
+                unreachable!("failed node property reader construction returned success");
+            }
+        };
         evidence.peak_open_input_readers = evidence.peak_open_input_readers.max(1);
-        for input in &mut reader {
-            let input = input.map_err(storage)?;
-            account_batch(&input, budgets, evidence)?;
-            if input.num_columns() == 2 {
-                continue;
-            }
-            let labels = required_string(&input, "label")?;
-            let mut groups = BTreeMap::<String, Vec<u32>>::new();
-            for row in 0..input.num_rows() {
-                groups
-                    .entry(labels.value(row).to_owned())
-                    .or_default()
-                    .push(u32::try_from(row).map_err(storage)?);
-            }
-            for (label, indexes) in groups {
-                let runtime_route = if ontology_mode == OntologyMode::Exploratory {
-                    "_untyped"
-                } else {
-                    label.as_str()
-                };
-                let owner = resolve_owner(
-                    semantic_context,
-                    semantic_bindings,
-                    SymbolKind::Entity,
-                    SemanticRouteKind::Entity,
-                    &label,
-                    runtime_route,
-                )?;
-                let projections = property_projections(
-                    &input,
-                    2,
-                    &indexes,
-                    &owner,
-                    SymbolKind::Entity,
-                    SemanticRouteKind::NodeProperty,
-                    semantic_context,
-                    semantic_bindings,
-                )?;
-                for (route, fields) in projections {
-                    let ordinal = ordinals.entry(route.clone()).or_default();
-                    let property = property_batch(
-                        &input,
-                        "node_uuid",
-                        "graphforge.entity_type",
-                        &owner.topology_route,
-                        &indexes,
-                        &fields,
-                        PropertyRouteKind::Node,
-                        &route,
-                        shape.parent_topology_generation + 1,
-                        *ordinal,
-                    )?;
-                    let property = if owner.symbol.is_some() {
-                        with_route_metadata_batch(
-                            &property,
-                            &route,
-                            semantic_context
-                                .expect("qualified owner has context")
-                                .fingerprint(),
-                        )?
+        let processed = (|| -> Result<(), GfError> {
+            for input in &mut reader {
+                let input = input.map_err(storage)?;
+                account_batch(&input, budgets, evidence)?;
+                if input.num_columns() == 2 {
+                    continue;
+                }
+                let labels = required_string(&input, "label")?;
+                let mut groups = BTreeMap::<String, Vec<u32>>::new();
+                for row in 0..input.num_rows() {
+                    groups
+                        .entry(labels.value(row).to_owned())
+                        .or_default()
+                        .push(u32::try_from(row).map_err(storage)?);
+                }
+                for (label, indexes) in groups {
+                    let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                        "_untyped"
                     } else {
-                        property
+                        label.as_str()
                     };
-                    let path = format!(
-                        "properties/{route}/{:020}-{ordinal:020}.parquet",
-                        shape.parent_topology_generation + 1
-                    );
-                    artifacts.push(write_parquet(output, &path, &property, evidence)?);
-                    *ordinal = ordinal.saturating_add(1);
+                    let owner = resolve_owner(
+                        semantic_context,
+                        semantic_bindings,
+                        SymbolKind::Entity,
+                        SemanticRouteKind::Entity,
+                        &label,
+                        runtime_route,
+                    )?;
+                    let projections = property_projections(
+                        &input,
+                        2,
+                        &indexes,
+                        &owner,
+                        SymbolKind::Entity,
+                        SemanticRouteKind::NodeProperty,
+                        semantic_context,
+                        semantic_bindings,
+                    )?;
+                    for (route, fields) in projections {
+                        let ordinal = ordinals.entry(route.clone()).or_default();
+                        let property = property_batch(
+                            &input,
+                            "node_uuid",
+                            "graphforge.entity_type",
+                            &owner.topology_route,
+                            &indexes,
+                            &fields,
+                            PropertyRouteKind::Node,
+                            &route,
+                            shape.parent_topology_generation + 1,
+                            *ordinal,
+                        )?;
+                        let property = if owner.symbol.is_some() {
+                            with_route_metadata_batch(
+                                &property,
+                                &route,
+                                semantic_context
+                                    .expect("qualified owner has context")
+                                    .fingerprint(),
+                            )?
+                        } else {
+                            property
+                        };
+                        let path = format!(
+                            "properties/{route}/{:020}-{ordinal:020}.parquet",
+                            shape.parent_topology_generation + 1
+                        );
+                        artifacts.push(write_parquet(
+                            output,
+                            &path,
+                            &property,
+                            cache_window,
+                            evidence,
+                        )?);
+                        *ordinal = ordinal.saturating_add(1);
+                    }
                 }
             }
-        }
+            Ok(())
+        })();
+        drop(reader);
+        combine_reader_cleanup(
+            processed,
+            cache_release.check_error().map_err(storage),
+            "node property",
+        )?;
+        account_cache_release(cache_release.evidence(), evidence);
         let (bytes, operations) = counter.values();
         evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
         evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
@@ -1052,138 +1234,174 @@ fn encode_edges(
         .edge_endpoints
         .as_deref()
         .ok_or_else(|| storage("edge rows lack resolved endpoints"))?;
-    let mut identities =
-        FixedReader::<IDENTITY_WIDTH>::open(source, shape_outputs, &shape.identities)?;
-    let mut details = FixedReader::<EDGE_DETAIL_WIDTH>::open(source, shape_outputs, details_name)?;
-    let mut endpoints =
-        FixedReader::<RESOLVED_ENDPOINT_WIDTH>::open(source, shape_outputs, endpoints_name)?;
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(4).map_err(storage)?;
+    let mut identities = FixedReader::<IDENTITY_WIDTH>::open(
+        source,
+        shape_outputs,
+        &shape.identities,
+        cache_window,
+    )?;
+    let mut details =
+        FixedReader::<EDGE_DETAIL_WIDTH>::open(source, shape_outputs, details_name, cache_window)?;
+    let mut endpoints = FixedReader::<RESOLVED_ENDPOINT_WIDTH>::open(
+        source,
+        shape_outputs,
+        endpoints_name,
+        cache_window,
+    )?;
     let rows_per_window = budgets
         .max_batch_rows
         .min((budgets.max_batch_bytes / 192).max(1));
-    loop {
-        if cancelled() {
-            return Err(storage("construction encoding cancelled"));
-        }
-        let mut out_uuid = Vec::with_capacity(rows_per_window);
-        let mut out_src = Vec::with_capacity(rows_per_window);
-        let mut out_dst = Vec::with_capacity(rows_per_window);
-        let mut out_id = Vec::with_capacity(rows_per_window);
-        let mut out_src_id = Vec::with_capacity(rows_per_window);
-        let mut out_dst_id = Vec::with_capacity(rows_per_window);
-        let mut groups = BTreeMap::<String, Vec<u32>>::new();
-        while out_uuid.len() < rows_per_window {
-            let (identity, detail) = match (next_kind(&mut identities, 1)?, details.next()?) {
-                (Some(identity), Some(detail)) => (identity, detail),
-                (None, None) => break,
-                _ => return Err(storage("edge detail and identity stream lengths differ")),
-            };
-            let (Some(source_endpoint), Some(target_endpoint)) =
-                (endpoints.next()?, endpoints.next()?)
-            else {
-                return Err(storage("edge endpoint stream ended early"));
-            };
-            let uuid: [u8; 16] = detail[..16].try_into().expect("fixed UUID");
-            if identity[..16] != uuid
-                || detail[..16] != uuid
-                || identity[17] != 0
-                || source_endpoint[..16] != uuid
-                || target_endpoint[..16] != uuid
-                || source_endpoint[16] != 0
-                || target_endpoint[16] != 1
-            {
-                return Err(storage("edge row/detail/identity/endpoint streams differ"));
-            }
-            let route_len = usize::from(detail[48]);
-            let route = std::str::from_utf8(&detail[49..49 + route_len]).map_err(storage)?;
-            out_uuid.push(uuid);
-            out_src.push(detail[16..32].try_into().expect("fixed UUID"));
-            out_dst.push(detail[32..48].try_into().expect("fixed UUID"));
-            out_id.push(u64::from_be_bytes(
-                identity[24..32].try_into().expect("fixed"),
-            ));
-            out_src_id.push(u64::from_be_bytes(
-                source_endpoint[24..32].try_into().expect("fixed"),
-            ));
-            out_dst_id.push(u64::from_be_bytes(
-                target_endpoint[24..32].try_into().expect("fixed"),
-            ));
-            groups
-                .entry(route.to_owned())
-                .or_default()
-                .push(u32::try_from(out_uuid.len() - 1).map_err(storage)?);
-            if out_uuid.len().is_multiple_of(4096) && cancelled() {
+    let encoded = (|| -> Result<(), GfError> {
+        loop {
+            if cancelled() {
                 return Err(storage("construction encoding cancelled"));
             }
-        }
-        if out_id.is_empty() {
-            break;
-        }
-        let canonical = edge_batch(
-            &out_uuid,
-            &out_src,
-            &out_dst,
-            &out_id,
-            &out_src_id,
-            &out_dst_id,
-            shape.runtime_catalog_now_micros,
-        )?;
-        account_batch(&canonical, budgets, evidence)?;
-        for (route, output_indexes) in groups {
-            let mut selected = select_rows(&canonical, &output_indexes)?;
-            let runtime_route = if ontology_mode == OntologyMode::Exploratory {
-                "_exploratory"
-            } else {
-                route.as_str()
-            };
-            let owner = resolve_owner(
-                semantic_context,
-                semantic_bindings,
-                SymbolKind::Relation,
-                SemanticRouteKind::Relation,
-                &route,
-                runtime_route,
-            )?;
-            let topology_route = if owner.symbol.is_none()
-                && ontology_mode == OntologyMode::Exploratory
-            {
-                let routes = StringArray::from(vec![route.as_str(); selected.num_rows()]);
-                let mut columns = selected.columns().to_vec();
-                columns.push(Arc::new(routes));
-                selected =
-                    RecordBatch::try_new(crate::schemas::EXPLORATORY_EDGE_SCHEMA.clone(), columns)
-                        .map_err(storage)?;
-                "_exploratory"
-            } else {
-                owner.topology_route.as_str()
-            };
-            if owner.symbol.is_some() {
-                selected = with_route_metadata_batch(
-                    &selected,
-                    topology_route,
-                    semantic_context
-                        .expect("qualified owner has context")
-                        .fingerprint(),
-                )?;
+            let mut out_uuid = Vec::with_capacity(rows_per_window);
+            let mut out_src = Vec::with_capacity(rows_per_window);
+            let mut out_dst = Vec::with_capacity(rows_per_window);
+            let mut out_id = Vec::with_capacity(rows_per_window);
+            let mut out_src_id = Vec::with_capacity(rows_per_window);
+            let mut out_dst_id = Vec::with_capacity(rows_per_window);
+            let mut groups = BTreeMap::<String, Vec<u32>>::new();
+            while out_uuid.len() < rows_per_window {
+                let (identity, detail) = match (next_kind(&mut identities, 1)?, details.next()?) {
+                    (Some(identity), Some(detail)) => (identity, detail),
+                    (None, None) => break,
+                    _ => return Err(storage("edge detail and identity stream lengths differ")),
+                };
+                let (Some(source_endpoint), Some(target_endpoint)) =
+                    (endpoints.next()?, endpoints.next()?)
+                else {
+                    return Err(storage("edge endpoint stream ended early"));
+                };
+                let uuid: [u8; 16] = detail[..16].try_into().expect("fixed UUID");
+                if identity[..16] != uuid
+                    || detail[..16] != uuid
+                    || identity[17] != 0
+                    || source_endpoint[..16] != uuid
+                    || target_endpoint[..16] != uuid
+                    || source_endpoint[16] != 0
+                    || target_endpoint[16] != 1
+                {
+                    return Err(storage("edge row/detail/identity/endpoint streams differ"));
+                }
+                let route_len = usize::from(detail[48]);
+                let route = std::str::from_utf8(&detail[49..49 + route_len]).map_err(storage)?;
+                out_uuid.push(uuid);
+                out_src.push(detail[16..32].try_into().expect("fixed UUID"));
+                out_dst.push(detail[32..48].try_into().expect("fixed UUID"));
+                out_id.push(u64::from_be_bytes(
+                    identity[24..32].try_into().expect("fixed"),
+                ));
+                out_src_id.push(u64::from_be_bytes(
+                    source_endpoint[24..32].try_into().expect("fixed"),
+                ));
+                out_dst_id.push(u64::from_be_bytes(
+                    target_endpoint[24..32].try_into().expect("fixed"),
+                ));
+                groups
+                    .entry(route.to_owned())
+                    .or_default()
+                    .push(u32::try_from(out_uuid.len() - 1).map_err(storage)?);
+                if out_uuid.len().is_multiple_of(4096) && cancelled() {
+                    return Err(storage("construction encoding cancelled"));
+                }
             }
-            let ids = selected
-                .column_by_name("edge_id")
-                .and_then(|array| array.as_any().downcast_ref::<UInt64Array>())
-                .ok_or_else(|| storage("canonical edge ids are incompatible"))?;
-            let first = ids.value(0);
-            let last = ids.value(ids.len() - 1);
-            let path = format!("topology/edges/{topology_route}/{first:020}-{last:020}.parquet");
-            artifacts.push(write_parquet(output, &path, &selected, evidence)?);
+            if out_id.is_empty() {
+                break;
+            }
+            let canonical = edge_batch(
+                &out_uuid,
+                &out_src,
+                &out_dst,
+                &out_id,
+                &out_src_id,
+                &out_dst_id,
+                shape.runtime_catalog_now_micros,
+            )?;
+            account_batch(&canonical, budgets, evidence)?;
+            for (route, output_indexes) in groups {
+                let mut selected = select_rows(&canonical, &output_indexes)?;
+                let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                    "_exploratory"
+                } else {
+                    route.as_str()
+                };
+                let owner = resolve_owner(
+                    semantic_context,
+                    semantic_bindings,
+                    SymbolKind::Relation,
+                    SemanticRouteKind::Relation,
+                    &route,
+                    runtime_route,
+                )?;
+                let topology_route =
+                    if owner.symbol.is_none() && ontology_mode == OntologyMode::Exploratory {
+                        let routes = StringArray::from(vec![route.as_str(); selected.num_rows()]);
+                        let mut columns = selected.columns().to_vec();
+                        columns.push(Arc::new(routes));
+                        selected = RecordBatch::try_new(
+                            crate::schemas::EXPLORATORY_EDGE_SCHEMA.clone(),
+                            columns,
+                        )
+                        .map_err(storage)?;
+                        "_exploratory"
+                    } else {
+                        owner.topology_route.as_str()
+                    };
+                if owner.symbol.is_some() {
+                    selected = with_route_metadata_batch(
+                        &selected,
+                        topology_route,
+                        semantic_context
+                            .expect("qualified owner has context")
+                            .fingerprint(),
+                    )?;
+                }
+                let ids = selected
+                    .column_by_name("edge_id")
+                    .and_then(|array| array.as_any().downcast_ref::<UInt64Array>())
+                    .ok_or_else(|| storage("canonical edge ids are incompatible"))?;
+                let first = ids.value(0);
+                let last = ids.value(ids.len() - 1);
+                let path =
+                    format!("topology/edges/{topology_route}/{first:020}-{last:020}.parquet");
+                artifacts.push(write_parquet(
+                    output,
+                    &path,
+                    &selected,
+                    cache_window,
+                    evidence,
+                )?);
+            }
         }
-    }
-    if details.next()?.is_some()
-        || endpoints.next()?.is_some()
-        || next_kind(&mut identities, 1)?.is_some()
-    {
-        return Err(storage("edge streams contain unconsumed rows"));
-    }
-    identities.authenticate_and_account(evidence)?;
-    details.authenticate_and_account(evidence)?;
-    endpoints.authenticate_and_account(evidence)?;
+        if details.next()?.is_some()
+            || endpoints.next()?.is_some()
+            || next_kind(&mut identities, 1)?.is_some()
+        {
+            return Err(storage("edge streams contain unconsumed rows"));
+        }
+        Ok(())
+    })();
+    let authenticate = encoded.is_ok();
+    let encoded = combine_reader_cleanup(
+        encoded,
+        identities.finish_and_account(authenticate, evidence),
+        "edge identity",
+    );
+    let encoded = combine_reader_cleanup(
+        encoded,
+        details.finish_and_account(authenticate, evidence),
+        "edge detail",
+    );
+    let encoded = combine_reader_cleanup(
+        encoded,
+        endpoints.finish_and_account(authenticate, evidence),
+        "edge endpoint",
+    );
+    encoded?;
     encode_edge_properties(
         source,
         output,
@@ -1220,88 +1438,119 @@ fn encode_edge_properties(
         }
         let (file, _spool_guard) =
             authenticated_source_spool(source, shape_outputs, name, output, evidence)?;
+        let cache_window =
+            graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage)?;
         let counter = IoCounter::default();
-        let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-            file,
-            counter: counter.clone(),
-        })
-        .map_err(storage)?
-        .with_batch_size(budgets.max_batch_rows)
-        .build()
-        .map_err(storage)?;
+        let chunk_reader =
+            CountingChunkReader::with_cache_window(file, counter.clone(), cache_window);
+        let cache_release = chunk_reader.cache_release_tracker();
+        let reader = (|| {
+            ParquetRecordBatchReaderBuilder::try_new(chunk_reader)
+                .map_err(storage)?
+                .with_batch_size(budgets.max_batch_rows)
+                .build()
+                .map_err(storage)
+        })();
+        let mut reader = match reader {
+            Ok(reader) => reader,
+            Err(primary) => {
+                combine_reader_cleanup(
+                    Err(primary),
+                    cache_release.check_error().map_err(storage),
+                    "edge property",
+                )?;
+                unreachable!("failed edge property reader construction returned success");
+            }
+        };
         evidence.peak_open_input_readers = evidence.peak_open_input_readers.max(1);
-        for input in &mut reader {
-            let input = input.map_err(storage)?;
-            account_batch(&input, budgets, evidence)?;
-            if input.num_columns() == 4 {
-                continue;
-            }
-            let routes = required_string(&input, "rel_type")?;
-            let mut groups = BTreeMap::<String, Vec<u32>>::new();
-            for row in 0..input.num_rows() {
-                groups
-                    .entry(routes.value(row).to_owned())
-                    .or_default()
-                    .push(u32::try_from(row).map_err(storage)?);
-            }
-            for (route, indexes) in groups {
-                let runtime_route = if ontology_mode == OntologyMode::Exploratory {
-                    "_exploratory"
-                } else {
-                    route.as_str()
-                };
-                let owner = resolve_owner(
-                    semantic_context,
-                    semantic_bindings,
-                    SymbolKind::Relation,
-                    SemanticRouteKind::Relation,
-                    &route,
-                    runtime_route,
-                )?;
-                let projections = property_projections(
-                    &input,
-                    4,
-                    &indexes,
-                    &owner,
-                    SymbolKind::Relation,
-                    SemanticRouteKind::EdgeProperty,
-                    semantic_context,
-                    semantic_bindings,
-                )?;
-                for (property_route, fields) in projections {
-                    let ordinal = ordinals.entry(property_route.clone()).or_default();
-                    let property = property_batch(
-                        &input,
-                        "edge_uuid",
-                        "graphforge.rel_type",
-                        &owner.topology_route,
-                        &indexes,
-                        &fields,
-                        PropertyRouteKind::Edge,
-                        &property_route,
-                        shape.parent_topology_generation + 1,
-                        *ordinal,
-                    )?;
-                    let property = if owner.symbol.is_some() {
-                        with_route_metadata_batch(
-                            &property,
-                            &property_route,
-                            semantic_context
-                                .expect("qualified owner has context")
-                                .fingerprint(),
-                        )?
+        let processed = (|| -> Result<(), GfError> {
+            for input in &mut reader {
+                let input = input.map_err(storage)?;
+                account_batch(&input, budgets, evidence)?;
+                if input.num_columns() == 4 {
+                    continue;
+                }
+                let routes = required_string(&input, "rel_type")?;
+                let mut groups = BTreeMap::<String, Vec<u32>>::new();
+                for row in 0..input.num_rows() {
+                    groups
+                        .entry(routes.value(row).to_owned())
+                        .or_default()
+                        .push(u32::try_from(row).map_err(storage)?);
+                }
+                for (route, indexes) in groups {
+                    let runtime_route = if ontology_mode == OntologyMode::Exploratory {
+                        "_exploratory"
                     } else {
-                        property
+                        route.as_str()
                     };
-                    let path = format!(
-                        "edge_properties/{property_route}/{:020}-{ordinal:020}.parquet",
-                        shape.parent_topology_generation + 1
-                    );
-                    artifacts.push(write_parquet(output, &path, &property, evidence)?);
-                    *ordinal = ordinal.saturating_add(1);
+                    let owner = resolve_owner(
+                        semantic_context,
+                        semantic_bindings,
+                        SymbolKind::Relation,
+                        SemanticRouteKind::Relation,
+                        &route,
+                        runtime_route,
+                    )?;
+                    let projections = property_projections(
+                        &input,
+                        4,
+                        &indexes,
+                        &owner,
+                        SymbolKind::Relation,
+                        SemanticRouteKind::EdgeProperty,
+                        semantic_context,
+                        semantic_bindings,
+                    )?;
+                    for (property_route, fields) in projections {
+                        let ordinal = ordinals.entry(property_route.clone()).or_default();
+                        let property = property_batch(
+                            &input,
+                            "edge_uuid",
+                            "graphforge.rel_type",
+                            &owner.topology_route,
+                            &indexes,
+                            &fields,
+                            PropertyRouteKind::Edge,
+                            &property_route,
+                            shape.parent_topology_generation + 1,
+                            *ordinal,
+                        )?;
+                        let property = if owner.symbol.is_some() {
+                            with_route_metadata_batch(
+                                &property,
+                                &property_route,
+                                semantic_context
+                                    .expect("qualified owner has context")
+                                    .fingerprint(),
+                            )?
+                        } else {
+                            property
+                        };
+                        let path = format!(
+                            "edge_properties/{property_route}/{:020}-{ordinal:020}.parquet",
+                            shape.parent_topology_generation + 1
+                        );
+                        artifacts.push(write_parquet(
+                            output,
+                            &path,
+                            &property,
+                            cache_window,
+                            evidence,
+                        )?);
+                        *ordinal = ordinal.saturating_add(1);
+                    }
                 }
             }
-        }
+            Ok(())
+        })();
+        drop(reader);
+        combine_reader_cleanup(
+            processed,
+            cache_release.check_error().map_err(storage),
+            "edge property",
+        )?;
+        account_cache_release(cache_release.evidence(), evidence);
         let (bytes, operations) = counter.values();
         evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
         evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
@@ -1479,33 +1728,56 @@ fn read_runtime_label_ids(
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<BTreeMap<String, u32>, GfError> {
     let counter = IoCounter::default();
-    let mut reader = ParquetRecordBatchReaderBuilder::try_new(CountingChunkReader {
-        file,
-        counter: counter.clone(),
-    })
-    .map_err(storage)?
-    .with_batch_size(budgets.max_batch_rows)
-    .build()
-    .map_err(storage)?;
+    let chunk_reader = CountingChunkReader::new(file, counter.clone());
+    let cache_release = chunk_reader.cache_release_tracker();
+    let reader = (|| {
+        ParquetRecordBatchReaderBuilder::try_new(chunk_reader)
+            .map_err(storage)?
+            .with_batch_size(budgets.max_batch_rows)
+            .build()
+            .map_err(storage)
+    })();
+    let mut reader = match reader {
+        Ok(reader) => reader,
+        Err(primary) => {
+            combine_reader_cleanup(
+                Err(primary),
+                cache_release.check_error().map_err(storage),
+                "runtime catalog",
+            )?;
+            unreachable!("failed runtime catalog reader construction returned success");
+        }
+    };
     let mut labels = BTreeMap::new();
-    for batch in &mut reader {
-        let batch = batch.map_err(storage)?;
-        account_batch(&batch, budgets, evidence)?;
-        let kinds = required_string(&batch, "entry_kind")?;
-        let names = required_string(&batch, "name")?;
-        let ids = batch
-            .column_by_name("runtime_id")
-            .and_then(|column| column.as_any().downcast_ref::<UInt32Array>())
-            .ok_or_else(|| storage("runtime catalog id is not UInt32"))?;
-        for row in 0..batch.num_rows() {
-            if kinds.value(row) == "entity_type" {
-                let tagged = runtime_entity_type_id(graphforge_ir::RuntimeTypeId(ids.value(row))).0;
-                if labels.insert(names.value(row).to_owned(), tagged).is_some() {
-                    return Err(storage("runtime catalog repeats an entity type"));
+    let decoded = (|| -> Result<(), GfError> {
+        for batch in &mut reader {
+            let batch = batch.map_err(storage)?;
+            account_batch(&batch, budgets, evidence)?;
+            let kinds = required_string(&batch, "entry_kind")?;
+            let names = required_string(&batch, "name")?;
+            let ids = batch
+                .column_by_name("runtime_id")
+                .and_then(|column| column.as_any().downcast_ref::<UInt32Array>())
+                .ok_or_else(|| storage("runtime catalog id is not UInt32"))?;
+            for row in 0..batch.num_rows() {
+                if kinds.value(row) == "entity_type" {
+                    let tagged =
+                        runtime_entity_type_id(graphforge_ir::RuntimeTypeId(ids.value(row))).0;
+                    if labels.insert(names.value(row).to_owned(), tagged).is_some() {
+                        return Err(storage("runtime catalog repeats an entity type"));
+                    }
                 }
             }
         }
-    }
+        Ok(())
+    })();
+    drop(reader);
+    combine_reader_cleanup(
+        decoded,
+        cache_release.check_error().map_err(storage),
+        "runtime catalog",
+    )?;
+    account_cache_release(cache_release.evidence(), evidence);
     let (bytes, operations) = counter.values();
     evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
     evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
@@ -1535,10 +1807,13 @@ fn write_surrogate_tails(
         ],
     )
     .map_err(storage)?;
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(1).map_err(storage)?;
     artifacts.push(write_parquet(
         output,
         "topology/surrogate_tails.parquet",
         &batch,
+        cache_window,
         evidence,
     )?);
     Ok(())
@@ -1548,6 +1823,7 @@ fn write_parquet(
     root: &StableDirectory,
     relative: &str,
     batch: &RecordBatch,
+    cache_window: std::num::NonZeroU64,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<ConstructionEncodedArtifact, GfError> {
     let (directory, name) = directory_for(root, relative)?;
@@ -1565,7 +1841,11 @@ fn write_parquet(
     let counter = IoCounter::default();
     let mut writer = ArrowWriter::try_new(
         CountingWriter {
-            inner: file,
+            inner: graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(
+                file,
+                cache_window,
+            )
+            .map_err(storage)?,
             counter: counter.clone(),
             digest: Sha256::new(),
         },
@@ -1574,8 +1854,10 @@ fn write_parquet(
     )
     .map_err(storage)?;
     writer.write(batch).map_err(storage)?;
-    let writer = writer.into_inner().map_err(storage)?;
-    writer.inner.sync_all().map_err(storage)?;
+    let mut writer = writer.into_inner().map_err(storage)?;
+    writer.inner.sync_all_and_release().map_err(storage)?;
+    let cache_release = writer.inner.evidence();
+    account_cache_release(cache_release, evidence);
     crate::graph_construction::construction_failpoint(&format!(
         "encode.parquet.after_temp_fsync.{relative}"
     ));
@@ -1595,7 +1877,10 @@ fn write_parquet(
     ));
     evidence.output_write_bytes = evidence.output_write_bytes.saturating_add(written);
     evidence.output_write_operations = evidence.output_write_operations.saturating_add(operations);
-    evidence.fsync_operations = evidence.fsync_operations.saturating_add(2);
+    evidence.fsync_operations = evidence
+        .fsync_operations
+        .saturating_add(1)
+        .saturating_add(cache_release.sync_operations);
     Ok(artifact)
 }
 
@@ -1606,6 +1891,8 @@ fn copy_artifact<R: Read + Seek>(
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
 ) -> Result<(), GfError> {
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage)?;
     let read_counter = IoCounter::default();
     source_file.rewind().map_err(storage)?;
     let mut input = BufReader::with_capacity(
@@ -1631,14 +1918,24 @@ fn copy_artifact<R: Read + Seek>(
     let mut writer = BufWriter::with_capacity(
         COPY_BUFFER_BYTES,
         CountingWriter {
-            inner: file,
+            inner: graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(
+                file,
+                cache_window,
+            )
+            .map_err(storage)?,
             counter: write_counter.clone(),
             digest: Sha256::new(),
         },
     );
     let bytes = std::io::copy(&mut input, &mut writer).map_err(storage)?;
     writer.flush().map_err(storage)?;
-    writer.get_ref().inner.sync_all().map_err(storage)?;
+    writer
+        .get_mut()
+        .inner
+        .sync_all_and_release()
+        .map_err(storage)?;
+    let cache_release = writer.get_ref().inner.evidence();
+    account_cache_release(cache_release, evidence);
     crate::graph_construction::construction_failpoint(&format!(
         "encode.copy.after_temp_fsync.{relative}"
     ));
@@ -1681,9 +1978,42 @@ fn copy_artifact<R: Read + Seek>(
     evidence.output_write_operations = evidence
         .output_write_operations
         .saturating_add(write_operations);
-    evidence.fsync_operations = evidence.fsync_operations.saturating_add(2);
+    evidence.fsync_operations = evidence
+        .fsync_operations
+        .saturating_add(1)
+        .saturating_add(cache_release.sync_operations);
     artifacts.push(artifact);
     Ok(())
+}
+
+fn copy_file_artifact(
+    source_file: File,
+    output: &StableDirectory,
+    relative: &str,
+    artifacts: &mut Vec<ConstructionEncodedArtifact>,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<(), GfError> {
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage)?;
+    let mut source = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+        source_file,
+        cache_window,
+        graphforge_filesystem::FileCacheReleaseTracker::default(),
+    )
+    .map_err(storage)?;
+    let copied = copy_artifact(&mut source, output, relative, artifacts, evidence);
+    let released = source.finish().map_err(storage);
+    match (copied, released) {
+        (Ok(()), Ok(released)) => {
+            account_cache_release(released, evidence);
+            Ok(())
+        }
+        (Ok(()), Err(error)) => Err(error),
+        (Err(primary), Ok(_)) => Err(primary),
+        (Err(primary), Err(release)) => Err(storage(format!(
+            "{primary}; copied-source cache release also failed: {release}"
+        ))),
+    }
 }
 
 fn directory_for(
@@ -1714,24 +2044,48 @@ fn directory_for(
     Ok((directory, name))
 }
 
-fn authenticate_file(path: &str, file: &mut File) -> Result<ConstructionEncodedArtifact, GfError> {
+fn authenticate_file(
+    path: &str,
+    file: File,
+) -> Result<
+    (
+        ConstructionEncodedArtifact,
+        graphforge_filesystem::FileCacheReleaseEvidence,
+        u64,
+    ),
+    GfError,
+> {
+    let mut file = graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(storage)?;
     let mut digest = Sha256::new();
     let mut bytes = 0_u64;
+    let mut operations = 0_u64;
     let mut buffer = vec![0_u8; COPY_BUFFER_BYTES];
     file.rewind().map_err(storage)?;
-    loop {
-        let read = file.read(&mut buffer).map_err(storage)?;
-        if read == 0 {
-            break;
+    let authentication = (|| -> Result<ConstructionEncodedArtifact, GfError> {
+        loop {
+            let read = file.read(&mut buffer).map_err(storage)?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+            bytes = bytes.saturating_add(read as u64);
+            operations = operations.saturating_add(1);
         }
-        digest.update(&buffer[..read]);
-        bytes = bytes.saturating_add(read as u64);
+        Ok(ConstructionEncodedArtifact {
+            path: path.to_owned(),
+            bytes,
+            sha256: hex(&digest.finalize()),
+        })
+    })();
+    let released = file.finish().map_err(storage);
+    match (authentication, released) {
+        (Ok(artifact), Ok(released)) => Ok((artifact, released, operations)),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(primary), Ok(_)) => Err(primary),
+        (Err(primary), Err(release)) => Err(storage(format!(
+            "{primary}; cache release after failed authentication also failed: {release}"
+        ))),
     }
-    Ok(ConstructionEncodedArtifact {
-        path: path.to_owned(),
-        bytes,
-        sha256: hex(&digest.finalize()),
-    })
 }
 
 pub(crate) fn read_inventory(
@@ -1850,7 +2204,7 @@ fn authenticate_inventory(
     root: &StableDirectory,
     inventory: &GraphConstructionEncoding,
     parent_index: Option<&AuthenticatedUuidIndexSnapshot>,
-) -> Result<(), GfError> {
+) -> Result<GraphConstructionEncodingEvidence, GfError> {
     if inventory.root != ENCODED_ROOT
         || inventory.shape_inputs_sha256.len() != 64
         || inventory.shape_authority_sha256.len() != 64
@@ -1877,15 +2231,19 @@ fn authenticate_inventory(
     {
         return Err(storage("canonical inventory invariants are invalid"));
     }
+    let mut evidence = GraphConstructionEncodingEvidence::default();
     for expected in &inventory.artifacts {
         let (directory, name) = directory_for(root, &expected.path)?;
-        let mut file = directory
+        let file = directory
             .open_child_file(OsStr::new(&name))
             .map_err(storage)?;
-        let actual = authenticate_file(&expected.path, &mut file)?;
+        let (actual, released, operations) = authenticate_file(&expected.path, file)?;
         if &actual != expected {
             return Err(storage("canonical artifact differs from inventory"));
         }
+        evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(actual.bytes);
+        evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
+        account_cache_release(released, &mut evidence);
     }
     if inventory.retained_artifacts.is_empty() {
         if inventory.evidence.retained_index_runs != 0 {
@@ -1920,7 +2278,7 @@ fn authenticate_inventory(
         }
         parent.authenticate_construction_references(&references)?;
     }
-    Ok(())
+    Ok(evidence)
 }
 
 /// Bind publication to the durable encoding control record without rereading
@@ -1947,7 +2305,7 @@ pub(crate) fn authenticate_inventory_control_for_publication(
         },
     ))
     .map_err(storage)?;
-    if &recorded != inventory {
+    if inventory_authority_sha256(&recorded)? != inventory_authority_sha256(inventory)? {
         return Err(storage(
             "publication inventory differs from durable encoding",
         ));
@@ -2001,7 +2359,7 @@ fn install_json<T: Serialize>(
 }
 
 struct FixedReader<const N: usize> {
-    reader: BufReader<CountingInput<File>>,
+    reader: BufReader<CountingInput<graphforge_filesystem::FileCacheReleasingReader>>,
     counter: IoCounter,
     identity: graphforge_filesystem::FileIdentity,
     expected_bytes: u64,
@@ -2015,6 +2373,7 @@ impl<const N: usize> FixedReader<N> {
         root: &StableDirectory,
         outputs: &[ArtifactReceipt],
         name: &str,
+        cache_window: std::num::NonZeroU64,
     ) -> Result<Self, GfError> {
         let authenticated = open_authenticated_shape_source(root, outputs, name)?;
         let file = authenticated.file;
@@ -2026,7 +2385,12 @@ impl<const N: usize> FixedReader<N> {
             reader: BufReader::with_capacity(
                 COPY_BUFFER_BYTES,
                 CountingInput {
-                    inner: file,
+                    inner: graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                        file,
+                        cache_window,
+                        graphforge_filesystem::FileCacheReleaseTracker::default(),
+                    )
+                    .map_err(storage)?,
                     counter: counter.clone(),
                 },
             ),
@@ -2057,23 +2421,58 @@ impl<const N: usize> FixedReader<N> {
         Ok(Some(record))
     }
 
-    fn authenticate_and_account(
-        &self,
+    fn finish_and_account(
+        &mut self,
+        authenticate: bool,
         evidence: &mut GraphConstructionEncodingEvidence,
     ) -> Result<(), GfError> {
-        if file_identity(&self.reader.get_ref().inner).map_err(storage)? != self.identity
-            || file_link_count(&self.reader.get_ref().inner).map_err(storage)? != 1
-            || self.consumed_bytes != self.expected_bytes
-            || hex(&self.digest.clone().finalize()) != self.expected_sha256
-        {
-            return Err(storage(
-                "fixed-width shaped source changed during consumption",
-            ));
+        let authentication = if authenticate {
+            (|| {
+                if file_identity(self.reader.get_ref().inner.file()).map_err(storage)?
+                    != self.identity
+                    || file_link_count(self.reader.get_ref().inner.file()).map_err(storage)? != 1
+                    || self.consumed_bytes != self.expected_bytes
+                    || hex(&self.digest.clone().finalize()) != self.expected_sha256
+                {
+                    return Err(storage(
+                        "fixed-width shaped source changed during consumption",
+                    ));
+                }
+                Ok(())
+            })()
+        } else {
+            Ok(())
+        };
+        let released = self.reader.get_mut().inner.finish().map_err(storage);
+        match (authentication, released) {
+            (Ok(()), Ok(released)) => account_cache_release(released, evidence),
+            (Ok(()), Err(release)) => return Err(release),
+            (Err(primary), Ok(_)) => return Err(primary),
+            (Err(primary), Err(release)) => {
+                return Err(storage(format!(
+                    "{primary}; fixed-width source cache release also failed: {release}"
+                )));
+            }
         }
         let (bytes, operations) = self.counter.values();
         evidence.input_read_bytes = evidence.input_read_bytes.saturating_add(bytes);
         evidence.input_read_operations = evidence.input_read_operations.saturating_add(operations);
         Ok(())
+    }
+}
+
+fn combine_reader_cleanup<T>(
+    primary: Result<T, GfError>,
+    cleanup: Result<(), GfError>,
+    source: &str,
+) -> Result<T, GfError> {
+    match (primary, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup)) => Err(cleanup),
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(cleanup)) => Err(storage(format!(
+            "{primary}; {source} cache cleanup also failed: {cleanup}"
+        ))),
     }
 }
 

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1612,6 +1612,7 @@ pub fn install_graph_object_file(
     install_graph_object_file_with_lease(&lease, source, expected_digest, expected_length)
 }
 
+#[allow(clippy::too_many_lines)] // The streamed copy keeps source authentication and destination durability atomic.
 fn install_graph_object_file_with_lease(
     lease: &GraphObjectPublicationLease,
     source: &Path,
@@ -1635,35 +1636,106 @@ fn install_graph_object_file_with_lease(
         expected_length,
         true,
         |output| {
-            let mut input = File::open(source)
-                .map_err(|error| storage("open graph object source", source, error))?;
-            let mut hasher = Sha256::new();
-            let mut total = 0_u64;
-            let mut buffer = vec![0_u8; BUFFER_BYTES];
-            loop {
-                let read = input
-                    .read(&mut buffer)
-                    .map_err(|error| storage("read graph object source", source, error))?;
-                if read == 0 {
-                    break;
-                }
-                read_calls.set(read_calls.get().saturating_add(1));
-                output.write_all(&buffer[..read]).map_err(|error| {
+            let cache_window =
+                graphforge_filesystem::cache_release_window_for_streams(2).map_err(|error| {
                     storage(
-                        "write temporary graph object",
+                        "derive graph object cache budget",
                         &lease.cas.diagnostic_root,
                         error,
                     )
                 })?;
-                write_calls.set(write_calls.get().saturating_add(1));
-                hasher.update(&buffer[..read]);
-                total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
-            }
-            if total != expected_length || hex_digest(hasher.finalize().into()) != expected_digest {
-                return Err(validation(
-                    "graph object source digest or length changed during install",
-                ));
-            }
+            let input = File::open(source)
+                .map_err(|error| storage("open graph object source", source, error))?;
+            let mut input = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                input,
+                cache_window,
+                graphforge_filesystem::FileCacheReleaseTracker::default(),
+            )
+            .map_err(|error| storage("open bounded graph object source", source, error))?;
+            #[cfg(unix)]
+            let mut bounded_output =
+                graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(
+                    output.try_clone().map_err(|error| {
+                        storage(
+                            "clone temporary graph object",
+                            &lease.cas.diagnostic_root,
+                            error,
+                        )
+                    })?,
+                    cache_window,
+                )
+                .map_err(|error| {
+                    storage(
+                        "open bounded temporary graph object",
+                        &lease.cas.diagnostic_root,
+                        error,
+                    )
+                })?;
+            let mut hasher = Sha256::new();
+            let mut total = 0_u64;
+            let mut buffer = vec![0_u8; BUFFER_BYTES];
+            let copied = (|| -> Result<u64, GfError> {
+                loop {
+                    let read = input
+                        .read(&mut buffer)
+                        .map_err(|error| storage("read graph object source", source, error))?;
+                    if read == 0 {
+                        break;
+                    }
+                    read_calls.set(read_calls.get().saturating_add(1));
+                    #[cfg(unix)]
+                    bounded_output.write_all(&buffer[..read]).map_err(|error| {
+                        storage(
+                            "write temporary graph object",
+                            &lease.cas.diagnostic_root,
+                            error,
+                        )
+                    })?;
+                    #[cfg(windows)]
+                    output.write_all(&buffer[..read]).map_err(|error| {
+                        storage(
+                            "write temporary graph object",
+                            &lease.cas.diagnostic_root,
+                            error,
+                        )
+                    })?;
+                    write_calls.set(write_calls.get().saturating_add(1));
+                    hasher.update(&buffer[..read]);
+                    total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+                }
+                if total != expected_length
+                    || hex_digest(hasher.finalize().into()) != expected_digest
+                {
+                    return Err(validation(
+                        "graph object source digest or length changed during install",
+                    ));
+                }
+                Ok(total)
+            })();
+            let released = input
+                .finish()
+                .map_err(|error| storage("release graph object source cache", source, error));
+            let total = match (copied, released) {
+                (Ok(total), Ok(_)) => total,
+                (Ok(_), Err(release)) => return Err(release),
+                (Err(primary), Ok(_)) => return Err(primary),
+                (Err(primary), Err(release)) => {
+                    return Err(storage(
+                        "copy and release graph object source",
+                        source,
+                        format!("{primary}; cache release also failed: {release}"),
+                    ));
+                }
+            };
+            #[cfg(unix)]
+            bounded_output.sync_all_and_release().map_err(|error| {
+                storage(
+                    "fsync temporary graph object",
+                    &lease.cas.diagnostic_root,
+                    error,
+                )
+            })?;
+            #[cfg(windows)]
             output.sync_all().map_err(|error| {
                 storage(
                     "fsync temporary graph object",
@@ -1862,6 +1934,7 @@ fn requires_single_link_materialization(relative_path: &str) -> bool {
             && crate::uuid_membership::is_exact_private_v4_name(name)))
 }
 
+#[allow(clippy::too_many_lines)] // One guarded publication owns copy, release, install, and verification cleanup.
 fn copy_single_link_materialized_object(
     cas: &CasRoot,
     source: &File,
@@ -1873,13 +1946,33 @@ fn copy_single_link_materialized_object(
         ".ordinal-v4-materialize-{}.tmp",
         Uuid::new_v4().simple()
     ));
-    let mut input = source
+    let input = source
         .try_clone()
         .map_err(|error| storage("clone materialization source", &cas.diagnostic_root, error))?;
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(2).map_err(|error| {
+            storage(
+                "derive materialization cache budget",
+                &cas.diagnostic_root,
+                error,
+            )
+        })?;
+    let mut input = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+        input,
+        cache_window,
+        graphforge_filesystem::FileCacheReleaseTracker::default(),
+    )
+    .map_err(|error| {
+        storage(
+            "open bounded materialization source",
+            &cas.diagnostic_root,
+            error,
+        )
+    })?;
     input
         .rewind()
         .map_err(|error| storage("rewind materialization source", &cas.diagnostic_root, error))?;
-    let mut output = parent
+    let output = parent
         .create_replaceable_child_file(&temporary_name)
         .map_err(|error| {
             storage(
@@ -1895,15 +1988,51 @@ fn copy_single_link_materialized_object(
             error,
         )
     })?;
+    let mut output =
+        graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(output, cache_window)
+            .map_err(|error| {
+                storage(
+                    "open bounded private materialization file",
+                    &cas.diagnostic_root,
+                    error,
+                )
+            })?;
     let mut installed = false;
     let result = (|| -> Result<MaterializeIoEvidence, GfError> {
-        let mut io = copy_and_authenticate_materialized_object(
+        let copied = copy_and_authenticate_materialized_object(
             &mut input,
             &mut output,
             entry,
             &cas.diagnostic_root,
-        )?;
-        drop(output);
+        );
+        let released = input.finish().map_err(|error| {
+            storage(
+                "release materialization source cache",
+                &cas.diagnostic_root,
+                error,
+            )
+        });
+        let mut io = match (copied, released) {
+            (Ok(io), Ok(_)) => io,
+            (Ok(_), Err(error)) => return Err(error),
+            (Err(primary), Ok(_)) => return Err(primary),
+            (Err(primary), Err(release)) => {
+                return Err(storage(
+                    "copy and release private materialization source",
+                    &cas.diagnostic_root,
+                    format!("{primary}; cache release also failed: {release}"),
+                ));
+            }
+        };
+        output.sync_all_and_release().map_err(|error| {
+            storage(
+                "sync private materialization file",
+                &cas.diagnostic_root,
+                error,
+            )
+        })?;
+        io.fsync_calls = output.evidence().sync_operations;
+        drop(output.into_file());
         parent
             .replace_child(&temporary_name, output_identity, name)
             .map_err(|error| {
@@ -1961,8 +2090,8 @@ fn copy_single_link_materialized_object(
 }
 
 fn copy_and_authenticate_materialized_object(
-    input: &mut File,
-    output: &mut File,
+    input: &mut impl Read,
+    output: &mut impl Write,
     entry: &crate::GraphFileEntry,
     diagnostic_root: &Path,
 ) -> Result<MaterializeIoEvidence, GfError> {
@@ -1993,16 +2122,13 @@ fn copy_and_authenticate_materialized_object(
             "private materialization bytes do not match inventory",
         ));
     }
-    output
-        .sync_all()
-        .map_err(|error| storage("sync private materialization file", diagnostic_root, error))?;
     Ok(MaterializeIoEvidence {
         copied: true,
         read_bytes: length,
         read_calls,
         write_bytes: length,
         write_calls,
-        fsync_calls: 1,
+        fsync_calls: 0,
     })
 }
 
@@ -2996,7 +3122,7 @@ struct ReadIoEvidence {
 }
 
 fn verify_file_counted(
-    mut file: File,
+    file: File,
     digest: &str,
     expected_length: u64,
     diagnostic: &Path,
@@ -3009,24 +3135,45 @@ fn verify_file_counted(
             "graph object handle is not the declared regular file",
         ));
     }
+    let mut file = graphforge_filesystem::FileCacheReleasingReader::new(file)
+        .map_err(|error| storage("open bounded graph object handle", diagnostic, error))?;
     let mut hasher = Sha256::new();
     let mut io = ReadIoEvidence::default();
     let mut buffer = vec![0_u8; BUFFER_BYTES];
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .map_err(|error| storage("read graph object handle", diagnostic, error))?;
-        if read == 0 {
-            break;
+    let verified = (|| -> Result<(), GfError> {
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .map_err(|error| storage("read graph object handle", diagnostic, error))?;
+            if read == 0 {
+                break;
+            }
+            io.bytes = io.bytes.saturating_add(read as u64);
+            io.calls = io.calls.saturating_add(1);
+            hasher.update(&buffer[..read]);
         }
-        io.bytes = io.bytes.saturating_add(read as u64);
-        io.calls = io.calls.saturating_add(1);
-        hasher.update(&buffer[..read]);
+        if hex_digest(hasher.finalize().into()) != digest {
+            return Err(validation("graph object digest does not match its address"));
+        }
+        Ok(())
+    })();
+    let released = file.finish().map_err(|error| {
+        storage(
+            "release graph object authentication cache",
+            diagnostic,
+            error,
+        )
+    });
+    match (verified, released) {
+        (Ok(()), Ok(_)) => Ok(io),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(primary), Ok(_)) => Err(primary),
+        (Err(primary), Err(release)) => Err(storage(
+            "authenticate graph object and release consumed cache",
+            diagnostic,
+            std::io::Error::other(format!("{primary}; {release}")),
+        )),
     }
-    if hex_digest(hasher.finalize().into()) != digest {
-        return Err(validation("graph object digest does not match its address"));
-    }
-    Ok(io)
 }
 
 fn verify_stream(

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1630,6 +1630,7 @@ fn install_graph_object_file_with_lease(
     }
     let read_calls = std::cell::Cell::new(0_u64);
     let write_calls = std::cell::Cell::new(0_u64);
+    let file_sync_calls = std::cell::Cell::new(0_u64);
     let result = install_object(
         &lease.cas,
         expected_digest,
@@ -1728,21 +1729,27 @@ fn install_graph_object_file_with_lease(
                 }
             };
             #[cfg(unix)]
-            bounded_output.sync_all_and_release().map_err(|error| {
-                storage(
-                    "fsync temporary graph object",
-                    &lease.cas.diagnostic_root,
-                    error,
-                )
-            })?;
+            {
+                bounded_output.sync_all_and_release().map_err(|error| {
+                    storage(
+                        "fsync temporary graph object",
+                        &lease.cas.diagnostic_root,
+                        error,
+                    )
+                })?;
+                file_sync_calls.set(bounded_output.evidence().sync_operations);
+            }
             #[cfg(windows)]
-            output.sync_all().map_err(|error| {
-                storage(
-                    "fsync temporary graph object",
-                    &lease.cas.diagnostic_root,
-                    error,
-                )
-            })?;
+            {
+                output.sync_all().map_err(|error| {
+                    storage(
+                        "fsync temporary graph object",
+                        &lease.cas.diagnostic_root,
+                        error,
+                    )
+                })?;
+                file_sync_calls.set(1);
+            }
             Ok(total)
         },
     );
@@ -1751,7 +1758,7 @@ fn install_graph_object_file_with_lease(
             evidence.read_calls = evidence.read_calls.saturating_add(read_calls.get());
             evidence.write_calls = evidence.write_calls.saturating_add(write_calls.get());
             evidence.write_bytes = evidence.write_bytes.saturating_add(expected_length);
-            evidence.fsync_calls = evidence.fsync_calls.saturating_add(1);
+            evidence.fsync_calls = evidence.fsync_calls.saturating_add(file_sync_calls.get());
         }
         evidence
     })
@@ -4246,6 +4253,51 @@ mod tests {
         let directory = open_empty_materialization_target(&second_target).unwrap();
         assert!(link_materialized_object(&directory, &source, "payload.bin", &digest, 7).is_err());
         assert!(!second_target.join("payload.bin").exists());
+    }
+
+    #[test]
+    fn file_install_receipts_count_actual_cache_window_synchronizations() {
+        let window = graphforge_filesystem::cache_release_window_for_streams(2)
+            .unwrap()
+            .get();
+        assert_eq!(window, 32 * 1024 * 1024);
+        for bytes in [window - 1, window, window + 1] {
+            let root = tempfile::tempdir().unwrap();
+            let source_root = tempfile::tempdir().unwrap();
+            let source = source_root.path().join("source");
+            let payload = vec![0x5a_u8; usize::try_from(bytes).unwrap()];
+            fs::write(&source, &payload).unwrap();
+            let digest = hex_digest(Sha256::digest(&payload).into());
+
+            let installed =
+                install_graph_object_file(root.path(), &source, &digest, bytes).unwrap();
+            let rollovers = u64::from(cfg!(target_os = "linux") && bytes > window);
+            assert_eq!(
+                installed.fsync_calls,
+                3 + rollovers,
+                "payload bytes {bytes}"
+            );
+            assert!(!installed.reused_existing);
+            assert_eq!(installed.bytes_installed, bytes);
+            assert_eq!(
+                read_graph_object(root.path(), &digest, bytes).unwrap(),
+                payload
+            );
+
+            let reused = install_graph_object_file(root.path(), &source, &digest, bytes).unwrap();
+            assert!(reused.reused_existing);
+            assert_eq!(reused.fsync_calls, 0);
+            assert_eq!(reused.write_bytes, 0);
+            assert!(
+                root.path()
+                    .join(GRAPH_OBJECTS_DIR)
+                    .join(TEMP_DIR)
+                    .read_dir()
+                    .unwrap()
+                    .next()
+                    .is_none()
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -45,8 +45,8 @@ pub use graph_construction::{
     CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, ConstructionChunkKind,
     ConstructionChunkReceipt, ConstructionRetainedArtifact, ConstructionSemanticAuthority,
     ConstructionShape, GraphConstructionBudgets, GraphConstructionEncoding,
-    GraphConstructionEncodingEvidence, GraphConstructionEvidence, GraphConstructionSession,
-    GraphConstructionState,
+    GraphConstructionEncodingEvidence, GraphConstructionEncodingInvocationEvidence,
+    GraphConstructionEvidence, GraphConstructionSession, GraphConstructionState,
 };
 
 pub mod graph_files;

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -171,6 +171,47 @@ pub(crate) struct V4OrdinalBuildMetrics {
     pub(crate) peak_temporary_bytes: u64,
     pub(crate) fsync_operations: u64,
     pub(crate) cancellation_polls: u64,
+    pub(crate) cache_release: graphforge_filesystem::FileCacheReleaseEvidence,
+}
+
+#[derive(Debug)]
+pub(crate) struct V4ConstructionArtifactBundle {
+    pub(crate) manifest: crate::V4OrdinalIdentityManifest,
+    pub(crate) metrics: V4OrdinalBuildMetrics,
+    publications: Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+}
+
+struct V4AuthorityTransactionProof;
+
+fn commit_v4_publications(
+    publications: Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    _proof: V4AuthorityTransactionProof,
+) -> Result<(), GfError> {
+    for (_, publication) in publications {
+        publication.commit().map_err(storage_err)?;
+    }
+    Ok(())
+}
+
+fn retain_v4_publication(
+    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    name: String,
+    publication: Option<graphforge_filesystem::UnpublishedArtifactGuard>,
+) {
+    if let Some(publication) = publication {
+        publications.push((name, publication));
+    }
+}
+
+fn cleanup_v4_publication(
+    publication: &mut graphforge_filesystem::UnpublishedArtifactGuard,
+) -> Result<(), GfError> {
+    publication
+        .cleanup_checked(|| {
+            take_v4_output_cleanup_failure()
+                .map_err(|_| std::io::Error::other("injected v4 output cleanup failure"))
+        })
+        .map_err(storage_err)
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -301,6 +342,10 @@ pub(crate) struct V4OrdinalAppendMetrics {
     pub(crate) peak_temporary_bytes: u64,
     /// Durable file flushes completed while constructing outputs.
     pub(crate) fsync_operations: u64,
+    /// Incremental compaction cache-release evidence.
+    pub(crate) cache_release: graphforge_filesystem::FileCacheReleaseEvidence,
+    /// Largest aggregate of configured windows for one compaction operation.
+    pub(crate) peak_configured_cache_window_bytes: u64,
     /// Per-record filesystem seeks are forbidden.
     pub(crate) per_record_seeks: u64,
     /// Unreferenced v4 candidates examined after publication.
@@ -346,9 +391,31 @@ where
     I: IntoIterator<Item = (Uuid, u64)>,
     F: FnMut() -> bool,
 {
+    let bundle = stage_v4_ordinal_bundle(records, generation, index, &mut cancelled)?;
+    index.sync().map_err(storage_err)?;
+    let V4ConstructionArtifactBundle {
+        manifest,
+        metrics,
+        publications,
+    } = bundle;
+    commit_v4_publications(publications, V4AuthorityTransactionProof)?;
+    Ok((manifest, metrics))
+}
+
+#[cfg(test)]
+fn stage_v4_ordinal_bundle<I, F>(
+    records: I,
+    generation: u64,
+    index: &graphforge_filesystem::StableDirectory,
+    cancelled: &mut F,
+) -> Result<V4ConstructionArtifactBundle, GfError>
+where
+    I: IntoIterator<Item = (Uuid, u64)>,
+    F: FnMut() -> bool,
+{
     let mut writer = V4OrdinalConstructionWriter::start(generation, index)?;
     for (uuid, node_id) in records {
-        writer.push_pair(uuid, node_id, &mut cancelled)?;
+        writer.push_pair(uuid, node_id, cancelled)?;
     }
     writer.finish()
 }
@@ -358,8 +425,10 @@ where
 pub(crate) struct V4OrdinalConstructionWriter<'a> {
     generation: u64,
     index: &'a graphforge_filesystem::StableDirectory,
+    cache_window: std::num::NonZeroU64,
     forward: StreamingV4Artifact,
     ranges: Vec<crate::V4OrdinalRange>,
+    publications: Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
     current: Option<V4OrdinalRangeWriter>,
     previous_forward_uuid: Option<[u8; 16]>,
     previous_ordinal_node_id: u64,
@@ -377,14 +446,37 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
         generation: u64,
         index: &'a graphforge_filesystem::StableDirectory,
     ) -> Result<Self, GfError> {
+        let cache_window =
+            graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage_err)?;
+        Self::start_with_cache_window(generation, index, cache_window)
+    }
+
+    pub(crate) fn start_with_cache_window(
+        generation: u64,
+        index: &'a graphforge_filesystem::StableDirectory,
+        cache_window: std::num::NonZeroU64,
+    ) -> Result<Self, GfError> {
         if generation == 0 {
             return Err(storage_err("v4 ordinal generation is zero"));
+        }
+        let forward = StreamingV4Artifact::create_with_window(index, "forward", cache_window)?;
+        let validated = graphforge_filesystem::validate_cache_release_operation_windows(&[forward
+            .writer
+            .get_ref()
+            .window_bytes()])
+        .map_err(storage_err)
+        .and_then(|_| v4_publication_failure("window_validation"));
+        if let Err(primary) = validated {
+            let (_, cleanup) = forward.cleanup_unpublished();
+            return combine_v4_cleanup(Err(primary), cleanup, "v4 setup cleanup");
         }
         Ok(Self {
             generation,
             index,
-            forward: StreamingV4Artifact::create(index, "forward")?,
+            cache_window,
+            forward,
             ranges: Vec::new(),
+            publications: Vec::new(),
             current: None,
             previous_forward_uuid: None,
             previous_ordinal_node_id: 0,
@@ -485,10 +577,10 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
                 .is_none_or(|expected| node_id != expected)
         {
             finish_streamed_v4_range(
-                self.index,
                 self.generation,
                 self.current.take().expect("range exists"),
                 &mut self.ranges,
+                &mut self.publications,
                 &mut self.metrics,
             )?;
         }
@@ -500,6 +592,7 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
                 self.index,
                 self.ranges.len(),
                 node_id,
+                self.cache_window,
             )?);
         }
         self.current
@@ -530,9 +623,7 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
         Ok(())
     }
 
-    pub(crate) fn finish(
-        mut self,
-    ) -> Result<(crate::V4OrdinalIdentityManifest, V4OrdinalBuildMetrics), GfError> {
+    pub(crate) fn finish(mut self) -> Result<V4ConstructionArtifactBundle, GfError> {
         if self.forward_count != self.ordinal_count
             || self.forward_commitment != self.ordinal_commitment
             || self.forward_commitment_two != self.ordinal_commitment_two
@@ -544,16 +635,15 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
         self.metrics.input_records = self.forward_count;
         if let Some(writer) = self.current.take() {
             finish_streamed_v4_range(
-                self.index,
                 self.generation,
                 writer,
                 &mut self.ranges,
+                &mut self.publications,
                 &mut self.metrics,
             )?;
         }
         let forward = finish_streamed_v4_artifact(
             self.forward,
-            self.index,
             "forward-v4",
             self.generation,
             crate::V4OrdinalArtifactKind::ForwardIdentities,
@@ -563,8 +653,7 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
         // Construction has no deletions, but an explicit authenticated empty run
         // commits that fact instead of leaving tombstone authority implicit.
         let tombstone = finish_streamed_v4_artifact(
-            StreamingV4Artifact::create(self.index, "tombstones")?,
-            self.index,
+            StreamingV4Artifact::create_with_window(self.index, "tombstones", self.cache_window)?,
             "tombstones-v4",
             self.generation,
             crate::V4OrdinalArtifactKind::NodeTombstones,
@@ -574,16 +663,31 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
         let manifest = crate::V4OrdinalIdentityManifest {
             format_version: crate::ORDINAL_IDENTITY_V4,
             topology_generation: self.generation,
-            forward_identities: vec![forward],
+            forward_identities: vec![forward.artifact],
             ordinal_ranges: self.ranges,
             tombstones: vec![crate::V4OrdinalTombstones {
                 generation: self.generation,
-                artifact: tombstone,
+                artifact: tombstone.artifact,
                 blocks: Vec::new(),
             }],
         };
+        v4_publication_failure("manifest_update")?;
         admit_v4_construction_manifest(&manifest)?;
-        Ok((manifest, self.metrics))
+        retain_v4_publication(
+            &mut self.publications,
+            manifest.forward_identities[0].name.clone(),
+            forward.publication,
+        );
+        retain_v4_publication(
+            &mut self.publications,
+            manifest.tombstones[0].artifact.name.clone(),
+            tombstone.publication,
+        );
+        Ok(V4ConstructionArtifactBundle {
+            manifest,
+            metrics: self.metrics,
+            publications: self.publications,
+        })
     }
 }
 
@@ -615,23 +719,44 @@ fn add_v4_mapping_commitment(commitment: &mut [u8; 32], domain: u8, uuid: [u8; 1
 }
 
 struct StreamingV4Artifact {
-    temporary_name: String,
-    writer: BufWriter<File>,
+    writer: BufWriter<graphforge_filesystem::DurableFileCacheWriter>,
+    publication: graphforge_filesystem::UnpublishedArtifactGuard,
     digest: Sha256,
     bytes: u64,
 }
 
 impl StreamingV4Artifact {
-    fn create(index: &graphforge_filesystem::StableDirectory, role: &str) -> Result<Self, GfError> {
+    fn create_with_window(
+        index: &graphforge_filesystem::StableDirectory,
+        role: &str,
+        cache_window: std::num::NonZeroU64,
+    ) -> Result<Self, GfError> {
         let temporary_name = format!(".v4-{role}-{}.tmp", Uuid::new_v4().simple());
+        let mut publication = index
+            .create_unpublished_replaceable_child(std::ffi::OsStr::new(&temporary_name))
+            .map_err(storage_err)?;
+        if let Err(primary) = publication
+            .verify_identity_with(|| v4_publication_io_failure("initial_file_identity"))
+            .map_err(storage_err)
+        {
+            let cleanup = cleanup_v4_publication(&mut publication);
+            return combine_v4_cleanup(Err(primary), cleanup, "v4 setup cleanup");
+        }
+        let file = publication.take_file().map_err(storage_err)?;
+        let writer = match graphforge_filesystem::DurableFileCacheWriter::with_window_bytes_checked(
+            file,
+            cache_window,
+            || v4_publication_io_failure("writer_construction"),
+        ) {
+            Ok(writer) => writer,
+            Err(primary) => {
+                let cleanup = cleanup_v4_publication(&mut publication);
+                return combine_v4_cleanup(Err(storage_err(primary)), cleanup, "v4 setup cleanup");
+            }
+        };
         Ok(Self {
-            writer: BufWriter::with_capacity(
-                V4_ORDINAL_BLOCK_BYTES,
-                index
-                    .create_replaceable_child_file(std::ffi::OsStr::new(&temporary_name))
-                    .map_err(storage_err)?,
-            ),
-            temporary_name,
+            writer: BufWriter::with_capacity(V4_ORDINAL_BLOCK_BYTES, writer),
+            publication,
             digest: Sha256::new(),
             bytes: 0,
         })
@@ -646,50 +771,148 @@ impl StreamingV4Artifact {
             .ok_or_else(|| storage_err("v4 artifact length overflow"))?;
         Ok(())
     }
+
+    fn cleanup_unpublished(
+        mut self,
+    ) -> (
+        graphforge_filesystem::FileCacheReleaseEvidence,
+        Result<(), GfError>,
+    ) {
+        let flushed = self.writer.flush().map_err(storage_err);
+        let synchronized = self
+            .writer
+            .get_mut()
+            .sync_all_and_release()
+            .map_err(storage_err);
+        let cache_release = self.writer.get_ref().evidence();
+        let finalized = combine_v4_cleanup(flushed, synchronized, "v4 output synchronization");
+        drop(self.writer);
+        let removed = cleanup_v4_publication(&mut self.publication);
+        (
+            cache_release,
+            combine_v4_cleanup(finalized, removed, "v4 output removal"),
+        )
+    }
 }
 
+#[derive(Debug)]
+struct GuardedV4Artifact {
+    artifact: crate::V4OrdinalArtifact,
+    publication: Option<graphforge_filesystem::UnpublishedArtifactGuard>,
+}
+
+#[allow(clippy::too_many_lines)]
 fn finish_streamed_v4_artifact(
     mut writer: StreamingV4Artifact,
-    index: &graphforge_filesystem::StableDirectory,
     prefix: &str,
     generation: u64,
     kind: crate::V4OrdinalArtifactKind,
     metrics: &mut V4OrdinalBuildMetrics,
-) -> Result<crate::V4OrdinalArtifact, GfError> {
-    writer.writer.flush().map_err(storage_err)?;
-    sync_uuid_file(writer.writer.get_ref())?;
-    metrics.fsync_operations = metrics
-        .fsync_operations
-        .checked_add(1)
-        .ok_or_else(|| storage_err("v4 fsync count overflow"))?;
-    let identity =
-        graphforge_filesystem::file_identity(writer.writer.get_ref()).map_err(storage_err)?;
-    let sha256 = hex_bytes(&writer.digest.finalize());
-    let artifact = crate::V4OrdinalArtifact {
-        name: format!("{prefix}-{generation}-{}.uuidx", &sha256[..16]),
-        kind,
-        generation,
-        bytes: writer.bytes,
-        sha256,
+) -> Result<GuardedV4Artifact, GfError> {
+    let finalized = writer.writer.flush().map_err(storage_err).and_then(|()| {
+        writer
+            .writer
+            .get_mut()
+            .sync_all_and_release()
+            .map_err(storage_err)
+    });
+    if let Err(primary) = finalized {
+        let (cache_release, cleanup) = writer.cleanup_unpublished();
+        merge_cache_release_evidence(&mut metrics.cache_release, cache_release);
+        return combine_v4_cleanup(Err(primary), cleanup, "v4 failed output cleanup");
+    }
+    let cache_release = writer.writer.get_ref().evidence();
+    let prepared = (|| -> Result<(_, _), GfError> {
+        v4_publication_failure("fsync_evidence_overflow")?;
+        let mut committed_metrics = metrics.clone();
+        merge_cache_release_evidence(&mut committed_metrics.cache_release, cache_release);
+        committed_metrics.fsync_operations = committed_metrics
+            .fsync_operations
+            .checked_add(cache_release.sync_operations)
+            .ok_or_else(|| storage_err("v4 fsync count overflow"))?;
+        v4_publication_failure("final_file_identity")?;
+        let identity = graphforge_filesystem::file_identity(writer.writer.get_ref().file())
+            .map_err(storage_err)?;
+        if identity != writer.publication.identity().map_err(storage_err)? {
+            return Err(storage_err("v4 final output identity changed"));
+        }
+        v4_publication_failure("file_space_usage")?;
+        let space = graphforge_filesystem::file_space_usage(writer.writer.get_ref().file())
+            .map_err(storage_err)?;
+        if space.logical_bytes != writer.bytes {
+            return Err(storage_err("v4 final output length changed"));
+        }
+        let sha256 = hex_bytes(&writer.digest.clone().finalize());
+        let artifact = crate::V4OrdinalArtifact {
+            name: format!("{prefix}-{generation}-{}.uuidx", &sha256[..16]),
+            kind,
+            generation,
+            bytes: writer.bytes,
+            sha256,
+        };
+        committed_metrics.artifact_bytes = committed_metrics
+            .artifact_bytes
+            .checked_add(artifact.bytes)
+            .ok_or_else(|| storage_err("v4 aggregate artifact length overflow"))?;
+        committed_metrics.peak_temporary_bytes = committed_metrics
+            .peak_temporary_bytes
+            .max(committed_metrics.artifact_bytes);
+        committed_metrics.write_blocks = committed_metrics
+            .write_blocks
+            .checked_add(artifact.bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64))
+            .ok_or_else(|| storage_err("v4 write block count overflow"))?;
+        Ok((artifact, committed_metrics))
+    })();
+    let (artifact, committed_metrics) = match prepared {
+        Ok(prepared) => prepared,
+        Err(primary) => {
+            let (cleanup_evidence, cleanup) = writer.cleanup_unpublished();
+            merge_cache_release_evidence(&mut metrics.cache_release, cleanup_evidence);
+            return combine_v4_cleanup(Err(primary), cleanup, "v4 setup publication cleanup");
+        }
     };
     drop(writer.writer);
-    index
-        .replace_child(
-            std::ffi::OsStr::new(&writer.temporary_name),
-            identity,
-            std::ffi::OsStr::new(&artifact.name),
-        )
-        .map_err(storage_err)?;
-    metrics.artifact_bytes = metrics
-        .artifact_bytes
-        .checked_add(artifact.bytes)
-        .ok_or_else(|| storage_err("v4 aggregate artifact length overflow"))?;
-    metrics.peak_temporary_bytes = metrics.peak_temporary_bytes.max(metrics.artifact_bytes);
-    metrics.write_blocks = metrics
-        .write_blocks
-        .checked_add(artifact.bytes.div_ceil(V4_ORDINAL_BLOCK_BYTES as u64))
-        .ok_or_else(|| storage_err("v4 write block count overflow"))?;
-    Ok(artifact)
+    let published = (|| -> Result<bool, GfError> {
+        v4_publication_failure("replace_child")?;
+        match writer
+            .publication
+            .install_child(std::ffi::OsStr::new(&artifact.name))
+        {
+            Ok(()) => {
+                writer.publication.sync_parent().map_err(storage_err)?;
+                v4_publication_failure("directory_sync")?;
+                v4_publication_failure("post_publication_metric_overflow")?;
+                Ok(true)
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let existing = writer
+                    .publication
+                    .open_sibling(std::ffi::OsStr::new(&artifact.name))
+                    .map_err(storage_err)?;
+                authenticate_private_v4_artifact_file(existing, &artifact)?;
+                cleanup_v4_publication(&mut writer.publication)?;
+                Ok(false)
+            }
+            Err(error) => Err(storage_err(error)),
+        }
+    })();
+    let owns_publication = match published {
+        Ok(owns_publication) => owns_publication,
+        Err(primary) => {
+            let cleanup = cleanup_v4_publication(&mut writer.publication);
+            return combine_v4_cleanup(Err(primary), cleanup, "v4 publication cleanup");
+        }
+    };
+    let publication = if owns_publication {
+        Some(writer.publication)
+    } else {
+        None
+    };
+    *metrics = committed_metrics;
+    Ok(GuardedV4Artifact {
+        artifact,
+        publication,
+    })
 }
 
 struct V4OrdinalRangeWriter {
@@ -705,9 +928,14 @@ impl V4OrdinalRangeWriter {
         index: &graphforge_filesystem::StableDirectory,
         ordinal: usize,
         first_node_id: u64,
+        cache_window: std::num::NonZeroU64,
     ) -> Result<Self, GfError> {
         Ok(Self {
-            artifact: StreamingV4Artifact::create(index, &format!("ordinal-{ordinal:08}"))?,
+            artifact: StreamingV4Artifact::create_with_window(
+                index,
+                &format!("ordinal-{ordinal:08}"),
+                cache_window,
+            )?,
             first_node_id,
             count: 0,
             block: Vec::with_capacity(V4_ORDINAL_BLOCK_BYTES),
@@ -744,33 +972,49 @@ impl V4OrdinalRangeWriter {
         self.block.clear();
         Ok(())
     }
+
+    fn cleanup_unpublished(
+        self,
+    ) -> (
+        graphforge_filesystem::FileCacheReleaseEvidence,
+        Result<(), GfError>,
+    ) {
+        self.artifact.cleanup_unpublished()
+    }
 }
 
 fn finish_streamed_v4_range(
-    index: &graphforge_filesystem::StableDirectory,
     generation: u64,
     mut writer: V4OrdinalRangeWriter,
     ranges: &mut Vec<crate::V4OrdinalRange>,
+    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
     metrics: &mut V4OrdinalBuildMetrics,
 ) -> Result<(), GfError> {
-    if writer.count == 0 {
-        return Err(storage_err("v4 ordinal range is empty"));
+    let prepared = if writer.count == 0 {
+        Err(storage_err("v4 ordinal range is empty"))
+    } else {
+        writer.finish_block()
+    };
+    if let Err(primary) = prepared {
+        let (cache_release, cleanup) = writer.cleanup_unpublished();
+        merge_cache_release_evidence(&mut metrics.cache_release, cache_release);
+        return combine_v4_cleanup(Err(primary), cleanup, "v4 ordinal failed output cleanup");
     }
-    writer.finish_block()?;
     let artifact = finish_streamed_v4_artifact(
         writer.artifact,
-        index,
         "ordinal-v4",
         generation,
         crate::V4OrdinalArtifactKind::OrdinalUuids,
         metrics,
     )?;
+    let artifact_name = artifact.artifact.name.clone();
     ranges.push(crate::V4OrdinalRange {
         first_node_id: writer.first_node_id,
         count: writer.count,
-        artifact,
+        artifact: artifact.artifact,
         blocks: writer.blocks,
     });
+    retain_v4_publication(publications, artifact_name, artifact.publication);
     Ok(())
 }
 
@@ -1281,6 +1525,7 @@ pub(crate) struct ConstructionIndexEncoding {
     pub retained_payload_bytes: u64,
     pub peak_buffer_bytes: u64,
     pub peak_temporary_bytes: u64,
+    pub cache_release: graphforge_filesystem::FileCacheReleaseEvidence,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -1293,10 +1538,72 @@ pub(crate) struct V4OrdinalPublicationMetrics {
 
 pub(crate) fn publish_v4_construction_artifacts(
     encoded: &graphforge_filesystem::StableDirectory,
-    manifest: &crate::V4OrdinalIdentityManifest,
+    bundle: V4ConstructionArtifactBundle,
     generation: u64,
     topology_delta_sha256: &str,
-) -> Result<(Vec<ConstructionIndexOutput>, V4OrdinalPublicationMetrics), GfError> {
+) -> Result<
+    (
+        Vec<ConstructionIndexOutput>,
+        V4OrdinalPublicationMetrics,
+        V4OrdinalBuildMetrics,
+    ),
+    GfError,
+> {
+    let V4ConstructionArtifactBundle {
+        manifest,
+        metrics,
+        mut publications,
+    } = bundle;
+    let published = publish_v4_construction_artifacts_inner(
+        encoded,
+        &manifest,
+        &metrics,
+        &mut publications,
+        generation,
+        topology_delta_sha256,
+    );
+    match published {
+        Ok(published) => {
+            commit_v4_publications(publications, V4AuthorityTransactionProof)?;
+            Ok(published)
+        }
+        Err(primary) => {
+            let cleanup = cleanup_v4_publications(&mut publications);
+            combine_v4_cleanup(Err(primary), cleanup, "v4 authority transaction cleanup")
+        }
+    }
+}
+
+fn cleanup_v4_publications(
+    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+) -> Result<(), GfError> {
+    let mut cleanup = Ok(());
+    for (_, mut publication) in publications.drain(..).rev() {
+        cleanup = combine_v4_cleanup(
+            cleanup,
+            cleanup_v4_publication(&mut publication),
+            "v4 publication guard cleanup",
+        );
+    }
+    cleanup
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn publish_v4_construction_artifacts_inner(
+    encoded: &graphforge_filesystem::StableDirectory,
+    manifest: &crate::V4OrdinalIdentityManifest,
+    metrics: &V4OrdinalBuildMetrics,
+    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    generation: u64,
+    topology_delta_sha256: &str,
+) -> Result<
+    (
+        Vec<ConstructionIndexOutput>,
+        V4OrdinalPublicationMetrics,
+        V4OrdinalBuildMetrics,
+    ),
+    GfError,
+> {
     let graph = encoded
         .open_child_directory(std::ffi::OsStr::new("graph"))
         .map_err(storage_err)?;
@@ -1327,6 +1634,7 @@ pub(crate) fn publish_v4_construction_artifacts(
         })
         .collect::<Vec<_>>();
     crate::graph_construction::construction_failpoint("v4_publish.after_artifacts");
+    v4_authority_failure("after_artifacts")?;
     index.sync().map_err(storage_err)?;
     work.fsync_operations = work.fsync_operations.saturating_add(1);
     crate::graph_construction::construction_failpoint("v4_publish.after_artifacts_fsync");
@@ -1338,43 +1646,36 @@ pub(crate) fn publish_v4_construction_artifacts(
     // The selected project generation is still unpublished. Install the
     // receipt first, then its manifest, and create the lock last so every
     // visible construction inventory is complete and reopenable.
-    outputs.push(install_construction_bytes(
-        &index,
-        V4_ORDINAL_RECEIPT,
-        &receipt_body,
-        &mut work,
-    )?);
+    let (receipt_output, receipt_publication) =
+        install_construction_bytes(&index, V4_ORDINAL_RECEIPT, &receipt_body, &mut work)?;
+    outputs.push(receipt_output);
+    publications.push((V4_ORDINAL_RECEIPT.to_owned(), receipt_publication));
     crate::graph_construction::construction_failpoint("v4_publish.after_receipt_install");
-    outputs.push(install_construction_bytes(
-        &index,
-        V4_ORDINAL_MANIFEST,
-        &manifest_body,
-        &mut work,
-    )?);
+    let (manifest_output, manifest_publication) =
+        install_construction_bytes(&index, V4_ORDINAL_MANIFEST, &manifest_body, &mut work)?;
+    outputs.push(manifest_output);
+    publications.push((V4_ORDINAL_MANIFEST.to_owned(), manifest_publication));
     crate::graph_construction::construction_failpoint("v4_publish.after_manifest_install");
-    outputs.push(install_construction_bytes(
-        &index,
-        "ordinal-v4.lock",
-        &[],
-        &mut work,
-    )?);
+    let (lock_output, lock_publication) =
+        install_construction_bytes(&index, "ordinal-v4.lock", &[], &mut work)?;
+    outputs.push(lock_output);
+    publications.push(("ordinal-v4.lock".to_owned(), lock_publication));
     crate::graph_construction::construction_failpoint("v4_publish.after_lock_install");
     index.sync().map_err(storage_err)?;
     topology.sync().map_err(storage_err)?;
     graph.sync().map_err(storage_err)?;
     encoded.sync().map_err(storage_err)?;
+    v4_authority_failure("directory_sync")?;
     work.fsync_operations = work.fsync_operations.saturating_add(4);
-    Ok((
-        outputs,
-        V4OrdinalPublicationMetrics {
-            write_bytes: work.write_bytes,
-            write_operations: work.write_operations,
-            fsync_operations: work.fsync_operations,
-            peak_temporary_bytes: artifact_bytes
-                .checked_add(work.write_bytes)
-                .ok_or_else(|| storage_err("v4 publication temporary byte count overflow"))?,
-        },
-    ))
+    let publication_metrics = V4OrdinalPublicationMetrics {
+        write_bytes: work.write_bytes,
+        write_operations: work.write_operations,
+        fsync_operations: work.fsync_operations,
+        peak_temporary_bytes: artifact_bytes
+            .checked_add(work.write_bytes)
+            .ok_or_else(|| storage_err("v4 publication temporary byte count overflow"))?,
+    };
+    Ok((outputs, publication_metrics, metrics.clone()))
 }
 
 #[derive(Default)]
@@ -1389,6 +1690,24 @@ struct ConstructionIndexWork {
     retained_payload_bytes: u64,
     peak_buffer_bytes: u64,
     peak_temporary_bytes: u64,
+    cache_release: graphforge_filesystem::FileCacheReleaseEvidence,
+}
+
+fn merge_cache_release_evidence(
+    target: &mut graphforge_filesystem::FileCacheReleaseEvidence,
+    source: graphforge_filesystem::FileCacheReleaseEvidence,
+) {
+    target.sync_operations = target
+        .sync_operations
+        .saturating_add(source.sync_operations);
+    target.release_operations = target
+        .release_operations
+        .saturating_add(source.release_operations);
+    target.unsupported_operations = target
+        .unsupported_operations
+        .saturating_add(source.unsupported_operations);
+    target.released_bytes = target.released_bytes.saturating_add(source.released_bytes);
+    target.peak_window_bytes = target.peak_window_bytes.max(source.peak_window_bytes);
 }
 
 #[derive(Serialize, Deserialize)]
@@ -2581,7 +2900,7 @@ fn encode_construction_index_inner(
     let mut work = ConstructionIndexWork::default();
     let identity_temp = format!(".construction-identities-{}.tmp", Uuid::new_v4().simple());
     let surrogate_temp = format!(".construction-surrogates-{}.tmp", Uuid::new_v4().simple());
-    let mut input = source
+    let input = source
         .open_child_file(std::ffi::OsStr::new(identities_name))
         .map_err(storage_err)?;
     let input_len = input.metadata().map_err(storage_err)?.len();
@@ -2613,16 +2932,34 @@ fn encode_construction_index_inner(
     );
     write_construction_intent(&index, &intent, &mut work)?;
     crate::graph_construction::construction_failpoint("uuid_encode.after_intent");
-    let mut identity_writer = index
+    let identity_writer = index
         .create_replaceable_child_file(std::ffi::OsStr::new(&identity_temp))
         .map_err(storage_err)?;
-    let mut surrogate_writer = index
+    let surrogate_writer = index
         .create_replaceable_child_file(std::ffi::OsStr::new(&surrogate_temp))
         .map_err(storage_err)?;
     let identity_identity =
         graphforge_filesystem::file_identity(&identity_writer).map_err(storage_err)?;
     let surrogate_identity =
         graphforge_filesystem::file_identity(&surrogate_writer).map_err(storage_err)?;
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(3).map_err(storage_err)?;
+    let mut input = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+        input,
+        cache_window,
+        graphforge_filesystem::FileCacheReleaseTracker::default(),
+    )
+    .map_err(storage_err)?;
+    let mut identity_writer = graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(
+        identity_writer,
+        cache_window,
+    )
+    .map_err(storage_err)?;
+    let mut surrogate_writer = graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(
+        surrogate_writer,
+        cache_window,
+    )
+    .map_err(storage_err)?;
     crate::graph_construction::construction_failpoint("uuid_encode.after_temps");
     let aligned_input_bytes = (BULK_IO_BYTES / IDENTITY_RECORD_WIDTH) * IDENTITY_RECORD_WIDTH;
     let aligned_surrogate_bytes =
@@ -2636,68 +2973,86 @@ fn encode_construction_index_inner(
     let mut edge_count = 0_u64;
     let mut source_digest = Sha256::new();
     let mut remaining = input_len;
-    while remaining != 0 {
-        if cancelled() {
-            return Err(storage_err("construction index encoding cancelled"));
-        }
-        let count =
-            usize::try_from(remaining.min(input_block.len() as u64)).map_err(storage_err)?;
-        input
-            .read_exact(&mut input_block[..count])
-            .map_err(storage_err)?;
-        source_digest.update(&input_block[..count]);
-        work.read_bytes = work.read_bytes.saturating_add(count as u64);
-        work.read_operations = work.read_operations.saturating_add(1);
-        for record in input_block[..count].chunks_exact_mut(IDENTITY_RECORD_WIDTH) {
-            let uuid: [u8; 16] = record[..16].try_into().expect("fixed UUID");
-            if previous_uuid.is_some_and(|prior| prior >= uuid)
-                || record[17..24].iter().any(|byte| *byte != 0)
-            {
-                return Err(storage_err("construction identity stream is not canonical"));
+    let streamed = (|| -> Result<(), GfError> {
+        while remaining != 0 {
+            if cancelled() {
+                return Err(storage_err("construction index encoding cancelled"));
             }
-            previous_uuid = Some(uuid);
-            match record[16] {
-                0 => {
-                    let surrogate = u64::from_be_bytes(record[24..32].try_into().expect("fixed"));
-                    if surrogate == 0 || surrogate <= previous_surrogate {
-                        return Err(storage_err(
-                            "construction node surrogate stream is not increasing",
-                        ));
-                    }
-                    previous_surrogate = surrogate;
-                    if surrogate_block.len() + NODE_LOOKUP_RECORD_WIDTH > aligned_surrogate_bytes {
-                        surrogate_writer
-                            .write_all(&surrogate_block)
-                            .map_err(storage_err)?;
-                        work.write_bytes = work
-                            .write_bytes
-                            .saturating_add(surrogate_block.len() as u64);
-                        work.write_operations = work.write_operations.saturating_add(1);
-                        surrogate_block.clear();
-                    }
-                    surrogate_block.extend_from_slice(&surrogate.to_be_bytes());
-                    surrogate_block.extend_from_slice(&uuid);
-                    node_count = node_count.saturating_add(1);
+            let count =
+                usize::try_from(remaining.min(input_block.len() as u64)).map_err(storage_err)?;
+            input
+                .read_exact(&mut input_block[..count])
+                .map_err(storage_err)?;
+            source_digest.update(&input_block[..count]);
+            work.read_bytes = work.read_bytes.saturating_add(count as u64);
+            work.read_operations = work.read_operations.saturating_add(1);
+            for record in input_block[..count].chunks_exact_mut(IDENTITY_RECORD_WIDTH) {
+                let uuid: [u8; 16] = record[..16].try_into().expect("fixed UUID");
+                if previous_uuid.is_some_and(|prior| prior >= uuid)
+                    || record[17..24].iter().any(|byte| *byte != 0)
+                {
+                    return Err(storage_err("construction identity stream is not canonical"));
                 }
-                1 => {
-                    // Construction assigns edge surrogates for topology; v3
-                    // edge membership deliberately stores zero.
-                    record[24..32].fill(0);
-                    edge_count = edge_count.saturating_add(1);
+                previous_uuid = Some(uuid);
+                match record[16] {
+                    0 => {
+                        let surrogate =
+                            u64::from_be_bytes(record[24..32].try_into().expect("fixed"));
+                        if surrogate == 0 || surrogate <= previous_surrogate {
+                            return Err(storage_err(
+                                "construction node surrogate stream is not increasing",
+                            ));
+                        }
+                        previous_surrogate = surrogate;
+                        if surrogate_block.len() + NODE_LOOKUP_RECORD_WIDTH
+                            > aligned_surrogate_bytes
+                        {
+                            surrogate_writer
+                                .write_all(&surrogate_block)
+                                .map_err(storage_err)?;
+                            work.write_bytes = work
+                                .write_bytes
+                                .saturating_add(surrogate_block.len() as u64);
+                            work.write_operations = work.write_operations.saturating_add(1);
+                            surrogate_block.clear();
+                        }
+                        surrogate_block.extend_from_slice(&surrogate.to_be_bytes());
+                        surrogate_block.extend_from_slice(&uuid);
+                        node_count = node_count.saturating_add(1);
+                    }
+                    1 => {
+                        // Construction assigns edge surrogates for topology; v3
+                        // edge membership deliberately stores zero.
+                        record[24..32].fill(0);
+                        edge_count = edge_count.saturating_add(1);
+                    }
+                    _ => return Err(storage_err("construction identity kind is invalid")),
                 }
-                _ => return Err(storage_err("construction identity kind is invalid")),
             }
+            identity_writer
+                .write_all(&input_block[..count])
+                .map_err(storage_err)?;
+            work.write_bytes = work.write_bytes.saturating_add(count as u64);
+            work.write_operations = work.write_operations.saturating_add(1);
+            remaining -= count as u64;
         }
-        identity_writer
-            .write_all(&input_block[..count])
-            .map_err(storage_err)?;
-        work.write_bytes = work.write_bytes.saturating_add(count as u64);
-        work.write_operations = work.write_operations.saturating_add(1);
-        remaining -= count as u64;
-    }
-    if hex_bytes(&source_digest.finalize()) != identities_sha256 {
-        return Err(storage_err("construction identity source digest changed"));
-    }
+        if hex_bytes(&source_digest.finalize()) != identities_sha256 {
+            return Err(storage_err("construction identity source digest changed"));
+        }
+        Ok(())
+    })();
+    let released = input.finish().map_err(storage_err);
+    let input_cache_release = match (streamed, released) {
+        (Ok(()), Ok(released)) => released,
+        (Ok(()), Err(release)) => return Err(release),
+        (Err(primary), Ok(_)) => return Err(primary),
+        (Err(primary), Err(release)) => {
+            return Err(storage_err(format!(
+                "{primary}; construction identity cache release also failed: {release}"
+            )));
+        }
+    };
+    merge_cache_release_evidence(&mut work.cache_release, input_cache_release);
     if !surrogate_block.is_empty() {
         surrogate_writer
             .write_all(&surrogate_block)
@@ -2716,11 +3071,28 @@ fn encode_construction_index_inner(
     }
     identity_writer.flush().map_err(storage_err)?;
     surrogate_writer.flush().map_err(storage_err)?;
-    identity_writer.sync_all().map_err(storage_err)?;
-    surrogate_writer.sync_all().map_err(storage_err)?;
-    work.fsync_operations = work.fsync_operations.saturating_add(2);
-    drop(identity_writer);
-    drop(surrogate_writer);
+    identity_writer
+        .sync_all_and_release()
+        .map_err(storage_err)?;
+    surrogate_writer
+        .sync_all_and_release()
+        .map_err(storage_err)?;
+    let identity_cache_release = identity_writer.evidence();
+    let surrogate_cache_release = surrogate_writer.evidence();
+    work.fsync_operations = work
+        .fsync_operations
+        .saturating_add(identity_cache_release.sync_operations)
+        .saturating_add(surrogate_cache_release.sync_operations);
+    merge_cache_release_evidence(&mut work.cache_release, identity_cache_release);
+    merge_cache_release_evidence(&mut work.cache_release, surrogate_cache_release);
+    let aggregate_peak = input_cache_release
+        .peak_window_bytes
+        .checked_add(identity_cache_release.peak_window_bytes)
+        .and_then(|peak| peak.checked_add(surrogate_cache_release.peak_window_bytes))
+        .ok_or_else(|| storage_err("construction index aggregate cache window overflow"))?;
+    work.cache_release.peak_window_bytes = work.cache_release.peak_window_bytes.max(aggregate_peak);
+    drop(identity_writer.into_file());
+    drop(surrogate_writer.into_file());
 
     let mut artifacts = Vec::new();
     let identity_record = describe_and_install_construction_run(
@@ -2816,7 +3188,8 @@ fn encode_construction_index_inner(
     validate_run_descriptors(&manifest)?;
 
     let body = serde_json::to_vec(&manifest).map_err(storage_err)?;
-    let manifest_output = install_construction_bytes(&index, MANIFEST, &body, &mut work)?;
+    let (manifest_output, manifest_publication) =
+        install_construction_bytes(&index, MANIFEST, &body, &mut work)?;
     crate::graph_construction::construction_failpoint("uuid_encode.after_manifest");
     artifacts.push(manifest_output);
     let retained_names = manifest_file_names(&manifest);
@@ -2893,6 +3266,10 @@ fn encode_construction_index_inner(
     graph.sync().map_err(storage_err)?;
     encoded.sync().map_err(storage_err)?;
     work.fsync_operations = work.fsync_operations.saturating_add(4);
+    commit_v4_publications(
+        vec![(MANIFEST.to_owned(), manifest_publication)],
+        V4AuthorityTransactionProof,
+    )?;
     Ok(ConstructionIndexEncoding {
         artifacts,
         retained_references,
@@ -2908,6 +3285,7 @@ fn encode_construction_index_inner(
         retained_payload_bytes: work.retained_payload_bytes,
         peak_buffer_bytes: work.peak_buffer_bytes,
         peak_temporary_bytes: work.peak_temporary_bytes,
+        cache_release: work.cache_release,
     })
 }
 
@@ -3162,11 +3540,11 @@ fn authenticate_private_v4_artifact_residue(
             allowed.insert(name.clone());
             continue;
         }
-        let mut file = index
+        let file = index
             .open_child_file(std::ffi::OsStr::new(name))
             .map_err(storage_err)?;
         let length = file.metadata().map_err(storage_err)?.len();
-        let digest = sha256_reader_streaming(&mut file)?;
+        let digest = sha256_reader_streaming(file)?;
         let suffix = name
             .strip_suffix(".uuidx")
             .and_then(|name| name.rsplit_once('-'))
@@ -3205,12 +3583,19 @@ fn authenticate_private_v4_artifact(
     if !is_exact_private_v4_name(&artifact.name) || artifact.name.starts_with(".v4-") {
         return Err(storage_err("private v4 artifact name is noncanonical"));
     }
-    let mut file = index
+    let file = index
         .open_child_file(std::ffi::OsStr::new(&artifact.name))
         .map_err(storage_err)?;
+    authenticate_private_v4_artifact_file(file, artifact)
+}
+
+fn authenticate_private_v4_artifact_file(
+    file: File,
+    artifact: &crate::V4OrdinalArtifact,
+) -> Result<(), GfError> {
     if graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1
         || file.metadata().map_err(storage_err)?.len() != artifact.bytes
-        || sha256_reader_streaming(&mut file)? != artifact.sha256
+        || sha256_reader_streaming(file)? != artifact.sha256
     {
         return Err(storage_err("private v4 artifact authentication failed"));
     }
@@ -3258,17 +3643,30 @@ fn canonical_lower_hex(value: &str, length: usize) -> bool {
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
-fn sha256_reader_streaming(reader: &mut impl Read) -> Result<String, GfError> {
+fn sha256_reader_streaming(file: File) -> Result<String, GfError> {
+    let mut reader =
+        graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(storage_err)?;
     let mut digest = Sha256::new();
     let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
-    loop {
-        let read = reader.read(&mut buffer).map_err(storage_err)?;
-        if read == 0 {
-            break;
+    let hashed = (|| -> Result<String, GfError> {
+        loop {
+            let read = reader.read(&mut buffer).map_err(storage_err)?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
         }
-        digest.update(&buffer[..read]);
+        Ok(hex_bytes(&digest.finalize()))
+    })();
+    let released = reader.finish().map_err(storage_err);
+    match (hashed, released) {
+        (Ok(digest), Ok(_)) => Ok(digest),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(primary), Ok(_)) => Err(primary),
+        (Err(primary), Err(release)) => Err(storage_err(format!(
+            "{primary}; private v4 cache release also failed: {release}"
+        ))),
     }
-    Ok(hex_bytes(&digest.finalize()))
 }
 
 fn write_construction_intent(
@@ -3389,7 +3787,7 @@ fn compact_construction_levels(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // Streamed merge keeps both reader cleanups coupled to the primary result.
 fn merge_construction_records(
     output: &graphforge_filesystem::StableDirectory,
     parent: Option<&AuthenticatedUuidIndexSnapshot>,
@@ -3404,22 +3802,67 @@ fn merge_construction_records(
     work: &mut ConstructionIndexWork,
     cancelled: &mut impl FnMut() -> bool,
 ) -> Result<FileRecord, GfError> {
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(3).map_err(storage_err)?;
     let mut left_reader = ConstructionBlockCursor::new(
         open_construction_source(output, parent, left, output_names, retained_payload_bytes)?,
         left.clone(),
         width,
+        cache_window,
     )?;
-    let mut right_reader = ConstructionBlockCursor::new(
-        open_construction_source(output, parent, right, output_names, retained_payload_bytes)?,
-        right.clone(),
-        width,
-    )?;
+    let right_source =
+        open_construction_source(output, parent, right, output_names, retained_payload_bytes);
+    let right_source = match right_source {
+        Ok(source) => source,
+        Err(primary) => {
+            return combine_cache_cleanup(
+                Err(primary),
+                left_reader.finish_cache(),
+                "left construction merge source",
+            );
+        }
+    };
+    let right_reader =
+        ConstructionBlockCursor::new(right_source, right.clone(), width, cache_window);
+    let mut right_reader = match right_reader {
+        Ok(reader) => reader,
+        Err(primary) => {
+            return combine_cache_cleanup(
+                Err(primary),
+                left_reader.finish_cache(),
+                "left construction merge source",
+            );
+        }
+    };
     let temporary = format!(".construction-merge-{}.tmp", Uuid::new_v4().simple());
     let file = output
         .create_replaceable_child_file(std::ffi::OsStr::new(&temporary))
-        .map_err(storage_err)?;
-    let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
-    let mut writer = file;
+        .map_err(storage_err);
+    let file = match file {
+        Ok(file) => file,
+        Err(primary) => {
+            return finish_construction_cursor_pair(primary, &mut left_reader, &mut right_reader);
+        }
+    };
+    let identity = match graphforge_filesystem::file_identity(&file).map_err(storage_err) {
+        Ok(identity) => identity,
+        Err(primary) => {
+            return finish_construction_cursor_pair(primary, &mut left_reader, &mut right_reader);
+        }
+    };
+    let mut writer =
+        match graphforge_filesystem::DurableFileCacheWriter::with_window_bytes(file, cache_window)
+            .map_err(storage_err)
+        {
+            Ok(writer) => writer,
+            Err(primary) => {
+                return finish_construction_cursor_pair(
+                    primary,
+                    &mut left_reader,
+                    &mut right_reader,
+                );
+            }
+        };
     let key_width = if width == IDENTITY_RECORD_WIDTH {
         16
     } else {
@@ -3427,47 +3870,64 @@ fn merge_construction_records(
     };
     let output_bytes = (BULK_IO_BYTES / width) * width;
     let mut output_block = Vec::with_capacity(output_bytes);
-    while left_reader.current().is_some() || right_reader.current().is_some() {
-        let take_left = match (left_reader.current(), right_reader.current()) {
-            (Some(left), Some(right)) => {
-                if left[..key_width] == right[..key_width] {
-                    return Err(storage_err("construction index merge found duplicate key"));
+    let merged = (|| -> Result<(), GfError> {
+        while left_reader.current().is_some() || right_reader.current().is_some() {
+            let take_left = match (left_reader.current(), right_reader.current()) {
+                (Some(left), Some(right)) => {
+                    if left[..key_width] == right[..key_width] {
+                        return Err(storage_err("construction index merge found duplicate key"));
+                    }
+                    left[..key_width] < right[..key_width]
                 }
-                left[..key_width] < right[..key_width]
+                (Some(_), None) => true,
+                (None, Some(_)) => false,
+                (None, None) => break,
+            };
+            let selected = if take_left {
+                left_reader.current().expect("left exists")
+            } else {
+                right_reader.current().expect("right exists")
+            };
+            output_block.extend_from_slice(selected);
+            if take_left {
+                left_reader.advance()?;
+            } else {
+                right_reader.advance()?;
             }
-            (Some(_), None) => true,
-            (None, Some(_)) => false,
-            (None, None) => break,
-        };
-        let selected = if take_left {
-            left_reader.current().expect("left exists")
-        } else {
-            right_reader.current().expect("right exists")
-        };
-        output_block.extend_from_slice(selected);
-        if take_left {
-            left_reader.advance()?;
-        } else {
-            right_reader.advance()?;
+            if output_block.len() + width > output_bytes {
+                if cancelled() {
+                    return Err(storage_err("construction index encoding cancelled"));
+                }
+                writer.write_all(&output_block).map_err(storage_err)?;
+                work.write_bytes = work.write_bytes.saturating_add(output_block.len() as u64);
+                work.write_operations = work.write_operations.saturating_add(1);
+                output_block.clear();
+            }
         }
-        if output_block.len() + width > output_bytes {
-            if cancelled() {
-                return Err(storage_err("construction index encoding cancelled"));
-            }
+        if !output_block.is_empty() {
             writer.write_all(&output_block).map_err(storage_err)?;
             work.write_bytes = work.write_bytes.saturating_add(output_block.len() as u64);
             work.write_operations = work.write_operations.saturating_add(1);
-            output_block.clear();
         }
-    }
-    if !output_block.is_empty() {
-        writer.write_all(&output_block).map_err(storage_err)?;
-        work.write_bytes = work.write_bytes.saturating_add(output_block.len() as u64);
-        work.write_operations = work.write_operations.saturating_add(1);
-    }
-    writer.flush().map_err(storage_err)?;
-    writer.sync_all().map_err(storage_err)?;
-    work.fsync_operations = work.fsync_operations.saturating_add(1);
+        writer.flush().map_err(storage_err)
+    })();
+    let merged = combine_cache_cleanup(
+        merged,
+        left_reader.finish_cache(),
+        "left construction merge source",
+    );
+    let merged = combine_cache_cleanup(
+        merged,
+        right_reader.finish_cache(),
+        "right construction merge source",
+    );
+    merged?;
+    writer.sync_all_and_release().map_err(storage_err)?;
+    let write_cache_release = writer.evidence();
+    work.fsync_operations = work
+        .fsync_operations
+        .saturating_add(write_cache_release.sync_operations);
+    merge_cache_release_evidence(&mut work.cache_release, write_cache_release);
     work.read_bytes = work
         .read_bytes
         .saturating_add(left_reader.read_bytes)
@@ -3476,14 +3936,16 @@ fn merge_construction_records(
         .read_operations
         .saturating_add(left_reader.read_operations)
         .saturating_add(right_reader.read_operations);
-    drop(writer);
+    merge_cache_release_evidence(&mut work.cache_release, left_reader.cache_release);
+    merge_cache_release_evidence(&mut work.cache_release, right_reader.cache_release);
+    drop(writer.into_file());
     describe_and_install_construction_run(
         output, &temporary, identity, prefix, generation, width, artifacts, work,
     )
 }
 
 struct ConstructionBlockCursor {
-    file: File,
+    file: graphforge_filesystem::FileCacheReleasingReader,
     descriptor: FileRecord,
     width: usize,
     block: Vec<u8>,
@@ -3494,12 +3956,24 @@ struct ConstructionBlockCursor {
     finished: bool,
     read_bytes: u64,
     read_operations: u64,
+    cache_release: graphforge_filesystem::FileCacheReleaseEvidence,
+    cache_finished: bool,
 }
 
 impl ConstructionBlockCursor {
-    fn new(file: File, descriptor: FileRecord, width: usize) -> Result<Self, GfError> {
+    fn new(
+        file: File,
+        descriptor: FileRecord,
+        width: usize,
+        cache_window: std::num::NonZeroU64,
+    ) -> Result<Self, GfError> {
         let mut cursor = Self {
-            file,
+            file: graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                file,
+                cache_window,
+                graphforge_filesystem::FileCacheReleaseTracker::default(),
+            )
+            .map_err(storage_err)?,
             descriptor,
             width,
             block: Vec::new(),
@@ -3510,8 +3984,17 @@ impl ConstructionBlockCursor {
             finished: false,
             read_bytes: 0,
             read_operations: 0,
+            cache_release: graphforge_filesystem::FileCacheReleaseEvidence::default(),
+            cache_finished: false,
         };
-        cursor.fill()?;
+        if let Err(primary) = cursor.fill() {
+            combine_cache_cleanup::<()>(
+                Err(primary),
+                cursor.finish_cache(),
+                "construction merge source",
+            )?;
+            unreachable!("failed construction cursor initialization returned success");
+        }
         Ok(cursor)
     }
 
@@ -3534,14 +4017,20 @@ impl ConstructionBlockCursor {
     fn fill(&mut self) -> Result<(), GfError> {
         if self.block_index == self.descriptor.blocks.len() {
             self.finished = true;
-            if self.records != self.descriptor.count
+            let authenticated = if self.records != self.descriptor.count
                 || hex_bytes(&self.digest.clone().finalize()) != self.descriptor.sha256
             {
-                return Err(storage_err(
+                Err(storage_err(
                     "construction merge source authentication failed",
-                ));
-            }
-            return Ok(());
+                ))
+            } else {
+                Ok(())
+            };
+            return combine_cache_cleanup(
+                authenticated,
+                self.finish_cache(),
+                "construction merge source",
+            );
         }
         let expected = &self.descriptor.blocks[self.block_index];
         if expected.offset != self.records.saturating_mul(self.width as u64)
@@ -3573,6 +4062,61 @@ impl ConstructionBlockCursor {
         self.within = 0;
         Ok(())
     }
+
+    fn finish_cache(&mut self) -> Result<(), GfError> {
+        if !self.cache_finished {
+            self.cache_release = self.file.finish().map_err(storage_err)?;
+            self.cache_finished = true;
+        }
+        Ok(())
+    }
+}
+
+fn combine_cache_cleanup<T>(
+    primary: Result<T, GfError>,
+    cleanup: Result<(), GfError>,
+    source: &str,
+) -> Result<T, GfError> {
+    match (primary, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup)) => Err(cleanup),
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(cleanup)) => Err(storage_err(format!(
+            "{primary}; {source} cache release also failed: {cleanup}"
+        ))),
+    }
+}
+
+fn combine_v4_cleanup<T>(
+    primary: Result<T, GfError>,
+    cleanup: Result<(), GfError>,
+    context: &str,
+) -> Result<T, GfError> {
+    match (primary, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(cleanup)) => Err(cleanup),
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(cleanup)) => Err(storage_err(format!(
+            "{primary}; {context} also failed: {cleanup}"
+        ))),
+    }
+}
+
+fn finish_construction_cursor_pair<T>(
+    primary: GfError,
+    left: &mut ConstructionBlockCursor,
+    right: &mut ConstructionBlockCursor,
+) -> Result<T, GfError> {
+    let result = combine_cache_cleanup(
+        Err(primary),
+        left.finish_cache(),
+        "left construction merge source",
+    );
+    combine_cache_cleanup(
+        result,
+        right.finish_cache(),
+        "right construction merge source",
+    )
 }
 
 fn open_construction_source(
@@ -3633,7 +4177,7 @@ fn describe_and_install_construction_run(
     artifacts: &mut Vec<ConstructionIndexOutput>,
     work: &mut ConstructionIndexWork,
 ) -> Result<FileRecord, GfError> {
-    let mut file = output
+    let file = output
         .open_child_file(std::ffi::OsStr::new(temporary))
         .map_err(storage_err)?;
     let bytes = file.metadata().map_err(storage_err)?.len();
@@ -3646,41 +4190,58 @@ fn describe_and_install_construction_run(
     } else {
         8
     };
+    let mut file =
+        graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(storage_err)?;
     let mut digest = Sha256::new();
     let mut blocks = Vec::new();
     let mut offset = 0_u64;
     let mut buffer = vec![0_u8; block_bytes];
-    loop {
-        let mut filled = 0;
-        while filled < buffer.len() {
-            let read = file.read(&mut buffer[filled..]).map_err(storage_err)?;
-            if read == 0 {
+    let described = (|| -> Result<(), GfError> {
+        loop {
+            let mut filled = 0;
+            while filled < buffer.len() {
+                let read = file.read(&mut buffer[filled..]).map_err(storage_err)?;
+                if read == 0 {
+                    break;
+                }
+                filled += read;
+                work.read_bytes = work.read_bytes.saturating_add(read as u64);
+                work.read_operations = work.read_operations.saturating_add(1);
+            }
+            if filled == 0 {
                 break;
             }
-            filled += read;
-            work.read_bytes = work.read_bytes.saturating_add(read as u64);
-            work.read_operations = work.read_operations.saturating_add(1);
+            if filled % width != 0 {
+                return Err(storage_err("construction index block framing changed"));
+            }
+            let block = &buffer[..filled];
+            digest.update(block);
+            blocks.push(BlockRecord {
+                offset,
+                len: u32::try_from(filled).map_err(storage_err)?,
+                first_key: hex_bytes(&block[..key_width]),
+                last_key: hex_bytes(&block[filled - width..filled - width + key_width]),
+                sha256: hex_sha256(block),
+            });
+            offset = offset.saturating_add(filled as u64);
+            if filled < buffer.len() {
+                break;
+            }
         }
-        if filled == 0 {
-            break;
+        Ok(())
+    })();
+    let released = file.finish().map_err(storage_err);
+    let read_cache_release = match (described, released) {
+        (Ok(()), Ok(released)) => released,
+        (Ok(()), Err(release)) => return Err(release),
+        (Err(primary), Ok(_)) => return Err(primary),
+        (Err(primary), Err(release)) => {
+            return Err(storage_err(format!(
+                "{primary}; construction run cache release also failed: {release}"
+            )));
         }
-        if filled % width != 0 {
-            return Err(storage_err("construction index block framing changed"));
-        }
-        let block = &buffer[..filled];
-        digest.update(block);
-        blocks.push(BlockRecord {
-            offset,
-            len: u32::try_from(filled).map_err(storage_err)?,
-            first_key: hex_bytes(&block[..key_width]),
-            last_key: hex_bytes(&block[filled - width..filled - width + key_width]),
-            sha256: hex_sha256(block),
-        });
-        offset = offset.saturating_add(filled as u64);
-        if filled < buffer.len() {
-            break;
-        }
-    }
+    };
+    merge_cache_release_evidence(&mut work.cache_release, read_cache_release);
     let sha256 = hex_bytes(&digest.finalize());
     let name = format!("{prefix}-{generation}-{}.uuidx", &sha256[..16]);
     output
@@ -3710,12 +4271,18 @@ fn install_construction_bytes(
     name: &str,
     bytes: &[u8],
     work: &mut ConstructionIndexWork,
-) -> Result<ConstructionIndexOutput, GfError> {
+) -> Result<
+    (
+        ConstructionIndexOutput,
+        graphforge_filesystem::UnpublishedArtifactGuard,
+    ),
+    GfError,
+> {
     let temporary = format!(".{name}-{}.tmp", Uuid::new_v4().simple());
-    let mut file = output
-        .create_replaceable_child_file(std::ffi::OsStr::new(&temporary))
+    let mut publication = output
+        .create_unpublished_replaceable_child(std::ffi::OsStr::new(&temporary))
         .map_err(storage_err)?;
-    let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
+    let mut file = publication.take_file().map_err(storage_err)?;
     file.write_all(bytes).map_err(storage_err)?;
     work.write_bytes = work.write_bytes.saturating_add(bytes.len() as u64);
     work.write_operations = work.write_operations.saturating_add(1);
@@ -3734,20 +4301,35 @@ fn install_construction_bytes(
         crate::graph_construction::construction_failpoint(failpoint);
     }
     drop(file);
-    output
-        .replace_child(
-            std::ffi::OsStr::new(&temporary),
-            identity,
-            std::ffi::OsStr::new(name),
-        )
-        .map_err(storage_err)?;
-    output.sync().map_err(storage_err)?;
+    let installed = publication
+        .install_child(std::ffi::OsStr::new(name))
+        .map_err(storage_err)
+        .and_then(|()| publication.sync_parent().map_err(storage_err));
+    if let Err(primary) = installed {
+        let cleanup = cleanup_v4_publication(&mut publication);
+        return combine_v4_cleanup(Err(primary), cleanup, "v4 construction control cleanup");
+    }
+    let authority_point = match name {
+        V4_ORDINAL_RECEIPT => Some("receipt_install"),
+        V4_ORDINAL_MANIFEST => Some("manifest_install"),
+        "ordinal-v4.lock" => Some("lock_install"),
+        _ => None,
+    };
+    if let Some(point) = authority_point
+        && let Err(primary) = v4_authority_failure(point)
+    {
+        let cleanup = cleanup_v4_publication(&mut publication);
+        return combine_v4_cleanup(Err(primary), cleanup, "v4 construction control cleanup");
+    }
     work.fsync_operations = work.fsync_operations.saturating_add(1);
-    Ok(ConstructionIndexOutput {
-        name: name.to_owned(),
-        bytes: bytes.len() as u64,
-        sha256: hex_sha256(bytes),
-    })
+    Ok((
+        ConstructionIndexOutput {
+            name: name.to_owned(),
+            bytes: bytes.len() as u64,
+            sha256: hex_sha256(bytes),
+        },
+        publication,
+    ))
 }
 
 impl UuidMembershipIndex {
@@ -6414,9 +6996,14 @@ pub(crate) fn prepare_v4_ordinal_delta(
     while let Some((node_id, uuid)) = read_surrogate_record(&mut ordinal)? {
         writer.push_ordinal(node_id, Uuid::from_bytes(uuid), &mut cancelled)?;
     }
-    let (delta_manifest, build) = writer.finish()?;
+    let V4ConstructionArtifactBundle {
+        manifest: delta_manifest,
+        metrics: build,
+        publications: delta_publications,
+    } = writer.finish()?;
     let (tombstones, tombstone_bytes, tombstone_blocks) =
         write_v4_tombstone_artifact(&artifacts, generation, &deleted)?;
+    let tombstone_name = tombstones.run.artifact.name.clone();
     crate::project_failpoint::hit(
         "v4_append.after_delta_artifacts",
         None,
@@ -6433,7 +7020,7 @@ pub(crate) fn prepare_v4_ordinal_delta(
     manifest
         .ordinal_ranges
         .extend(delta_manifest.ordinal_ranges);
-    manifest.tombstones.push(tombstones);
+    manifest.tombstones.push(tombstones.run);
     manifest
         .ordinal_ranges
         .sort_unstable_by_key(|range| range.first_node_id);
@@ -6447,7 +7034,7 @@ pub(crate) fn prepare_v4_ordinal_delta(
         .map(|artifact| (artifact.name.clone(), artifacts_path.join(&artifact.name)))
         .collect::<HashMap<_, _>>();
     let delta_created_artifacts = u64::try_from(created.len()).map_err(storage_err)?;
-    let compaction = compact_v4_binary_carry(
+    let mut compaction = compact_v4_binary_carry(
         pinned,
         &artifacts,
         &artifacts_path,
@@ -6463,6 +7050,7 @@ pub(crate) fn prepare_v4_ordinal_delta(
             false,
         )?;
     }
+    v4_publication_failure("manifest_update")?;
     admit_v4_construction_manifest(&manifest)?;
 
     let destination = project_dir.join(INDEX_DIR);
@@ -6566,9 +7154,11 @@ pub(crate) fn prepare_v4_ordinal_delta(
             .saturating_add(compaction.fsync_operations)
             .saturating_add(u64::try_from(outputs.len()).map_err(storage_err)?)
             .saturating_add(2),
+        cache_release: compaction.cache_release,
+        peak_configured_cache_window_bytes: compaction.peak_configured_cache_window_bytes,
         ..Default::default()
     };
-    Ok(PreparedV4OrdinalDelta {
+    let prepared = PreparedV4OrdinalDelta {
         expected_generation: generation,
         auxiliary: crate::AuxiliaryReceipt {
             kind: "uuid-membership/v4".to_owned(),
@@ -6579,7 +7169,27 @@ pub(crate) fn prepare_v4_ordinal_delta(
         },
         metrics,
         manifest,
-    })
+    };
+    let mut authority_publications = Vec::new();
+    if retained_names.contains(&tombstone_name) {
+        retain_v4_publication(
+            &mut authority_publications,
+            tombstone_name,
+            tombstones.publication,
+        );
+    }
+    for (name, publication) in delta_publications {
+        if retained_names.contains(&name) {
+            authority_publications.push((name, publication));
+        }
+    }
+    for (name, publication) in compaction.publications.drain(..) {
+        if retained_names.contains(&name) {
+            authority_publications.push((name, publication));
+        }
+    }
+    commit_v4_publications(authority_publications, V4AuthorityTransactionProof)?;
+    Ok(prepared)
 }
 
 const V4_PLAN_PREFIX: &str = "uuid-membership-v4-plan-";
@@ -6787,7 +7397,7 @@ fn write_v4_tombstone_artifact(
     index: &graphforge_filesystem::StableDirectory,
     generation: u64,
     ids: &[u64],
-) -> Result<(crate::V4OrdinalTombstones, u64, u64), GfError> {
+) -> Result<(GuardedV4Tombstones, u64, u64), GfError> {
     let mut writer = V4TombstoneStreamWriter::new(index, generation)?;
     for &id in ids {
         writer.push(id)?;
@@ -6795,8 +7405,12 @@ fn write_v4_tombstone_artifact(
     writer.finish()
 }
 
-struct V4TombstoneStreamWriter<'a> {
-    index: &'a graphforge_filesystem::StableDirectory,
+struct GuardedV4Tombstones {
+    run: crate::V4OrdinalTombstones,
+    publication: Option<graphforge_filesystem::UnpublishedArtifactGuard>,
+}
+
+struct V4TombstoneStreamWriter {
     generation: u64,
     artifact: StreamingV4Artifact,
     blocks: Vec<crate::V4OrdinalTombstoneBlock>,
@@ -6805,15 +7419,28 @@ struct V4TombstoneStreamWriter<'a> {
     previous: Option<u64>,
 }
 
-impl<'a> V4TombstoneStreamWriter<'a> {
+impl V4TombstoneStreamWriter {
     fn new(
-        index: &'a graphforge_filesystem::StableDirectory,
+        index: &graphforge_filesystem::StableDirectory,
         generation: u64,
     ) -> Result<Self, GfError> {
+        let cache_window =
+            graphforge_filesystem::cache_release_window_for_streams(1).map_err(storage_err)?;
+        Self::new_with_cache_window(index, generation, cache_window)
+    }
+
+    fn new_with_cache_window(
+        index: &graphforge_filesystem::StableDirectory,
+        generation: u64,
+        cache_window: std::num::NonZeroU64,
+    ) -> Result<Self, GfError> {
         Ok(Self {
-            index,
             generation,
-            artifact: StreamingV4Artifact::create(index, "tombstones-delta")?,
+            artifact: StreamingV4Artifact::create_with_window(
+                index,
+                "tombstones-delta",
+                cache_window,
+            )?,
             blocks: Vec::new(),
             block: Vec::with_capacity(V4_ORDINAL_BLOCK_BYTES),
             offset: 0,
@@ -6840,32 +7467,73 @@ impl<'a> V4TombstoneStreamWriter<'a> {
         Ok(())
     }
 
-    fn finish(mut self) -> Result<(crate::V4OrdinalTombstones, u64, u64), GfError> {
-        finish_v4_tombstone_block(
+    fn finish(self) -> Result<(GuardedV4Tombstones, u64, u64), GfError> {
+        let (run, bytes, fsyncs, _) = self.finish_with_cache_evidence()?;
+        Ok((run, bytes, fsyncs))
+    }
+
+    fn finish_with_cache_evidence(
+        mut self,
+    ) -> Result<
+        (
+            GuardedV4Tombstones,
+            u64,
+            u64,
+            graphforge_filesystem::FileCacheReleaseEvidence,
+        ),
+        GfError,
+    > {
+        let prepared = finish_v4_tombstone_block(
             &mut self.artifact,
             &mut self.blocks,
             &mut self.block,
             &mut self.offset,
-        )?;
+        );
+        if let Err(primary) = prepared {
+            let (_, cleanup) = self.cleanup_unpublished();
+            return combine_v4_cleanup(Err(primary), cleanup, "v4 tombstone failed output cleanup");
+        }
         let byte_count = self.artifact.bytes;
         let mut metrics = V4OrdinalBuildMetrics::default();
         let artifact = finish_streamed_v4_artifact(
             self.artifact,
-            self.index,
             "tombstones-v4",
             self.generation,
             crate::V4OrdinalArtifactKind::NodeTombstones,
             &mut metrics,
         )?;
         Ok((
-            crate::V4OrdinalTombstones {
-                generation: self.generation,
-                artifact,
-                blocks: self.blocks,
+            GuardedV4Tombstones {
+                run: crate::V4OrdinalTombstones {
+                    generation: self.generation,
+                    artifact: artifact.artifact,
+                    blocks: self.blocks,
+                },
+                publication: artifact.publication,
             },
             byte_count,
             metrics.fsync_operations,
+            metrics.cache_release,
         ))
+    }
+
+    fn cleanup_unpublished(
+        mut self,
+    ) -> (
+        graphforge_filesystem::FileCacheReleaseEvidence,
+        Result<(), GfError>,
+    ) {
+        let prepared = finish_v4_tombstone_block(
+            &mut self.artifact,
+            &mut self.blocks,
+            &mut self.block,
+            &mut self.offset,
+        );
+        let (cache_release, cleanup) = self.artifact.cleanup_unpublished();
+        (
+            cache_release,
+            combine_v4_cleanup(prepared, cleanup, "v4 tombstone output cleanup"),
+        )
     }
 }
 
@@ -6919,9 +7587,31 @@ struct V4CompactionWork {
     write_bytes: u64,
     write_blocks: u64,
     fsync_operations: u64,
+    cache_release: graphforge_filesystem::FileCacheReleaseEvidence,
+    peak_configured_cache_window_bytes: u64,
+    publications: Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
 }
 
 fn compact_v4_binary_carry(
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    artifacts: &graphforge_filesystem::StableDirectory,
+    artifacts_path: &Path,
+    manifest: &mut crate::V4OrdinalIdentityManifest,
+    created: &mut HashMap<String, PathBuf>,
+) -> Result<V4CompactionWork, GfError> {
+    let prior_manifest = manifest.clone();
+    let prior_created = created.clone();
+    match compact_v4_binary_carry_inner(pinned, artifacts, artifacts_path, manifest, created) {
+        Ok(work) => Ok(work),
+        Err(error) => {
+            *manifest = prior_manifest;
+            *created = prior_created;
+            Err(error)
+        }
+    }
+}
+
+fn compact_v4_binary_carry_inner(
     pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
     artifacts: &graphforge_filesystem::StableDirectory,
     artifacts_path: &Path,
@@ -6949,13 +7639,18 @@ fn compact_v4_binary_carry(
             &mut work,
         )?;
         created.insert(
-            merged_forward.name.clone(),
-            artifacts_path.join(&merged_forward.name),
+            merged_forward.artifact.name.clone(),
+            artifacts_path.join(&merged_forward.artifact.name),
         );
         work.created_artifacts = work.created_artifacts.saturating_add(1);
         manifest
             .forward_identities
-            .splice(left.2..=right.2, std::iter::once(merged_forward));
+            .splice(left.2..=right.2, std::iter::once(merged_forward.artifact));
+        retain_v4_publication(
+            &mut work.publications,
+            manifest.forward_identities[left.2].name.clone(),
+            merged_forward.publication,
+        );
 
         compact_v4_ordinal_interval(
             pinned,
@@ -7028,56 +7723,277 @@ fn read_v4_forward_record(reader: &mut impl Read) -> Result<Option<([u8; 16], u6
     )))
 }
 
+type V4CompactionReader = BufReader<graphforge_filesystem::FileCacheReleasingReader>;
+
+fn finish_v4_compaction_readers<T>(
+    mut primary: Result<T, GfError>,
+    readers: &mut [V4CompactionReader],
+    work: &mut V4CompactionWork,
+    source: &str,
+) -> Result<T, GfError> {
+    for reader in readers {
+        let released = reader.get_mut().finish().map_err(storage_err);
+        if let Ok(evidence) = released {
+            merge_cache_release_evidence(&mut work.cache_release, evidence);
+        }
+        let released = inject_v4_input_release_result(released);
+        primary = combine_cache_cleanup(primary, released.map(|_| ()), source);
+    }
+    primary
+}
+
+fn record_v4_compaction_windows(
+    work: &mut V4CompactionWork,
+    windows: &[std::num::NonZeroU64],
+) -> Result<(), GfError> {
+    let aggregate = graphforge_filesystem::validate_cache_release_operation_windows(windows)
+        .map_err(storage_err)?;
+    work.peak_configured_cache_window_bytes =
+        work.peak_configured_cache_window_bytes.max(aggregate);
+    Ok(())
+}
+
+#[cfg(test)]
+thread_local! {
+    static V4_COMPACTION_POST_WRITE_FAILURE: std::cell::RefCell<Option<&'static str>> =
+        const { std::cell::RefCell::new(None) };
+    static V4_OUTPUT_CLEANUP_FAILURE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static V4_INPUT_RELEASE_FAILURE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static V4_PUBLICATION_FAILURE: std::cell::RefCell<Option<&'static str>> =
+        const { std::cell::RefCell::new(None) };
+    static V4_AUTHORITY_FAILURE: std::cell::RefCell<Option<&'static str>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn inject_v4_compaction_post_write_failure(point: &'static str) {
+    V4_COMPACTION_POST_WRITE_FAILURE.with(|failure| *failure.borrow_mut() = Some(point));
+}
+
+#[cfg(test)]
+pub(crate) fn inject_v4_output_cleanup_failure() {
+    V4_OUTPUT_CLEANUP_FAILURE.with(|failure| failure.set(true));
+}
+
+#[cfg(test)]
+fn inject_v4_input_release_failure() {
+    V4_INPUT_RELEASE_FAILURE.with(|failure| failure.set(true));
+}
+
+#[cfg(test)]
+fn inject_v4_publication_failure(point: &'static str) {
+    V4_PUBLICATION_FAILURE.with(|failure| *failure.borrow_mut() = Some(point));
+}
+
+#[cfg(test)]
+pub(crate) fn inject_v4_authority_failure(point: &'static str) {
+    V4_AUTHORITY_FAILURE.with(|failure| *failure.borrow_mut() = Some(point));
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn v4_authority_failure(point: &str) -> Result<(), GfError> {
+    #[cfg(test)]
+    V4_AUTHORITY_FAILURE.with(|failure| {
+        if failure
+            .borrow()
+            .is_some_and(|configured| configured == point)
+        {
+            failure.borrow_mut().take();
+            return Err(storage_err(format!(
+                "injected v4 authority failure at {point}"
+            )));
+        }
+        Ok(())
+    })?;
+    #[cfg(not(test))]
+    let _ = point;
+    Ok(())
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn v4_publication_failure(point: &str) -> Result<(), GfError> {
+    #[cfg(test)]
+    V4_PUBLICATION_FAILURE.with(|failure| {
+        if failure
+            .borrow()
+            .is_some_and(|configured| configured == point)
+        {
+            failure.borrow_mut().take();
+            return Err(storage_err(format!(
+                "injected v4 publication failure at {point}"
+            )));
+        }
+        Ok(())
+    })?;
+    #[cfg(not(test))]
+    let _ = point;
+    Ok(())
+}
+
+fn v4_publication_io_failure(point: &str) -> std::io::Result<()> {
+    v4_publication_failure(point)
+        .map_err(|_| std::io::Error::other(format!("injected v4 publication failure at {point}")))
+}
+
+fn inject_v4_input_release_result(
+    released: Result<graphforge_filesystem::FileCacheReleaseEvidence, GfError>,
+) -> Result<graphforge_filesystem::FileCacheReleaseEvidence, GfError> {
+    #[cfg(test)]
+    if released.is_ok() && V4_INPUT_RELEASE_FAILURE.with(|failure| failure.replace(false)) {
+        return Err(storage_err("injected v4 input release failure"));
+    }
+    released
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn take_v4_output_cleanup_failure() -> Result<(), GfError> {
+    #[cfg(test)]
+    if V4_OUTPUT_CLEANUP_FAILURE.with(|failure| failure.replace(false)) {
+        return Err(storage_err("injected v4 output cleanup failure"));
+    }
+    Ok(())
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn v4_compaction_post_write_failure(point: &str) -> Result<(), GfError> {
+    #[cfg(test)]
+    V4_COMPACTION_POST_WRITE_FAILURE.with(|failure| {
+        if failure
+            .borrow()
+            .is_some_and(|configured| configured == point)
+        {
+            failure.borrow_mut().take();
+            return Err(storage_err(format!(
+                "v4 compaction cancelled after {point} output"
+            )));
+        }
+        Ok(())
+    })?;
+    #[cfg(not(test))]
+    let _ = point;
+    Ok(())
+}
+
+fn fail_v4_compaction_with_output_cleanup<T>(
+    primary: GfError,
+    writer: StreamingV4Artifact,
+    work: &mut V4CompactionWork,
+    context: &str,
+) -> Result<T, GfError> {
+    let (cache_release, cleanup) = writer.cleanup_unpublished();
+    merge_cache_release_evidence(&mut work.cache_release, cache_release);
+    combine_v4_cleanup(Err(primary), cleanup, context)
+}
+
+#[allow(clippy::too_many_lines)]
 fn merge_v4_forward_artifacts(
     left: File,
     right: File,
     index: &graphforge_filesystem::StableDirectory,
     generation: u64,
     work: &mut V4CompactionWork,
-) -> Result<crate::V4OrdinalArtifact, GfError> {
+) -> Result<GuardedV4Artifact, GfError> {
+    let cache_window =
+        graphforge_filesystem::cache_release_window_for_streams(3).map_err(storage_err)?;
     let mut readers = [
-        BufReader::with_capacity(V4_ORDINAL_BLOCK_BYTES, left),
-        BufReader::with_capacity(V4_ORDINAL_BLOCK_BYTES, right),
+        BufReader::with_capacity(
+            V4_ORDINAL_BLOCK_BYTES,
+            graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                left,
+                cache_window,
+                graphforge_filesystem::FileCacheReleaseTracker::default(),
+            )
+            .map_err(storage_err)?,
+        ),
+        BufReader::with_capacity(
+            V4_ORDINAL_BLOCK_BYTES,
+            graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                right,
+                cache_window,
+                graphforge_filesystem::FileCacheReleaseTracker::default(),
+            )
+            .map_err(storage_err)?,
+        ),
     ];
-    let mut heads = [
-        read_v4_forward_record(&mut readers[0])?,
-        read_v4_forward_record(&mut readers[1])?,
-    ];
-    let mut writer = StreamingV4Artifact::create(index, "forward-compact")?;
-    let mut previous = None;
-    loop {
-        let source = match (heads[0], heads[1]) {
-            (None, None) => break,
-            (Some(_), None) => 0,
-            (None, Some(_)) => 1,
-            (Some(left), Some(right)) => usize::from(left.0 >= right.0),
-        };
-        let record = heads[source].expect("selected head");
-        if heads[0].is_some_and(|candidate| candidate.0 == record.0)
-            && heads[1].is_some_and(|candidate| candidate.0 == record.0)
-        {
-            let newer = heads[1].expect("right duplicate");
-            heads[0] = read_v4_forward_record(&mut readers[0])?;
-            heads[1] = read_v4_forward_record(&mut readers[1])?;
-            if record.1 != newer.1 {
-                return Err(storage_err("v4 compaction observed UUID reuse"));
+    let mut writer =
+        StreamingV4Artifact::create_with_window(index, "forward-compact", cache_window)?;
+    let configured = record_v4_compaction_windows(
+        work,
+        &[
+            readers[0].get_ref().window_bytes(),
+            readers[1].get_ref().window_bytes(),
+            writer.writer.get_ref().window_bytes(),
+        ],
+    );
+    if let Err(primary) = configured {
+        let primary = finish_v4_compaction_readers::<()>(
+            Err(primary),
+            &mut readers,
+            work,
+            "v4 forward compaction source",
+        )
+        .expect_err("primary configuration failure is retained");
+        return fail_v4_compaction_with_output_cleanup(
+            primary,
+            writer,
+            work,
+            "v4 forward output cleanup",
+        );
+    }
+    let merged = (|| -> Result<(), GfError> {
+        let mut heads = [
+            read_v4_forward_record(&mut readers[0])?,
+            read_v4_forward_record(&mut readers[1])?,
+        ];
+        let mut previous = None;
+        loop {
+            let source = match (heads[0], heads[1]) {
+                (None, None) => break,
+                (Some(_), None) => 0,
+                (None, Some(_)) => 1,
+                (Some(left), Some(right)) => usize::from(left.0 >= right.0),
+            };
+            let record = heads[source].expect("selected head");
+            if heads[0].is_some_and(|candidate| candidate.0 == record.0)
+                && heads[1].is_some_and(|candidate| candidate.0 == record.0)
+            {
+                let newer = heads[1].expect("right duplicate");
+                heads[0] = read_v4_forward_record(&mut readers[0])?;
+                heads[1] = read_v4_forward_record(&mut readers[1])?;
+                if record.1 != newer.1 {
+                    return Err(storage_err("v4 compaction observed UUID reuse"));
+                }
+                write_v4_forward_record(&mut writer, newer)?;
+                v4_compaction_post_write_failure("forward")?;
+                previous = Some(newer.0);
+                continue;
             }
-            write_v4_forward_record(&mut writer, newer)?;
-            previous = Some(newer.0);
-            continue;
+            if previous.is_some_and(|uuid| uuid >= record.0) {
+                return Err(storage_err("v4 compaction input is not sorted unique"));
+            }
+            write_v4_forward_record(&mut writer, record)?;
+            v4_compaction_post_write_failure("forward")?;
+            previous = Some(record.0);
+            heads[source] = read_v4_forward_record(&mut readers[source])?;
         }
-        if previous.is_some_and(|uuid| uuid >= record.0) {
-            return Err(storage_err("v4 compaction input is not sorted unique"));
-        }
-        write_v4_forward_record(&mut writer, record)?;
-        previous = Some(record.0);
-        heads[source] = read_v4_forward_record(&mut readers[source])?;
+        Ok(())
+    })();
+    let merged =
+        finish_v4_compaction_readers(merged, &mut readers, work, "v4 forward compaction source");
+    if let Err(primary) = merged {
+        return fail_v4_compaction_with_output_cleanup(
+            primary,
+            writer,
+            work,
+            "v4 forward output cleanup",
+        );
     }
     let input_bytes = readers
         .iter()
         .map(|reader| {
             reader
                 .get_ref()
+                .file()
                 .metadata()
                 .map_or(0, |metadata| metadata.len())
         })
@@ -7093,7 +8009,6 @@ fn merge_v4_forward_artifacts(
     let mut metrics = V4OrdinalBuildMetrics::default();
     let artifact = finish_streamed_v4_artifact(
         writer,
-        index,
         "forward-v4",
         generation,
         crate::V4OrdinalArtifactKind::ForwardIdentities,
@@ -7106,6 +8021,15 @@ fn merge_v4_forward_artifacts(
     work.fsync_operations = work
         .fsync_operations
         .saturating_add(metrics.fsync_operations);
+    let reader_peak = readers.iter().try_fold(0_u64, |sum, reader| {
+        sum.checked_add(reader.get_ref().tracker().evidence().peak_window_bytes)
+            .ok_or_else(|| storage_err("v4 forward reader cache window overflow"))
+    })?;
+    let aggregate_peak = reader_peak
+        .checked_add(metrics.cache_release.peak_window_bytes)
+        .ok_or_else(|| storage_err("v4 forward aggregate cache window overflow"))?;
+    merge_cache_release_evidence(&mut work.cache_release, metrics.cache_release);
+    work.cache_release.peak_window_bytes = work.cache_release.peak_window_bytes.max(aggregate_peak);
     Ok(artifact)
 }
 
@@ -7117,7 +8041,7 @@ fn write_v4_forward_record(
     writer.push(&node_id.to_be_bytes())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn compact_v4_ordinal_interval(
     pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
     index: &graphforge_filesystem::StableDirectory,
@@ -7159,36 +8083,85 @@ fn compact_v4_ordinal_interval(
         if end - start == 1 {
             replacement.push(manifest.ordinal_ranges[start].clone());
         } else {
+            let cache_window =
+                graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage_err)?;
             let mut writer = V4OrdinalRangeWriter::new(
                 index,
                 replacement.len(),
                 manifest.ordinal_ranges[start].first_node_id,
+                cache_window,
             )?;
-            for source in &manifest.ordinal_ranges[start..end] {
-                let mut file = BufReader::with_capacity(
-                    V4_ORDINAL_BLOCK_BYTES,
-                    v4_planned_file(pinned, created, &source.artifact.name)?,
-                );
-                while let Some(uuid) = read_exact_record::<16>(&mut file)? {
-                    writer.push(uuid)?;
+            let compacted = (|| -> Result<u64, GfError> {
+                let mut reader_peak = 0_u64;
+                for source in &manifest.ordinal_ranges[start..end] {
+                    let file = graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                        v4_planned_file(pinned, created, &source.artifact.name)?,
+                        cache_window,
+                        graphforge_filesystem::FileCacheReleaseTracker::default(),
+                    )
+                    .map_err(storage_err)?;
+                    let mut readers = [BufReader::with_capacity(V4_ORDINAL_BLOCK_BYTES, file)];
+                    let copied = record_v4_compaction_windows(
+                        work,
+                        &[
+                            readers[0].get_ref().window_bytes(),
+                            writer.artifact.writer.get_ref().window_bytes(),
+                        ],
+                    )
+                    .and_then(|()| {
+                        while let Some(uuid) = read_exact_record::<16>(&mut readers[0])? {
+                            writer.push(uuid)?;
+                            v4_compaction_post_write_failure("ordinal")?;
+                        }
+                        Ok(())
+                    });
+                    finish_v4_compaction_readers(
+                        copied,
+                        &mut readers,
+                        work,
+                        "v4 ordinal compaction source",
+                    )?;
+                    reader_peak = reader_peak
+                        .max(readers[0].get_ref().tracker().evidence().peak_window_bytes);
+                    work.read_bytes = work.read_bytes.saturating_add(source.artifact.bytes);
+                    work.read_calls = work.read_calls.saturating_add(
+                        source
+                            .artifact
+                            .bytes
+                            .div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
+                    );
+                    work.read_blocks = work.read_blocks.saturating_add(
+                        source
+                            .artifact
+                            .bytes
+                            .div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
+                    );
                 }
-                work.read_bytes = work.read_bytes.saturating_add(source.artifact.bytes);
-                work.read_calls = work.read_calls.saturating_add(
-                    source
-                        .artifact
-                        .bytes
-                        .div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
-                );
-                work.read_blocks = work.read_blocks.saturating_add(
-                    source
-                        .artifact
-                        .bytes
-                        .div_ceil(V4_ORDINAL_BLOCK_BYTES as u64),
-                );
-            }
+                Ok(reader_peak)
+            })();
+            let reader_peak = match compacted {
+                Ok(reader_peak) => reader_peak,
+                Err(primary) => {
+                    let (cache_release, cleanup) = writer.cleanup_unpublished();
+                    merge_cache_release_evidence(&mut work.cache_release, cache_release);
+                    return combine_v4_cleanup(Err(primary), cleanup, "v4 ordinal output cleanup");
+                }
+            };
             let mut ranges = Vec::new();
             let mut metrics = V4OrdinalBuildMetrics::default();
-            finish_streamed_v4_range(index, last_generation, writer, &mut ranges, &mut metrics)?;
+            finish_streamed_v4_range(
+                last_generation,
+                writer,
+                &mut ranges,
+                &mut work.publications,
+                &mut metrics,
+            )?;
+            let aggregate_peak = reader_peak
+                .checked_add(metrics.cache_release.peak_window_bytes)
+                .ok_or_else(|| storage_err("v4 ordinal aggregate cache window overflow"))?;
+            merge_cache_release_evidence(&mut work.cache_release, metrics.cache_release);
+            work.cache_release.peak_window_bytes =
+                work.cache_release.peak_window_bytes.max(aggregate_peak);
             let merged = ranges.pop().expect("one merged range");
             created.insert(
                 merged.artifact.name.clone(),
@@ -7213,7 +8186,7 @@ fn compact_v4_ordinal_interval(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn compact_v4_tombstone_interval(
     pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
     index: &graphforge_filesystem::StableDirectory,
@@ -7233,40 +8206,86 @@ fn compact_v4_tombstone_interval(
     if selected.len() < 2 {
         return Ok(());
     }
+    let active_streams = selected
+        .len()
+        .checked_add(1)
+        .ok_or_else(|| storage_err("v4 tombstone compaction stream count overflow"))?;
+    let cache_window = graphforge_filesystem::cache_release_window_for_streams(active_streams)
+        .map_err(storage_err)?;
     let mut readers = selected
         .iter()
         .map(|run| {
-            v4_planned_file(pinned, created, &run.artifact.name)
-                .map(|file| BufReader::with_capacity(V4_ORDINAL_BLOCK_BYTES, file))
+            graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                v4_planned_file(pinned, created, &run.artifact.name)?,
+                cache_window,
+                graphforge_filesystem::FileCacheReleaseTracker::default(),
+            )
+            .map(|file| BufReader::with_capacity(V4_ORDINAL_BLOCK_BYTES, file))
+            .map_err(storage_err)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let mut heap = BinaryHeap::<Reverse<(u64, usize)>>::new();
-    for (source, reader) in readers.iter_mut().enumerate() {
-        if let Some(bytes) = read_exact_record::<8>(reader)? {
-            heap.push(Reverse((u64::from_be_bytes(bytes), source)));
+    let mut merged =
+        V4TombstoneStreamWriter::new_with_cache_window(index, last_generation, cache_window)?;
+    let mut windows = readers
+        .iter()
+        .map(|reader| reader.get_ref().window_bytes())
+        .collect::<Vec<_>>();
+    windows.push(merged.artifact.writer.get_ref().window_bytes());
+    let combined = record_v4_compaction_windows(work, &windows).and_then(|()| {
+        let mut heap = BinaryHeap::<Reverse<(u64, usize)>>::new();
+        for (source, reader) in readers.iter_mut().enumerate() {
+            if let Some(bytes) = read_exact_record::<8>(reader)? {
+                heap.push(Reverse((u64::from_be_bytes(bytes), source)));
+            }
         }
+        let mut previous = None;
+        while let Some(Reverse((id, source))) = heap.pop() {
+            if previous != Some(id) {
+                merged.push(id)?;
+                v4_compaction_post_write_failure("tombstone")?;
+                previous = Some(id);
+            }
+            if let Some(bytes) = read_exact_record::<8>(&mut readers[source])? {
+                heap.push(Reverse((u64::from_be_bytes(bytes), source)));
+            }
+        }
+        Ok(())
+    });
+    let combined = finish_v4_compaction_readers(
+        combined,
+        &mut readers,
+        work,
+        "v4 tombstone compaction source",
+    );
+    if let Err(primary) = combined {
+        let (cache_release, cleanup) = merged.cleanup_unpublished();
+        merge_cache_release_evidence(&mut work.cache_release, cache_release);
+        return combine_v4_cleanup(Err(primary), cleanup, "v4 tombstone output cleanup");
     }
-    let mut merged = V4TombstoneStreamWriter::new(index, last_generation)?;
-    let mut previous = None;
-    while let Some(Reverse((id, source))) = heap.pop() {
-        if previous != Some(id) {
-            merged.push(id)?;
-            previous = Some(id);
-        }
-        if let Some(bytes) = read_exact_record::<8>(&mut readers[source])? {
-            heap.push(Reverse((u64::from_be_bytes(bytes), source)));
-        }
-    }
-    let (run, bytes, fsyncs) = merged.finish()?;
+    let reader_peak = readers.iter().try_fold(0_u64, |sum, reader| {
+        sum.checked_add(reader.get_ref().tracker().evidence().peak_window_bytes)
+            .ok_or_else(|| storage_err("v4 tombstone reader cache window overflow"))
+    })?;
+    let (run, bytes, fsyncs, writer_cache_release) = merged.finish_with_cache_evidence()?;
+    let aggregate_peak = reader_peak
+        .checked_add(writer_cache_release.peak_window_bytes)
+        .ok_or_else(|| storage_err("v4 tombstone aggregate cache window overflow"))?;
+    merge_cache_release_evidence(&mut work.cache_release, writer_cache_release);
+    work.cache_release.peak_window_bytes = work.cache_release.peak_window_bytes.max(aggregate_peak);
     created.insert(
-        run.artifact.name.clone(),
-        artifacts_path.join(&run.artifact.name),
+        run.run.artifact.name.clone(),
+        artifacts_path.join(&run.run.artifact.name),
     );
     work.created_artifacts = work.created_artifacts.saturating_add(1);
     manifest
         .tombstones
         .retain(|candidate| !(first_generation..=last_generation).contains(&candidate.generation));
-    manifest.tombstones.push(run);
+    manifest.tombstones.push(run.run);
+    retain_v4_publication(
+        &mut work.publications,
+        manifest.tombstones.last().unwrap().artifact.name.clone(),
+        run.publication,
+    );
     manifest
         .tombstones
         .sort_unstable_by_key(|run| run.generation);
@@ -7383,6 +8402,7 @@ pub fn rebuild_v4_ordinal_identity_with_evidence(
         .ok_or_else(|| storage_err("v4 ordinal rebuild produced no evidence"))
 }
 
+#[allow(clippy::too_many_lines)]
 fn stage_v4_ordinal_rebuild_locked(
     project_dir: &Path,
     generation: u64,
@@ -7470,7 +8490,11 @@ fn stage_v4_ordinal_rebuild_locked(
     while let Some((node_id, uuid)) = read_surrogate_record(&mut ordinal)? {
         writer.push_ordinal(node_id, Uuid::from_bytes(uuid), &mut cancelled)?;
     }
-    let (manifest, v4_metrics) = writer.finish()?;
+    let V4ConstructionArtifactBundle {
+        manifest,
+        metrics: v4_metrics,
+        publications,
+    } = writer.finish()?;
     scratch_accounting.register_artifacts(v4_metrics.peak_temporary_bytes)?;
     metrics.node_count = v4_metrics.input_records;
     stage_v4_rebuild_artifacts(
@@ -7490,6 +8514,7 @@ fn stage_v4_ordinal_rebuild_locked(
             .map_err(|_| storage_err("v4 ordinal manifest length overflow"))?,
     )?;
     scratch_accounting.release_scratch()?;
+    commit_v4_publications(publications, V4AuthorityTransactionProof)?;
     Ok(StagedV4OrdinalRebuild {
         generation,
         build: metrics,
@@ -8727,6 +9752,16 @@ pub(crate) mod tests {
         )
         .unwrap();
         assert_eq!(planned_third.metrics.compactions, 1);
+        assert_eq!(
+            planned_third.metrics.peak_configured_cache_window_bytes,
+            graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        );
+        assert!(
+            planned_third.metrics.cache_release.peak_window_bytes
+                <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        );
+        #[cfg(target_os = "linux")]
+        assert!(planned_third.metrics.cache_release.release_operations > 0);
         assert_eq!(planned_third.manifest.forward_identities.len(), 2);
         assert_eq!(planned_third.manifest.ordinal_ranges.len(), 2);
         assert_eq!(planned_third.manifest.tombstones.len(), 2);
@@ -8813,6 +9848,456 @@ pub(crate) mod tests {
                 .is_err()
             );
             assert!(batch.is_empty());
+        }
+    }
+
+    #[test]
+    fn v4_compaction_fan_in_budget_uses_opened_reader_and_writer_windows() {
+        let root = tempfile::tempdir().unwrap();
+        let index = graphforge_filesystem::StableDirectory::open(root.path()).unwrap();
+        let input_count = 8_usize;
+        let window =
+            graphforge_filesystem::cache_release_window_for_streams(input_count + 1).unwrap();
+        let mut readers = Vec::new();
+        for ordinal in 0..input_count {
+            let path = root.path().join(format!("input-{ordinal}"));
+            std::fs::write(&path, []).unwrap();
+            readers.push(
+                graphforge_filesystem::FileCacheReleasingReader::with_window_bytes(
+                    File::open(path).unwrap(),
+                    window,
+                    graphforge_filesystem::FileCacheReleaseTracker::default(),
+                )
+                .unwrap(),
+            );
+        }
+        let writer = V4TombstoneStreamWriter::new_with_cache_window(&index, 9, window).unwrap();
+        let mut windows = readers
+            .iter()
+            .map(graphforge_filesystem::FileCacheReleasingReader::window_bytes)
+            .collect::<Vec<_>>();
+        windows.push(writer.artifact.writer.get_ref().window_bytes());
+
+        let aggregate =
+            graphforge_filesystem::validate_cache_release_operation_windows(&windows).unwrap();
+        assert!(aggregate <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES);
+        assert!(windows.iter().all(|configured| configured.get() > 0));
+    }
+
+    #[test]
+    fn v4_forward_compaction_failure_releases_consumed_input_without_masking_primary() {
+        let root = tempfile::tempdir().unwrap();
+        let index = graphforge_filesystem::StableDirectory::open(root.path()).unwrap();
+        let left_path = root.path().join("left");
+        let right_path = root.path().join("right");
+        let mut left = Vec::new();
+        left.extend_from_slice(Uuid::from_u128(1).as_bytes());
+        left.extend_from_slice(&1_u64.to_be_bytes());
+        left.push(0xff);
+        let mut right = Vec::new();
+        right.extend_from_slice(Uuid::from_u128(2).as_bytes());
+        right.extend_from_slice(&2_u64.to_be_bytes());
+        std::fs::write(&left_path, left).unwrap();
+        std::fs::write(&right_path, right).unwrap();
+        let mut work = V4CompactionWork::default();
+
+        let error = merge_v4_forward_artifacts(
+            File::open(left_path).unwrap(),
+            File::open(right_path).unwrap(),
+            &index,
+            2,
+            &mut work,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("truncated"), "{error}");
+        assert!(work.peak_configured_cache_window_bytes > 0);
+        assert!(
+            work.peak_configured_cache_window_bytes
+                <= graphforge_filesystem::DEFAULT_CACHE_RELEASE_WINDOW_BYTES
+        );
+        assert!(
+            index
+                .child_names()
+                .unwrap()
+                .into_iter()
+                .all(|name| !name.to_string_lossy().starts_with(".v4-"))
+        );
+        assert!(work.cache_release.sync_operations > 0);
+        #[cfg(target_os = "linux")]
+        assert!(work.cache_release.release_operations >= 3);
+    }
+
+    fn write_v4_test_artifact(
+        index_path: &Path,
+        name: &str,
+        kind: crate::V4OrdinalArtifactKind,
+        generation: u64,
+        bytes: &[u8],
+    ) -> crate::V4OrdinalArtifact {
+        fs::write(index_path.join(name), bytes).unwrap();
+        crate::V4OrdinalArtifact {
+            name: name.to_owned(),
+            kind,
+            generation,
+            bytes: u64::try_from(bytes.len()).unwrap(),
+            sha256: hex_sha256(bytes),
+        }
+    }
+
+    fn assert_no_v4_temporary(index: &graphforge_filesystem::StableDirectory) {
+        assert!(
+            index
+                .child_names()
+                .unwrap()
+                .into_iter()
+                .all(|name| !name.to_string_lossy().starts_with(".v4-"))
+        );
+    }
+
+    #[test]
+    fn v4_forward_cancellation_finalizes_and_removes_unpublished_output() {
+        let root = tempfile::tempdir().unwrap();
+        let index = graphforge_filesystem::StableDirectory::open(root.path()).unwrap();
+        let left = root.path().join("left");
+        let right = root.path().join("right");
+        let mut left_bytes = Vec::new();
+        left_bytes.extend_from_slice(Uuid::from_u128(1).as_bytes());
+        left_bytes.extend_from_slice(&1_u64.to_be_bytes());
+        let mut right_bytes = Vec::new();
+        right_bytes.extend_from_slice(Uuid::from_u128(2).as_bytes());
+        right_bytes.extend_from_slice(&2_u64.to_be_bytes());
+        fs::write(&left, left_bytes).unwrap();
+        fs::write(&right, right_bytes).unwrap();
+        inject_v4_compaction_post_write_failure("forward");
+        inject_v4_output_cleanup_failure();
+        let mut work = V4CompactionWork::default();
+
+        let error = merge_v4_forward_artifacts(
+            File::open(left).unwrap(),
+            File::open(right).unwrap(),
+            &index,
+            2,
+            &mut work,
+        )
+        .unwrap_err()
+        .to_string();
+
+        let primary = error
+            .find("v4 compaction cancelled after forward output")
+            .unwrap();
+        let cleanup = error.find("v4 forward output cleanup also failed").unwrap();
+        assert!(primary < cleanup, "{error}");
+        assert!(
+            error.contains("unpublished artifact cleanup finalization failed"),
+            "{error}"
+        );
+        assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+        assert_no_v4_temporary(&index);
+        assert!(work.cache_release.sync_operations > 0);
+        #[cfg(target_os = "linux")]
+        assert!(work.cache_release.release_operations >= 3);
+
+        inject_v4_input_release_failure();
+        let mut release_work = V4CompactionWork::default();
+        let error = merge_v4_forward_artifacts(
+            File::open(root.path().join("left")).unwrap(),
+            File::open(root.path().join("right")).unwrap(),
+            &index,
+            3,
+            &mut release_work,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("injected v4 input release failure"),
+            "{error}"
+        );
+        assert_no_v4_temporary(&index);
+        assert!(release_work.cache_release.sync_operations > 0);
+    }
+
+    #[test]
+    fn streamed_v4_publication_guard_covers_setup_and_post_rename_failures() {
+        let points = [
+            "initial_file_identity",
+            "writer_construction",
+            "window_validation",
+            "fsync_evidence_overflow",
+            "final_file_identity",
+            "file_space_usage",
+            "replace_child",
+            "directory_sync",
+            "post_publication_metric_overflow",
+            "manifest_update",
+        ];
+        for point in points {
+            let root = tempfile::tempdir().unwrap();
+            let index = graphforge_filesystem::StableDirectory::open(root.path()).unwrap();
+            if matches!(point, "initial_file_identity" | "writer_construction") {
+                inject_v4_output_cleanup_failure();
+            }
+            inject_v4_publication_failure(point);
+            let error = stage_v4_ordinal_artifacts([(Uuid::from_u128(1), 1)], 7, &index, || false)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains(&format!("injected v4 publication failure at {point}")),
+                "{error}"
+            );
+            if matches!(point, "initial_file_identity" | "writer_construction") {
+                let primary = error.find("injected v4 publication failure").unwrap();
+                let cleanup = error
+                    .find("unpublished artifact cleanup finalization failed")
+                    .unwrap();
+                assert!(primary < cleanup, "{error}");
+            }
+            assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+            let names = index
+                .child_names()
+                .unwrap()
+                .into_iter()
+                .filter_map(|name| name.into_string().ok())
+                .collect::<Vec<_>>();
+            assert!(
+                names
+                    .iter()
+                    .all(|name| !name.starts_with(".v4-") && !name.ends_with(".uuidx")),
+                "{point}: {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn content_addressed_v4_install_reuses_identical_and_preserves_collisions() {
+        let root = tempfile::tempdir().unwrap();
+        let encoded = graphforge_filesystem::StableDirectory::open(root.path()).unwrap();
+        let graph = encoded
+            .create_child_directory(std::ffi::OsStr::new("graph"))
+            .unwrap();
+        let topology = graph
+            .create_child_directory(std::ffi::OsStr::new("topology"))
+            .unwrap();
+        let index = topology
+            .create_child_directory(std::ffi::OsStr::new("uuid-membership"))
+            .unwrap();
+        let mappings = [(Uuid::from_u128(1), 1_u64), (Uuid::from_u128(2), 2_u64)];
+        let (manifest, _) = stage_v4_ordinal_artifacts(mappings, 1, &index, || false).unwrap();
+        let names = v4_manifest_artifact_names(&manifest);
+        let originals = names
+            .iter()
+            .map(|name| {
+                let file = index.open_child_file(std::ffi::OsStr::new(name)).unwrap();
+                (
+                    name.clone(),
+                    graphforge_filesystem::file_identity(&file).unwrap(),
+                    fs::read(
+                        root.path()
+                            .join("graph/topology/uuid-membership")
+                            .join(name),
+                    )
+                    .unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let reused = stage_v4_ordinal_bundle(mappings, 1, &index, &mut || false).unwrap();
+        assert!(reused.publications.is_empty());
+        inject_v4_authority_failure("after_artifacts");
+        let error = publish_v4_construction_artifacts(&encoded, reused, 1, &hex_sha256(b"delta"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("injected v4 authority failure at after_artifacts"));
+        for (name, identity, bytes) in &originals {
+            let file = index.open_child_file(std::ffi::OsStr::new(name)).unwrap();
+            assert_eq!(
+                graphforge_filesystem::file_identity(&file).unwrap(),
+                *identity
+            );
+            assert_eq!(
+                fs::read(
+                    root.path()
+                        .join("graph/topology/uuid-membership")
+                        .join(name)
+                )
+                .unwrap(),
+                *bytes
+            );
+        }
+
+        let (conflict_name, conflict_identity, _) = &originals[0];
+        let conflict = b"occupied conflicting authority";
+        fs::write(
+            root.path()
+                .join("graph/topology/uuid-membership")
+                .join(conflict_name),
+            conflict,
+        )
+        .unwrap();
+        let error = stage_v4_ordinal_bundle(mappings, 1, &index, &mut || false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("authentication failed"), "{error}");
+        let file = index
+            .open_child_file(std::ffi::OsStr::new(conflict_name))
+            .unwrap();
+        assert_eq!(
+            graphforge_filesystem::file_identity(&file).unwrap(),
+            *conflict_identity
+        );
+        assert_eq!(
+            fs::read(
+                root.path()
+                    .join("graph/topology/uuid-membership")
+                    .join(conflict_name)
+            )
+            .unwrap(),
+            conflict
+        );
+        assert_no_v4_temporary(&index);
+    }
+
+    #[test]
+    fn v4_ordinal_cancellation_finalizes_and_removes_unpublished_output() {
+        let root = tempfile::tempdir().unwrap();
+        let index_path = root.path().join(INDEX_DIR);
+        fs::create_dir_all(&index_path).unwrap();
+        let index = graphforge_filesystem::StableDirectory::open(&index_path).unwrap();
+        let first_uuid = *Uuid::from_u128(1).as_bytes();
+        let second_uuid = *Uuid::from_u128(2).as_bytes();
+        let first = write_v4_test_artifact(
+            &index_path,
+            "ordinal-one.uuidx",
+            crate::V4OrdinalArtifactKind::OrdinalUuids,
+            1,
+            &first_uuid,
+        );
+        let second = write_v4_test_artifact(
+            &index_path,
+            "ordinal-two.uuidx",
+            crate::V4OrdinalArtifactKind::OrdinalUuids,
+            2,
+            &second_uuid,
+        );
+        let mut manifest = crate::V4OrdinalIdentityManifest {
+            format_version: crate::ORDINAL_IDENTITY_V4,
+            topology_generation: 2,
+            forward_identities: Vec::new(),
+            ordinal_ranges: vec![
+                crate::V4OrdinalRange {
+                    first_node_id: 1,
+                    count: 1,
+                    artifact: first,
+                    blocks: Vec::new(),
+                },
+                crate::V4OrdinalRange {
+                    first_node_id: 2,
+                    count: 1,
+                    artifact: second,
+                    blocks: Vec::new(),
+                },
+            ],
+            tombstones: Vec::new(),
+        };
+        let pinned = pinned_v4_update(root.path(), manifest.clone());
+        let mut created = HashMap::new();
+        let mut work = V4CompactionWork::default();
+        inject_v4_compaction_post_write_failure("ordinal");
+
+        let error = compact_v4_ordinal_interval(
+            &pinned,
+            &index,
+            &index_path,
+            &mut manifest,
+            &mut created,
+            1,
+            2,
+            &mut work,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("v4 compaction cancelled after ordinal output"));
+        assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+        assert_no_v4_temporary(&index);
+        assert!(created.is_empty());
+        assert!(work.cache_release.sync_operations > 0);
+        #[cfg(target_os = "linux")]
+        assert!(work.cache_release.release_operations >= 2);
+    }
+
+    #[test]
+    fn v4_tombstone_cancellation_finalizes_and_removes_unpublished_output() {
+        let root = tempfile::tempdir().unwrap();
+        let index_path = root.path().join(INDEX_DIR);
+        fs::create_dir_all(&index_path).unwrap();
+        let index = graphforge_filesystem::StableDirectory::open(&index_path).unwrap();
+        let first_bytes = 1_u64.to_be_bytes();
+        let second_bytes = 2_u64.to_be_bytes();
+        let first = write_v4_test_artifact(
+            &index_path,
+            "tombstone-one.uuidx",
+            crate::V4OrdinalArtifactKind::NodeTombstones,
+            1,
+            &first_bytes,
+        );
+        let second = write_v4_test_artifact(
+            &index_path,
+            "tombstone-two.uuidx",
+            crate::V4OrdinalArtifactKind::NodeTombstones,
+            2,
+            &second_bytes,
+        );
+        let mut manifest = crate::V4OrdinalIdentityManifest {
+            format_version: crate::ORDINAL_IDENTITY_V4,
+            topology_generation: 2,
+            forward_identities: Vec::new(),
+            ordinal_ranges: Vec::new(),
+            tombstones: vec![
+                crate::V4OrdinalTombstones {
+                    generation: 1,
+                    artifact: first,
+                    blocks: Vec::new(),
+                },
+                crate::V4OrdinalTombstones {
+                    generation: 2,
+                    artifact: second,
+                    blocks: Vec::new(),
+                },
+            ],
+        };
+        let pinned = pinned_v4_update(root.path(), manifest.clone());
+        let mut created = HashMap::new();
+        let mut work = V4CompactionWork::default();
+        inject_v4_compaction_post_write_failure("tombstone");
+
+        let error = compact_v4_tombstone_interval(
+            &pinned,
+            &index,
+            &index_path,
+            &mut manifest,
+            &mut created,
+            1,
+            2,
+            &mut work,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("v4 compaction cancelled after tombstone output"));
+        assert!(!error.contains(root.path().to_string_lossy().as_ref()));
+        assert_no_v4_temporary(&index);
+        assert!(created.is_empty());
+        assert!(work.cache_release.sync_operations > 0);
+        #[cfg(target_os = "linux")]
+        {
+            assert!(work.cache_release.release_operations >= 2);
+            assert!(
+                work.cache_release.released_bytes >= 24,
+                "{:?}",
+                work.cache_release
+            );
         }
     }
 
@@ -9220,8 +10705,8 @@ pub(crate) mod tests {
             .create_child_directory(std::ffi::OsStr::new("uuid-membership"))
             .unwrap();
         let mappings = [(Uuid::from_u128(1), 1_u64), (Uuid::from_u128(2), 3_u64)];
-        let (manifest, _) = stage_v4_ordinal_artifacts(mappings, 1, &index, || false).unwrap();
-        publish_v4_construction_artifacts(&encoded, &manifest, 1, &hex_sha256(b"delta")).unwrap();
+        let bundle = stage_v4_ordinal_bundle(mappings, 1, &index, &mut || false).unwrap();
+        publish_v4_construction_artifacts(&encoded, bundle, 1, &hex_sha256(b"delta")).unwrap();
 
         cleanup_private_construction_index(&encoded).unwrap();
         assert!(index.child_names().unwrap().is_empty());

--- a/scripts/ci/graph500-generator-identity.py
+++ b/scripts/ci/graph500-generator-identity.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Check or regenerate current-source Graph500 generator identity bindings."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+HISTORICAL_COMMIT = "6255f9393362c996b5840566d255569761e881d7"
+HISTORICAL_GENERATOR_IDENTITY = (
+    "sha256:3b4bdf5ae4f41523f911dc1998db2328dadd2fa9e5f95e49478f148e81a14ce2"
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def generator_identity(root: Path) -> str:
+    source = root / "benchmarks/runners/graph500-generator/src/main.rs"
+    return f"sha256:{hashlib.sha256(source.read_bytes()).hexdigest()}"
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: root must be an object")
+    return value
+
+
+def generator_action(value: dict[str, Any], path: Path) -> dict[str, Any]:
+    actions = [
+        phase.get("action")
+        for phase in value.get("phases", [])
+        if isinstance(phase, dict)
+        and isinstance(phase.get("action"), dict)
+        and phase["action"].get("interface") == "benchmark_generator"
+    ]
+    if len(actions) != 1:
+        raise ValueError(f"{path}: expected exactly one benchmark_generator action")
+    return actions[0]
+
+
+def current_documents(root: Path) -> list[tuple[Path, list[dict[str, Any]]]]:
+    documents: list[tuple[Path, list[dict[str, Any]]]] = []
+    profile_dir = root / "benchmarks/profiles/graph500"
+    for path in sorted(profile_dir.glob("*.json")):
+        value = load_object(path)
+        generator = value.get("generator")
+        if not isinstance(generator, dict):
+            raise ValueError(f"{path}: generator must be an object")
+        documents.append((path, [generator, generator_action(value, path)]))
+    fixture = root / "benchmarks/fixtures/progressive/tiny-executable.json"
+    value = load_object(fixture)
+    documents.append((fixture, [generator_action(value, fixture)]))
+    return documents
+
+
+def validate_historical_evidence(root: Path) -> None:
+    path = root / "benchmarks/fixtures/parity/ladder-bundle/manifest.json"
+    manifest = load_object(path)
+    if manifest.get("commit") != HISTORICAL_COMMIT:
+        raise ValueError(f"{path}: historical commit identity changed")
+    if manifest.get("generator_identity") != HISTORICAL_GENERATOR_IDENTITY:
+        raise ValueError(f"{path}: historical generator identity changed")
+
+
+def update_document(path: Path, bindings: list[dict[str, Any]], expected: str) -> int:
+    stale = [binding.get("identity") for binding in bindings if binding.get("identity") != expected]
+    if not all(isinstance(value, str) for value in stale):
+        raise ValueError(f"{path}: current generator identity must be a string")
+    text = path.read_text(encoding="utf-8")
+    for observed, count in Counter(stale).items():
+        quoted = json.dumps(observed)
+        if text.count(quoted) != count:
+            raise ValueError(f"{path}: generator identity occurs outside bound fields")
+        text = text.replace(quoted, json.dumps(expected))
+    if stale:
+        path.write_text(text, encoding="utf-8")
+    return len(stale)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=repo_root())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    validate_historical_evidence(root)
+    expected = generator_identity(root)
+    stale: list[tuple[Path, list[dict[str, Any]]]] = []
+    for path, bindings in current_documents(root):
+        if any(binding.get("identity") != expected for binding in bindings):
+            stale.append((path, bindings))
+    if stale and not args.write:
+        print(f"current Graph500 generator identity is stale: {expected}", file=sys.stderr)
+        return 1
+    updated = sum(update_document(path, bindings, expected) for path, bindings in stale)
+    print(f"current Graph500 generator identity verified: {expected} ({updated} updated)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "0e8388776ea735062c4becc7eb3ef7200fbb16b15d36ceae80b74286a1326a4d",
+  "sha256": "b86739fcc00c0ff528956d8c6e28a5350455393d0b3cf75c84913efdad3a9ff2",
   "entries": [
     {
       "name": "graphforge-api",
@@ -13,6 +13,15 @@
           "features": [
             "prettyprint"
           ],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": null,
+          "target": null
+        },
+        {
+          "name": "bytes",
+          "req": "^1",
+          "features": [],
           "optional": false,
           "uses_default_features": true,
           "kind": null,
@@ -92,11 +101,11 @@
         },
         {
           "name": "graphforge-filesystem",
-          "req": "*",
+          "req": "^0.5.2",
           "features": [],
           "optional": false,
           "uses_default_features": true,
-          "kind": "dev",
+          "kind": null,
           "target": null
         },
         {


### PR DESCRIPTION
Durable construction can exhaust its memory envelope through file-backed cache. Shared filesystem readers and writers now bound active cache windows, synchronize writes before Linux cache advice, and carry measured synchronization evidence through construction and import receipts.

Closes #1110. Refs #951 and #952. #951 retains the full-lifecycle attribution and S20/conditional S22 host outcomes.

The integration fixes three verified defects: empty reads incorrectly marked unread input as exhausted; CAS payload copies discarded periodic synchronization counts; and Windows direct-file certification attempted to synchronize a read-only handle. Boundary tests preserve exact synchronization counts, bytes, hashes, reopened content, and cleanup. Existing Windows CI now exercises the direct-file regression. A reproduced ETXTBSY race in test shell fixtures is fixed by invoking the shell explicitly.

Validation on OVHC-AGENCY:

- Filesystem: 31 tests passed; storage: 946 passed, 2 unchanged ignores; import: 14 passed; actual 1x/2x/4x scale lifecycle: 23 passed.
- Benchmark certification: 24 passed; generator: 2 passed; progressive qualification: 17 passed.
- Boundary regressions failed before the fixes and passed afterward. Native strace confirmed payload synchronization counts 1/1/2 below/at/above each tested window, before successful cache advice. Linux tiny-lifecycle receipt counts reconcile exactly to 38/63/113.
- Workspace and benchmark all-targets clippy, generator identity, formatting, and fast checks passed. Storage tests used an isolated ext4 temporary root as ubuntu.
- Independent review found no remaining issues. Exact-head CI Gate, native Windows regression, Rust, bindings, durability, concurrency, and real tiny lifecycle checks passed at `c34ae921`. Squash-merged as `581b44a2`; #1110 is closed.

No host-scale certification outcome is claimed by this implementation PR.
