### PR TITLE
test(bench): execute live SNB BI2 through the public API

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1827,8 +1827,11 @@ dependencies = [
 name = "graphforge-benchmark-gdc-snb-bi"
 version = "0.0.0"
 dependencies = [
+ "arrow",
+ "graphforge-api",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -110,14 +110,27 @@ PYTHONPATH=harness GRAPHFORGE_GDC_FINBENCH_TRANSACTION_BIN=target/debug/graphfor
 
 Per-suite adapters own workload semantics through their own Rust runner and
 harness module. The SNB BI suite (`gdc_snb_bi`) maps the 20 `BI*` analytical
-reads onto the public Cypher / analyst-verb surface, fails closed on weighted
-shortest-path reads and the `INS*`/`DEL*` batch maintenance stream, validates
-reads against pinned references, and records per-phase resources (load, query,
-spill, RSS, I/O) in a section kept distinct from correctness. Its evidence
-stamps `certification: false`:
+reads onto the public Cypher / analyst-verb surface and fails closed on weighted
+shortest-path reads and the `INS*`/`DEL*` batch maintenance stream. The
+`snb-bi-tiny` fixtures are legacy static validator-contract fixtures: their
+historical `snb-bi-sf0.003` identifier is not an official SF0.003 dataset, their
+`.graph`/`.out` bytes are synthetic replay inputs, and they provide no live
+engine evidence.
+
+The explicit `snb-bi-live` lane closes that static-replay gap for BI2. It loads
+the committed deterministic seed into `GraphForge()` (in-memory), executes the
+supported BI2 shape through `GraphForge.execute`, and sends the resulting rows
+to the existing Rust normalized validator. The reference is independently
+derived from the seed. `identity.json` pins the official SNB specification and
+BI query release/commit while explicitly identifying the synthetic fixture and
+internal Python driver; it does not claim LDBC datagen, official parameters,
+SF0.003, or certification. Live resource timings and row counts remain separate
+from correctness, and unobserved spill/RSS/I/O fields are named rather than
+invented. All evidence stamps `certification: false`:
 
 ```bash
-PYTHONPATH=harness uv run --locked python -m unittest tests.test_gdc_snb_bi
+PYTHONPATH=benchmarks/harness uv run python -m unittest \
+  benchmarks.tests.test_gdc_snb_bi
 ```
 
 ## Public-interface certification runner

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -329,8 +329,8 @@ make -C benchmarks smoke
 The smoke installs only the locked benchmark environment, imports ReFrame and
 BenchExec, discovers the checked-in fixtures, runs the Python unit tests, and
 checks the Rust runners and their public-facade dependency boundary. This includes
-the bounded in-memory Graphalytics fixture through the real GraphForge API. It
-does not start a provider or execute the host scale ladder.
+the bounded in-memory Graphalytics and SNB BI2 fixtures through the real GraphForge
+API. It does not start a provider or execute the host scale ladder.
 
 ## Native local admission
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -118,15 +118,22 @@ historical `snb-bi-sf0.003` identifier is not an official SF0.003 dataset, their
 engine evidence.
 
 The explicit `snb-bi-live` lane closes that static-replay gap for BI2. It loads
-the committed deterministic seed into `GraphForge()` (in-memory), executes the
-supported BI2 shape through `GraphForge.execute`, and sends the resulting rows
-to the existing Rust normalized validator. The reference is independently
-derived from the seed. `identity.json` pins the official SNB specification and
-BI query release/commit while explicitly identifying the synthetic fixture and
-internal Python driver; it does not claim LDBC datagen, official parameters,
-SF0.003, or certification. Live resource timings and row counts remain separate
-from correctness, and unobserved spill/RSS/I/O fields are named rather than
-invented. All evidence stamps `certification: false`:
+the committed deterministic seed into `GraphForge::new(None)`, executes the BI2
+shape through `graphforge_api::GraphForge::execute_with_params`, validates the
+official `diff DESC, tag.name ASC` total order in the same trusted Rust process,
+and directly constructs the evidence. The command accepts no caller result
+rows, source label, parameter digest, or producer field. `run-static-suite` is
+the separate legacy replay command and cannot emit live evidence.
+
+The expected rows are independently derived from the seed. `identity.json`
+pins the complete closed operation context, official SNB specification and BI
+query release/commit, typed parameter names/kinds/values, content-addressed
+synthetic fixture, reference, normalization, and internal Rust driver contract.
+Runner evidence binds its actual executable digest; no nonexistent GraphForge
+release or commit is used. This lane does not claim LDBC datagen, official
+parameters, SF0.003, or certification. Live resource timings and row counts
+remain separate from correctness, and unobserved spill/RSS/I/O fields are named
+rather than invented. All evidence stamps `certification: false`:
 
 ```bash
 PYTHONPATH=benchmarks/harness uv run python -m unittest \

--- a/benchmarks/fixtures/gdc/snb-bi-live/expected-bi2.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-live/expected-bi2.ref
@@ -1,6 +1,7 @@
-# Independently derived from seed.json, not captured from GraphForge.
-# For MusicalArtist tags in [0,100) and [100,200):
-# Beta=(1,3), Gamma=(2,1), Alpha=(2,1); diff=abs(window1-window2).
+# Independently derived from seed.json using official BI2 semantics.
+# ORDER BY diff DESC, tag.name ASC. MusicalArtist windows [0,100)/[100,200):
+# Beta=(1,3) diff=2; Alpha=(2,1) diff=1; Gamma=(2,1) diff=1.
+# SportsTeam Strikers is excluded by $tagClass.
 Beta 1 3 2
-Gamma 2 1 1
 Alpha 2 1 1
+Gamma 2 1 1

--- a/benchmarks/fixtures/gdc/snb-bi-live/expected-bi2.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-live/expected-bi2.ref
@@ -1,6 +1,6 @@
 # Independently derived from seed.json, not captured from GraphForge.
 # For MusicalArtist tags in [0,100) and [100,200):
-# Beta=(1,3), Gamma=(2,0), Alpha=(2,1); diff=abs(window1-window2).
+# Beta=(1,3), Gamma=(2,1), Alpha=(2,1); diff=abs(window1-window2).
 Beta 1 3 2
-Gamma 2 0 2
+Gamma 2 1 1
 Alpha 2 1 1

--- a/benchmarks/fixtures/gdc/snb-bi-live/expected-bi2.ref
+++ b/benchmarks/fixtures/gdc/snb-bi-live/expected-bi2.ref
@@ -1,0 +1,6 @@
+# Independently derived from seed.json, not captured from GraphForge.
+# For MusicalArtist tags in [0,100) and [100,200):
+# Beta=(1,3), Gamma=(2,0), Alpha=(2,1); diff=abs(window1-window2).
+Beta 1 3 2
+Gamma 2 0 2
+Alpha 2 1 1

--- a/benchmarks/fixtures/gdc/snb-bi-live/identity.json
+++ b/benchmarks/fixtures/gdc/snb-bi-live/identity.json
@@ -1,0 +1,46 @@
+{
+  "schema": "graphforge-gdc-snb-bi-live-identity/1",
+  "suite_id": "snb-bi",
+  "operation": "BI2",
+  "certification": false,
+  "upstream_spec": {
+    "source": "https://github.com/ldbc/ldbc_snb_docs",
+    "release": "v2.2.4",
+    "commit": "5f7956e07a214373c363b371a3b88bc83ddcd118"
+  },
+  "upstream_query": {
+    "source": "https://github.com/ldbc/ldbc_snb_bi",
+    "release": "v1.0.0",
+    "commit": "abf8cd4862f2b96ba9267e6298a1f7402439040b",
+    "path": "cypher/queries/bi-2.cypher"
+  },
+  "fixture": {
+    "kind": "synthetic_minimal_snb_shaped",
+    "generator": "committed deterministic seed 963; not ldbc_snb_datagen_spark",
+    "scale_factor": null,
+    "path": "seed.json",
+    "sha256": "9acb1d3413c35a72c0f1ffbf40ef69a330483f8ca2a6da76e939c9adaf999689"
+  },
+  "parameters": {
+    "kind": "internal_deterministic_bi2_parameters",
+    "path": "parameters.json",
+    "sha256": "72806ba8eae872db38f4ee064292e312993741221354706c24f595db03bf6d73"
+  },
+  "reference": {
+    "authority": "independent_semantic_derivation_from_seed",
+    "captured_from_engine": false,
+    "path": "expected-bi2.ref",
+    "sha256": "b8be3e0d66ee2a776ef91d1c67e5b88ed7c436fe0b5a51ab38fd41560a63fb28"
+  },
+  "driver": {
+    "kind": "internal_python_public_api_driver",
+    "durable": false,
+    "interface": "GraphForge.execute",
+    "result_validator": "graphforge-benchmark-gdc-snb-bi"
+  },
+  "normalization": {
+    "upstream_temporal_window": "$date plus 100-day durations",
+    "internal_equivalent": "precomputed integer day boundaries [0,100), [100,200)",
+    "reason": "exercise the current supported Cypher surface without claiming temporal-literal parity"
+  }
+}

--- a/benchmarks/fixtures/gdc/snb-bi-live/identity.json
+++ b/benchmarks/fixtures/gdc/snb-bi-live/identity.json
@@ -19,7 +19,7 @@
     "generator": "committed deterministic seed 963; not ldbc_snb_datagen_spark",
     "scale_factor": null,
     "path": "seed.json",
-    "sha256": "9acb1d3413c35a72c0f1ffbf40ef69a330483f8ca2a6da76e939c9adaf999689"
+    "sha256": "9dc8c9987d4ce403a30808c268d25a6f9fdb451b7a5c68fbd2d37d700b4cb88e"
   },
   "parameters": {
     "kind": "internal_deterministic_bi2_parameters",
@@ -30,7 +30,7 @@
     "authority": "independent_semantic_derivation_from_seed",
     "captured_from_engine": false,
     "path": "expected-bi2.ref",
-    "sha256": "b8be3e0d66ee2a776ef91d1c67e5b88ed7c436fe0b5a51ab38fd41560a63fb28"
+    "sha256": "2a6af839fd9b6dc3b9f92305eea309b71dba26973885a0ae04a3c276a52d9e19"
   },
   "driver": {
     "kind": "internal_python_public_api_driver",

--- a/benchmarks/fixtures/gdc/snb-bi-live/identity.json
+++ b/benchmarks/fixtures/gdc/snb-bi-live/identity.json
@@ -1,7 +1,8 @@
 {
-  "schema": "graphforge-gdc-snb-bi-live-identity/1",
+  "schema": "graphforge-gdc-snb-bi-live-identity/2",
   "suite_id": "snb-bi",
   "operation": "BI2",
+  "source_mode": "runner_owned_rust_api",
   "certification": false,
   "upstream_spec": {
     "source": "https://github.com/ldbc/ldbc_snb_docs",
@@ -15,32 +16,42 @@
     "path": "cypher/queries/bi-2.cypher"
   },
   "fixture": {
+    "dataset_id": "snb-bi-synthetic-minimal",
     "kind": "synthetic_minimal_snb_shaped",
-    "generator": "committed deterministic seed 963; not ldbc_snb_datagen_spark",
+    "provenance_kind": "content_addressed_committed_fixture",
+    "seed": 963,
     "scale_factor": null,
     "path": "seed.json",
     "sha256": "9dc8c9987d4ce403a30808c268d25a6f9fdb451b7a5c68fbd2d37d700b4cb88e"
   },
   "parameters": {
-    "kind": "internal_deterministic_bi2_parameters",
+    "kind": "typed_internal_deterministic_bi2_parameters",
     "path": "parameters.json",
-    "sha256": "72806ba8eae872db38f4ee064292e312993741221354706c24f595db03bf6d73"
+    "file_sha256": "55a5c78e5573909531b6290a38ccc7d670b1a8eb09136ebfc4b4668c45646d7a",
+    "names_kinds_values_sha256": "79ef56283a4ac9320c82415977eb1f2c27574970bccb247e04cfaf02e59384b5"
   },
   "reference": {
     "authority": "independent_semantic_derivation_from_seed",
     "captured_from_engine": false,
+    "validation": "exact_order_numeric_text_normalized",
     "path": "expected-bi2.ref",
-    "sha256": "2a6af839fd9b6dc3b9f92305eea309b71dba26973885a0ae04a3c276a52d9e19"
+    "sha256": "bd4c037d3aae1881e9329e148743d153d4bf671afc1f35d3d7ab4eaab0748d7b"
   },
   "driver": {
-    "kind": "internal_python_public_api_driver",
+    "kind": "internal_rust_public_api_driver",
+    "source_mode": "runner_executes_query_no_caller_result",
+    "interface": "graphforge_api::GraphForge::execute_with_params",
     "durable": false,
-    "interface": "GraphForge.execute",
-    "result_validator": "graphforge-benchmark-gdc-snb-bi"
+    "validator": "same_process_exact_order"
   },
   "normalization": {
     "upstream_temporal_window": "$date plus 100-day durations",
     "internal_equivalent": "precomputed integer day boundaries [0,100), [100,200)",
-    "reason": "exercise the current supported Cypher surface without claiming temporal-literal parity"
+    "reason": "exercise supported Cypher while not claiming temporal-literal parity",
+    "result_order": [
+      "diff DESC",
+      "tag.name ASC"
+    ],
+    "numeric_format": "base10_i64"
   }
 }

--- a/benchmarks/fixtures/gdc/snb-bi-live/parameters.json
+++ b/benchmarks/fixtures/gdc/snb-bi-live/parameters.json
@@ -1,8 +1,22 @@
 {
-  "schema": "graphforge-gdc-snb-bi-live-parameters/1",
+  "schema": "graphforge-gdc-snb-bi-live-parameters/2",
   "operation": "BI2",
-  "tagClass": "MusicalArtist",
-  "window1Start": 0,
-  "window2Start": 100,
-  "windowEnd": 200
+  "bindings": {
+    "tagClass": {
+      "kind": "string",
+      "value": "MusicalArtist"
+    },
+    "window1Start": {
+      "kind": "int64",
+      "value": 0
+    },
+    "window2Start": {
+      "kind": "int64",
+      "value": 100
+    },
+    "windowEnd": {
+      "kind": "int64",
+      "value": 200
+    }
+  }
 }

--- a/benchmarks/fixtures/gdc/snb-bi-live/parameters.json
+++ b/benchmarks/fixtures/gdc/snb-bi-live/parameters.json
@@ -1,0 +1,8 @@
+{
+  "schema": "graphforge-gdc-snb-bi-live-parameters/1",
+  "operation": "BI2",
+  "tagClass": "MusicalArtist",
+  "window1Start": 0,
+  "window2Start": 100,
+  "windowEnd": 200
+}

--- a/benchmarks/fixtures/gdc/snb-bi-live/seed.json
+++ b/benchmarks/fixtures/gdc/snb-bi-live/seed.json
@@ -1,0 +1,68 @@
+{
+  "schema": "graphforge-gdc-snb-bi-synthetic-seed/1",
+  "seed": 963,
+  "tag_classes": [
+    "MusicalArtist",
+    "SportsTeam"
+  ],
+  "tags": [
+    {
+      "name": "Alpha",
+      "tag_class": "MusicalArtist"
+    },
+    {
+      "name": "Beta",
+      "tag_class": "MusicalArtist"
+    },
+    {
+      "name": "Gamma",
+      "tag_class": "MusicalArtist"
+    },
+    {
+      "name": "Strikers",
+      "tag_class": "SportsTeam"
+    }
+  ],
+  "messages": [
+    {
+      "id": 1,
+      "creation_day": 10,
+      "tags": ["Alpha"]
+    },
+    {
+      "id": 2,
+      "creation_day": 20,
+      "tags": ["Alpha", "Gamma"]
+    },
+    {
+      "id": 3,
+      "creation_day": 30,
+      "tags": ["Beta", "Gamma"]
+    },
+    {
+      "id": 4,
+      "creation_day": 110,
+      "tags": ["Alpha"]
+    },
+    {
+      "id": 5,
+      "creation_day": 120,
+      "tags": ["Beta"]
+    },
+    {
+      "id": 6,
+      "creation_day": 130,
+      "tags": ["Beta"]
+    },
+    {
+      "id": 7,
+      "creation_day": 140,
+      "tags": ["Beta"]
+    },
+    {
+      "id": 8,
+      "creation_day": 15,
+      "tags": ["Strikers"]
+    }
+  ]
+}

--- a/benchmarks/fixtures/gdc/snb-bi-live/seed.json
+++ b/benchmarks/fixtures/gdc/snb-bi-live/seed.json
@@ -47,7 +47,7 @@
     {
       "id": 5,
       "creation_day": 120,
-      "tags": ["Beta"]
+      "tags": ["Beta", "Gamma"]
     },
     {
       "id": 6,

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/acquisition.json
@@ -10,14 +10,16 @@
   "recorded_generator": {
     "name": "graphforge_synthetic_snb_bi_fixture",
     "source": "https://github.com/CurateLabs/graphforge",
-    "release": "synthetic-fixture-v1",
-    "commit": null
+    "provenance_kind": "content_addressed_synthetic",
+    "content_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+    "content_description": "exact committed synthetic static fixture bytes"
   },
   "recorded_driver": {
-    "name": "graphforge_internal_snb_bi_driver",
+    "name": "graphforge_benchmark_gdc_snb_bi",
     "source": "https://github.com/CurateLabs/graphforge",
-    "release": "internal-driver-v1",
-    "commit": null
+    "provenance_kind": "repository_source",
+    "content_sha256": "b2759b99f60e395c541bf8d42cac8189b5e174cbc85d2e6d845017e1b0b791d4",
+    "content_description": "sha256 of sorted runner Cargo.toml and src path-content framing"
   },
   "assets": [
     {

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/acquisition.json
@@ -18,7 +18,7 @@
     "name": "graphforge_benchmark_gdc_snb_bi",
     "source": "https://github.com/CurateLabs/graphforge",
     "provenance_kind": "repository_source",
-    "content_sha256": "b2759b99f60e395c541bf8d42cac8189b5e174cbc85d2e6d845017e1b0b791d4",
+    "content_sha256": "377f162c73b34c877420bc860b6c0a349de78bdbea4ccf2548bbc50612e808d2",
     "content_description": "sha256 of sorted runner Cargo.toml and src path-content framing"
   },
   "assets": [

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/compatible/acquisition.json
@@ -2,29 +2,29 @@
   "schema": "graphforge-gdc-acquisition/1",
   "suite_id": "snb-bi",
   "recorded_spec": {
-    "name": "ldbc-snb",
-    "source": "https://ldbcouncil.org/benchmarks/snb/",
-    "release": "engineering-pin",
-    "commit": null
+    "name": "ldbc_snb_docs",
+    "source": "https://github.com/ldbc/ldbc_snb_docs",
+    "release": "v2.2.4",
+    "commit": "5f7956e07a214373c363b371a3b88bc83ddcd118"
   },
   "recorded_generator": {
-    "name": "ldbc_snb_datagen_spark",
-    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
-    "release": null,
-    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "name": "graphforge_synthetic_snb_bi_fixture",
+    "source": "https://github.com/CurateLabs/graphforge",
+    "release": "synthetic-fixture-v1",
+    "commit": null
   },
   "recorded_driver": {
-    "name": "ldbc_snb_bi_driver",
-    "source": "https://github.com/ldbc/ldbc_snb_bi_opensource",
-    "release": null,
-    "commit": "dddddddddddddddddddddddddddddddddddddddd"
+    "name": "graphforge_internal_snb_bi_driver",
+    "source": "https://github.com/CurateLabs/graphforge",
+    "release": "internal-driver-v1",
+    "commit": null
   },
   "assets": [
     {
       "id": "snb-bi-sf0.003",
       "path": "snb-bi-sf0.003.graph",
       "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
-      "license": "LDBC-SNB-terms",
+      "license": "Apache-2.0",
       "acquisition": "fixture"
     }
   ],

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/acquisition.json
@@ -10,14 +10,16 @@
   "recorded_generator": {
     "name": "graphforge_synthetic_snb_bi_fixture",
     "source": "https://github.com/CurateLabs/graphforge",
-    "release": "synthetic-fixture-v1",
-    "commit": null
+    "provenance_kind": "content_addressed_synthetic",
+    "content_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+    "content_description": "exact committed synthetic static fixture bytes"
   },
   "recorded_driver": {
-    "name": "graphforge_internal_snb_bi_driver",
+    "name": "graphforge_benchmark_gdc_snb_bi",
     "source": "https://github.com/CurateLabs/graphforge",
-    "release": "internal-driver-v1",
-    "commit": null
+    "provenance_kind": "repository_source",
+    "content_sha256": "b2759b99f60e395c541bf8d42cac8189b5e174cbc85d2e6d845017e1b0b791d4",
+    "content_description": "sha256 of sorted runner Cargo.toml and src path-content framing"
   },
   "assets": [
     {

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/acquisition.json
@@ -18,7 +18,7 @@
     "name": "graphforge_benchmark_gdc_snb_bi",
     "source": "https://github.com/CurateLabs/graphforge",
     "provenance_kind": "repository_source",
-    "content_sha256": "b2759b99f60e395c541bf8d42cac8189b5e174cbc85d2e6d845017e1b0b791d4",
+    "content_sha256": "377f162c73b34c877420bc860b6c0a349de78bdbea4ccf2548bbc50612e808d2",
     "content_description": "sha256 of sorted runner Cargo.toml and src path-content framing"
   },
   "assets": [

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/reference-mismatch/acquisition.json
@@ -2,29 +2,29 @@
   "schema": "graphforge-gdc-acquisition/1",
   "suite_id": "snb-bi",
   "recorded_spec": {
-    "name": "ldbc-snb",
-    "source": "https://ldbcouncil.org/benchmarks/snb/",
-    "release": "engineering-pin",
-    "commit": null
+    "name": "ldbc_snb_docs",
+    "source": "https://github.com/ldbc/ldbc_snb_docs",
+    "release": "v2.2.4",
+    "commit": "5f7956e07a214373c363b371a3b88bc83ddcd118"
   },
   "recorded_generator": {
-    "name": "ldbc_snb_datagen_spark",
-    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
-    "release": null,
-    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "name": "graphforge_synthetic_snb_bi_fixture",
+    "source": "https://github.com/CurateLabs/graphforge",
+    "release": "synthetic-fixture-v1",
+    "commit": null
   },
   "recorded_driver": {
-    "name": "ldbc_snb_bi_driver",
-    "source": "https://github.com/ldbc/ldbc_snb_bi_opensource",
-    "release": null,
-    "commit": "dddddddddddddddddddddddddddddddddddddddd"
+    "name": "graphforge_internal_snb_bi_driver",
+    "source": "https://github.com/CurateLabs/graphforge",
+    "release": "internal-driver-v1",
+    "commit": null
   },
   "assets": [
     {
       "id": "snb-bi-sf0.003",
       "path": "snb-bi-sf0.003.graph",
       "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
-      "license": "LDBC-SNB-terms",
+      "license": "Apache-2.0",
       "acquisition": "fixture"
     }
   ],

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/acquisition.json
@@ -10,14 +10,16 @@
   "recorded_generator": {
     "name": "graphforge_synthetic_snb_bi_fixture",
     "source": "https://github.com/CurateLabs/graphforge",
-    "release": "synthetic-fixture-v1",
-    "commit": null
+    "provenance_kind": "content_addressed_synthetic",
+    "content_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+    "content_description": "exact committed synthetic static fixture bytes"
   },
   "recorded_driver": {
-    "name": "graphforge_internal_snb_bi_driver",
+    "name": "graphforge_benchmark_gdc_snb_bi",
     "source": "https://github.com/CurateLabs/graphforge",
-    "release": "internal-driver-v1",
-    "commit": null
+    "provenance_kind": "repository_source",
+    "content_sha256": "b2759b99f60e395c541bf8d42cac8189b5e174cbc85d2e6d845017e1b0b791d4",
+    "content_description": "sha256 of sorted runner Cargo.toml and src path-content framing"
   },
   "assets": [
     {

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/acquisition.json
@@ -18,7 +18,7 @@
     "name": "graphforge_benchmark_gdc_snb_bi",
     "source": "https://github.com/CurateLabs/graphforge",
     "provenance_kind": "repository_source",
-    "content_sha256": "b2759b99f60e395c541bf8d42cac8189b5e174cbc85d2e6d845017e1b0b791d4",
+    "content_sha256": "377f162c73b34c877420bc860b6c0a349de78bdbea4ccf2548bbc50612e808d2",
     "content_description": "sha256 of sorted runner Cargo.toml and src path-content framing"
   },
   "assets": [

--- a/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/acquisition.json
+++ b/benchmarks/fixtures/gdc/snb-bi-tiny/semantic-incompat/acquisition.json
@@ -2,29 +2,29 @@
   "schema": "graphforge-gdc-acquisition/1",
   "suite_id": "snb-bi",
   "recorded_spec": {
-    "name": "ldbc-snb",
-    "source": "https://ldbcouncil.org/benchmarks/snb/",
-    "release": "engineering-pin",
-    "commit": null
+    "name": "ldbc_snb_docs",
+    "source": "https://github.com/ldbc/ldbc_snb_docs",
+    "release": "v2.2.4",
+    "commit": "5f7956e07a214373c363b371a3b88bc83ddcd118"
   },
   "recorded_generator": {
-    "name": "ldbc_snb_datagen_spark",
-    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
-    "release": null,
-    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "name": "graphforge_synthetic_snb_bi_fixture",
+    "source": "https://github.com/CurateLabs/graphforge",
+    "release": "synthetic-fixture-v1",
+    "commit": null
   },
   "recorded_driver": {
-    "name": "ldbc_snb_bi_driver",
-    "source": "https://github.com/ldbc/ldbc_snb_bi_opensource",
-    "release": null,
-    "commit": "dddddddddddddddddddddddddddddddddddddddd"
+    "name": "graphforge_internal_snb_bi_driver",
+    "source": "https://github.com/CurateLabs/graphforge",
+    "release": "internal-driver-v1",
+    "commit": null
   },
   "assets": [
     {
       "id": "snb-bi-sf0.003",
       "path": "snb-bi-sf0.003.graph",
       "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
-      "license": "LDBC-SNB-terms",
+      "license": "Apache-2.0",
       "acquisition": "fixture"
     }
   ],

--- a/benchmarks/harness/graphforge_bench/gdc_contracts.py
+++ b/benchmarks/harness/graphforge_bench/gdc_contracts.py
@@ -66,12 +66,7 @@ def _validate(validator: Draft202012Validator, document: Mapping[str, Any], labe
 def _tool_key(identity: Mapping[str, Any] | None) -> tuple[Any, ...]:
     if identity is None:
         return ("null",)
-    return (
-        identity.get("name"),
-        identity.get("source"),
-        identity.get("release"),
-        identity.get("commit"),
-    )
+    return ("identity", json.dumps(dict(identity), sort_keys=True, separators=(",", ":")))
 
 
 def _sha256_file(path: Path) -> str:
@@ -131,7 +126,27 @@ def _reject_incomplete_pin(pin: Mapping[str, Any]) -> None:
             raise GdcContractError("incomplete_provenance", f"{tool_name} identity is incomplete")
         if not tool.get("name") or not tool.get("source"):
             raise GdcContractError("incomplete_provenance", f"{tool_name} identity is incomplete")
-        if tool.get("release") is None and tool.get("commit") is None:
+        provenance_kind = tool.get("provenance_kind")
+        if provenance_kind is not None:
+            if pin.get("suite_id") != "snb-bi":
+                raise GdcContractError(
+                    "incomplete_provenance",
+                    "content-addressed tool identity is restricted to the SNB BI synthetic fixture",
+                )
+            if provenance_kind not in {
+                "content_addressed_synthetic",
+                "repository_source",
+            }:
+                raise GdcContractError(
+                    "incomplete_provenance",
+                    f"{tool_name} provenance kind is unsupported",
+                )
+            if not tool.get("content_sha256") or not tool.get("content_description"):
+                raise GdcContractError(
+                    "incomplete_provenance",
+                    f"{tool_name} content identity is incomplete",
+                )
+        elif tool.get("release") is None and tool.get("commit") is None:
             raise GdcContractError(
                 "incomplete_provenance",
                 f"{tool_name} requires release or commit",

--- a/benchmarks/harness/graphforge_bench/gdc_snb_bi.py
+++ b/benchmarks/harness/graphforge_bench/gdc_snb_bi.py
@@ -13,13 +13,12 @@ certification (the runner stamps ``certification: false``).
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import tempfile
-import time
 from typing import Any
 
 from graphforge_bench.gdc_contracts import (
@@ -37,8 +36,7 @@ OPERATIONS = ANALYTICAL_READS + BATCH_INSERTS + BATCH_DELETES
 JOB_SCHEMA = "graphforge-gdc-snb-bi-job/1"
 EVIDENCE_SCHEMA = "graphforge-gdc-snb-bi-evidence/1"
 RESOURCE_SCHEMA = "graphforge-gdc-snb-bi-resources/1"
-LIVE_EVIDENCE_SCHEMA = "graphforge-gdc-snb-bi-live-evidence/1"
-LIVE_RESULT_SCHEMA = "graphforge-gdc-snb-bi-live-result/1"
+LIVE_EVIDENCE_SCHEMA = "graphforge-gdc-snb-bi-live-evidence/2"
 LIVE_OPERATION = "BI2"
 LIVE_FIXTURE = "snb-bi-live"
 
@@ -47,37 +45,6 @@ WEIGHTED_PATH_CAUSE = "weighted_shortest_path_not_exposed"
 WEIGHTED_PATH_READS = ("BI15", "BI19", "BI20")
 
 BOUNDED_TINY_DATASET = "snb-bi-sf0.003"
-
-_PINNED_SPEC = {
-    "source": "https://github.com/ldbc/ldbc_snb_docs",
-    "release": "v2.2.4",
-    "commit": "5f7956e07a214373c363b371a3b88bc83ddcd118",
-}
-_PINNED_QUERY = {
-    "source": "https://github.com/ldbc/ldbc_snb_bi",
-    "release": "v1.0.0",
-    "commit": "abf8cd4862f2b96ba9267e6298a1f7402439040b",
-    "path": "cypher/queries/bi-2.cypher",
-}
-
-_LIVE_BI2 = """
-MATCH (tag:Tag)-[:HAS_TYPE]->(:TagClass {name: $tagClass})
-OPTIONAL MATCH (message1:Message)-[:HAS_TAG]->(tag)
-  WHERE $window1Start <= message1.creationDate
-    AND message1.creationDate < $window2Start
-WITH tag, count(message1) AS countWindow1
-OPTIONAL MATCH (message2:Message)-[:HAS_TAG]->(tag)
-  WHERE $window2Start <= message2.creationDate
-    AND message2.creationDate < $windowEnd
-WITH tag, countWindow1, count(message2) AS countWindow2
-RETURN
-  tag.name AS tagName,
-  countWindow1,
-  countWindow2,
-  abs(countWindow1 - countWindow2) AS diff
-ORDER BY diff DESC, tagName ASC
-LIMIT 100
-""".strip()
 
 
 class SnbBiSuiteError(ValueError):
@@ -119,128 +86,30 @@ def _run_runner(args: list[str], root: Path | None = None) -> subprocess.Complet
     )
 
 
-def _sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+def _raise_live_error(completed: subprocess.CompletedProcess[str]) -> None:
+    message = completed.stderr.strip()
+    if "reference_mismatch" in message:
+        raise SnbBiSuiteError("reference_mismatch", message)
+    if "parameter" in message:
+        raise SnbBiSuiteError("parameter_identity_mismatch", message)
+    if "identity" in message:
+        raise SnbBiSuiteError("identity_drift", message)
+    if "checksum" in message:
+        raise SnbBiSuiteError("checksum_mismatch", message)
+    raise SnbBiSuiteError("invalid_document", message)
 
 
-def validate_live_fixture(fixture: Path) -> dict[str, Any]:
-    """Validate immutable live-lane identity and every byte-bearing input."""
-    try:
-        identity = json.loads((fixture / "identity.json").read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise SnbBiSuiteError("invalid_document", f"invalid live identity: {error}") from error
-    if identity.get("schema") != "graphforge-gdc-snb-bi-live-identity/1":
-        raise SnbBiSuiteError("invalid_document", "unexpected live identity schema")
-    if identity.get("certification") is not False:
-        raise SnbBiSuiteError("invalid_document", "live lane must set certification=false")
-    if identity.get("upstream_spec") != _PINNED_SPEC:
-        raise SnbBiSuiteError("identity_drift", "pinned upstream SNB specification drifted")
-    if identity.get("upstream_query") != _PINNED_QUERY:
-        raise SnbBiSuiteError("identity_drift", "pinned upstream BI2 query drifted")
-    if identity.get("fixture", {}).get("kind") != "synthetic_minimal_snb_shaped":
-        raise SnbBiSuiteError("identity_drift", "fixture must disclose synthetic provenance")
-    if identity.get("fixture", {}).get("scale_factor") is not None:
-        raise SnbBiSuiteError(
-            "identity_drift", "synthetic fixture must not claim an SNB scale factor"
-        )
-    if identity.get("reference", {}).get("captured_from_engine") is not False:
-        raise SnbBiSuiteError("identity_drift", "reference must be independently derived")
-    if identity.get("driver", {}).get("kind") != "internal_python_public_api_driver":
-        raise SnbBiSuiteError("identity_drift", "live lane must disclose its internal driver")
-    for key in ("fixture", "parameters", "reference"):
-        item = identity.get(key, {})
-        path = fixture / item.get("path", "")
-        if not path.is_file():
-            raise SnbBiSuiteError("missing_assets", f"missing live {key}: {path.name}")
-        if _sha256(path) != item.get("sha256"):
-            raise SnbBiSuiteError("checksum_mismatch", f"live {key} bytes drifted")
-    return identity
-
-
-def _load_live_inputs(
+def validate_live_fixture(
     fixture: Path,
-    parameters_override: dict[str, Any] | None,
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], str]:
-    identity = validate_live_fixture(fixture)
-    seed = json.loads((fixture / identity["fixture"]["path"]).read_text(encoding="utf-8"))
-    parameters = json.loads((fixture / identity["parameters"]["path"]).read_text(encoding="utf-8"))
-    parameters_sha256 = identity["parameters"]["sha256"]
-    if parameters_override:
-        parameters.update(parameters_override)
-        parameters_sha256 = hashlib.sha256(
-            json.dumps(parameters, sort_keys=True, separators=(",", ":")).encode()
-        ).hexdigest()
-    if seed.get("schema") != "graphforge-gdc-snb-bi-synthetic-seed/1":
-        raise SnbBiSuiteError("invalid_document", "unexpected live seed schema")
-    if seed.get("seed") != 963:
-        raise SnbBiSuiteError("identity_drift", "deterministic seed must remain 963")
-    if parameters.get("schema") != "graphforge-gdc-snb-bi-live-parameters/1":
-        raise SnbBiSuiteError("invalid_document", "unexpected live parameter schema")
-    if parameters.get("operation") != LIVE_OPERATION:
-        raise SnbBiSuiteError("invalid_document", "live parameters must select BI2")
-    return identity, seed, parameters, parameters_sha256
-
-
-def _load_seed_into_graphforge(forge: Any, seed: dict[str, Any]) -> int:
-    for name in seed["tag_classes"]:
-        forge.execute("CREATE (:TagClass {name: $name})", {"name": name})
-    for tag in seed["tags"]:
-        forge.execute("CREATE (:Tag {name: $name})", {"name": tag["name"]})
-        forge.execute(
-            "MATCH (tag:Tag {name: $tag}), (class:TagClass {name: $class}) "
-            "CREATE (tag)-[:HAS_TYPE]->(class)",
-            {"tag": tag["name"], "class": tag["tag_class"]},
-        )
-    tagged_edges = 0
-    for message in seed["messages"]:
-        forge.execute(
-            "CREATE (:Message {id: $id, creationDate: $creationDate})",
-            {"id": message["id"], "creationDate": message["creation_day"]},
-        )
-        for tag in message["tags"]:
-            forge.execute(
-                "MATCH (message:Message {id: $id}), (tag:Tag {name: $tag}) "
-                "CREATE (message)-[:HAS_TAG]->(tag)",
-                {"id": message["id"], "tag": tag},
-            )
-            tagged_edges += 1
-    return (
-        len(seed["tag_classes"])
-        + len(seed["tags"])
-        + len(seed["tags"])
-        + len(seed["messages"])
-        + tagged_edges
-    )
-
-
-def validate_live_result_document(
-    result_path: Path,
     *,
     root: Path | None = None,
-    fixture: Path | None = None,
-) -> None:
+) -> dict[str, Any]:
+    """Ask the trusted Rust runner to validate the complete closed context."""
     base = root or workspace_root()
-    live_fixture = fixture or (base / "fixtures" / "gdc" / LIVE_FIXTURE)
-    identity = validate_live_fixture(live_fixture)
-    reference = live_fixture / identity["reference"]["path"]
-    completed = _run_runner(
-        [
-            "validate-live",
-            str(reference),
-            str(result_path),
-            identity["parameters"]["sha256"],
-        ],
-        base,
-    )
+    completed = _run_runner(["validate-live-context", str(fixture)], base)
     if completed.returncode != 0:
-        message = completed.stderr.strip()
-        if "reference_mismatch" in message:
-            raise SnbBiSuiteError("reference_mismatch", message)
-        if "parameter_identity_mismatch" in message:
-            raise SnbBiSuiteError("parameter_identity_mismatch", message)
-        if "static_output_rejected" in message or "invalid live result" in message:
-            raise SnbBiSuiteError("static_output_rejected", message)
-        raise SnbBiSuiteError("invalid_document", message)
+        _raise_live_error(completed)
+    return json.loads((fixture / "identity.json").read_text(encoding="utf-8"))
 
 
 def run_live_bi2(
@@ -248,67 +117,33 @@ def run_live_bi2(
     root: Path | None = None,
     parameters_override: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Execute normalized BI2 through the real in-memory public Python API."""
-    from graphforge import GraphForge
-
+    """Run the trusted Rust-owned in-memory API execution and evidence path."""
     base = root or workspace_root()
     fixture = base / "fixtures" / "gdc" / LIVE_FIXTURE
-    identity, seed, parameters, parameters_sha256 = _load_live_inputs(fixture, parameters_override)
-    forge = GraphForge()
-    load_started = time.perf_counter_ns()
-    rows_loaded = _load_seed_into_graphforge(forge, seed)
-    load_ms = (time.perf_counter_ns() - load_started) // 1_000_000
-
-    query_parameters = {
-        key: parameters[key] for key in ("tagClass", "window1Start", "window2Start", "windowEnd")
-    }
-    query_started = time.perf_counter_ns()
-    table = forge.execute(_LIVE_BI2, query_parameters)
-    query_ms = (time.perf_counter_ns() - query_started) // 1_000_000
-    columns = ["tagName", "countWindow1", "countWindow2", "diff"]
-    rows = [
-        " ".join(str(row[column]) for column in columns)
-        for row in table.select(columns).to_pylist()
-    ]
-    result = {
-        "schema": LIVE_RESULT_SCHEMA,
-        "operation": LIVE_OPERATION,
-        "source": "graphforge_public_python_api",
-        "parameters_sha256": parameters_sha256,
-        "columns": columns,
-        "rows": rows,
-    }
     with tempfile.TemporaryDirectory(prefix="gdc-snb-bi-live-") as tmp:
-        result_path = Path(tmp) / "live-result.json"
-        result_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
-        validation_started = time.perf_counter_ns()
-        validate_live_result_document(result_path, root=base, fixture=fixture)
-        validation_ms = (time.perf_counter_ns() - validation_started) // 1_000_000
-
-    return {
-        "schema": LIVE_EVIDENCE_SCHEMA,
-        "suite_id": "snb-bi",
-        "lane": "live_in_memory",
-        "operation": LIVE_OPERATION,
-        "status": "passed",
-        "certification": False,
-        "phases": ["load", "query", "validation"],
-        "identities": identity,
-        "correctness": {
-            "status": "passed",
-            "validation_mode": "normalized",
-            "validator": "graphforge-benchmark-gdc-snb-bi",
-            "reference_authority": identity["reference"]["authority"],
-            "rows": rows,
-        },
-        "resources": {
-            "correctness_authority": False,
-            "load": {"wall_ms": load_ms, "rows_loaded": rows_loaded},
-            "query": {"wall_ms": query_ms, "rows_returned": len(rows)},
-            "validation": {"wall_ms": validation_ms},
-            "unobserved": ["spill_bytes", "peak_rss_bytes", "io_bytes"],
-        },
-    }
+        temp = Path(tmp)
+        execution_fixture = fixture
+        if parameters_override:
+            execution_fixture = temp / "fixture"
+            shutil.copytree(fixture, execution_fixture)
+            parameter_path = execution_fixture / "parameters.json"
+            parameters = json.loads(parameter_path.read_text(encoding="utf-8"))
+            for name, value in parameters_override.items():
+                parameters["bindings"][name]["value"] = value
+            parameter_path.write_text(json.dumps(parameters, indent=2) + "\n", encoding="utf-8")
+        evidence_path = temp / "evidence.json"
+        completed = _run_runner(
+            ["run-live", str(execution_fixture), str(evidence_path)],
+            base,
+        )
+        if completed.returncode != 0:
+            _raise_live_error(completed)
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    if evidence.get("schema") != LIVE_EVIDENCE_SCHEMA:
+        raise SnbBiSuiteError("invalid_document", "unexpected live evidence schema")
+    if evidence.get("certification") is not False:
+        raise SnbBiSuiteError("invalid_document", "live evidence must set certification=false")
+    return evidence
 
 
 def list_operation_rules(root: Path | None = None) -> dict[str, dict[str, str]]:
@@ -354,7 +189,7 @@ def run_tiny_suite(
         out_evidence = evidence_path or (tmp_path / "evidence.json")
         completed = _run_runner(
             [
-                "run-suite",
+                "run-static-suite",
                 str(fixture / "jobs"),
                 str(fixture / "references"),
                 str(fixture / "system-outputs"),
@@ -461,7 +296,6 @@ __all__ = [
     "LIVE_EVIDENCE_SCHEMA",
     "LIVE_FIXTURE",
     "LIVE_OPERATION",
-    "LIVE_RESULT_SCHEMA",
     "OPERATIONS",
     "RESOURCE_SCHEMA",
     "WEIGHTED_PATH_CAUSE",
@@ -476,5 +310,4 @@ __all__ = [
     "run_live_bi2",
     "run_tiny_suite",
     "validate_live_fixture",
-    "validate_live_result_document",
 ]

--- a/benchmarks/harness/graphforge_bench/gdc_snb_bi.py
+++ b/benchmarks/harness/graphforge_bench/gdc_snb_bi.py
@@ -13,11 +13,13 @@ certification (the runner stamps ``certification: false``).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
 import subprocess
 import tempfile
+import time
 from typing import Any
 
 from graphforge_bench.gdc_contracts import (
@@ -35,12 +37,47 @@ OPERATIONS = ANALYTICAL_READS + BATCH_INSERTS + BATCH_DELETES
 JOB_SCHEMA = "graphforge-gdc-snb-bi-job/1"
 EVIDENCE_SCHEMA = "graphforge-gdc-snb-bi-evidence/1"
 RESOURCE_SCHEMA = "graphforge-gdc-snb-bi-resources/1"
+LIVE_EVIDENCE_SCHEMA = "graphforge-gdc-snb-bi-live-evidence/1"
+LIVE_RESULT_SCHEMA = "graphforge-gdc-snb-bi-live-result/1"
+LIVE_OPERATION = "BI2"
+LIVE_FIXTURE = "snb-bi-live"
 
 BATCH_UPDATE_CAUSE = "bi_batch_update_stream_not_exposed"
 WEIGHTED_PATH_CAUSE = "weighted_shortest_path_not_exposed"
 WEIGHTED_PATH_READS = ("BI15", "BI19", "BI20")
 
 BOUNDED_TINY_DATASET = "snb-bi-sf0.003"
+
+_PINNED_SPEC = {
+    "source": "https://github.com/ldbc/ldbc_snb_docs",
+    "release": "v2.2.4",
+    "commit": "5f7956e07a214373c363b371a3b88bc83ddcd118",
+}
+_PINNED_QUERY = {
+    "source": "https://github.com/ldbc/ldbc_snb_bi",
+    "release": "v1.0.0",
+    "commit": "abf8cd4862f2b96ba9267e6298a1f7402439040b",
+    "path": "cypher/queries/bi-2.cypher",
+}
+
+_LIVE_BI2 = """
+MATCH (tag:Tag)-[:HAS_TYPE]->(:TagClass {name: $tagClass})
+OPTIONAL MATCH (message1:Message)-[:HAS_TAG]->(tag)
+  WHERE $window1Start <= message1.creationDate
+    AND message1.creationDate < $window2Start
+WITH tag, count(message1) AS countWindow1
+OPTIONAL MATCH (message2:Message)-[:HAS_TAG]->(tag)
+  WHERE $window2Start <= message2.creationDate
+    AND message2.creationDate < $windowEnd
+WITH tag, countWindow1, count(message2) AS countWindow2
+RETURN
+  tag.name AS tagName,
+  countWindow1,
+  countWindow2,
+  abs(countWindow1 - countWindow2) AS diff
+ORDER BY diff DESC, tagName ASC
+LIMIT 100
+""".strip()
 
 
 class SnbBiSuiteError(ValueError):
@@ -82,6 +119,198 @@ def _run_runner(args: list[str], root: Path | None = None) -> subprocess.Complet
     )
 
 
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def validate_live_fixture(fixture: Path) -> dict[str, Any]:
+    """Validate immutable live-lane identity and every byte-bearing input."""
+    try:
+        identity = json.loads((fixture / "identity.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SnbBiSuiteError("invalid_document", f"invalid live identity: {error}") from error
+    if identity.get("schema") != "graphforge-gdc-snb-bi-live-identity/1":
+        raise SnbBiSuiteError("invalid_document", "unexpected live identity schema")
+    if identity.get("certification") is not False:
+        raise SnbBiSuiteError("invalid_document", "live lane must set certification=false")
+    if identity.get("upstream_spec") != _PINNED_SPEC:
+        raise SnbBiSuiteError("identity_drift", "pinned upstream SNB specification drifted")
+    if identity.get("upstream_query") != _PINNED_QUERY:
+        raise SnbBiSuiteError("identity_drift", "pinned upstream BI2 query drifted")
+    if identity.get("fixture", {}).get("kind") != "synthetic_minimal_snb_shaped":
+        raise SnbBiSuiteError("identity_drift", "fixture must disclose synthetic provenance")
+    if identity.get("fixture", {}).get("scale_factor") is not None:
+        raise SnbBiSuiteError(
+            "identity_drift", "synthetic fixture must not claim an SNB scale factor"
+        )
+    if identity.get("reference", {}).get("captured_from_engine") is not False:
+        raise SnbBiSuiteError("identity_drift", "reference must be independently derived")
+    if identity.get("driver", {}).get("kind") != "internal_python_public_api_driver":
+        raise SnbBiSuiteError("identity_drift", "live lane must disclose its internal driver")
+    for key in ("fixture", "parameters", "reference"):
+        item = identity.get(key, {})
+        path = fixture / item.get("path", "")
+        if not path.is_file():
+            raise SnbBiSuiteError("missing_assets", f"missing live {key}: {path.name}")
+        if _sha256(path) != item.get("sha256"):
+            raise SnbBiSuiteError("checksum_mismatch", f"live {key} bytes drifted")
+    return identity
+
+
+def _load_live_inputs(
+    fixture: Path,
+    parameters_override: dict[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], str]:
+    identity = validate_live_fixture(fixture)
+    seed = json.loads((fixture / identity["fixture"]["path"]).read_text(encoding="utf-8"))
+    parameters = json.loads((fixture / identity["parameters"]["path"]).read_text(encoding="utf-8"))
+    parameters_sha256 = identity["parameters"]["sha256"]
+    if parameters_override:
+        parameters.update(parameters_override)
+        parameters_sha256 = hashlib.sha256(
+            json.dumps(parameters, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+    if seed.get("schema") != "graphforge-gdc-snb-bi-synthetic-seed/1":
+        raise SnbBiSuiteError("invalid_document", "unexpected live seed schema")
+    if seed.get("seed") != 963:
+        raise SnbBiSuiteError("identity_drift", "deterministic seed must remain 963")
+    if parameters.get("schema") != "graphforge-gdc-snb-bi-live-parameters/1":
+        raise SnbBiSuiteError("invalid_document", "unexpected live parameter schema")
+    if parameters.get("operation") != LIVE_OPERATION:
+        raise SnbBiSuiteError("invalid_document", "live parameters must select BI2")
+    return identity, seed, parameters, parameters_sha256
+
+
+def _load_seed_into_graphforge(forge: Any, seed: dict[str, Any]) -> int:
+    for name in seed["tag_classes"]:
+        forge.execute("CREATE (:TagClass {name: $name})", {"name": name})
+    for tag in seed["tags"]:
+        forge.execute("CREATE (:Tag {name: $name})", {"name": tag["name"]})
+        forge.execute(
+            "MATCH (tag:Tag {name: $tag}), (class:TagClass {name: $class}) "
+            "CREATE (tag)-[:HAS_TYPE]->(class)",
+            {"tag": tag["name"], "class": tag["tag_class"]},
+        )
+    tagged_edges = 0
+    for message in seed["messages"]:
+        forge.execute(
+            "CREATE (:Message {id: $id, creationDate: $creationDate})",
+            {"id": message["id"], "creationDate": message["creation_day"]},
+        )
+        for tag in message["tags"]:
+            forge.execute(
+                "MATCH (message:Message {id: $id}), (tag:Tag {name: $tag}) "
+                "CREATE (message)-[:HAS_TAG]->(tag)",
+                {"id": message["id"], "tag": tag},
+            )
+            tagged_edges += 1
+    return (
+        len(seed["tag_classes"])
+        + len(seed["tags"])
+        + len(seed["tags"])
+        + len(seed["messages"])
+        + tagged_edges
+    )
+
+
+def validate_live_result_document(
+    result_path: Path,
+    *,
+    root: Path | None = None,
+    fixture: Path | None = None,
+) -> None:
+    base = root or workspace_root()
+    live_fixture = fixture or (base / "fixtures" / "gdc" / LIVE_FIXTURE)
+    identity = validate_live_fixture(live_fixture)
+    reference = live_fixture / identity["reference"]["path"]
+    completed = _run_runner(
+        [
+            "validate-live",
+            str(reference),
+            str(result_path),
+            identity["parameters"]["sha256"],
+        ],
+        base,
+    )
+    if completed.returncode != 0:
+        message = completed.stderr.strip()
+        if "reference_mismatch" in message:
+            raise SnbBiSuiteError("reference_mismatch", message)
+        if "parameter_identity_mismatch" in message:
+            raise SnbBiSuiteError("parameter_identity_mismatch", message)
+        if "static_output_rejected" in message or "invalid live result" in message:
+            raise SnbBiSuiteError("static_output_rejected", message)
+        raise SnbBiSuiteError("invalid_document", message)
+
+
+def run_live_bi2(
+    *,
+    root: Path | None = None,
+    parameters_override: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute normalized BI2 through the real in-memory public Python API."""
+    from graphforge import GraphForge
+
+    base = root or workspace_root()
+    fixture = base / "fixtures" / "gdc" / LIVE_FIXTURE
+    identity, seed, parameters, parameters_sha256 = _load_live_inputs(fixture, parameters_override)
+    forge = GraphForge()
+    load_started = time.perf_counter_ns()
+    rows_loaded = _load_seed_into_graphforge(forge, seed)
+    load_ms = (time.perf_counter_ns() - load_started) // 1_000_000
+
+    query_parameters = {
+        key: parameters[key] for key in ("tagClass", "window1Start", "window2Start", "windowEnd")
+    }
+    query_started = time.perf_counter_ns()
+    table = forge.execute(_LIVE_BI2, query_parameters)
+    query_ms = (time.perf_counter_ns() - query_started) // 1_000_000
+    columns = ["tagName", "countWindow1", "countWindow2", "diff"]
+    rows = [
+        " ".join(str(row[column]) for column in columns)
+        for row in table.select(columns).to_pylist()
+    ]
+    result = {
+        "schema": LIVE_RESULT_SCHEMA,
+        "operation": LIVE_OPERATION,
+        "source": "graphforge_public_python_api",
+        "parameters_sha256": parameters_sha256,
+        "columns": columns,
+        "rows": rows,
+    }
+    with tempfile.TemporaryDirectory(prefix="gdc-snb-bi-live-") as tmp:
+        result_path = Path(tmp) / "live-result.json"
+        result_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+        validation_started = time.perf_counter_ns()
+        validate_live_result_document(result_path, root=base, fixture=fixture)
+        validation_ms = (time.perf_counter_ns() - validation_started) // 1_000_000
+
+    return {
+        "schema": LIVE_EVIDENCE_SCHEMA,
+        "suite_id": "snb-bi",
+        "lane": "live_in_memory",
+        "operation": LIVE_OPERATION,
+        "status": "passed",
+        "certification": False,
+        "phases": ["load", "query", "validation"],
+        "identities": identity,
+        "correctness": {
+            "status": "passed",
+            "validation_mode": "normalized",
+            "validator": "graphforge-benchmark-gdc-snb-bi",
+            "reference_authority": identity["reference"]["authority"],
+            "rows": rows,
+        },
+        "resources": {
+            "correctness_authority": False,
+            "load": {"wall_ms": load_ms, "rows_loaded": rows_loaded},
+            "query": {"wall_ms": query_ms, "rows_returned": len(rows)},
+            "validation": {"wall_ms": validation_ms},
+            "unobserved": ["spill_bytes", "peak_rss_bytes", "io_bytes"],
+        },
+    }
+
+
 def list_operation_rules(root: Path | None = None) -> dict[str, dict[str, str]]:
     completed = _run_runner(["list-operations"], root)
     if completed.returncode != 0:
@@ -110,7 +339,7 @@ def run_tiny_suite(
     root: Path | None = None,
     evidence_path: Path | None = None,
 ) -> dict[str, Any]:
-    """Run the bounded snb-bi-sf0.003 SNB BI suite through the Rust runner."""
+    """Replay the legacy synthetic static contract fixture through Rust."""
     base = root or workspace_root()
     fixture = base / "fixtures" / "gdc" / "snb-bi-tiny" / fixture_name
     pin = load_pinned_identity(identity_path(base))
@@ -174,11 +403,11 @@ def map_operation_file(path: Path, root: Path | None = None) -> dict[str, Any]:
 
 
 def assert_large_scale_factors_are_opt_in(root: Path | None = None) -> None:
-    """Only the bounded tiny fixture is executed by default; larger SFs are opt-in.
+    """Only the synthetic tiny fixture is replayed by default; scale runs are opt-in.
 
-    The suite declaration must advertise exactly the bounded ``snb-bi-sf0.003``
-    fixture. Any larger scale factor is external/opt-in and must never be baked
-    into the default declaration.
+    ``snb-bi-sf0.003`` is a historical synthetic fixture identifier, not an
+    official scale-factor claim. Real generated scale factors are external and
+    opt-in.
     """
     base = root or workspace_root()
     suite = json.loads((base / "suites" / "gdc-snb-bi.json").read_text(encoding="utf-8"))
@@ -229,6 +458,10 @@ __all__ = [
     "BOUNDED_TINY_DATASET",
     "EVIDENCE_SCHEMA",
     "JOB_SCHEMA",
+    "LIVE_EVIDENCE_SCHEMA",
+    "LIVE_FIXTURE",
+    "LIVE_OPERATION",
+    "LIVE_RESULT_SCHEMA",
     "OPERATIONS",
     "RESOURCE_SCHEMA",
     "WEIGHTED_PATH_CAUSE",
@@ -240,5 +473,8 @@ __all__ = [
     "identity_path",
     "list_operation_rules",
     "map_operation_file",
+    "run_live_bi2",
     "run_tiny_suite",
+    "validate_live_fixture",
+    "validate_live_result_document",
 ]

--- a/benchmarks/profiles/gdc/snb-bi-identity.json
+++ b/benchmarks/profiles/gdc/snb-bi-identity.json
@@ -11,14 +11,16 @@
   "generator": {
     "name": "graphforge_synthetic_snb_bi_fixture",
     "source": "https://github.com/CurateLabs/graphforge",
-    "release": "synthetic-fixture-v1",
-    "commit": null
+    "provenance_kind": "content_addressed_synthetic",
+    "content_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
+    "content_description": "exact committed synthetic static fixture bytes"
   },
   "driver": {
-    "name": "graphforge_internal_snb_bi_driver",
+    "name": "graphforge_benchmark_gdc_snb_bi",
     "source": "https://github.com/CurateLabs/graphforge",
-    "release": "internal-driver-v1",
-    "commit": null
+    "provenance_kind": "repository_source",
+    "content_sha256": "b2759b99f60e395c541bf8d42cac8189b5e174cbc85d2e6d845017e1b0b791d4",
+    "content_description": "sha256 of sorted runner Cargo.toml and src path-content framing"
   },
   "datasets": [
     {

--- a/benchmarks/profiles/gdc/snb-bi-identity.json
+++ b/benchmarks/profiles/gdc/snb-bi-identity.json
@@ -3,31 +3,31 @@
   "suite_id": "snb-bi",
   "disposition": "executable",
   "spec": {
-    "name": "ldbc-snb",
-    "source": "https://ldbcouncil.org/benchmarks/snb/",
-    "release": "engineering-pin",
-    "commit": null
+    "name": "ldbc_snb_docs",
+    "source": "https://github.com/ldbc/ldbc_snb_docs",
+    "release": "v2.2.4",
+    "commit": "5f7956e07a214373c363b371a3b88bc83ddcd118"
   },
   "generator": {
-    "name": "ldbc_snb_datagen_spark",
-    "source": "https://github.com/ldbc/ldbc_snb_datagen_spark",
-    "release": null,
-    "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "name": "graphforge_synthetic_snb_bi_fixture",
+    "source": "https://github.com/CurateLabs/graphforge",
+    "release": "synthetic-fixture-v1",
+    "commit": null
   },
   "driver": {
-    "name": "ldbc_snb_bi_driver",
-    "source": "https://github.com/ldbc/ldbc_snb_bi_opensource",
-    "release": null,
-    "commit": "dddddddddddddddddddddddddddddddddddddddd"
+    "name": "graphforge_internal_snb_bi_driver",
+    "source": "https://github.com/CurateLabs/graphforge",
+    "release": "internal-driver-v1",
+    "commit": null
   },
   "datasets": [
     {
       "id": "snb-bi-sf0.003",
-      "role": "dataset",
+      "role": "other",
       "checksum_sha256": "c0fd57903065bb4950244cc77023e9ce0803f723596922b114141f190ea521d8",
-      "license": "LDBC-SNB-terms",
+      "license": "Apache-2.0",
       "acquisition": "fixture",
-      "source": "https://github.com/ldbc/ldbc_snb_datagen_spark"
+      "source": "https://github.com/CurateLabs/graphforge"
     }
   ],
   "references": [
@@ -35,7 +35,7 @@
       "dataset_id": "snb-bi-sf0.003",
       "workload_key": "bi-validation",
       "checksum_sha256": "20368ad845455de99ef737732930bf7d07d9d44adde19a31ec7ba6ec332b25db",
-      "source": "https://github.com/ldbc/ldbc_snb_bi_opensource"
+      "source": "https://github.com/CurateLabs/graphforge"
     }
   ]
 }

--- a/benchmarks/profiles/gdc/snb-bi-identity.json
+++ b/benchmarks/profiles/gdc/snb-bi-identity.json
@@ -19,7 +19,7 @@
     "name": "graphforge_benchmark_gdc_snb_bi",
     "source": "https://github.com/CurateLabs/graphforge",
     "provenance_kind": "repository_source",
-    "content_sha256": "b2759b99f60e395c541bf8d42cac8189b5e174cbc85d2e6d845017e1b0b791d4",
+    "content_sha256": "377f162c73b34c877420bc860b6c0a349de78bdbea4ccf2548bbc50612e808d2",
     "content_description": "sha256 of sorted runner Cargo.toml and src path-content framing"
   },
   "datasets": [

--- a/benchmarks/runners/gdc-snb-bi/Cargo.toml
+++ b/benchmarks/runners/gdc-snb-bi/Cargo.toml
@@ -7,8 +7,11 @@ publish.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+arrow.workspace = true
+graphforge-api = { version = "0.5.2", path = "../../../crates/graphforge-api" }
 serde.workspace = true
 serde_json.workspace = true
+sha2 = "0.11"
 
 [[bin]]
 name = "graphforge-benchmark-gdc-snb-bi"

--- a/benchmarks/runners/gdc-snb-bi/src/lib.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/lib.rs
@@ -13,16 +13,20 @@
 #![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
+use std::time::Instant;
 
 pub const EVIDENCE_SCHEMA: &str = "graphforge-gdc-snb-bi-evidence/1";
 pub const JOB_SCHEMA: &str = "graphforge-gdc-snb-bi-job/1";
 pub const LADDER_SCHEMA: &str = "graphforge-gdc-snb-bi-ladder/1";
-pub const LIVE_RESULT_SCHEMA: &str = "graphforge-gdc-snb-bi-live-result/1";
+pub const LIVE_EVIDENCE_SCHEMA: &str = "graphforge-gdc-snb-bi-live-evidence/2";
+pub const LIVE_IDENTITY_SCHEMA: &str = "graphforge-gdc-snb-bi-live-identity/2";
+pub const LIVE_PARAMETERS_SCHEMA: &str = "graphforge-gdc-snb-bi-live-parameters/2";
 pub const RESOURCE_SCHEMA: &str = "graphforge-gdc-snb-bi-resources/1";
 pub const SUITE_ID: &str = "snb-bi";
 
@@ -287,9 +291,10 @@ impl Operation {
     fn intended_validation(self) -> ValidationMode {
         match self {
             // Grouped/set-shaped aggregations without a spec-mandated total
-            // tie-break (tag lists, message-count histogram, related-tag
-            // co-occurrence): compared order-insensitively.
-            Self::Bi2 | Self::Bi12 | Self::Bi16 => ValidationMode::Normalized,
+            // tie-break (message-count histogram, related-tag co-occurrence):
+            // compared order-insensitively. BI2 has the explicit total order
+            // `diff DESC, tag.name ASC` and therefore remains exact.
+            Self::Bi12 | Self::Bi16 => ValidationMode::Normalized,
             _ => ValidationMode::Exact,
         }
     }
@@ -624,8 +629,8 @@ pub fn map_operation(operation: Operation) -> MappingOutcome {
         Operation::Bi2 => compatible(
             "cypher",
             "MATCH (t:Tag)<-[:HAS_TAG]-(m:Message) WHERE m.creationDate window \
-             RETURN t.name, countWindow1, countWindow2, abs(diff) ORDER BY diff DESC, t.name",
-            "tag evolution: per-tag message counts across two windows; grouped tag set (normalized validation)",
+             RETURN t.name, countWindow1, countWindow2, abs(diff) ORDER BY diff DESC, t.name ASC",
+            "tag evolution: per-tag message counts across two windows; official total order diff DESC, tag.name ASC",
         ),
         Operation::Bi3 => compatible(
             "cypher",
@@ -798,74 +803,586 @@ pub fn parse_result_rows(text: &str) -> ResultRows {
         .collect()
 }
 
-/// Result produced by the explicit live lane after a public GraphForge call.
-///
-/// The source and parameter digest prevent the validator CLI from accepting
-/// the legacy static `.out` replay as live evidence. The rows remain ordinary
-/// strings so the same Rust-owned normalization and multiset validator used by
-/// the suite is authoritative.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct LiveResultDocument {
+pub struct LiveIdentity {
+    pub schema: String,
+    pub suite_id: String,
+    pub operation: Operation,
+    pub source_mode: String,
+    pub certification: bool,
+    pub upstream_spec: UpstreamIdentity,
+    pub upstream_query: UpstreamQueryIdentity,
+    pub fixture: LiveFixtureIdentity,
+    pub parameters: LiveParametersIdentity,
+    pub reference: LiveReferenceIdentity,
+    pub driver: LiveDriverIdentity,
+    pub normalization: LiveNormalizationIdentity,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamIdentity {
+    pub source: String,
+    pub release: String,
+    pub commit: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamQueryIdentity {
+    pub source: String,
+    pub release: String,
+    pub commit: String,
+    pub path: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveFixtureIdentity {
+    pub dataset_id: String,
+    pub kind: String,
+    pub provenance_kind: String,
+    pub seed: u64,
+    pub scale_factor: Option<String>,
+    pub path: String,
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveParametersIdentity {
+    pub kind: String,
+    pub path: String,
+    pub file_sha256: String,
+    pub names_kinds_values_sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveReferenceIdentity {
+    pub authority: String,
+    pub captured_from_engine: bool,
+    pub validation: String,
+    pub path: String,
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveDriverIdentity {
+    pub kind: String,
+    pub source_mode: String,
+    pub interface: String,
+    pub durable: bool,
+    pub validator: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveNormalizationIdentity {
+    pub upstream_temporal_window: String,
+    pub internal_equivalent: String,
+    pub reason: String,
+    pub result_order: Vec<String>,
+    pub numeric_format: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveParameters {
     pub schema: String,
     pub operation: Operation,
-    pub source: String,
-    pub parameters_sha256: String,
-    pub columns: Vec<String>,
-    pub rows: Vec<String>,
+    pub bindings: LiveBindings,
 }
 
-pub fn load_live_result_document(path: &Path) -> Result<LiveResultDocument, SuiteError> {
-    let text = fs::read_to_string(path).map_err(|error| {
-        SuiteError::InvalidDocument(format!("failed to read {}: {error}", path.display()))
-    })?;
-    serde_json::from_str(&text)
-        .map_err(|error| SuiteError::InvalidDocument(format!("invalid live result: {error}")))
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveBindings {
+    #[serde(rename = "tagClass")]
+    pub tag_class: StringBinding,
+    #[serde(rename = "window1Start")]
+    pub window_1_start: Int64Binding,
+    #[serde(rename = "window2Start")]
+    pub window_2_start: Int64Binding,
+    #[serde(rename = "windowEnd")]
+    pub window_end: Int64Binding,
 }
 
-pub fn validate_live_result(
-    expected_parameters_sha256: &str,
-    reference: &ResultRows,
-    document: &LiveResultDocument,
-) -> Result<(), SuiteError> {
-    if document.schema != LIVE_RESULT_SCHEMA {
-        return Err(SuiteError::InvalidDocument(format!(
-            "unexpected live result schema: {}",
-            document.schema
-        )));
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StringBinding {
+    pub kind: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Int64Binding {
+    pub kind: String,
+    pub value: i64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct LiveSeed {
+    schema: String,
+    seed: u64,
+    tag_classes: Vec<String>,
+    tags: Vec<LiveSeedTag>,
+    messages: Vec<LiveSeedMessage>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct LiveSeedTag {
+    name: String,
+    tag_class: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct LiveSeedMessage {
+    id: i64,
+    creation_day: i64,
+    tags: Vec<String>,
+}
+
+struct ValidatedLiveContext {
+    identity: LiveIdentity,
+    parameters: LiveParameters,
+    seed: LiveSeed,
+    reference: ResultRows,
+}
+
+const LIVE_BI2_QUERY: &str = "\
+MATCH (tag:Tag)-[:HAS_TYPE]->(:TagClass {name: $tagClass}) \
+OPTIONAL MATCH (message1:Message)-[:HAS_TAG]->(tag) \
+WHERE $window1Start <= message1.creationDate AND message1.creationDate < $window2Start \
+WITH tag, count(message1) AS countWindow1 \
+OPTIONAL MATCH (message2:Message)-[:HAS_TAG]->(tag) \
+WHERE $window2Start <= message2.creationDate AND message2.creationDate < $windowEnd \
+WITH tag, countWindow1, count(message2) AS countWindow2 \
+RETURN tag.name AS tagName, countWindow1, countWindow2, \
+abs(countWindow1 - countWindow2) AS diff \
+ORDER BY diff DESC, tagName ASC LIMIT 100";
+
+fn expected_live_identity() -> LiveIdentity {
+    LiveIdentity {
+        schema: LIVE_IDENTITY_SCHEMA.into(),
+        suite_id: SUITE_ID.into(),
+        operation: Operation::Bi2,
+        source_mode: "runner_owned_rust_api".into(),
+        certification: false,
+        upstream_spec: UpstreamIdentity {
+            source: "https://github.com/ldbc/ldbc_snb_docs".into(),
+            release: "v2.2.4".into(),
+            commit: "5f7956e07a214373c363b371a3b88bc83ddcd118".into(),
+        },
+        upstream_query: UpstreamQueryIdentity {
+            source: "https://github.com/ldbc/ldbc_snb_bi".into(),
+            release: "v1.0.0".into(),
+            commit: "abf8cd4862f2b96ba9267e6298a1f7402439040b".into(),
+            path: "cypher/queries/bi-2.cypher".into(),
+        },
+        fixture: LiveFixtureIdentity {
+            dataset_id: "snb-bi-synthetic-minimal".into(),
+            kind: "synthetic_minimal_snb_shaped".into(),
+            provenance_kind: "content_addressed_committed_fixture".into(),
+            seed: 963,
+            scale_factor: None,
+            path: "seed.json".into(),
+            sha256: "9dc8c9987d4ce403a30808c268d25a6f9fdb451b7a5c68fbd2d37d700b4cb88e".into(),
+        },
+        parameters: LiveParametersIdentity {
+            kind: "typed_internal_deterministic_bi2_parameters".into(),
+            path: "parameters.json".into(),
+            file_sha256: "55a5c78e5573909531b6290a38ccc7d670b1a8eb09136ebfc4b4668c45646d7a".into(),
+            names_kinds_values_sha256:
+                "79ef56283a4ac9320c82415977eb1f2c27574970bccb247e04cfaf02e59384b5".into(),
+        },
+        reference: LiveReferenceIdentity {
+            authority: "independent_semantic_derivation_from_seed".into(),
+            captured_from_engine: false,
+            validation: "exact_order_numeric_text_normalized".into(),
+            path: "expected-bi2.ref".into(),
+            sha256: "bd4c037d3aae1881e9329e148743d153d4bf671afc1f35d3d7ab4eaab0748d7b".into(),
+        },
+        driver: LiveDriverIdentity {
+            kind: "internal_rust_public_api_driver".into(),
+            source_mode: "runner_executes_query_no_caller_result".into(),
+            interface: "graphforge_api::GraphForge::execute_with_params".into(),
+            durable: false,
+            validator: "same_process_exact_order".into(),
+        },
+        normalization: LiveNormalizationIdentity {
+            upstream_temporal_window: "$date plus 100-day durations".into(),
+            internal_equivalent: "precomputed integer day boundaries [0,100), [100,200)".into(),
+            reason: "exercise supported Cypher while not claiming temporal-literal parity".into(),
+            result_order: vec!["diff DESC".into(), "tag.name ASC".into()],
+            numeric_format: "base10_i64".into(),
+        },
     }
-    if document.operation != Operation::Bi2 {
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    encoded
+}
+
+fn read_bytes(path: &Path, label: &str) -> Result<Vec<u8>, SuiteError> {
+    fs::read(path).map_err(|error| {
+        SuiteError::InvalidDocument(format!(
+            "failed to read {label} {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn parse_closed_json<T: for<'de> Deserialize<'de>>(
+    bytes: &[u8],
+    label: &str,
+) -> Result<T, SuiteError> {
+    serde_json::from_slice(bytes)
+        .map_err(|error| SuiteError::InvalidDocument(format!("invalid {label}: {error}")))
+}
+
+/// Independently derive official BI2 rows from the seed and typed windows.
+///
+/// Semantics match upstream `bi-2.cypher`: every tag of `$tagClass` appears,
+/// `countWindow1`/`countWindow2` use the half-open windows, `diff` is the
+/// absolute count delta, and the total order is `diff DESC, tag.name ASC`
+/// with `LIMIT 100`. This derivation is the reference authority; the committed
+/// `.ref` file must match it and is never captured from GraphForge.
+fn derive_expected_bi2(seed: &LiveSeed, bindings: &LiveBindings) -> ResultRows {
+    let tag_class = &bindings.tag_class.value;
+    let window_1_start = bindings.window_1_start.value;
+    let window_2_start = bindings.window_2_start.value;
+    let window_end = bindings.window_end.value;
+    let mut rows: Vec<(i64, String, i64, i64)> = seed
+        .tags
+        .iter()
+        .filter(|tag| tag.tag_class == *tag_class)
+        .map(|tag| {
+            let count_window_1 = seed
+                .messages
+                .iter()
+                .filter(|message| {
+                    message.tags.iter().any(|name| name == &tag.name)
+                        && window_1_start <= message.creation_day
+                        && message.creation_day < window_2_start
+                })
+                .count() as i64;
+            let count_window_2 = seed
+                .messages
+                .iter()
+                .filter(|message| {
+                    message.tags.iter().any(|name| name == &tag.name)
+                        && window_2_start <= message.creation_day
+                        && message.creation_day < window_end
+                })
+                .count() as i64;
+            let diff = (count_window_1 - count_window_2).abs();
+            (diff, tag.name.clone(), count_window_1, count_window_2)
+        })
+        .collect();
+    rows.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1)));
+    rows.truncate(100);
+    rows.into_iter()
+        .map(|(diff, name, count_window_1, count_window_2)| {
+            format!("{name} {count_window_1} {count_window_2} {diff}")
+        })
+        .collect()
+}
+
+fn validate_live_context(fixture: &Path) -> Result<ValidatedLiveContext, SuiteError> {
+    let identity_bytes = read_bytes(&fixture.join("identity.json"), "live identity")?;
+    let identity: LiveIdentity = parse_closed_json(&identity_bytes, "live identity")?;
+    if identity != expected_live_identity() {
         return Err(SuiteError::InvalidDocument(
-            "live lane supports exactly BI2".into(),
+            "live_identity_drift: complete expected identity mismatch".into(),
         ));
     }
-    if document.source != "graphforge_public_python_api" {
+
+    let seed_bytes = read_bytes(&fixture.join(&identity.fixture.path), "live seed")?;
+    if sha256_bytes(&seed_bytes) != identity.fixture.sha256 {
         return Err(SuiteError::InvalidDocument(
-            "static_output_rejected: live result source must be graphforge_public_python_api"
-                .into(),
+            "live_fixture_checksum_mismatch".into(),
         ));
     }
-    if document.parameters_sha256 != expected_parameters_sha256 {
-        return Err(SuiteError::InvalidDocument(
-            "parameter_identity_mismatch".into(),
-        ));
-    }
-    if document.columns
-        != ["tagName", "countWindow1", "countWindow2", "diff"]
-            .map(str::to_string)
-            .to_vec()
+    let seed: LiveSeed = parse_closed_json(&seed_bytes, "live seed")?;
+    if seed.schema != "graphforge-gdc-snb-bi-synthetic-seed/1" || seed.seed != identity.fixture.seed
     {
         return Err(SuiteError::InvalidDocument(
-            "unexpected BI2 live result columns".into(),
+            "live_fixture_identity_mismatch".into(),
         ));
     }
-    if document.rows.iter().any(|row| row.trim().is_empty()) {
+
+    let parameter_bytes = read_bytes(&fixture.join(&identity.parameters.path), "live parameters")?;
+    if sha256_bytes(&parameter_bytes) != identity.parameters.file_sha256 {
         return Err(SuiteError::InvalidDocument(
-            "live result rows must not be empty".into(),
+            "live_parameter_file_checksum_mismatch".into(),
         ));
     }
-    let system = document.rows.iter().map(|row| normalize_row(row)).collect();
-    validate_result(ValidationMode::Normalized, reference, &system)
+    let parameters: LiveParameters = parse_closed_json(&parameter_bytes, "live parameters")?;
+    if parameters.schema != LIVE_PARAMETERS_SCHEMA || parameters.operation != Operation::Bi2 {
+        return Err(SuiteError::InvalidDocument(
+            "live_parameter_identity_mismatch".into(),
+        ));
+    }
+    let binding_bytes = serde_json::to_vec(&parameters.bindings).map_err(|error| {
+        SuiteError::InvalidDocument(format!("failed to canonicalize live parameters: {error}"))
+    })?;
+    if sha256_bytes(&binding_bytes) != identity.parameters.names_kinds_values_sha256 {
+        return Err(SuiteError::InvalidDocument(
+            "live_parameter_binding_digest_mismatch".into(),
+        ));
+    }
+    let expected_parameters = LiveParameters {
+        schema: LIVE_PARAMETERS_SCHEMA.into(),
+        operation: Operation::Bi2,
+        bindings: LiveBindings {
+            tag_class: StringBinding {
+                kind: "string".into(),
+                value: "MusicalArtist".into(),
+            },
+            window_1_start: Int64Binding {
+                kind: "int64".into(),
+                value: 0,
+            },
+            window_2_start: Int64Binding {
+                kind: "int64".into(),
+                value: 100,
+            },
+            window_end: Int64Binding {
+                kind: "int64".into(),
+                value: 200,
+            },
+        },
+    };
+    if parameters != expected_parameters {
+        return Err(SuiteError::InvalidDocument(
+            "live_parameter_values_mismatch".into(),
+        ));
+    }
+
+    let reference_bytes = read_bytes(&fixture.join(&identity.reference.path), "live reference")?;
+    if sha256_bytes(&reference_bytes) != identity.reference.sha256 {
+        return Err(SuiteError::InvalidDocument(
+            "live_reference_checksum_mismatch".into(),
+        ));
+    }
+    let reference = parse_result_rows(std::str::from_utf8(&reference_bytes).map_err(|error| {
+        SuiteError::InvalidDocument(format!("reference is not UTF-8: {error}"))
+    })?);
+    let derived = derive_expected_bi2(&seed, &parameters.bindings);
+    if derived != reference {
+        return Err(SuiteError::ReferenceMismatch(
+            "live_reference_does_not_match_independent_semantic_derivation".into(),
+        ));
+    }
+    Ok(ValidatedLiveContext {
+        identity,
+        parameters,
+        seed,
+        reference,
+    })
+}
+
+pub fn validate_live_fixture_context(fixture: &Path) -> Result<(), SuiteError> {
+    validate_live_context(fixture).map(|_| ())
+}
+
+fn api_error(context: &str, error: impl fmt::Display) -> SuiteError {
+    SuiteError::InvalidDocument(format!("live_api_execution_failed:{context}: {error}"))
+}
+
+fn execute_with_params(
+    forge: &graphforge_api::GraphForge,
+    query: &str,
+    params: std::collections::HashMap<String, graphforge_api::IrLiteral>,
+) -> Result<(), SuiteError> {
+    forge
+        .execute_with_params(query, &params)
+        .map(|_| ())
+        .map_err(|error| api_error("load", error))
+}
+
+fn load_live_seed(forge: &graphforge_api::GraphForge, seed: &LiveSeed) -> Result<u64, SuiteError> {
+    use graphforge_api::IrLiteral;
+    use std::collections::HashMap;
+
+    for name in &seed.tag_classes {
+        execute_with_params(
+            forge,
+            "CREATE (:TagClass {name: $name})",
+            HashMap::from([("name".into(), IrLiteral::Str(name.clone()))]),
+        )?;
+    }
+    for tag in &seed.tags {
+        execute_with_params(
+            forge,
+            "CREATE (:Tag {name: $name})",
+            HashMap::from([("name".into(), IrLiteral::Str(tag.name.clone()))]),
+        )?;
+        execute_with_params(
+            forge,
+            "MATCH (tag:Tag {name: $tag}), (class:TagClass {name: $class}) \
+             CREATE (tag)-[:HAS_TYPE]->(class)",
+            HashMap::from([
+                ("tag".into(), IrLiteral::Str(tag.name.clone())),
+                ("class".into(), IrLiteral::Str(tag.tag_class.clone())),
+            ]),
+        )?;
+    }
+    let mut tagged_edges = 0_u64;
+    for message in &seed.messages {
+        execute_with_params(
+            forge,
+            "CREATE (:Message {id: $id, creationDate: $creationDate})",
+            HashMap::from([
+                ("id".into(), IrLiteral::Int(message.id)),
+                ("creationDate".into(), IrLiteral::Int(message.creation_day)),
+            ]),
+        )?;
+        for tag in &message.tags {
+            execute_with_params(
+                forge,
+                "MATCH (message:Message {id: $id}), (tag:Tag {name: $tag}) \
+                 CREATE (message)-[:HAS_TAG]->(tag)",
+                HashMap::from([
+                    ("id".into(), IrLiteral::Int(message.id)),
+                    ("tag".into(), IrLiteral::Str(tag.clone())),
+                ]),
+            )?;
+            tagged_edges += 1;
+        }
+    }
+    Ok(
+        (seed.tag_classes.len() + seed.tags.len() + seed.tags.len() + seed.messages.len()) as u64
+            + tagged_edges,
+    )
+}
+
+fn execute_live_bi2(
+    forge: &graphforge_api::GraphForge,
+    bindings: &LiveBindings,
+) -> Result<ResultRows, SuiteError> {
+    use arrow::array::{Int64Array, StringArray};
+    use graphforge_api::IrLiteral;
+    use std::collections::HashMap;
+
+    let params = HashMap::from([
+        (
+            "tagClass".into(),
+            IrLiteral::Str(bindings.tag_class.value.clone()),
+        ),
+        (
+            "window1Start".into(),
+            IrLiteral::Int(bindings.window_1_start.value),
+        ),
+        (
+            "window2Start".into(),
+            IrLiteral::Int(bindings.window_2_start.value),
+        ),
+        (
+            "windowEnd".into(),
+            IrLiteral::Int(bindings.window_end.value),
+        ),
+    ]);
+    let result = forge
+        .execute_with_params(LIVE_BI2_QUERY, &params)
+        .map_err(|error| api_error("query", error))?;
+    let mut rows = Vec::new();
+    for batch in result.batches {
+        let tags = batch
+            .column_by_name("tagName")
+            .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| SuiteError::InvalidDocument("BI2 tagName is not Utf8".into()))?;
+        let count_1 = batch
+            .column_by_name("countWindow1")
+            .and_then(|column| column.as_any().downcast_ref::<Int64Array>())
+            .ok_or_else(|| SuiteError::InvalidDocument("BI2 countWindow1 is not Int64".into()))?;
+        let count_2 = batch
+            .column_by_name("countWindow2")
+            .and_then(|column| column.as_any().downcast_ref::<Int64Array>())
+            .ok_or_else(|| SuiteError::InvalidDocument("BI2 countWindow2 is not Int64".into()))?;
+        let diff = batch
+            .column_by_name("diff")
+            .and_then(|column| column.as_any().downcast_ref::<Int64Array>())
+            .ok_or_else(|| SuiteError::InvalidDocument("BI2 diff is not Int64".into()))?;
+        for row in 0..batch.num_rows() {
+            rows.push(format!(
+                "{} {} {} {}",
+                tags.value(row),
+                count_1.value(row),
+                count_2.value(row),
+                diff.value(row)
+            ));
+        }
+    }
+    Ok(rows)
+}
+
+pub fn run_live_fixture(
+    fixture: &Path,
+    executable: &Path,
+) -> Result<serde_json::Value, SuiteError> {
+    let context = validate_live_context(fixture)?;
+    let executable_sha256 = sha256_bytes(&read_bytes(executable, "runner executable")?);
+    let forge =
+        graphforge_api::GraphForge::new(None).map_err(|error| api_error("initialize", error))?;
+
+    let load_started = Instant::now();
+    let rows_loaded = load_live_seed(&forge, &context.seed)?;
+    let load_ms = u64::try_from(load_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+    let query_started = Instant::now();
+    let rows = execute_live_bi2(&forge, &context.parameters.bindings)?;
+    let query_ms = u64::try_from(query_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+    let validation_started = Instant::now();
+    let derived = derive_expected_bi2(&context.seed, &context.parameters.bindings);
+    validate_result(ValidationMode::Exact, &derived, &context.reference)?;
+    validate_result(ValidationMode::Exact, &derived, &rows)?;
+    let validation_ms = u64::try_from(validation_started.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+    Ok(serde_json::json!({
+        "schema": LIVE_EVIDENCE_SCHEMA,
+        "suite_id": SUITE_ID,
+        "lane": "live_in_memory",
+        "operation": "BI2",
+        "source_mode": "runner_owned_rust_api",
+        "status": "passed",
+        "certification": false,
+        "phases": ["load", "query", "validation"],
+        "identity": context.identity,
+        "execution_authority": {
+            "interface": "graphforge_api::GraphForge::execute_with_params",
+            "runner_executable_sha256": executable_sha256,
+            "caller_supplied_result": false
+        },
+        "correctness": {
+            "status": "passed",
+            "validation_mode": "exact",
+            "numeric_format": "base10_i64",
+            "reference_authority": "independent_semantic_derivation_from_seed",
+            "rows": rows
+        },
+        "resources": {
+            "correctness_authority": false,
+            "load": {"wall_ms": load_ms, "rows_loaded": rows_loaded},
+            "query": {"wall_ms": query_ms, "rows_returned": context.reference.len()},
+            "validation": {"wall_ms": validation_ms},
+            "unobserved": ["spill_bytes", "peak_rss_bytes", "io_bytes"]
+        }
+    }))
 }
 
 fn normalize_row(row: &str) -> String {
@@ -1046,6 +1563,7 @@ pub fn operation_rules() -> BTreeMap<&'static str, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     fn sample_job(operation: Operation) -> OperationJob {
         OperationJob {
@@ -1182,51 +1700,189 @@ mod tests {
         assert!(validate_result(ValidationMode::Normalized, &reference, &missing).is_err());
     }
 
-    fn sample_live_result(rows: &[&str]) -> LiveResultDocument {
-        LiveResultDocument {
-            schema: LIVE_RESULT_SCHEMA.into(),
-            operation: Operation::Bi2,
-            source: "graphforge_public_python_api".into(),
-            parameters_sha256: "a".repeat(64),
-            columns: ["tagName", "countWindow1", "countWindow2", "diff"]
-                .map(str::to_string)
-                .to_vec(),
-            rows: rows.iter().map(|row| (*row).into()).collect(),
+    fn sample_live_seed() -> LiveSeed {
+        LiveSeed {
+            schema: "graphforge-gdc-snb-bi-synthetic-seed/1".into(),
+            seed: 963,
+            tag_classes: vec!["MusicalArtist".into(), "SportsTeam".into()],
+            tags: vec![
+                LiveSeedTag {
+                    name: "Alpha".into(),
+                    tag_class: "MusicalArtist".into(),
+                },
+                LiveSeedTag {
+                    name: "Beta".into(),
+                    tag_class: "MusicalArtist".into(),
+                },
+                LiveSeedTag {
+                    name: "Gamma".into(),
+                    tag_class: "MusicalArtist".into(),
+                },
+                LiveSeedTag {
+                    name: "Strikers".into(),
+                    tag_class: "SportsTeam".into(),
+                },
+            ],
+            messages: vec![
+                LiveSeedMessage {
+                    id: 1,
+                    creation_day: 10,
+                    tags: vec!["Alpha".into()],
+                },
+                LiveSeedMessage {
+                    id: 2,
+                    creation_day: 20,
+                    tags: vec!["Alpha".into(), "Gamma".into()],
+                },
+                LiveSeedMessage {
+                    id: 3,
+                    creation_day: 30,
+                    tags: vec!["Beta".into(), "Gamma".into()],
+                },
+                LiveSeedMessage {
+                    id: 4,
+                    creation_day: 110,
+                    tags: vec!["Alpha".into()],
+                },
+                LiveSeedMessage {
+                    id: 5,
+                    creation_day: 120,
+                    tags: vec!["Beta".into(), "Gamma".into()],
+                },
+                LiveSeedMessage {
+                    id: 6,
+                    creation_day: 130,
+                    tags: vec!["Beta".into()],
+                },
+                LiveSeedMessage {
+                    id: 7,
+                    creation_day: 140,
+                    tags: vec!["Beta".into()],
+                },
+                LiveSeedMessage {
+                    id: 8,
+                    creation_day: 15,
+                    tags: vec!["Strikers".into()],
+                },
+            ],
+        }
+    }
+
+    fn sample_live_bindings() -> LiveBindings {
+        LiveBindings {
+            tag_class: StringBinding {
+                kind: "string".into(),
+                value: "MusicalArtist".into(),
+            },
+            window_1_start: Int64Binding {
+                kind: "int64".into(),
+                value: 0,
+            },
+            window_2_start: Int64Binding {
+                kind: "int64".into(),
+                value: 100,
+            },
+            window_end: Int64Binding {
+                kind: "int64".into(),
+                value: 200,
+            },
         }
     }
 
     #[test]
-    fn live_bi2_uses_authoritative_normalized_validation() {
-        let reference = parse_result_rows("Beta 1 3 2\nGamma 2 1 1\nAlpha 2 1 1\n");
-        let reordered = sample_live_result(&["Alpha 2 1 1", "Gamma 2 1 1", "Beta 1 3 2"]);
-        validate_live_result(&"a".repeat(64), &reference, &reordered).unwrap();
-
-        let mismatch = sample_live_result(&["Alpha 2 1 1", "Gamma 2 1 1"]);
+    fn live_bi2_has_total_order_and_rejects_swapped_ties() {
+        assert_eq!(
+            Operation::Bi2.validation_mode(),
+            Some(ValidationMode::Exact)
+        );
+        assert!(LIVE_BI2_QUERY.contains("ORDER BY diff DESC, tagName ASC"));
+        let reference = parse_result_rows("Beta 1 3 2\nAlpha 2 1 1\nGamma 2 1 1\n");
+        validate_result(ValidationMode::Exact, &reference, &reference).unwrap();
+        let swapped_tie = parse_result_rows("Beta 1 3 2\nGamma 2 1 1\nAlpha 2 1 1\n");
         assert!(matches!(
-            validate_live_result(&"a".repeat(64), &reference, &mismatch),
+            validate_result(ValidationMode::Exact, &reference, &swapped_tie),
             Err(SuiteError::ReferenceMismatch(_))
         ));
     }
 
     #[test]
-    fn live_validation_rejects_static_source_and_parameter_mutation() {
-        let reference = parse_result_rows("Alpha 2 1 1\n");
-        let mut document = sample_live_result(&["Alpha 2 1 1"]);
-        document.source = "committed_static_output".into();
-        assert!(
-            validate_live_result(&"a".repeat(64), &reference, &document)
-                .unwrap_err()
-                .to_string()
-                .contains("static_output_rejected")
+    fn independent_bi2_derivation_orders_beta_alpha_gamma() {
+        let derived = derive_expected_bi2(&sample_live_seed(), &sample_live_bindings());
+        assert_eq!(
+            derived,
+            vec![
+                "Beta 1 3 2".to_string(),
+                "Alpha 2 1 1".to_string(),
+                "Gamma 2 1 1".to_string(),
+            ]
         );
+        let official_swapped_gamma_first =
+            parse_result_rows("Beta 1 3 2\nGamma 2 1 1\nAlpha 2 1 1\n");
+        assert_ne!(derived, official_swapped_gamma_first);
+    }
 
-        document.source = "graphforge_public_python_api".into();
-        document.parameters_sha256 = "b".repeat(64);
-        assert!(
-            validate_live_result(&"a".repeat(64), &reference, &document)
-                .unwrap_err()
-                .to_string()
-                .contains("parameter_identity_mismatch")
+    #[test]
+    fn committed_live_fixture_matches_closed_identity_and_derivation() {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/gdc/snb-bi-live");
+        validate_live_fixture_context(&fixture).unwrap();
+        let context = validate_live_context(&fixture).unwrap();
+        assert_eq!(
+            context.reference,
+            vec![
+                "Beta 1 3 2".to_string(),
+                "Alpha 2 1 1".to_string(),
+                "Gamma 2 1 1".to_string(),
+            ]
+        );
+        assert!(!context.identity.certification);
+        assert_eq!(
+            context.identity.fixture.provenance_kind,
+            "content_addressed_committed_fixture"
+        );
+        assert!(context.identity.upstream_spec.release.starts_with('v'));
+        assert_eq!(context.identity.upstream_query.release, "v1.0.0");
+    }
+
+    #[test]
+    fn trusted_runner_executes_public_in_memory_graphforge() {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/gdc/snb-bi-live");
+        let executable = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        let evidence = run_live_fixture(&fixture, &executable).unwrap();
+        assert_eq!(evidence["schema"], LIVE_EVIDENCE_SCHEMA);
+        assert_eq!(evidence["source_mode"], "runner_owned_rust_api");
+        assert_eq!(evidence["certification"], serde_json::json!(false));
+        assert_eq!(
+            evidence["execution_authority"]["caller_supplied_result"],
+            serde_json::json!(false)
+        );
+        assert_eq!(
+            evidence["correctness"]["rows"],
+            serde_json::json!(["Beta 1 3 2", "Alpha 2 1 1", "Gamma 2 1 1"])
+        );
+        assert_eq!(evidence["correctness"]["validation_mode"], "exact");
+        assert_eq!(
+            evidence["resources"]["unobserved"],
+            serde_json::json!(["spill_bytes", "peak_rss_bytes", "io_bytes"])
+        );
+    }
+
+    #[test]
+    fn live_expected_identity_is_closed_and_non_certifying() {
+        let identity = expected_live_identity();
+        assert_eq!(identity.schema, LIVE_IDENTITY_SCHEMA);
+        assert_eq!(identity.suite_id, SUITE_ID);
+        assert_eq!(identity.operation, Operation::Bi2);
+        assert_eq!(identity.source_mode, "runner_owned_rust_api");
+        assert!(!identity.certification);
+        assert!(!identity.reference.captured_from_engine);
+        assert_eq!(
+            identity.reference.validation,
+            "exact_order_numeric_text_normalized"
+        );
+        assert!(!identity.driver.durable);
+        assert_eq!(
+            identity.driver.interface,
+            "graphforge_api::GraphForge::execute_with_params"
         );
     }
 
@@ -1240,23 +1896,19 @@ mod tests {
 
         let insert = run_job(&sample_job(Operation::Ins1), None, None);
         assert_eq!(insert.status, OperationStatus::SemanticIncompatibility);
-        assert!(
-            insert
-                .cause
-                .as_deref()
-                .unwrap()
-                .contains("bi_batch_update_stream_not_exposed")
-        );
+        assert!(insert
+            .cause
+            .as_deref()
+            .unwrap()
+            .contains("bi_batch_update_stream_not_exposed"));
 
         let weighted = run_job(&sample_job(Operation::Bi15), None, None);
         assert_eq!(weighted.status, OperationStatus::SemanticIncompatibility);
-        assert!(
-            weighted
-                .cause
-                .as_deref()
-                .unwrap()
-                .contains("weighted_shortest_path_not_exposed")
-        );
+        assert!(weighted
+            .cause
+            .as_deref()
+            .unwrap()
+            .contains("weighted_shortest_path_not_exposed"));
 
         let missing_output = run_job(&sample_job(Operation::Bi1), Some(&reference), None);
         assert_eq!(missing_output.status, OperationStatus::Failed);
@@ -1272,12 +1924,11 @@ mod tests {
         let system = parse_result_rows("1 WRONG\n");
         let read = run_job(&sample_job(Operation::Bi1), Some(&reference), Some(&system));
         assert_eq!(read.status, OperationStatus::Failed);
-        assert!(
-            read.cause
-                .as_deref()
-                .unwrap()
-                .contains("reference_mismatch")
-        );
+        assert!(read
+            .cause
+            .as_deref()
+            .unwrap()
+            .contains("reference_mismatch"));
     }
 
     #[test]

--- a/benchmarks/runners/gdc-snb-bi/src/lib.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/lib.rs
@@ -1274,7 +1274,6 @@ fn execute_live_bi2(
     forge: &graphforge_api::GraphForge,
     bindings: &LiveBindings,
 ) -> Result<ResultRows, SuiteError> {
-    use arrow::array::{Int64Array, StringArray};
     use graphforge_api::IrLiteral;
     use std::collections::HashMap;
 
@@ -1299,8 +1298,16 @@ fn execute_live_bi2(
     let result = forge
         .execute_with_params(LIVE_BI2_QUERY, &params)
         .map_err(|error| api_error("query", error))?;
+    extract_live_bi2_rows(&result.batches)
+}
+
+fn extract_live_bi2_rows(
+    batches: &[arrow::record_batch::RecordBatch],
+) -> Result<ResultRows, SuiteError> {
+    use arrow::array::{Array, Int64Array, StringArray};
+
     let mut rows = Vec::new();
-    for batch in result.batches {
+    for batch in batches {
         let tags = batch
             .column_by_name("tagName")
             .and_then(|column| column.as_any().downcast_ref::<StringArray>())
@@ -1317,6 +1324,18 @@ fn execute_live_bi2(
             .column_by_name("diff")
             .and_then(|column| column.as_any().downcast_ref::<Int64Array>())
             .ok_or_else(|| SuiteError::InvalidDocument("BI2 diff is not Int64".into()))?;
+        for (name, column) in [
+            ("tagName", tags as &dyn Array),
+            ("countWindow1", count_1 as &dyn Array),
+            ("countWindow2", count_2 as &dyn Array),
+            ("diff", diff as &dyn Array),
+        ] {
+            if column.null_count() != 0 {
+                return Err(SuiteError::InvalidDocument(format!(
+                    "BI2 {name} contains null values"
+                )));
+            }
+        }
         for row in 0..batch.num_rows() {
             rows.push(format!(
                 "{} {} {} {}",
@@ -1841,6 +1860,40 @@ mod tests {
         );
         assert!(context.identity.upstream_spec.release.starts_with('v'));
         assert_eq!(context.identity.upstream_query.release, "v1.0.0");
+    }
+
+    #[test]
+    fn live_bi2_rejects_nulls_with_reference_matching_payloads() {
+        use arrow::array::{ArrayRef, Int64Array, StringArray};
+        use arrow::buffer::Buffer;
+        use arrow::record_batch::RecordBatch;
+        use std::sync::Arc;
+
+        let columns: Vec<(&str, ArrayRef)> = vec![
+            ("tagName", Arc::new(StringArray::from(vec!["Beta"]))),
+            ("countWindow1", Arc::new(Int64Array::from(vec![1]))),
+            ("countWindow2", Arc::new(Int64Array::from(vec![3]))),
+            ("diff", Arc::new(Int64Array::from(vec![2]))),
+        ];
+        let valid = RecordBatch::try_from_iter(columns.clone()).unwrap();
+        assert_eq!(extract_live_bi2_rows(&[valid]).unwrap(), vec!["Beta 1 3 2"]);
+        for index in 0..columns.len() {
+            let mut nullable = columns.clone();
+            let data = nullable[index]
+                .1
+                .to_data()
+                .into_builder()
+                .null_bit_buffer(Some(Buffer::from([0_u8])))
+                .build()
+                .unwrap();
+            nullable[index].1 = arrow::array::make_array(data);
+            assert!(nullable[index].1.is_null(0));
+            let batch = RecordBatch::try_from_iter(nullable).unwrap();
+            let error = extract_live_bi2_rows(&[batch]).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains(&format!("BI2 {} contains null values", columns[index].0)));
+        }
     }
 
     #[test]

--- a/benchmarks/runners/gdc-snb-bi/src/lib.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/lib.rs
@@ -1197,11 +1197,11 @@ mod tests {
 
     #[test]
     fn live_bi2_uses_authoritative_normalized_validation() {
-        let reference = parse_result_rows("Beta 1 3 2\nGamma 2 0 2\nAlpha 2 1 1\n");
-        let reordered = sample_live_result(&["Alpha 2 1 1", "Gamma 2 0 2", "Beta 1 3 2"]);
+        let reference = parse_result_rows("Beta 1 3 2\nGamma 2 1 1\nAlpha 2 1 1\n");
+        let reordered = sample_live_result(&["Alpha 2 1 1", "Gamma 2 1 1", "Beta 1 3 2"]);
         validate_live_result(&"a".repeat(64), &reference, &reordered).unwrap();
 
-        let mismatch = sample_live_result(&["Alpha 2 1 1", "Gamma 2 0 2"]);
+        let mismatch = sample_live_result(&["Alpha 2 1 1", "Gamma 2 1 1"]);
         assert!(matches!(
             validate_live_result(&"a".repeat(64), &reference, &mismatch),
             Err(SuiteError::ReferenceMismatch(_))

--- a/benchmarks/runners/gdc-snb-bi/src/lib.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/lib.rs
@@ -22,10 +22,11 @@ use std::str::FromStr;
 pub const EVIDENCE_SCHEMA: &str = "graphforge-gdc-snb-bi-evidence/1";
 pub const JOB_SCHEMA: &str = "graphforge-gdc-snb-bi-job/1";
 pub const LADDER_SCHEMA: &str = "graphforge-gdc-snb-bi-ladder/1";
+pub const LIVE_RESULT_SCHEMA: &str = "graphforge-gdc-snb-bi-live-result/1";
 pub const RESOURCE_SCHEMA: &str = "graphforge-gdc-snb-bi-resources/1";
 pub const SUITE_ID: &str = "snb-bi";
 
-/// The bounded engineering fixture dataset every ladder and suite run begins on.
+/// Historical ID of the synthetic static validator fixture (not official SF0.003).
 pub const BOUNDED_TINY_DATASET: &str = "snb-bi-sf0.003";
 
 /// SNB BI workload category.
@@ -797,6 +798,76 @@ pub fn parse_result_rows(text: &str) -> ResultRows {
         .collect()
 }
 
+/// Result produced by the explicit live lane after a public GraphForge call.
+///
+/// The source and parameter digest prevent the validator CLI from accepting
+/// the legacy static `.out` replay as live evidence. The rows remain ordinary
+/// strings so the same Rust-owned normalization and multiset validator used by
+/// the suite is authoritative.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LiveResultDocument {
+    pub schema: String,
+    pub operation: Operation,
+    pub source: String,
+    pub parameters_sha256: String,
+    pub columns: Vec<String>,
+    pub rows: Vec<String>,
+}
+
+pub fn load_live_result_document(path: &Path) -> Result<LiveResultDocument, SuiteError> {
+    let text = fs::read_to_string(path).map_err(|error| {
+        SuiteError::InvalidDocument(format!("failed to read {}: {error}", path.display()))
+    })?;
+    serde_json::from_str(&text)
+        .map_err(|error| SuiteError::InvalidDocument(format!("invalid live result: {error}")))
+}
+
+pub fn validate_live_result(
+    expected_parameters_sha256: &str,
+    reference: &ResultRows,
+    document: &LiveResultDocument,
+) -> Result<(), SuiteError> {
+    if document.schema != LIVE_RESULT_SCHEMA {
+        return Err(SuiteError::InvalidDocument(format!(
+            "unexpected live result schema: {}",
+            document.schema
+        )));
+    }
+    if document.operation != Operation::Bi2 {
+        return Err(SuiteError::InvalidDocument(
+            "live lane supports exactly BI2".into(),
+        ));
+    }
+    if document.source != "graphforge_public_python_api" {
+        return Err(SuiteError::InvalidDocument(
+            "static_output_rejected: live result source must be graphforge_public_python_api"
+                .into(),
+        ));
+    }
+    if document.parameters_sha256 != expected_parameters_sha256 {
+        return Err(SuiteError::InvalidDocument(
+            "parameter_identity_mismatch".into(),
+        ));
+    }
+    if document.columns
+        != ["tagName", "countWindow1", "countWindow2", "diff"]
+            .map(str::to_string)
+            .to_vec()
+    {
+        return Err(SuiteError::InvalidDocument(
+            "unexpected BI2 live result columns".into(),
+        ));
+    }
+    if document.rows.iter().any(|row| row.trim().is_empty()) {
+        return Err(SuiteError::InvalidDocument(
+            "live result rows must not be empty".into(),
+        ));
+    }
+    let system = document.rows.iter().map(|row| normalize_row(row)).collect();
+    validate_result(ValidationMode::Normalized, reference, &system)
+}
+
 fn normalize_row(row: &str) -> String {
     row.split_whitespace().collect::<Vec<_>>().join(" ")
 }
@@ -1109,6 +1180,54 @@ mod tests {
 
         let missing = parse_result_rows("tag-a 3\ntag-c 9\n");
         assert!(validate_result(ValidationMode::Normalized, &reference, &missing).is_err());
+    }
+
+    fn sample_live_result(rows: &[&str]) -> LiveResultDocument {
+        LiveResultDocument {
+            schema: LIVE_RESULT_SCHEMA.into(),
+            operation: Operation::Bi2,
+            source: "graphforge_public_python_api".into(),
+            parameters_sha256: "a".repeat(64),
+            columns: ["tagName", "countWindow1", "countWindow2", "diff"]
+                .map(str::to_string)
+                .to_vec(),
+            rows: rows.iter().map(|row| (*row).into()).collect(),
+        }
+    }
+
+    #[test]
+    fn live_bi2_uses_authoritative_normalized_validation() {
+        let reference = parse_result_rows("Beta 1 3 2\nGamma 2 0 2\nAlpha 2 1 1\n");
+        let reordered = sample_live_result(&["Alpha 2 1 1", "Gamma 2 0 2", "Beta 1 3 2"]);
+        validate_live_result(&"a".repeat(64), &reference, &reordered).unwrap();
+
+        let mismatch = sample_live_result(&["Alpha 2 1 1", "Gamma 2 0 2"]);
+        assert!(matches!(
+            validate_live_result(&"a".repeat(64), &reference, &mismatch),
+            Err(SuiteError::ReferenceMismatch(_))
+        ));
+    }
+
+    #[test]
+    fn live_validation_rejects_static_source_and_parameter_mutation() {
+        let reference = parse_result_rows("Alpha 2 1 1\n");
+        let mut document = sample_live_result(&["Alpha 2 1 1"]);
+        document.source = "committed_static_output".into();
+        assert!(
+            validate_live_result(&"a".repeat(64), &reference, &document)
+                .unwrap_err()
+                .to_string()
+                .contains("static_output_rejected")
+        );
+
+        document.source = "graphforge_public_python_api".into();
+        document.parameters_sha256 = "b".repeat(64);
+        assert!(
+            validate_live_result(&"a".repeat(64), &reference, &document)
+                .unwrap_err()
+                .to_string()
+                .contains("parameter_identity_mismatch")
+        );
     }
 
     #[test]

--- a/benchmarks/runners/gdc-snb-bi/src/lib.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/lib.rs
@@ -1890,9 +1890,11 @@ mod tests {
             assert!(nullable[index].1.is_null(0));
             let batch = RecordBatch::try_from_iter(nullable).unwrap();
             let error = extract_live_bi2_rows(&[batch]).unwrap_err();
-            assert!(error
-                .to_string()
-                .contains(&format!("BI2 {} contains null values", columns[index].0)));
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("BI2 {} contains null values", columns[index].0))
+            );
         }
     }
 
@@ -1949,19 +1951,23 @@ mod tests {
 
         let insert = run_job(&sample_job(Operation::Ins1), None, None);
         assert_eq!(insert.status, OperationStatus::SemanticIncompatibility);
-        assert!(insert
-            .cause
-            .as_deref()
-            .unwrap()
-            .contains("bi_batch_update_stream_not_exposed"));
+        assert!(
+            insert
+                .cause
+                .as_deref()
+                .unwrap()
+                .contains("bi_batch_update_stream_not_exposed")
+        );
 
         let weighted = run_job(&sample_job(Operation::Bi15), None, None);
         assert_eq!(weighted.status, OperationStatus::SemanticIncompatibility);
-        assert!(weighted
-            .cause
-            .as_deref()
-            .unwrap()
-            .contains("weighted_shortest_path_not_exposed"));
+        assert!(
+            weighted
+                .cause
+                .as_deref()
+                .unwrap()
+                .contains("weighted_shortest_path_not_exposed")
+        );
 
         let missing_output = run_job(&sample_job(Operation::Bi1), Some(&reference), None);
         assert_eq!(missing_output.status, OperationStatus::Failed);
@@ -1977,11 +1983,12 @@ mod tests {
         let system = parse_result_rows("1 WRONG\n");
         let read = run_job(&sample_job(Operation::Bi1), Some(&reference), Some(&system));
         assert_eq!(read.status, OperationStatus::Failed);
-        assert!(read
-            .cause
-            .as_deref()
-            .unwrap()
-            .contains("reference_mismatch"));
+        assert!(
+            read.cause
+                .as_deref()
+                .unwrap()
+                .contains("reference_mismatch")
+        );
     }
 
     #[test]

--- a/benchmarks/runners/gdc-snb-bi/src/main.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/main.rs
@@ -1,6 +1,7 @@
 use graphforge_benchmark_gdc_snb_bi::{
     JOB_SCHEMA, MappingOutcome, Operation, OperationJob, OperationStatus, assemble_evidence,
-    load_resource_report, load_result_rows, map_operation, operation_rules, run_job,
+    load_live_result_document, load_resource_report, load_result_rows, map_operation,
+    operation_rules, run_job, validate_live_result,
 };
 use std::env;
 use std::fs;
@@ -39,6 +40,32 @@ fn main() -> ExitCode {
                         ExitCode::from(3)
                     }
                 },
+                Err(error) => {
+                    eprintln!("{error}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        "validate-live" => {
+            let Some(reference_path) = args.next() else {
+                eprintln!("usage: validate-live REFERENCE RESULT.json PARAMETERS_SHA256");
+                return ExitCode::from(2);
+            };
+            let Some(result_path) = args.next() else {
+                eprintln!("missing RESULT.json");
+                return ExitCode::from(2);
+            };
+            let Some(parameters_sha256) = args.next() else {
+                eprintln!("missing PARAMETERS_SHA256");
+                return ExitCode::from(2);
+            };
+            let reference_path = PathBuf::from(reference_path);
+            let result_path = PathBuf::from(result_path);
+            match load_result_rows(&reference_path).and_then(|reference| {
+                let result = load_live_result_document(&result_path)?;
+                validate_live_result(&parameters_sha256, &reference, &result)
+            }) {
+                Ok(()) => ExitCode::SUCCESS,
                 Err(error) => {
                     eprintln!("{error}");
                     ExitCode::FAILURE

--- a/benchmarks/runners/gdc-snb-bi/src/main.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/main.rs
@@ -1,7 +1,7 @@
 use graphforge_benchmark_gdc_snb_bi::{
-    JOB_SCHEMA, MappingOutcome, Operation, OperationJob, OperationStatus, assemble_evidence,
-    load_live_result_document, load_resource_report, load_result_rows, map_operation,
-    operation_rules, run_job, validate_live_result,
+    assemble_evidence, load_resource_report, load_result_rows, map_operation, operation_rules,
+    run_job, run_live_fixture, validate_live_fixture_context, MappingOutcome, Operation,
+    OperationJob, OperationStatus, JOB_SCHEMA,
 };
 use std::env;
 use std::fs;
@@ -12,7 +12,8 @@ fn main() -> ExitCode {
     let mut args = env::args().skip(1);
     let Some(command) = args.next() else {
         eprintln!(
-            "usage: graphforge-benchmark-gdc-snb-bi <list-operations|map-operation|run-suite> ..."
+            "usage: graphforge-benchmark-gdc-snb-bi \
+             <list-operations|map-operation|validate-live-context|run-live|run-static-suite> ..."
         );
         return ExitCode::from(2);
     };
@@ -46,25 +47,16 @@ fn main() -> ExitCode {
                 }
             }
         }
-        "validate-live" => {
-            let Some(reference_path) = args.next() else {
-                eprintln!("usage: validate-live REFERENCE RESULT.json PARAMETERS_SHA256");
+        "validate-live-context" => {
+            let Some(fixture_path) = args.next() else {
+                eprintln!("usage: validate-live-context FIXTURE_DIR");
                 return ExitCode::from(2);
             };
-            let Some(result_path) = args.next() else {
-                eprintln!("missing RESULT.json");
+            if args.next().is_some() {
+                eprintln!("validate-live-context accepts only FIXTURE_DIR");
                 return ExitCode::from(2);
-            };
-            let Some(parameters_sha256) = args.next() else {
-                eprintln!("missing PARAMETERS_SHA256");
-                return ExitCode::from(2);
-            };
-            let reference_path = PathBuf::from(reference_path);
-            let result_path = PathBuf::from(result_path);
-            match load_result_rows(&reference_path).and_then(|reference| {
-                let result = load_live_result_document(&result_path)?;
-                validate_live_result(&parameters_sha256, &reference, &result)
-            }) {
+            }
+            match validate_live_fixture_context(&PathBuf::from(fixture_path)) {
                 Ok(()) => ExitCode::SUCCESS,
                 Err(error) => {
                     eprintln!("{error}");
@@ -72,10 +64,48 @@ fn main() -> ExitCode {
                 }
             }
         }
-        "run-suite" => {
+        "run-live" => {
+            let Some(fixture_path) = args.next() else {
+                eprintln!("usage: run-live FIXTURE_DIR EVIDENCE.json");
+                return ExitCode::from(2);
+            };
+            let Some(evidence_path) = args.next() else {
+                eprintln!("missing EVIDENCE.json");
+                return ExitCode::from(2);
+            };
+            if args.next().is_some() {
+                eprintln!("run-live accepts only FIXTURE_DIR EVIDENCE.json");
+                return ExitCode::from(2);
+            }
+            let executable = match env::current_exe() {
+                Ok(path) => path,
+                Err(error) => {
+                    eprintln!("failed to identify runner executable: {error}");
+                    return ExitCode::FAILURE;
+                }
+            };
+            match run_live_fixture(&PathBuf::from(fixture_path), &executable) {
+                Ok(evidence) => {
+                    let payload = serde_json::to_string_pretty(&evidence).unwrap();
+                    match fs::write(evidence_path, format!("{payload}\n")) {
+                        Ok(()) => ExitCode::SUCCESS,
+                        Err(error) => {
+                            eprintln!("failed to write live evidence: {error}");
+                            ExitCode::FAILURE
+                        }
+                    }
+                }
+                Err(error) => {
+                    eprintln!("{error}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        "run-static-suite" => {
             let Some(jobs_dir) = args.next() else {
                 eprintln!(
-                    "usage: run-suite JOBS_DIR REFERENCE_DIR OUTPUT_DIR RESOURCES.json IDENTITIES.json EVIDENCE.json"
+                    "usage: run-static-suite JOBS_DIR REFERENCE_DIR OUTPUT_DIR \
+                     RESOURCES.json IDENTITIES.json EVIDENCE.json"
                 );
                 return ExitCode::from(2);
             };

--- a/benchmarks/runners/gdc-snb-bi/src/main.rs
+++ b/benchmarks/runners/gdc-snb-bi/src/main.rs
@@ -1,7 +1,7 @@
 use graphforge_benchmark_gdc_snb_bi::{
-    assemble_evidence, load_resource_report, load_result_rows, map_operation, operation_rules,
-    run_job, run_live_fixture, validate_live_fixture_context, MappingOutcome, Operation,
-    OperationJob, OperationStatus, JOB_SCHEMA,
+    JOB_SCHEMA, MappingOutcome, Operation, OperationJob, OperationStatus, assemble_evidence,
+    load_resource_report, load_result_rows, map_operation, operation_rules, run_job,
+    run_live_fixture, validate_live_fixture_context,
 };
 use std::env;
 use std::fs;

--- a/benchmarks/schemas/gdc-acquisition.json
+++ b/benchmarks/schemas/gdc-acquisition.json
@@ -21,12 +21,14 @@
     "recorded_generator": {
       "oneOf": [
         { "$ref": "#/$defs/toolIdentity" },
+        { "$ref": "#/$defs/contentIdentity" },
         { "type": "null" }
       ]
     },
     "recorded_driver": {
       "oneOf": [
         { "$ref": "#/$defs/toolIdentity" },
+        { "$ref": "#/$defs/contentIdentity" },
         { "type": "null" }
       ]
     },
@@ -53,6 +55,32 @@
     "references"
   ],
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "suite_id": { "not": { "const": "snb-bi" } }
+        },
+        "required": ["suite_id"]
+      },
+      "then": {
+        "properties": {
+          "recorded_generator": {
+            "oneOf": [
+              { "$ref": "#/$defs/toolIdentity" },
+              { "type": "null" }
+            ]
+          },
+          "recorded_driver": {
+            "oneOf": [
+              { "$ref": "#/$defs/toolIdentity" },
+              { "type": "null" }
+            ]
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "sha256": {
       "type": "string",
@@ -92,6 +120,33 @@
           "required": ["commit"]
         }
       ]
+    },
+    "contentIdentity": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "source": {
+          "type": "string",
+          "pattern": "^https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+        },
+        "provenance_kind": {
+          "enum": ["content_addressed_synthetic", "repository_source"]
+        },
+        "content_sha256": { "$ref": "#/$defs/sha256" },
+        "content_description": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        }
+      },
+      "required": [
+        "name",
+        "source",
+        "provenance_kind",
+        "content_sha256",
+        "content_description"
+      ],
+      "additionalProperties": false
     },
     "asset": {
       "type": "object",

--- a/benchmarks/schemas/gdc-pinned-identity.json
+++ b/benchmarks/schemas/gdc-pinned-identity.json
@@ -18,12 +18,14 @@
     "generator": {
       "oneOf": [
         { "$ref": "#/$defs/toolIdentity" },
+        { "$ref": "#/$defs/contentIdentity" },
         { "type": "null" }
       ]
     },
     "driver": {
       "oneOf": [
         { "$ref": "#/$defs/toolIdentity" },
+        { "$ref": "#/$defs/contentIdentity" },
         { "type": "null" }
       ]
     },
@@ -67,9 +69,34 @@
       },
       "else": {
         "properties": {
-          "generator": { "$ref": "#/$defs/toolIdentity" },
-          "driver": { "$ref": "#/$defs/toolIdentity" },
+          "generator": {
+            "oneOf": [
+              { "$ref": "#/$defs/toolIdentity" },
+              { "$ref": "#/$defs/contentIdentity" }
+            ]
+          },
+          "driver": {
+            "oneOf": [
+              { "$ref": "#/$defs/toolIdentity" },
+              { "$ref": "#/$defs/contentIdentity" }
+            ]
+          },
           "datasets": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "suite_id": { "not": { "const": "snb-bi" } },
+          "disposition": { "const": "executable" }
+        },
+        "required": ["suite_id", "disposition"]
+      },
+      "then": {
+        "properties": {
+          "generator": { "$ref": "#/$defs/toolIdentity" },
+          "driver": { "$ref": "#/$defs/toolIdentity" }
         }
       }
     }
@@ -109,6 +136,33 @@
           "required": ["commit"]
         }
       ]
+    },
+    "contentIdentity": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "source": {
+          "type": "string",
+          "pattern": "^https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+        },
+        "provenance_kind": {
+          "enum": ["content_addressed_synthetic", "repository_source"]
+        },
+        "content_sha256": { "$ref": "#/$defs/sha256" },
+        "content_description": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        }
+      },
+      "required": [
+        "name",
+        "source",
+        "provenance_kind",
+        "content_sha256",
+        "content_description"
+      ],
+      "additionalProperties": false
     },
     "datasetPin": {
       "type": "object",

--- a/benchmarks/schemas/gdc-suite-evidence.json
+++ b/benchmarks/schemas/gdc-suite-evidence.json
@@ -34,12 +34,14 @@
         "generator": {
           "oneOf": [
             { "$ref": "#/$defs/toolIdentity" },
+            { "$ref": "#/$defs/contentIdentity" },
             { "type": "null" }
           ]
         },
         "driver": {
           "oneOf": [
             { "$ref": "#/$defs/toolIdentity" },
+            { "$ref": "#/$defs/contentIdentity" },
             { "type": "null" }
           ]
         }
@@ -98,12 +100,67 @@
       },
       "then": { "properties": { "cause": { "type": "null" } } },
       "else": { "properties": { "cause": { "type": "string" } } }
+    },
+    {
+      "if": {
+        "properties": {
+          "suite_id": { "not": { "const": "snb-bi" } }
+        },
+        "required": ["suite_id"]
+      },
+      "then": {
+        "properties": {
+          "identities": {
+            "properties": {
+              "generator": {
+                "oneOf": [
+                  { "$ref": "#/$defs/toolIdentity" },
+                  { "type": "null" }
+                ]
+              },
+              "driver": {
+                "oneOf": [
+                  { "$ref": "#/$defs/toolIdentity" },
+                  { "type": "null" }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   ],
   "$defs": {
     "sha256": {
       "type": "string",
       "pattern": "^[a-f0-9]{64}$"
+    },
+    "contentIdentity": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "source": {
+          "type": "string",
+          "pattern": "^https://[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]+$"
+        },
+        "provenance_kind": {
+          "enum": ["content_addressed_synthetic", "repository_source"]
+        },
+        "content_sha256": { "$ref": "#/$defs/sha256" },
+        "content_description": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        }
+      },
+      "required": [
+        "name",
+        "source",
+        "provenance_kind",
+        "content_sha256",
+        "content_description"
+      ],
+      "additionalProperties": false
     },
     "toolIdentity": {
       "type": "object",

--- a/benchmarks/tests/test_gdc_contracts.py
+++ b/benchmarks/tests/test_gdc_contracts.py
@@ -338,6 +338,44 @@ class GdcContractTests(unittest.TestCase):
             validate_acquisition(self.static_pin, acquisition, self.fixtures / "identity-drift")
         self.assertEqual(raised.exception.cause, "identity_drift")
 
+    def test_content_addressed_tool_identity_is_narrowly_snb_bi_only(self) -> None:
+        pin_path = self.root / "profiles" / "gdc" / "snb-bi-identity.json"
+        pin = load_pinned_identity(pin_path)
+        self.assertEqual(
+            pin["generator"]["provenance_kind"],
+            "content_addressed_synthetic",
+        )
+        self.assertNotIn("release", pin["generator"])
+        self.assertNotIn("commit", pin["generator"])
+        self.assertEqual(pin["driver"]["provenance_kind"], "repository_source")
+        self.assertNotIn("release", pin["driver"])
+        self.assertNotIn("commit", pin["driver"])
+
+        acquisition_path = self.fixtures / "snb-bi-tiny" / "compatible" / "acquisition.json"
+        acquisition = load_acquisition(acquisition_path)
+        evidence = validate_acquisition(
+            pin,
+            acquisition,
+            self.fixtures / "snb-bi-tiny" / "compatible",
+        )
+        self.assertEqual(evidence["status"], "passed")
+
+        pin_schema = Draft202012Validator(
+            json.loads(
+                (self.root / "schemas" / "gdc-pinned-identity.json").read_text(encoding="utf-8")
+            )
+        )
+        foreign_pin = copy.deepcopy(pin)
+        foreign_pin["suite_id"] = "graphalytics"
+        self.assertTrue(list(pin_schema.iter_errors(foreign_pin)))
+
+        acquisition_schema = Draft202012Validator(
+            json.loads((self.root / "schemas" / "gdc-acquisition.json").read_text(encoding="utf-8"))
+        )
+        foreign_acquisition = copy.deepcopy(acquisition)
+        foreign_acquisition["suite_id"] = "graphalytics"
+        self.assertTrue(list(acquisition_schema.iter_errors(foreign_acquisition)))
+
     def test_inventory_only_spb_shares_contracts_without_workload_assets(self) -> None:
         pin = load_pinned_identity(self.root / "profiles" / "gdc" / "spb-identity.json")
         acquisition = {

--- a/benchmarks/tests/test_gdc_snb_bi.py
+++ b/benchmarks/tests/test_gdc_snb_bi.py
@@ -210,7 +210,7 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
     def test_live_phase_and_resource_evidence_stays_out_of_correctness(self) -> None:
         evidence = run_live_bi2()
         self.assertEqual(evidence["phases"], ["load", "query", "validation"])
-        self.assertEqual(evidence["resources"]["load"]["rows_loaded"], 28)
+        self.assertEqual(evidence["resources"]["load"]["rows_loaded"], 29)
         self.assertEqual(evidence["resources"]["query"]["rows_returned"], 3)
         self.assertIs(evidence["resources"]["correctness_authority"], False)
         self.assertNotIn("resources", evidence["correctness"])

--- a/benchmarks/tests/test_gdc_snb_bi.py
+++ b/benchmarks/tests/test_gdc_snb_bi.py
@@ -85,9 +85,7 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
             digest.update((runner / relative).read_bytes())
             digest.update(b"\0")
         identity = json.loads(
-            (self.root / "profiles" / "gdc" / "snb-bi-identity.json").read_text(
-                encoding="utf-8"
-            )
+            (self.root / "profiles" / "gdc" / "snb-bi-identity.json").read_text(encoding="utf-8")
         )
         self.assertEqual(identity["driver"]["content_sha256"], digest.hexdigest())
 

--- a/benchmarks/tests/test_gdc_snb_bi.py
+++ b/benchmarks/tests/test_gdc_snb_bi.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
+import tempfile
 import unittest
 
 from graphforge_bench.gdc_contracts import list_gdc_suites, workspace_root
@@ -13,6 +15,8 @@ from graphforge_bench.gdc_snb_bi import (
     BATCH_INSERTS,
     BATCH_UPDATE_CAUSE,
     EVIDENCE_SCHEMA,
+    LIVE_EVIDENCE_SCHEMA,
+    LIVE_RESULT_SCHEMA,
     OPERATIONS,
     RESOURCE_SCHEMA,
     WEIGHTED_PATH_CAUSE,
@@ -22,7 +26,10 @@ from graphforge_bench.gdc_snb_bi import (
     assert_separate_from_other_suites,
     list_operation_rules,
     map_operation_file,
+    run_live_bi2,
     run_tiny_suite,
+    validate_live_fixture,
+    validate_live_result_document,
 )
 from jsonschema import Draft202012Validator
 
@@ -121,6 +128,97 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
                 (self.root / "schemas" / "gdc-snb-bi-evidence.json").read_text(encoding="utf-8")
             )
         ).validate(evidence)
+
+    def _write_live_result(self, directory: Path, rows: list[str]) -> Path:
+        fixture = self.root / "fixtures" / "gdc" / "snb-bi-live"
+        identity = validate_live_fixture(fixture)
+        result = {
+            "schema": LIVE_RESULT_SCHEMA,
+            "operation": "BI2",
+            "source": "graphforge_public_python_api",
+            "parameters_sha256": identity["parameters"]["sha256"],
+            "columns": ["tagName", "countWindow1", "countWindow2", "diff"],
+            "rows": rows,
+        }
+        path = directory / "result.json"
+        path.write_text(json.dumps(result) + "\n", encoding="utf-8")
+        return path
+
+    def test_live_bi2_executes_real_in_memory_graphforge(self) -> None:
+        evidence = run_live_bi2()
+        self.assertEqual(evidence["schema"], LIVE_EVIDENCE_SCHEMA)
+        self.assertEqual(evidence["lane"], "live_in_memory")
+        self.assertEqual(evidence["operation"], "BI2")
+        self.assertEqual(evidence["status"], "passed")
+        self.assertIs(evidence["certification"], False)
+        self.assertEqual(
+            set(evidence["correctness"]["rows"]),
+            {"Beta 1 3 2", "Gamma 2 0 2", "Alpha 2 1 1"},
+        )
+        self.assertEqual(
+            evidence["correctness"]["validator"],
+            "graphforge-benchmark-gdc-snb-bi",
+        )
+
+    def test_live_validator_normalizes_reordering_and_rejects_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            reordered = self._write_live_result(
+                directory,
+                ["Alpha 2 1 1", "Gamma 2 0 2", "Beta 1 3 2"],
+            )
+            validate_live_result_document(reordered)
+            mismatch = self._write_live_result(
+                directory,
+                ["Alpha 2 1 1", "Gamma 2 0 2"],
+            )
+            with self.assertRaises(SnbBiSuiteError) as raised:
+                validate_live_result_document(mismatch)
+            self.assertEqual(raised.exception.cause, "reference_mismatch")
+
+    def test_live_lane_rejects_parameter_mutation_and_static_output(self) -> None:
+        with self.assertRaises(SnbBiSuiteError) as raised:
+            run_live_bi2(parameters_override={"tagClass": "SportsTeam"})
+        self.assertEqual(raised.exception.cause, "parameter_identity_mismatch")
+
+        static_output = (
+            self.root
+            / "fixtures"
+            / "gdc"
+            / "snb-bi-tiny"
+            / "compatible"
+            / "system-outputs"
+            / "snb-bi-sf0.003-BI2.out"
+        )
+        with self.assertRaises(SnbBiSuiteError) as raised_static:
+            validate_live_result_document(static_output)
+        self.assertEqual(raised_static.exception.cause, "static_output_rejected")
+
+    def test_live_fixture_rejects_identity_drift(self) -> None:
+        source = self.root / "fixtures" / "gdc" / "snb-bi-live"
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = Path(tmp) / "fixture"
+            shutil.copytree(source, fixture)
+            identity_path = fixture / "identity.json"
+            identity = json.loads(identity_path.read_text(encoding="utf-8"))
+            identity["upstream_query"]["commit"] = "0" * 40
+            identity_path.write_text(json.dumps(identity) + "\n", encoding="utf-8")
+            with self.assertRaises(SnbBiSuiteError) as raised:
+                validate_live_fixture(fixture)
+            self.assertEqual(raised.exception.cause, "identity_drift")
+
+    def test_live_phase_and_resource_evidence_stays_out_of_correctness(self) -> None:
+        evidence = run_live_bi2()
+        self.assertEqual(evidence["phases"], ["load", "query", "validation"])
+        self.assertEqual(evidence["resources"]["load"]["rows_loaded"], 27)
+        self.assertEqual(evidence["resources"]["query"]["rows_returned"], 3)
+        self.assertIs(evidence["resources"]["correctness_authority"], False)
+        self.assertNotIn("resources", evidence["correctness"])
+        self.assertNotIn("wall_ms", evidence["correctness"])
+        self.assertEqual(
+            evidence["resources"]["unobserved"],
+            ["spill_bytes", "peak_rss_bytes", "io_bytes"],
+        )
 
     def test_resources_recorded_separately_from_correctness(self) -> None:
         evidence = run_tiny_suite(fixture_name="compatible")

--- a/benchmarks/tests/test_gdc_snb_bi.py
+++ b/benchmarks/tests/test_gdc_snb_bi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -16,7 +17,6 @@ from graphforge_bench.gdc_snb_bi import (
     BATCH_UPDATE_CAUSE,
     EVIDENCE_SCHEMA,
     LIVE_EVIDENCE_SCHEMA,
-    LIVE_RESULT_SCHEMA,
     OPERATIONS,
     RESOURCE_SCHEMA,
     WEIGHTED_PATH_CAUSE,
@@ -29,7 +29,6 @@ from graphforge_bench.gdc_snb_bi import (
     run_live_bi2,
     run_tiny_suite,
     validate_live_fixture,
-    validate_live_result_document,
 )
 from jsonschema import Draft202012Validator
 
@@ -77,6 +76,21 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
         self.assertEqual(suite["datasets"][0], "snb-bi-sf0.003")
         assert_separate_from_other_suites()
 
+    def test_internal_driver_identity_matches_actual_source_bytes(self) -> None:
+        runner = self.root / "runners" / "gdc-snb-bi"
+        digest = hashlib.sha256()
+        for relative in ("Cargo.toml", "src/lib.rs", "src/main.rs"):
+            digest.update(relative.encode())
+            digest.update(b"\0")
+            digest.update((runner / relative).read_bytes())
+            digest.update(b"\0")
+        identity = json.loads(
+            (self.root / "profiles" / "gdc" / "snb-bi-identity.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(identity["driver"]["content_sha256"], digest.hexdigest())
+
     def test_all_operations_declare_mapping_and_validation_rules(self) -> None:
         rules = list_operation_rules()
         self.assertEqual(set(rules), set(OPERATIONS))
@@ -89,7 +103,7 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
                 self.assertEqual(rules[read]["validation"], "none", read)
             else:
                 self.assertEqual(rules[read]["mapping"], "compatible", read)
-        self.assertEqual(rules["BI2"]["validation"], "normalized")
+        self.assertEqual(rules["BI2"]["validation"], "exact")
         self.assertEqual(rules["BI12"]["validation"], "normalized")
         self.assertEqual(rules["BI16"]["validation"], "normalized")
         self.assertEqual(rules["BI1"]["validation"], "exact")
@@ -129,83 +143,186 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
             )
         ).validate(evidence)
 
-    def _write_live_result(self, directory: Path, rows: list[str]) -> Path:
-        fixture = self.root / "fixtures" / "gdc" / "snb-bi-live"
-        identity = validate_live_fixture(fixture)
-        result = {
-            "schema": LIVE_RESULT_SCHEMA,
-            "operation": "BI2",
-            "source": "graphforge_public_python_api",
-            "parameters_sha256": identity["parameters"]["sha256"],
-            "columns": ["tagName", "countWindow1", "countWindow2", "diff"],
-            "rows": rows,
-        }
-        path = directory / "result.json"
-        path.write_text(json.dumps(result) + "\n", encoding="utf-8")
-        return path
-
     def test_live_bi2_executes_real_in_memory_graphforge(self) -> None:
         evidence = run_live_bi2()
         self.assertEqual(evidence["schema"], LIVE_EVIDENCE_SCHEMA)
         self.assertEqual(evidence["lane"], "live_in_memory")
         self.assertEqual(evidence["operation"], "BI2")
+        self.assertEqual(evidence["source_mode"], "runner_owned_rust_api")
         self.assertEqual(evidence["status"], "passed")
         self.assertIs(evidence["certification"], False)
         self.assertEqual(
-            set(evidence["correctness"]["rows"]),
-            {"Beta 1 3 2", "Gamma 2 1 1", "Alpha 2 1 1"},
+            evidence["correctness"]["rows"],
+            ["Beta 1 3 2", "Alpha 2 1 1", "Gamma 2 1 1"],
         )
         self.assertEqual(
-            evidence["correctness"]["validator"],
-            "graphforge-benchmark-gdc-snb-bi",
+            evidence["correctness"]["validation_mode"],
+            "exact",
         )
-
-    def test_live_validator_normalizes_reordering_and_rejects_mismatch(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            directory = Path(tmp)
-            reordered = self._write_live_result(
-                directory,
-                ["Alpha 2 1 1", "Gamma 2 1 1", "Beta 1 3 2"],
-            )
-            validate_live_result_document(reordered)
-            mismatch = self._write_live_result(
-                directory,
-                ["Alpha 2 1 1", "Gamma 2 1 1"],
-            )
-            with self.assertRaises(SnbBiSuiteError) as raised:
-                validate_live_result_document(mismatch)
-            self.assertEqual(raised.exception.cause, "reference_mismatch")
+        self.assertFalse(evidence["execution_authority"]["caller_supplied_result"])
+        self.assertRegex(
+            evidence["execution_authority"]["runner_executable_sha256"],
+            r"^[a-f0-9]{64}$",
+        )
 
     def test_live_lane_rejects_parameter_mutation_and_static_output(self) -> None:
         with self.assertRaises(SnbBiSuiteError) as raised:
             run_live_bi2(parameters_override={"tagClass": "SportsTeam"})
         self.assertEqual(raised.exception.cause, "parameter_identity_mismatch")
 
-        static_output = (
-            self.root
-            / "fixtures"
-            / "gdc"
-            / "snb-bi-tiny"
-            / "compatible"
-            / "system-outputs"
-            / "snb-bi-sf0.003-BI2.out"
-        )
-        with self.assertRaises(SnbBiSuiteError) as raised_static:
-            validate_live_result_document(static_output)
-        self.assertEqual(raised_static.exception.cause, "static_output_rejected")
-
-    def test_live_fixture_rejects_identity_drift(self) -> None:
-        source = self.root / "fixtures" / "gdc" / "snb-bi-live"
+        fixture = self.root / "fixtures" / "gdc" / "snb-bi-live"
+        identity = validate_live_fixture(fixture)
+        forged = {
+            "schema": LIVE_EVIDENCE_SCHEMA,
+            "source_mode": "runner_owned_rust_api",
+            "parameters": identity["parameters"],
+            "rows": ["Beta 1 3 2", "Alpha 2 1 1", "Gamma 2 1 1"],
+        }
         with tempfile.TemporaryDirectory() as tmp:
-            fixture = Path(tmp) / "fixture"
-            shutil.copytree(source, fixture)
-            identity_path = fixture / "identity.json"
-            identity = json.loads(identity_path.read_text(encoding="utf-8"))
-            identity["upstream_query"]["commit"] = "0" * 40
-            identity_path.write_text(json.dumps(identity) + "\n", encoding="utf-8")
-            with self.assertRaises(SnbBiSuiteError) as raised:
-                validate_live_fixture(fixture)
-            self.assertEqual(raised.exception.cause, "identity_drift")
+            forged_path = Path(tmp) / "forged.json"
+            forged_path.write_text(json.dumps(forged) + "\n", encoding="utf-8")
+            evidence_path = Path(tmp) / "evidence.json"
+            completed = subprocess.run(
+                [str(self.binary), "run-live", str(forged_path), str(evidence_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertFalse(evidence_path.exists())
+
+    def test_python_wrapper_cannot_supply_rows_or_identity(self) -> None:
+        for replacement in (
+            {"rows": ["Beta 1 3 2", "Alpha 2 1 1", "Gamma 2 1 1"]},
+            {"identities": {}},
+            {"source": "graphforge_public_python_api"},
+            {"result_path": Path("forged.json")},
+        ):
+            with self.assertRaises(TypeError):
+                run_live_bi2(**replacement)
+
+    def test_adversarial_caller_envelope_cannot_emit_live_success(self) -> None:
+        fixture = self.root / "fixtures" / "gdc" / "snb-bi-live"
+        forged = {
+            "schema": "graphforge-gdc-snb-bi-live-result/1",
+            "operation": "BI2",
+            "source": "graphforge_public_python_api",
+            "parameters_sha256": "0" * 64,
+            "columns": ["tagName", "countWindow1", "countWindow2", "diff"],
+            "rows": ["Beta 1 3 2", "Alpha 2 1 1", "Gamma 2 1 1"],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            envelope = tmp_path / "forged-envelope.json"
+            evidence = tmp_path / "evidence.json"
+            envelope.write_text(json.dumps(forged) + "\n", encoding="utf-8")
+            retired = subprocess.run(
+                [
+                    str(self.binary),
+                    "validate-live",
+                    str(envelope),
+                    str(fixture / "expected-bi2.ref"),
+                    "0" * 64,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(retired.returncode, 2)
+            self.assertIn("unknown command", retired.stderr)
+            self.assertFalse(evidence.exists())
+
+            extra = subprocess.run(
+                [str(self.binary), "run-live", str(fixture), str(evidence), str(envelope)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(extra.returncode, 2)
+            self.assertIn("accepts only FIXTURE_DIR EVIDENCE.json", extra.stderr)
+            self.assertFalse(evidence.exists())
+
+    def test_live_seed_parameter_and_reference_mutations_fail_closed(self) -> None:
+        source = self.root / "fixtures" / "gdc" / "snb-bi-live"
+        cases = (
+            ("seed.json", "checksum_mismatch"),
+            ("parameters.json", "parameter_identity_mismatch"),
+            ("expected-bi2.ref", "checksum_mismatch"),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            for filename, cause in cases:
+                fixture = Path(tmp) / filename
+                shutil.copytree(source, fixture)
+                path = fixture / filename
+                path.write_bytes(path.read_bytes() + b"\nmutated\n")
+                with self.subTest(filename=filename), self.assertRaises(SnbBiSuiteError) as raised:
+                    validate_live_fixture(fixture)
+                self.assertEqual(raised.exception.cause, cause)
+                shutil.rmtree(fixture)
+
+    def test_static_replay_uses_an_explicit_non_live_command(self) -> None:
+        evidence = run_tiny_suite(fixture_name="compatible")
+        self.assertEqual(evidence["schema"], EVIDENCE_SCHEMA)
+        self.assertNotIn("execution_authority", evidence)
+        self.assertNotEqual(evidence.get("lane"), "live_in_memory")
+
+    def test_every_live_identity_field_and_member_is_closed(self) -> None:
+        source = self.root / "fixtures" / "gdc" / "snb-bi-live"
+        original = json.loads((source / "identity.json").read_text(encoding="utf-8"))
+
+        def leaves(value: object, path: tuple[object, ...] = ()) -> list[tuple[object, ...]]:
+            if isinstance(value, dict):
+                return [
+                    leaf for key, child in value.items() for leaf in leaves(child, (*path, key))
+                ]
+            if isinstance(value, list):
+                return [
+                    leaf
+                    for index, child in enumerate(value)
+                    for leaf in leaves(child, (*path, index))
+                ]
+            return [path]
+
+        def mutate(value: object) -> object:
+            if value is None:
+                return "mutated"
+            if isinstance(value, bool):
+                return not value
+            if isinstance(value, int):
+                return value + 1
+            if isinstance(value, str):
+                return f"{value}-mutated"
+            raise AssertionError(type(value))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            for index, path in enumerate(leaves(original)):
+                fixture = base / f"fixture-{index}"
+                shutil.copytree(source, fixture)
+                changed = json.loads(json.dumps(original))
+                parent = changed
+                for member in path[:-1]:
+                    parent = parent[member]
+                parent[path[-1]] = mutate(parent[path[-1]])
+                (fixture / "identity.json").write_text(
+                    json.dumps(changed) + "\n",
+                    encoding="utf-8",
+                )
+                with self.subTest(path=path), self.assertRaises(SnbBiSuiteError) as raised:
+                    validate_live_fixture(fixture)
+                self.assertEqual(raised.exception.cause, "identity_drift")
+                shutil.rmtree(fixture)
+
+            unknown = base / "fixture-unknown"
+            shutil.copytree(source, unknown)
+            changed = json.loads(json.dumps(original))
+            changed["unexpected"] = "forbidden"
+            (unknown / "identity.json").write_text(
+                json.dumps(changed) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(SnbBiSuiteError):
+                validate_live_fixture(unknown)
 
     def test_live_phase_and_resource_evidence_stays_out_of_correctness(self) -> None:
         evidence = run_live_bi2()

--- a/benchmarks/tests/test_gdc_snb_bi.py
+++ b/benchmarks/tests/test_gdc_snb_bi.py
@@ -153,7 +153,7 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
         self.assertIs(evidence["certification"], False)
         self.assertEqual(
             set(evidence["correctness"]["rows"]),
-            {"Beta 1 3 2", "Gamma 2 0 2", "Alpha 2 1 1"},
+            {"Beta 1 3 2", "Gamma 2 1 1", "Alpha 2 1 1"},
         )
         self.assertEqual(
             evidence["correctness"]["validator"],
@@ -165,12 +165,12 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
             directory = Path(tmp)
             reordered = self._write_live_result(
                 directory,
-                ["Alpha 2 1 1", "Gamma 2 0 2", "Beta 1 3 2"],
+                ["Alpha 2 1 1", "Gamma 2 1 1", "Beta 1 3 2"],
             )
             validate_live_result_document(reordered)
             mismatch = self._write_live_result(
                 directory,
-                ["Alpha 2 1 1", "Gamma 2 0 2"],
+                ["Alpha 2 1 1", "Gamma 2 1 1"],
             )
             with self.assertRaises(SnbBiSuiteError) as raised:
                 validate_live_result_document(mismatch)
@@ -210,7 +210,7 @@ class GdcSnbBiSuiteTests(unittest.TestCase):
     def test_live_phase_and_resource_evidence_stays_out_of_correctness(self) -> None:
         evidence = run_live_bi2()
         self.assertEqual(evidence["phases"], ["load", "query", "validation"])
-        self.assertEqual(evidence["resources"]["load"]["rows_loaded"], 27)
+        self.assertEqual(evidence["resources"]["load"]["rows_loaded"], 28)
         self.assertEqual(evidence["resources"]["query"]["rows_returned"], 3)
         self.assertIs(evidence["resources"]["correctness_authority"], False)
         self.assertNotIn("resources", evidence["correctness"])


### PR DESCRIPTION
The SNB BI suite previously validated replayed results without proving public GraphForge execution. Add a bounded BI2 fixture that loads through the real Rust facade and executes the pinned query with public parameter binding. Validate its Arrow result against an independent seed-derived reference and keep load/query/resource evidence separate from correctness.

BI2 is the live execution proof. The remaining mapped BI reads retain explicitly labeled static/reference replay coverage; this change does not claim the entire SNB BI workload is live or benchmark-certified. The synthetic seed and repository driver use content hashes rather than invented upstream commit identities, with strict acquisition/schema matching and source-drift tests. Large factors remain opt-in external work.

Reject nulls in every required BI2 result column before reading Arrow payloads. The regression preserves reference-matching payload bytes beneath null bits, proving they cannot falsely pass validation.

Validation on the integrated tree:
- `make -C benchmarks smoke`: passed, including 378 Python tests, all Rust runner tests (18 SNB BI tests), benchmark workspace Clippy, formatting, and the real Cargo dependency check.
- Real CLI/facade execution, independent reference validation, null rejection, source identity, and negative provenance/parameter cases passed.
- `make pre-push-fast` and final diff checks: passed.
- Integration retained current dependency versions; the lockfile only adds SNB BI’s declared Arrow, facade, and SHA-2 edges.

Closes #963. #952 remains the broader M11 completion gate. Exact-head CI run 33945956077 passed at `1ee4852a21b04b504f2d8a87c3fea48f0e791c6f`; CI Gate passed, the merge state was CLEAN, and no review threads were unresolved. Squash merged as `f5fe689b515720b99cfa034678bc2d01b0365160`; issue #963 is closed.
