### PR TITLE
feat(bench): run Graph500 ladder under local-linux-cgroups-v2

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -115,6 +115,10 @@ ingest-ladder-bundle: install
 
 # OVHC-AGENCY / local-linux-cgroups-v2 host ladder (no Fly). WORK_ROOT must share
 # the process-root filesystem device with `/` (ext4 on this host).
+# Host BenchExec must use system Python (BenchExec + pystemd). The harness venv
+# BenchExec cannot attach cgroups even inside a delegated systemd scope.
+BENCHEXEC_PYTHON ?= /usr/bin/python3
+
 progressive-host-ladder-plan: install progressive-qualification-binaries
 	test -n "$(RUNG)" && test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_host_run \
@@ -122,6 +126,7 @@ progressive-host-ladder-plan: install progressive-qualification-binaries
 		--gf "$(CURDIR)/../target/release/gf" \
 		--certify "$(CURDIR)/target/release/graphforge-benchmark-certify" \
 		--generator "$(CURDIR)/target/release/graphforge-benchmark-graph500-generator" \
+		--benchexec-python "$(BENCHEXEC_PYTHON)" \
 		$(if $(HOST_CAPACITY),--host-capacity "$(HOST_CAPACITY)",)
 
 progressive-host-ladder-run: install progressive-qualification-binaries
@@ -131,6 +136,7 @@ progressive-host-ladder-run: install progressive-qualification-binaries
 		--gf "$(CURDIR)/../target/release/gf" \
 		--certify "$(CURDIR)/target/release/graphforge-benchmark-certify" \
 		--generator "$(CURDIR)/target/release/graphforge-benchmark-graph500-generator" \
+		--benchexec-python "$(BENCHEXEC_PYTHON)" \
 		$(if $(HOST_CAPACITY),--host-capacity "$(HOST_CAPACITY)",)
 
 progressive-host-ladder-inventory: install

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-storage-qualification progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness ingest-ladder-bundle parity-gate
+.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-storage-qualification progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness ingest-ladder-bundle parity-gate progressive-host-ladder-plan progressive-host-ladder-run progressive-host-ladder-inventory progressive-host-ladder-reclaim
 
 install:
 	uv sync --locked
@@ -112,3 +112,33 @@ ingest-ladder-bundle: install
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.ladder_bundle_ingest \
 		--source "$(SOURCE)" $(if $(DESTINATION),--destination "$(DESTINATION)",) \
 		$(if $(filter 1 true yes,$(VALIDATE_ONLY)),--validate-only,)
+
+# OVHC-AGENCY / local-linux-cgroups-v2 host ladder (no Fly). WORK_ROOT must share
+# the process-root filesystem device with `/` (ext4 on this host).
+progressive-host-ladder-plan: install progressive-qualification-binaries
+	test -n "$(RUNG)" && test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_host_run \
+		--rung "$(RUNG)" --output-dir "$(OUTPUT_DIR)" --work-root "$(WORK_ROOT)" --dry-run \
+		--gf "$(CURDIR)/../target/release/gf" \
+		--certify "$(CURDIR)/target/release/graphforge-benchmark-certify" \
+		--generator "$(CURDIR)/target/release/graphforge-benchmark-graph500-generator" \
+		$(if $(HOST_CAPACITY),--host-capacity "$(HOST_CAPACITY)",)
+
+progressive-host-ladder-run: install progressive-qualification-binaries
+	test -n "$(RUNG)" && test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_host_run \
+		--rung "$(RUNG)" --output-dir "$(OUTPUT_DIR)" --work-root "$(WORK_ROOT)" \
+		--gf "$(CURDIR)/../target/release/gf" \
+		--certify "$(CURDIR)/target/release/graphforge-benchmark-certify" \
+		--generator "$(CURDIR)/target/release/graphforge-benchmark-graph500-generator" \
+		$(if $(HOST_CAPACITY),--host-capacity "$(HOST_CAPACITY)",)
+
+progressive-host-ladder-inventory: install
+	test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_host_run \
+		--inventory --output-dir "$(OUTPUT_DIR)" --work-root "$(WORK_ROOT)"
+
+progressive-host-ladder-reclaim: install
+	test -n "$(RUNG_SCALE)" && test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_host_run \
+		--reclaim "$(RUNG_SCALE)" --output-dir "$(OUTPUT_DIR)" --work-root "$(WORK_ROOT)"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -300,6 +300,41 @@ particular, macOS and Docker Desktop do not prove native Linux admission and
 must not be used as substitutes. This probe creates no Fly resources and does
 not authorize a Graph500 scale run.
 
+## OVHC-AGENCY host ladder (`local-linux-cgroups-v2`)
+
+Issue #900/#745 certify on dedicated host **OVHC-AGENCY** under BenchExec
+cgroups v2. Disposable Fly execution remains optional offline tooling and is
+not the close path.
+
+Prepare controllers once (root), then admit and run as the unprivileged user:
+
+```bash
+sudo benchmarks/scripts/prepare-ovhc-agency-host.sh
+# After first install, reboot or recreate the user manager so Delegate=yes applies.
+mkdir -p "$HOME/graphforge-ladder"/{evidence,workspace,tmp}
+WORK_ROOT=$HOME/graphforge-ladder
+OUTPUT_DIR=$WORK_ROOT/evidence
+# Admission (must pass before ladder execution):
+GRAPHFORGE_ADMISSION_EVIDENCE=$PWD/benchmarks/outputs/local-admission-evidence.json GRAPHFORGE_EXPECTED_UID=$(id -u) GRAPHFORGE_SYSTEMD_SCOPE_MODE=user GRAPHFORGE_SYSTEMD_SCOPE=gf-admit.scope   systemd-run --user --scope --slice=benchexec -p Delegate=yes --unit=gf-admit   "$PWD/benchmarks/scripts/run-delegated-local-admission.sh"
+```
+
+Execute rungs sequentially. `WORK_ROOT` must share the process-root filesystem
+device with `/` (ext4 on OVHC-AGENCY). Do not use `/tmp` (tmpfs).
+
+```bash
+make -C benchmarks progressive-host-ladder-run   RUNG=S18 OUTPUT_DIR=$OUTPUT_DIR WORK_ROOT=$WORK_ROOT
+# after accepted evidence:
+make -C benchmarks progressive-host-ladder-reclaim   RUNG_SCALE=18 OUTPUT_DIR=$OUTPUT_DIR WORK_ROOT=$WORK_ROOT
+# S20+ also requires:
+#   HOST_CAPACITY=benchmarks/fixtures/progressive/ovhc-agency-host-capacity.json
+```
+
+Terminal teardown proof:
+
+```bash
+make -C benchmarks progressive-host-ladder-inventory   OUTPUT_DIR=$OUTPUT_DIR WORK_ROOT=$WORK_ROOT
+```
+
 ## Progressive Graph500 qualification
 
 `profiles/graph500/` contains distinct declarative S18 and S19 local profiles

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -322,6 +322,8 @@ Execute rungs sequentially. `WORK_ROOT` must share the process-root filesystem
 device with `/` (ext4 on OVHC-AGENCY). Do not use `/tmp` (tmpfs). Host runs
 default to `--benchexec-python /usr/bin/python3` (BenchExec + pystemd); the
 locked harness venv BenchExec cannot attach cgroups under a delegated scope.
+Product RSS remains the 4 GiB process VmHWM envelope; host BenchExec uses a
+raised cgroup kill ceiling so durable NVMe page cache does not false-OOM.
 
 ```bash
 make -C benchmarks progressive-host-ladder-run   RUNG=S18 OUTPUT_DIR=$OUTPUT_DIR WORK_ROOT=$WORK_ROOT
@@ -519,15 +521,18 @@ evidence therefore also requires an authenticated `graphforge-lifecycle-storage/
 owner-union receipt for retained and transient lifecycle maxima. The controller
 fails closed while that ordinary receipt is absent rather than summing project
 owners or treating portable logical payload bytes as allocated storage.
-Newly assembled rungs identify `graphforge-progressive-rung-assembly/2`; for
+Newly assembled rungs identify `graphforge-progressive-rung-assembly/3`; for
 that provenance the rung schema requires the lifecycle receipt's authoritative
 `source_project_current_allocated_bytes` and the complete closed
-`storage_attribution` payload. That payload copies the source and imported
-ten-category snapshots, committed construction application-I/O phases,
-portable-writer allocation, lifecycle unions, and reopened counts from the
-ordinary sanitized receipts. Historical version-1 rungs remain schema-readable
-but cannot supply #951 adapter evidence. The controller rejects any missing,
-malformed, or non-reconciling authority before emitting a new passed rung.
+`storage_attribution` payload. Process `peak_rss_bytes` comes from GraphForge
+certify VmHWM phase observations (`graphforge_process`), not BenchExec cgroup
+`memory.peak` (which includes durable page cache on host NVMe mounts). That
+payload copies the source and imported ten-category snapshots, committed
+construction application-I/O phases, portable-writer allocation, lifecycle
+unions, and reopened counts from the ordinary sanitized receipts. Historical
+version-1 rungs remain schema-readable but cannot supply #951 adapter
+evidence. The controller rejects any missing, malformed, or non-reconciling
+authority before emitting a new passed rung.
 The Rust certification runner owns that allocation session: it deduplicates
 stable native identities for the generated inputs, source project, result
 sinks, portable package, and clean-imported project; consumes writer-owned

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -319,7 +319,9 @@ GRAPHFORGE_ADMISSION_EVIDENCE=$PWD/benchmarks/outputs/local-admission-evidence.j
 ```
 
 Execute rungs sequentially. `WORK_ROOT` must share the process-root filesystem
-device with `/` (ext4 on OVHC-AGENCY). Do not use `/tmp` (tmpfs).
+device with `/` (ext4 on OVHC-AGENCY). Do not use `/tmp` (tmpfs). Host runs
+default to `--benchexec-python /usr/bin/python3` (BenchExec + pystemd); the
+locked harness venv BenchExec cannot attach cgroups under a delegated scope.
 
 ```bash
 make -C benchmarks progressive-host-ladder-run   RUNG=S18 OUTPUT_DIR=$OUTPUT_DIR WORK_ROOT=$WORK_ROOT

--- a/benchmarks/fixtures/parity/ladder-bundle/s18-rung.json
+++ b/benchmarks/fixtures/parity/ladder-bundle/s18-rung.json
@@ -5,7 +5,6 @@
   "metric_sources": {
     "benchexec": [
       "wall_seconds",
-      "peak_rss_bytes",
       "physical_read_bytes",
       "physical_write_bytes"
     ],
@@ -20,6 +19,9 @@
       "logical_write_bytes",
       "reader_calls",
       "publication_work_units"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
     ]
   },
   "metrics": {

--- a/benchmarks/fixtures/parity/ladder-bundle/s19-rung.json
+++ b/benchmarks/fixtures/parity/ladder-bundle/s19-rung.json
@@ -5,7 +5,6 @@
   "metric_sources": {
     "benchexec": [
       "wall_seconds",
-      "peak_rss_bytes",
       "physical_read_bytes",
       "physical_write_bytes"
     ],
@@ -20,6 +19,9 @@
       "logical_write_bytes",
       "reader_calls",
       "publication_work_units"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
     ]
   },
   "metrics": {

--- a/benchmarks/fixtures/parity/rung/s18-pass.json
+++ b/benchmarks/fixtures/parity/rung/s18-pass.json
@@ -32,7 +32,6 @@
   "metric_sources": {
     "benchexec": [
       "wall_seconds",
-      "peak_rss_bytes",
       "physical_read_bytes",
       "physical_write_bytes"
     ],
@@ -44,7 +43,13 @@
       "reader_calls",
       "publication_work_units"
     ],
-    "query_qualification": ["live_edges", "correctness"]
+    "query_qualification": [
+      "live_edges",
+      "correctness"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
+    ]
   },
   "storage_components": {
     "source_allocated_physical_bytes": 1048576,

--- a/benchmarks/fixtures/progressive/ovhc-agency-host-capacity.json
+++ b/benchmarks/fixtures/progressive/ovhc-agency-host-capacity.json
@@ -1,0 +1,10 @@
+{
+  "schema": "graphforge-host-capacity/1",
+  "host_profile_id": "local-linux-cgroups-v2",
+  "volume_bytes": 536870912000,
+  "reserved_headroom_bytes": 80530636800,
+  "physical_read_bytes_per_second": 1000000000,
+  "physical_write_bytes_per_second": 1000000000,
+  "reader_calls_per_second": 1000000,
+  "publication_work_per_second": 1000000
+}

--- a/benchmarks/harness/graphforge_bench/progressive_host_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_host_run.py
@@ -1,6 +1,6 @@
 """Fail-closed OVHC-AGENCY host ladder under local-linux-cgroups-v2.
 
-Runs S18–S26 through ordinary BenchExec authority on a durable ext4 work root.
+Runs S18-S26 through ordinary BenchExec authority on a durable ext4 work root.
 Fly image digests and disposable provider mounts are intentionally out of scope;
 retain those adapters as optional offline tooling only.
 """
@@ -9,10 +9,8 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping, Sequence
-import hashlib
 from importlib.metadata import PackageNotFoundError, version
 import json
-import os
 from pathlib import Path
 import shutil
 import stat
@@ -95,7 +93,7 @@ def require_work_root(work_root: Path) -> Path:
     if not resolved.is_dir() or resolved.is_symlink():
         raise HostRunError("work_root_invalid")
     try:
-        if os.stat(resolved).st_dev != os.stat("/").st_dev:
+        if resolved.stat().st_dev != Path("/").stat().st_dev:
             raise HostRunError("work_root_invalid")
     except OSError as error:
         raise HostRunError("work_root_invalid") from error
@@ -160,7 +158,7 @@ def _admit_projection(
     capacity: Mapping[str, Any],
 ) -> tuple[dict[str, Any], str]:
     if scale not in PROVIDER_SCALES:
-        raise HostRunError("projection is only required for S20–S26")
+        raise HostRunError("projection is only required for S20-S26")
     profiles = load_profiles(root / "profiles" / "graph500")
     profile = next(item for item in profiles if item.scale == scale)
     completed = completed_prefix(root, output_dir)

--- a/benchmarks/harness/graphforge_bench/progressive_host_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_host_run.py
@@ -14,6 +14,7 @@ import json
 from pathlib import Path
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 from typing import Any
@@ -30,6 +31,7 @@ from graphforge_bench.progressive_run import (
     Executables,
     _digest,
     _native_authority,
+    _preserve_failure_artifacts,
     _run_benchexec,
     _stage_benchmark_xml,
     ingest_benchexec_result,
@@ -50,10 +52,43 @@ CAPACITY_RATE_FIELDS = (
     "reader_calls_per_second",
     "publication_work_per_second",
 )
+SYSTEM_BENCHEXEC_PYTHON = Path("/usr/bin/python3")
 
 
 class HostRunError(ControllerError):
     """Host-native ladder planning or execution refused."""
+
+
+def resolve_host_benchexec_python(candidate: Path | None = None) -> Path:
+    """Prefer package BenchExec with pystemd for host cgroup delegation.
+
+    The locked harness venv installs BenchExec without pystemd. Nested under an
+    already-delegated systemd scope, that build cannot attach required cgroups.
+    System Python on OVHC-AGENCY carries BenchExec 3.x + pystemd and is the
+    ReFrame admission interpreter.
+    """
+    path = Path(candidate) if candidate is not None else SYSTEM_BENCHEXEC_PYTHON
+    if not path.is_file():
+        raise HostRunError(f"BenchExec Python is missing: {path}")
+    probe = subprocess.run(
+        [
+            str(path),
+            "-c",
+            "import benchexec, pystemd; print('ok')",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode != 0 or probe.stdout.strip() != "ok":
+        raise HostRunError(
+            "host ladder requires BenchExec Python with pystemd "
+            f"(tried {path}; install system BenchExec/pystemd or pass --benchexec-python)"
+        )
+    cli = path.parent / "benchexec"
+    if not cli.is_file():
+        raise HostRunError(f"BenchExec CLI is missing beside {path}")
+    return path.resolve()
 
 
 def _json(path: Path) -> Any:
@@ -366,18 +401,23 @@ def run(
                 home=work_root,
             )
             if status != 0:
+                _preserve_failure_artifacts(stage, output_dir, scale)
                 failed = _result(plan, "failed", "benchexec_failed")
                 _validate(root, "progressive-host-run-result.json", failed)
                 publish_json_no_clobber(result_path, failed)
                 raise HostRunError("benchexec_failed")
-            benchexec, graphforge, rung = ingest_benchexec_result(
-                root=root,
-                stage=stage,
-                scale=scale,
-                plan=plan,
-                profile_id=str(identities["profile_id"]),
-                source=_source_for(scale),
-            )
+            try:
+                benchexec, graphforge, rung = ingest_benchexec_result(
+                    root=root,
+                    stage=stage,
+                    scale=scale,
+                    plan=plan,
+                    profile_id=str(identities["profile_id"]),
+                    source=_source_for(scale),
+                )
+            except (ControllerError, OSError, ValueError):
+                _preserve_failure_artifacts(stage, output_dir, scale)
+                raise
     except HostRunError:
         raise
     except (ControllerError, OSError, ValueError) as error:
@@ -419,7 +459,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--gf")
     parser.add_argument("--certify")
     parser.add_argument("--generator")
-    parser.add_argument("--benchexec-python", default=sys.executable)
+    parser.add_argument(
+        "--benchexec-python",
+        default=str(SYSTEM_BENCHEXEC_PYTHON),
+        help="Python that provides BenchExec + pystemd (default: /usr/bin/python3)",
+    )
     parser.add_argument("--host-capacity", type=Path)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
@@ -442,11 +486,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.host_capacity is None:
                 raise HostRunError("S20+ requires --host-capacity")
             capacity = load_host_capacity(root, args.host_capacity)
+        benchexec_python = resolve_host_benchexec_python(Path(args.benchexec_python))
         executables = resolve_executables(
             gf=args.gf,
             certify=args.certify,
             generator=args.generator,
-            benchexec_python=args.benchexec_python,
+            benchexec_python=str(benchexec_python),
         )
         plan = build_plan(
             root=root,

--- a/benchmarks/harness/graphforge_bench/progressive_host_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_host_run.py
@@ -278,6 +278,16 @@ def _rewrite_profile_for_work_root(profile_text: str, scale: int, work_root: Pat
     )
 
 
+def _wrap_executable_for_tmp(staged: Path, tmp_dir: Path) -> None:
+    real = staged.with_name(f"{staged.name}.real")
+    staged.rename(real)
+    staged.write_text(
+        f'#!/bin/sh\nexport TMPDIR="{tmp_dir}"\nexec "{real}" "$@"\n',
+        encoding="utf-8",
+    )
+    staged.chmod(staged.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
 def _safe_stage_host(
     root: Path,
     profile_path: Path,
@@ -296,6 +306,8 @@ def _safe_stage_host(
     _stage_benchmark_xml(root, stage)
     bin_dir = stage / "bin"
     bin_dir.mkdir()
+    tmp_dir = work_root / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
     for name, source, identity_key in (
         ("gf", executables.gf, "gf_sha256"),
         ("graphforge-benchmark-certify", executables.certify, "certify_sha256"),
@@ -310,6 +322,7 @@ def _safe_stage_host(
         staged.chmod(staged.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         if _digest(staged) != identities.get(identity_key):
             raise HostRunError(f"staged executable identity mismatch: {name}")
+        _wrap_executable_for_tmp(staged, tmp_dir.resolve())
     stage.chmod(0o777)
     for path in stage.rglob("*"):
         if path.is_dir():

--- a/benchmarks/harness/graphforge_bench/progressive_host_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_host_run.py
@@ -243,16 +243,6 @@ def _rewrite_profile_for_work_root(profile_text: str, scale: int, work_root: Pat
     )
 
 
-def _wrap_executable_for_tmp(staged: Path, tmp_dir: Path) -> None:
-    real = staged.with_name(f"{staged.name}.real")
-    staged.rename(real)
-    staged.write_text(
-        f'#!/bin/sh\nexport TMPDIR="{tmp_dir}"\nexec "{real}" "$@"\n',
-        encoding="utf-8",
-    )
-    staged.chmod(staged.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-
-
 def _safe_stage_host(
     root: Path,
     profile_path: Path,
@@ -271,8 +261,6 @@ def _safe_stage_host(
     _stage_benchmark_xml(root, stage)
     bin_dir = stage / "bin"
     bin_dir.mkdir()
-    tmp_dir = work_root / "tmp"
-    tmp_dir.mkdir(parents=True, exist_ok=True)
     for name, source, identity_key in (
         ("gf", executables.gf, "gf_sha256"),
         ("graphforge-benchmark-certify", executables.certify, "certify_sha256"),
@@ -287,7 +275,6 @@ def _safe_stage_host(
         staged.chmod(staged.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         if _digest(staged) != identities.get(identity_key):
             raise HostRunError(f"staged executable identity mismatch: {name}")
-        _wrap_executable_for_tmp(staged, tmp_dir)
     stage.chmod(0o777)
     for path in stage.rglob("*"):
         if path.is_dir():

--- a/benchmarks/harness/graphforge_bench/progressive_host_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_host_run.py
@@ -1,0 +1,500 @@
+"""Fail-closed OVHC-AGENCY host ladder under local-linux-cgroups-v2.
+
+Runs S18–S26 through ordinary BenchExec authority on a durable ext4 work root.
+Fly image digests and disposable provider mounts are intentionally out of scope;
+retain those adapters as optional offline tooling only.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import hashlib
+from importlib.metadata import PackageNotFoundError, version
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import sys
+import tempfile
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from graphforge_bench.progressive_qualification import (
+    QualificationError,
+    load_profiles,
+    project,
+)
+from graphforge_bench.progressive_run import (
+    ControllerError,
+    Executables,
+    _digest,
+    _native_authority,
+    _run_benchexec,
+    _stage_benchmark_xml,
+    ingest_benchexec_result,
+    publish_json_no_clobber,
+    repository_commit,
+    resolve_executables,
+)
+
+PLAN_SCHEMA = "graphforge-progressive-host-run-plan/1"
+RESULT_SCHEMA = "graphforge-progressive-host-run-result/1"
+HOST_PROFILE_ID = "local-linux-cgroups-v2"
+LADDER = (18, 19, 20, 22, 24, 25, 26)
+LOCAL_SCALES = (18, 19)
+PROVIDER_SCALES = (20, 22, 24, 25, 26)
+CAPACITY_RATE_FIELDS = (
+    "physical_read_bytes_per_second",
+    "physical_write_bytes_per_second",
+    "reader_calls_per_second",
+    "publication_work_per_second",
+)
+
+
+class HostRunError(ControllerError):
+    """Host-native ladder planning or execution refused."""
+
+
+def _json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HostRunError(f"invalid evidence document: {path.name}") from error
+
+
+def _validate(root: Path, schema_name: str, document: Any) -> None:
+    schema = _json(root / "schemas" / schema_name)
+    error = next(Draft202012Validator(schema).iter_errors(document), None)
+    if error is not None:
+        raise HostRunError(f"{schema_name} validation failed: {error.message}")
+
+
+def _profile_path(root: Path, scale: int) -> Path:
+    suffix = "local" if scale in LOCAL_SCALES else "provider"
+    return root / "profiles" / "graph500" / f"s{scale}-{suffix}.json"
+
+
+def _profile_id(scale: int) -> str:
+    suffix = "local" if scale in LOCAL_SCALES else "provider"
+    return f"graph500-s{scale}-{suffix}"
+
+
+def _source_for(scale: int) -> str:
+    return "progressive_profile" if scale in LOCAL_SCALES else "canonical_ladder"
+
+
+def require_work_root(work_root: Path) -> Path:
+    """Refuse tmpfs/cross-volume work roots; durable projects must stay on process-root FS."""
+    try:
+        resolved = work_root.resolve(strict=True)
+    except OSError as error:
+        raise HostRunError("work_root_invalid") from error
+    if not resolved.is_dir() or resolved.is_symlink():
+        raise HostRunError("work_root_invalid")
+    try:
+        if os.stat(resolved).st_dev != os.stat("/").st_dev:
+            raise HostRunError("work_root_invalid")
+    except OSError as error:
+        raise HostRunError("work_root_invalid") from error
+    return resolved
+
+
+def load_host_capacity(root: Path, path: Path) -> Mapping[str, Any]:
+    document = _json(path)
+    _validate(root, "host-capacity.json", document)
+    if document.get("host_profile_id") != HOST_PROFILE_ID:
+        raise HostRunError("host capacity profile mismatch")
+    return document
+
+
+def _passed_rung(root: Path, output_dir: Path, scale: int) -> Mapping[str, Any] | None:
+    path = output_dir / f"s{scale}-rung.json"
+    if not path.exists():
+        return None
+    document = _json(path)
+    _validate(root, "progressive-qualification-rung-evidence.json", document)
+    if (
+        document.get("scale") != scale
+        or document.get("status") != "passed"
+        or document.get("profile_id") != _profile_id(scale)
+        or document.get("source") != _source_for(scale)
+        or document.get("live_edges") != 16 * (1 << scale)
+    ):
+        raise HostRunError(f"S{scale} evidence is not a passed matching host rung")
+    return document
+
+
+def completed_prefix(root: Path, output_dir: Path) -> list[Mapping[str, Any]]:
+    completed: list[Mapping[str, Any]] = []
+    gap = False
+    for scale in LADDER:
+        rung = _passed_rung(root, output_dir, scale)
+        if rung is None:
+            gap = True
+            continue
+        if gap:
+            raise HostRunError("rung evidence is out of order")
+        result = _json(output_dir / f"s{scale}-result.json")
+        _validate(root, "progressive-host-run-result.json", result)
+        if result.get("status") != "passed" or result.get("rung") != f"S{scale}":
+            raise HostRunError(f"S{scale} host result contradicts passed rung evidence")
+        completed.append(rung)
+    return completed
+
+
+def require_order(root: Path, output_dir: Path, scale: int) -> None:
+    completed = completed_prefix(root, output_dir)
+    expected_completed = list(LADDER[: LADDER.index(scale)])
+    actual = [int(item["scale"]) for item in completed]
+    if actual != expected_completed:
+        raise HostRunError(f"S{scale} requires completed prefix {expected_completed}")
+
+
+def _admit_projection(
+    root: Path,
+    output_dir: Path,
+    scale: int,
+    capacity: Mapping[str, Any],
+) -> tuple[dict[str, Any], str]:
+    if scale not in PROVIDER_SCALES:
+        raise HostRunError("projection is only required for S20–S26")
+    profiles = load_profiles(root / "profiles" / "graph500")
+    profile = next(item for item in profiles if item.scale == scale)
+    completed = completed_prefix(root, output_dir)
+    rates = {name: int(capacity[name]) for name in CAPACITY_RATE_FIELDS}
+    try:
+        evidence = project(profile, completed, rates)
+    except QualificationError as error:
+        raise HostRunError("projection_refused") from error
+    _validate(root, "progressive-qualification-evidence.json", evidence)
+    if evidence.get("decision") != "admitted":
+        raise HostRunError("projection_refused")
+    path = output_dir / f"s{scale}-projection.json"
+    publish_json_no_clobber(path, evidence)
+    return evidence, _digest(path)
+
+
+def build_plan(
+    *,
+    root: Path,
+    output_dir: Path,
+    scale: int,
+    commit: str,
+    executables: Executables,
+    capacity: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    require_order(root, output_dir, scale)
+    profile_path = _profile_path(root, scale)
+    profile = _json(profile_path)
+    _validate(root, "progressive-qualification-profile.json", profile)
+    if profile.get("id") != _profile_id(scale) or profile.get("scale") != scale:
+        raise HostRunError("canonical rung profile contradicts the selected scale")
+    generator_digest = "sha256:" + _digest(root / "runners/graph500-generator/src/main.rs")
+    if generator_digest != profile["generator"]["identity"]:
+        raise HostRunError("generator source identity contradicts the checked-in profile")
+    try:
+        benchexec_version = version("BenchExec")
+    except PackageNotFoundError as error:
+        raise HostRunError("BenchExec package identity unavailable") from error
+    host_profile_path = root / "profiles" / f"{HOST_PROFILE_ID}.json"
+    identities: dict[str, Any] = {
+        "commit": commit,
+        "host_profile_id": HOST_PROFILE_ID,
+        "host_profile_sha256": _digest(host_profile_path),
+        "profile_id": profile["id"],
+        "profile_sha256": _digest(profile_path),
+        "generator": generator_digest,
+        "generator_executable_sha256": _digest(executables.generator),
+        "gf_sha256": _digest(executables.gf),
+        "certify_sha256": _digest(executables.certify),
+        "benchexec_python_sha256": _digest(executables.benchexec_python),
+        "benchexec_version": benchexec_version,
+    }
+    if scale in PROVIDER_SCALES:
+        if capacity is None:
+            raise HostRunError("host capacity is required before S20+")
+        _, projection_digest = _admit_projection(root, output_dir, scale, capacity)
+        identities["admitted_projection_sha256"] = projection_digest
+    plan = {
+        "schema": PLAN_SCHEMA,
+        "rung": f"S{scale}",
+        "execution": "native_linux_benchexec_host",
+        "identities": identities,
+        "limits": {"wall_seconds": 14_400, "memory_bytes": 4_294_967_296, "cores": 16},
+        "outputs": [
+            f"s{scale}-plan.json",
+            f"s{scale}-benchexec.json",
+            f"s{scale}-graphforge.json",
+            f"s{scale}-rung.json",
+            f"s{scale}-result.json",
+        ],
+        "claim": "engineering_evidence_only",
+    }
+    _validate(root, "progressive-host-run-plan.json", plan)
+    return plan
+
+
+def _rewrite_profile_for_work_root(profile_text: str, scale: int, work_root: Path) -> str:
+    relative = f"workspace/s{scale}"
+    absolute = str((work_root / relative).resolve())
+    return profile_text.replace(f'"{relative}/', f'"{absolute}/').replace(
+        f'"{relative}"', f'"{absolute}"'
+    )
+
+
+def _wrap_executable_for_tmp(staged: Path, tmp_dir: Path) -> None:
+    real = staged.with_name(f"{staged.name}.real")
+    staged.rename(real)
+    staged.write_text(
+        f'#!/bin/sh\nexport TMPDIR="{tmp_dir}"\nexec "{real}" "$@"\n',
+        encoding="utf-8",
+    )
+    staged.chmod(staged.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _safe_stage_host(
+    root: Path,
+    profile_path: Path,
+    executables: Executables,
+    identities: Mapping[str, Any],
+    parent: Path,
+    *,
+    scale: int,
+    work_root: Path,
+) -> Path:
+    stage = Path(tempfile.mkdtemp(prefix="gf-host-progressive-", dir=parent))
+    profile_text = _rewrite_profile_for_work_root(
+        profile_path.read_text(encoding="utf-8"), scale, work_root
+    )
+    (stage / "profile.json").write_text(profile_text, encoding="utf-8")
+    _stage_benchmark_xml(root, stage)
+    bin_dir = stage / "bin"
+    bin_dir.mkdir()
+    tmp_dir = work_root / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    for name, source, identity_key in (
+        ("gf", executables.gf, "gf_sha256"),
+        ("graphforge-benchmark-certify", executables.certify, "certify_sha256"),
+        (
+            "graphforge-benchmark-graph500-generator",
+            executables.generator,
+            "generator_executable_sha256",
+        ),
+    ):
+        staged = bin_dir / name
+        shutil.copy2(source, staged)
+        staged.chmod(staged.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        if _digest(staged) != identities.get(identity_key):
+            raise HostRunError(f"staged executable identity mismatch: {name}")
+        _wrap_executable_for_tmp(staged, tmp_dir)
+    stage.chmod(0o777)
+    for path in stage.rglob("*"):
+        if path.is_dir():
+            path.chmod(0o777)
+    return stage
+
+
+def _result(
+    plan: Mapping[str, Any],
+    status: str,
+    failure: str | None,
+    artifacts: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema": RESULT_SCHEMA,
+        "rung": plan["rung"],
+        "status": status,
+        "failure": failure,
+        "identities": plan["identities"],
+        "artifacts": artifacts,
+        "claim": "engineering_evidence_only",
+    }
+
+
+def reclaim_rung_workspace(work_root: Path, scale: int) -> None:
+    """Delete a rung's datasets/projects after evidence is accepted."""
+    target = work_root / "workspace" / f"s{scale}"
+    if target.exists():
+        shutil.rmtree(target)
+
+
+def inventory_work_root(work_root: Path) -> dict[str, Any]:
+    """Return a sanitized inventory proving temporary debris state."""
+    workspace = work_root / "workspace"
+    remaining: list[str] = []
+    if workspace.is_dir():
+        for path in sorted(workspace.rglob("*")):
+            if path.is_file() or path.is_dir():
+                remaining.append(path.relative_to(work_root).as_posix())
+    return {
+        "schema": "graphforge-host-work-root-inventory/1",
+        "host_profile_id": HOST_PROFILE_ID,
+        "workspace_entries": remaining,
+        "empty": remaining == [],
+    }
+
+
+def run(
+    *,
+    root: Path,
+    output_dir: Path,
+    work_root: Path,
+    scale: int,
+    plan: Mapping[str, Any],
+    executables: Executables,
+) -> None:
+    work_root = require_work_root(work_root)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (work_root / "workspace" / f"s{scale}").mkdir(parents=True, exist_ok=True)
+    (work_root / "tmp").mkdir(parents=True, exist_ok=True)
+    result_path = output_dir / f"s{scale}-result.json"
+    try:
+        _native_authority()
+    except (ControllerError, OSError) as error:
+        failed = _result(plan, "failed", "native_authority_unavailable")
+        _validate(root, "progressive-host-run-result.json", failed)
+        publish_json_no_clobber(result_path, failed)
+        raise HostRunError("native_authority_unavailable") from error
+    profile_path = _profile_path(root, scale)
+    try:
+        with tempfile.TemporaryDirectory(prefix=".gf-host-authority-", dir=work_root) as temporary:
+            identities = plan["identities"]
+            if not isinstance(identities, Mapping):
+                raise HostRunError("run plan identities are malformed")
+            stage = _safe_stage_host(
+                root,
+                profile_path,
+                executables,
+                identities,
+                Path(temporary),
+                scale=scale,
+                work_root=work_root,
+            )
+            status = _run_benchexec(
+                stage,
+                executables,
+                identities,
+                durable_root=work_root,
+                home=work_root,
+            )
+            if status != 0:
+                failed = _result(plan, "failed", "benchexec_failed")
+                _validate(root, "progressive-host-run-result.json", failed)
+                publish_json_no_clobber(result_path, failed)
+                raise HostRunError("benchexec_failed")
+            benchexec, graphforge, rung = ingest_benchexec_result(
+                root=root,
+                stage=stage,
+                scale=scale,
+                plan=plan,
+                profile_id=str(identities["profile_id"]),
+                source=_source_for(scale),
+            )
+    except HostRunError:
+        raise
+    except (ControllerError, OSError, ValueError) as error:
+        failure = (
+            "ordinary_receipt_missing"
+            if "receipt" in str(error) or "evidence" in str(error)
+            else "staging_failed"
+        )
+        failed = _result(plan, "failed", failure)
+        _validate(root, "progressive-host-run-result.json", failed)
+        publish_json_no_clobber(result_path, failed)
+        raise HostRunError(failure) from error
+    artifact_paths = {
+        "plan_sha256": output_dir / f"s{scale}-plan.json",
+        "benchexec_sha256": output_dir / f"s{scale}-benchexec.json",
+        "graphforge_sha256": output_dir / f"s{scale}-graphforge.json",
+        "rung_sha256": output_dir / f"s{scale}-rung.json",
+    }
+    publish_json_no_clobber(artifact_paths["benchexec_sha256"], benchexec)
+    publish_json_no_clobber(artifact_paths["graphforge_sha256"], graphforge)
+    publish_json_no_clobber(artifact_paths["rung_sha256"], rung)
+    artifacts = {name: _digest(path) for name, path in artifact_paths.items()}
+    passed = _result(plan, "passed", None, artifacts)
+    _validate(root, "progressive-host-run-result.json", passed)
+    publish_json_no_clobber(result_path, passed)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument(
+        "--rung",
+        choices=tuple(f"S{scale}" for scale in LADDER),
+    )
+    action.add_argument("--inventory", action="store_true")
+    action.add_argument("--reclaim", type=int, choices=LADDER)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--work-root", type=Path, required=True)
+    parser.add_argument("--gf")
+    parser.add_argument("--certify")
+    parser.add_argument("--generator")
+    parser.add_argument("--benchexec-python", default=sys.executable)
+    parser.add_argument("--host-capacity", type=Path)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    root = Path(__file__).resolve().parents[2]
+    try:
+        work_root = require_work_root(args.work_root)
+        if args.inventory:
+            document = inventory_work_root(work_root)
+            publish_json_no_clobber(args.output_dir / "work-root-inventory.json", document)
+            print(json.dumps(document, sort_keys=True))
+            return 0 if document["empty"] else 2
+        if args.reclaim is not None:
+            reclaim_rung_workspace(work_root, args.reclaim)
+            return 0
+        if not all((args.gf, args.certify, args.generator)):
+            raise HostRunError("rung execution requires gf, certify, and generator")
+        scale = int(args.rung[1:])
+        capacity = None
+        if scale in PROVIDER_SCALES:
+            if args.host_capacity is None:
+                raise HostRunError("S20+ requires --host-capacity")
+            capacity = load_host_capacity(root, args.host_capacity)
+        executables = resolve_executables(
+            gf=args.gf,
+            certify=args.certify,
+            generator=args.generator,
+            benchexec_python=args.benchexec_python,
+        )
+        plan = build_plan(
+            root=root,
+            output_dir=args.output_dir,
+            scale=scale,
+            commit=repository_commit(root),
+            executables=executables,
+            capacity=capacity,
+        )
+        publish_json_no_clobber(args.output_dir / f"s{scale}-plan.json", plan)
+        if not args.dry_run:
+            run(
+                root=root,
+                output_dir=args.output_dir,
+                work_root=work_root,
+                scale=scale,
+                plan=plan,
+                executables=executables,
+            )
+        return 0
+    except (HostRunError, ControllerError, QualificationError) as error:
+        print(
+            json.dumps(
+                {
+                    "schema": RESULT_SCHEMA,
+                    "status": "failed",
+                    "failure": str(error),
+                },
+                sort_keys=True,
+            )
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/harness/graphforge_bench/progressive_host_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_host_run.py
@@ -15,7 +15,6 @@ from pathlib import Path
 import shutil
 import stat
 import subprocess
-import sys
 import tempfile
 from typing import Any
 

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -524,8 +524,17 @@ def _stage_benchmark_xml(root: Path, stage: Path) -> None:
     (stage / "benchmark.xml").write_text(text, encoding="utf-8")
 
 
-def _benchexec_memory_limit() -> list[str]:
-    return []
+# Host durable writes charge page cache into cgroup memory.peak. Keep the product
+# envelope at 4 GiB process VmHWM, but raise the BenchExec kill ceiling so NVMe
+# page cache cannot false-OOM an otherwise bounded construction. Host runs also
+# default to `--benchexec-python /usr/bin/python3` (system BenchExec + pystemd).
+HOST_BENCHEXEC_MEMORY_CEILING = "96GB"
+
+
+def _benchexec_memory_limit(*, durable_root: Path | None = None) -> list[str]:
+    if durable_root is None:
+        return []
+    return ["--memorylimit", HOST_BENCHEXEC_MEMORY_CEILING]
 
 
 def _benchexec_container_flags(stage: Path, *, durable_root: Path | None = None) -> list[str]:
@@ -603,7 +612,7 @@ def _run_benchexec(
         "--tool-directory",
         str(_benchexec_tool_directory(stage, prefer_stage=durable_root is not None)),
         *_benchexec_container_flags(stage, durable_root=durable_root),
-        *_benchexec_memory_limit(),
+        *_benchexec_memory_limit(durable_root=durable_root),
         "--no-compress-results",
         "--outputpath",
         str(raw_output),
@@ -1009,8 +1018,18 @@ def assemble_rung_evidence(
     if not isinstance(authority, Mapping):
         raise ControllerError("BenchExec authority is missing")
     phases = [phase.get("phase") for phase in graphforge.get("phases", [])]
+    process_peak_rss = 0
+    for phase in graphforge.get("phases", []):
+        if not isinstance(phase, Mapping):
+            continue
+        phase_rss = phase.get("peak_rss_bytes")
+        if isinstance(phase_rss, bool) or not isinstance(phase_rss, int) or phase_rss < 0:
+            raise ControllerError("GraphForge phase peak_rss_bytes is malformed")
+        process_peak_rss = max(process_peak_rss, phase_rss)
+    if process_peak_rss <= 0:
+        raise ControllerError("GraphForge process VmHWM peak_rss_bytes is missing")
     rung = {
-        "assembly_contract": "graphforge-progressive-rung-assembly/2",
+        "assembly_contract": "graphforge-progressive-rung-assembly/3",
         "profile_id": profile_id or f"graph500-s{scale}-local",
         "source": source,
         "scale": scale,
@@ -1020,7 +1039,9 @@ def assemble_rung_evidence(
         "phases": phases,
         "metrics": {
             "wall_seconds": int(float(authority["wall_seconds"]) + 0.999_999),
-            "peak_rss_bytes": int(authority["peak_rss_bytes"]),
+            # Process VmHWM from the public certify runner — not cgroup memory.peak,
+            # which includes durable page cache on host NVMe full-access mounts.
+            "peak_rss_bytes": process_peak_rss,
             **{name: lifecycle_storage[name] for name in lifecycle_names},
             **{
                 name: construction[name]
@@ -1037,10 +1058,10 @@ def assemble_rung_evidence(
         "metric_sources": {
             "benchexec": [
                 "wall_seconds",
-                "peak_rss_bytes",
                 "physical_read_bytes",
                 "physical_write_bytes",
             ],
+            "graphforge_process": ["peak_rss_bytes"],
             "storage_attribution": [
                 "retained_storage_bytes",
                 "transient_peak_storage_bytes",

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -543,7 +543,7 @@ def _benchexec_container_flags(stage: Path, *, durable_root: Path | None = None)
         ]
     if durable_root is not None:
         return [
-            "--read-only-dir",
+            "--overlay-dir",
             "/",
             "--hidden-dir",
             "/run",

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -542,8 +542,10 @@ def _benchexec_container_flags(stage: Path, *, durable_root: Path | None = None)
             "/work",
         ]
     if durable_root is not None:
+        # Keep TMPDIR off the full-access work root: fuse-overlayfs deadlocks when
+        # the container temp directory is also marked full-access.
         return [
-            "--overlay-dir",
+            "--read-only-dir",
             "/",
             "--hidden-dir",
             "/run",
@@ -579,9 +581,9 @@ def _run_benchexec(
         (Path("/work") / "tmp").mkdir(exist_ok=True)
         environment["TMPDIR"] = str(resolved_home / "tmp")
     elif durable_root is not None:
-        tmp = durable_root / "tmp"
-        tmp.mkdir(parents=True, exist_ok=True)
-        environment["TMPDIR"] = str(tmp)
+        # Intentionally leave TMPDIR unset / default-hidden so fuse-overlayfs
+        # (or namespace temp) is not placed under the full-access work root.
+        environment.pop("TMPDIR", None)
     command = [
         str(_benchexec_cli(executables.benchexec_python)),
         "--tool-directory",

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -406,7 +406,50 @@ def _make_benchexec_stage_writable(stage: Path) -> None:
 def _native_authority() -> Mapping[str, Any]:
     if platform.system() != "Linux":
         raise ControllerError("native Linux BenchExec authority is required")
-    evidence = qualify_local_host()
+    # ReFrame admission uses /usr/bin/python3 so package-managed BenchExec and
+    # pystemd can obtain a delegated cgroup. Preserve the user D-Bus session so
+    # pystemd can create that scope when this controller is already nested.
+    system_python = Path("/usr/bin/python3")
+    harness = str(Path(__file__).resolve().parents[1])
+    if system_python.is_file():
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key
+            in {
+                "HOME",
+                "PATH",
+                "USER",
+                "LOGNAME",
+                "XDG_RUNTIME_DIR",
+                "DBUS_SESSION_BUS_ADDRESS",
+                "DBUS_SESSION_BUS_PID",
+            }
+            and value
+        }
+        environment.update(
+            {
+                "LANG": "C.UTF-8",
+                "LC_ALL": "C.UTF-8",
+                "PYTHONPATH": harness,
+                "PYTHONDONTWRITEBYTECODE": "1",
+            }
+        )
+        completed = subprocess.run(
+            [str(system_python), "-m", "graphforge_bench.local_admission"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=environment,
+        )
+        try:
+            evidence = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise ControllerError("native BenchExec admission evidence is malformed") from error
+        if not isinstance(evidence, Mapping):
+            raise ControllerError("native BenchExec admission evidence is malformed")
+    else:
+        evidence = qualify_local_host()
     if evidence.get("result") != "passed":
         cause = evidence.get("cause")
         raise ControllerError(f"native BenchExec admission refused: {cause}")

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -461,9 +461,9 @@ def _authority_staging_parent(output_dir: Path) -> Path | None:
     return None
 
 
-def _benchexec_tool_directory(stage: Path) -> Path:
+def _benchexec_tool_directory(stage: Path, *, prefer_stage: bool = False) -> Path:
     """Prefer image-local executables once staged identity checks have passed."""
-    if _provider_volume_mounted():
+    if prefer_stage or _provider_volume_mounted():
         return stage / "bin"
     local = Path("/usr/local/bin")
     try:
@@ -485,8 +485,8 @@ def _benchexec_memory_limit() -> list[str]:
     return []
 
 
-def _benchexec_container_flags(stage: Path) -> list[str]:
-    """Configure BenchExec container mounts for durable provider-volume runs."""
+def _benchexec_container_flags(stage: Path, *, durable_root: Path | None = None) -> list[str]:
+    """Configure BenchExec container mounts for durable provider/host work roots."""
     if _provider_volume_mounted():
         return [
             "--read-only-dir",
@@ -498,17 +498,35 @@ def _benchexec_container_flags(stage: Path) -> list[str]:
             "--full-access-dir",
             "/work",
         ]
+    if durable_root is not None:
+        return [
+            "--read-only-dir",
+            "/",
+            "--hidden-dir",
+            "/run",
+            "--hidden-dir",
+            "/tmp",
+            "--full-access-dir",
+            str(durable_root.resolve()),
+        ]
     if stage.is_dir():
         return ["--full-access-dir", str(stage.resolve())]
     return []
 
 
-def _run_benchexec(stage: Path, executables: Executables, identities: Mapping[str, Any]) -> int:
+def _run_benchexec(
+    stage: Path,
+    executables: Executables,
+    identities: Mapping[str, Any],
+    *,
+    durable_root: Path | None = None,
+    home: Path | None = None,
+) -> int:
     raw_output = stage / "raw"
     raw_output.mkdir()
-    home = _bench_home(stage)
+    resolved_home = home or _bench_home(stage)
     environment = {
-        "HOME": str(home),
+        "HOME": str(resolved_home),
         "LANG": "C.UTF-8",
         "LC_ALL": "C.UTF-8",
         "PATH": f"{stage / 'bin'}:/usr/local/bin:{Path(sys.executable).parent}:/usr/bin:/bin",
@@ -516,12 +534,16 @@ def _run_benchexec(stage: Path, executables: Executables, identities: Mapping[st
     }
     if _provider_volume_mounted():
         (Path("/work") / "tmp").mkdir(exist_ok=True)
-        environment["TMPDIR"] = str(home / "tmp")
+        environment["TMPDIR"] = str(resolved_home / "tmp")
+    elif durable_root is not None:
+        tmp = durable_root / "tmp"
+        tmp.mkdir(parents=True, exist_ok=True)
+        environment["TMPDIR"] = str(tmp)
     command = [
         str(_benchexec_cli(executables.benchexec_python)),
         "--tool-directory",
-        str(_benchexec_tool_directory(stage)),
-        *_benchexec_container_flags(stage),
+        str(_benchexec_tool_directory(stage, prefer_stage=durable_root is not None)),
+        *_benchexec_container_flags(stage, durable_root=durable_root),
         *_benchexec_memory_limit(),
         "--no-compress-results",
         "--outputpath",

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -591,9 +591,12 @@ def _run_benchexec(
         (Path("/work") / "tmp").mkdir(exist_ok=True)
         environment["TMPDIR"] = str(resolved_home / "tmp")
     elif durable_root is not None:
-        # Intentionally leave TMPDIR unset / default-hidden so fuse-overlayfs
-        # (or namespace temp) is not placed under the full-access work root.
-        environment.pop("TMPDIR", None)
+        # Keep process temp on the durable work-root device. Default /tmp is tmpfs
+        # here and causes EXDEV when GraphForge installs CAS objects into the project.
+        # Do not combine this with fuse-overlayfs mounts of the same path.
+        tmp = durable_root / "tmp"
+        tmp.mkdir(parents=True, exist_ok=True)
+        environment["TMPDIR"] = str(tmp.resolve())
         environment["GRAPHFORGE_HOST_WORK_ROOT"] = str(durable_root.resolve())
     command = [
         str(_benchexec_cli(executables.benchexec_python)),

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -577,6 +577,16 @@ def _run_benchexec(
         "PATH": f"{stage / 'bin'}:/usr/local/bin:{Path(sys.executable).parent}:/usr/bin:/bin",
         "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
     }
+    for key in (
+        "XDG_RUNTIME_DIR",
+        "DBUS_SESSION_BUS_ADDRESS",
+        "DBUS_SESSION_BUS_PID",
+        "USER",
+        "LOGNAME",
+    ):
+        value = os.environ.get(key)
+        if value:
+            environment[key] = value
     if _provider_volume_mounted():
         (Path("/work") / "tmp").mkdir(exist_ok=True)
         environment["TMPDIR"] = str(resolved_home / "tmp")
@@ -584,6 +594,7 @@ def _run_benchexec(
         # Intentionally leave TMPDIR unset / default-hidden so fuse-overlayfs
         # (or namespace temp) is not placed under the full-access work root.
         environment.pop("TMPDIR", None)
+        environment["GRAPHFORGE_HOST_WORK_ROOT"] = str(durable_root.resolve())
     command = [
         str(_benchexec_cli(executables.benchexec_python)),
         "--tool-directory",

--- a/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
@@ -24,7 +24,7 @@ QUALIFICATION_SCHEMA = (
 )
 PROVIDER_RESULT_SCHEMA = BENCHMARK_ROOT / "schemas/progressive-provider-run-result.json"
 PROVIDER_PLAN_SCHEMA = BENCHMARK_ROOT / "schemas/progressive-provider-run-plan.json"
-ASSEMBLY_CONTRACT = "graphforge-progressive-rung-assembly/2"
+ASSEMBLY_CONTRACT = "graphforge-progressive-rung-assembly/3"
 QUALIFICATION_CONTRACT = "graphforge-g500-ladder-qualification/3"
 S26_EDGES = 1 << 30
 S26_NODES = 1 << 26

--- a/benchmarks/harness/graphforge_bench/tools/graphforge_certify.py
+++ b/benchmarks/harness/graphforge_bench/tools/graphforge_certify.py
@@ -15,6 +15,14 @@ def _certify_evidence_path() -> str:
             return str(tmp / "graphforge-certify-evidence.json")
     except OSError:
         pass
+    host_root = os.environ.get("GRAPHFORGE_HOST_WORK_ROOT")
+    if host_root:
+        try:
+            tmp = Path(host_root) / "tmp"
+            tmp.mkdir(parents=True, exist_ok=True)
+            return str(tmp / "graphforge-certify-evidence.json")
+        except OSError:
+            pass
     return "evidence.json"
 
 

--- a/benchmarks/schemas/host-capacity.json
+++ b/benchmarks/schemas/host-capacity.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-host-capacity-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "host_profile_id",
+    "volume_bytes",
+    "reserved_headroom_bytes",
+    "physical_read_bytes_per_second",
+    "physical_write_bytes_per_second",
+    "reader_calls_per_second",
+    "publication_work_per_second"
+  ],
+  "properties": {
+    "schema": {"const": "graphforge-host-capacity/1"},
+    "host_profile_id": {"const": "local-linux-cgroups-v2"},
+    "volume_bytes": {"type": "integer", "minimum": 1},
+    "reserved_headroom_bytes": {"type": "integer", "minimum": 0},
+    "physical_read_bytes_per_second": {"type": "integer", "minimum": 1},
+    "physical_write_bytes_per_second": {"type": "integer", "minimum": 1},
+    "reader_calls_per_second": {"type": "integer", "minimum": 1},
+    "publication_work_per_second": {"type": "integer", "minimum": 1}
+  }
+}

--- a/benchmarks/schemas/progressive-host-run-plan.json
+++ b/benchmarks/schemas/progressive-host-run-plan.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-progressive-host-run-plan-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "rung", "execution", "identities", "limits", "outputs", "claim"],
+  "properties": {
+    "schema": {"const": "graphforge-progressive-host-run-plan/1"},
+    "rung": {"enum": ["S18", "S19", "S20", "S22", "S24", "S25", "S26"]},
+    "execution": {"const": "native_linux_benchexec_host"},
+    "identities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commit",
+        "host_profile_id",
+        "host_profile_sha256",
+        "profile_id",
+        "profile_sha256",
+        "generator",
+        "generator_executable_sha256",
+        "gf_sha256",
+        "certify_sha256",
+        "benchexec_python_sha256",
+        "benchexec_version"
+      ],
+      "properties": {
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "host_profile_id": {"const": "local-linux-cgroups-v2"},
+        "host_profile_sha256": {"$ref": "#/$defs/digest"},
+        "profile_id": {
+          "enum": [
+            "graph500-s18-local",
+            "graph500-s19-local",
+            "graph500-s20-provider",
+            "graph500-s22-provider",
+            "graph500-s24-provider",
+            "graph500-s25-provider",
+            "graph500-s26-provider"
+          ]
+        },
+        "profile_sha256": {"$ref": "#/$defs/digest"},
+        "generator": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "generator_executable_sha256": {"$ref": "#/$defs/digest"},
+        "gf_sha256": {"$ref": "#/$defs/digest"},
+        "certify_sha256": {"$ref": "#/$defs/digest"},
+        "benchexec_python_sha256": {"$ref": "#/$defs/digest"},
+        "benchexec_version": {"type": "string", "pattern": "^[0-9]+(\\.[0-9]+)+$"},
+        "admitted_projection_sha256": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wall_seconds", "memory_bytes", "cores"],
+      "properties": {
+        "wall_seconds": {"const": 14400},
+        "memory_bytes": {"const": 4294967296},
+        "cores": {"const": 16}
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^s(18|19|20|22|24|25|26)-(plan|benchexec|graphforge|rung|result)\\.json$"
+      }
+    },
+    "claim": {"const": "engineering_evidence_only"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"rung": {"enum": ["S20", "S22", "S24", "S25", "S26"]}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "identities": {"required": ["admitted_projection_sha256"]}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"rung": {"const": "S18"}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "outputs": {
+            "const": [
+              "s18-plan.json",
+              "s18-benchexec.json",
+              "s18-graphforge.json",
+              "s18-rung.json",
+              "s18-result.json"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {"properties": {"rung": {"const": "S19"}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "outputs": {
+            "const": [
+              "s19-plan.json",
+              "s19-benchexec.json",
+              "s19-graphforge.json",
+              "s19-rung.json",
+              "s19-result.json"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {"properties": {"rung": {"const": "S20"}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "outputs": {
+            "const": [
+              "s20-plan.json",
+              "s20-benchexec.json",
+              "s20-graphforge.json",
+              "s20-rung.json",
+              "s20-result.json"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {"properties": {"rung": {"const": "S22"}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "outputs": {
+            "const": [
+              "s22-plan.json",
+              "s22-benchexec.json",
+              "s22-graphforge.json",
+              "s22-rung.json",
+              "s22-result.json"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {"properties": {"rung": {"const": "S24"}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "outputs": {
+            "const": [
+              "s24-plan.json",
+              "s24-benchexec.json",
+              "s24-graphforge.json",
+              "s24-rung.json",
+              "s24-result.json"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {"properties": {"rung": {"const": "S25"}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "outputs": {
+            "const": [
+              "s25-plan.json",
+              "s25-benchexec.json",
+              "s25-graphforge.json",
+              "s25-rung.json",
+              "s25-result.json"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {"properties": {"rung": {"const": "S26"}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "outputs": {
+            "const": [
+              "s26-plan.json",
+              "s26-benchexec.json",
+              "s26-graphforge.json",
+              "s26-rung.json",
+              "s26-result.json"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {"digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}}
+}

--- a/benchmarks/schemas/progressive-host-run-result.json
+++ b/benchmarks/schemas/progressive-host-run-result.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema": "graphforge-progressive-host-run-result-schema/1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "rung", "status", "failure", "identities", "artifacts", "claim"],
+  "properties": {
+    "schema": {"const": "graphforge-progressive-host-run-result/1"},
+    "rung": {"enum": ["S18", "S19", "S20", "S22", "S24", "S25", "S26"]},
+    "status": {"enum": ["passed", "failed"]},
+    "failure": {
+      "enum": [
+        null,
+        "native_authority_unavailable",
+        "staging_failed",
+        "execution_boundary_failed",
+        "benchexec_failed",
+        "ordinary_receipt_missing",
+        "stored_plan_mismatch",
+        "projection_refused",
+        "work_root_invalid"
+      ]
+    },
+    "identities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commit",
+        "host_profile_id",
+        "host_profile_sha256",
+        "profile_id",
+        "profile_sha256",
+        "generator",
+        "generator_executable_sha256",
+        "gf_sha256",
+        "certify_sha256",
+        "benchexec_python_sha256",
+        "benchexec_version"
+      ],
+      "properties": {
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "host_profile_id": {"const": "local-linux-cgroups-v2"},
+        "host_profile_sha256": {"$ref": "#/$defs/digest"},
+        "profile_id": {
+          "enum": [
+            "graph500-s18-local",
+            "graph500-s19-local",
+            "graph500-s20-provider",
+            "graph500-s22-provider",
+            "graph500-s24-provider",
+            "graph500-s25-provider",
+            "graph500-s26-provider"
+          ]
+        },
+        "profile_sha256": {"$ref": "#/$defs/digest"},
+        "generator": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "generator_executable_sha256": {"$ref": "#/$defs/digest"},
+        "gf_sha256": {"$ref": "#/$defs/digest"},
+        "certify_sha256": {"$ref": "#/$defs/digest"},
+        "benchexec_python_sha256": {"$ref": "#/$defs/digest"},
+        "benchexec_version": {"type": "string", "pattern": "^[0-9]+(\\.[0-9]+)+$"},
+        "admitted_projection_sha256": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "artifacts": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["plan_sha256", "benchexec_sha256", "graphforge_sha256", "rung_sha256"],
+          "properties": {
+            "plan_sha256": {"$ref": "#/$defs/digest"},
+            "benchexec_sha256": {"$ref": "#/$defs/digest"},
+            "graphforge_sha256": {"$ref": "#/$defs/digest"},
+            "rung_sha256": {"$ref": "#/$defs/digest"}
+          }
+        }
+      ]
+    },
+    "claim": {"const": "engineering_evidence_only"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "passed"}}, "required": ["status"]},
+      "then": {"properties": {"failure": {"type": "null"}, "artifacts": {"type": "object"}}},
+      "else": {"properties": {"failure": {"type": "string"}, "artifacts": {"type": "null"}}}
+    },
+    {
+      "if": {"properties": {"rung": {"enum": ["S20", "S22", "S24", "S25", "S26"]}}, "required": ["rung"]},
+      "then": {
+        "properties": {
+          "identities": {"required": ["admitted_projection_sha256"]}
+        }
+      }
+    }
+  ],
+  "$defs": {"digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}}
+}

--- a/benchmarks/schemas/progressive-qualification-rung-evidence.json
+++ b/benchmarks/schemas/progressive-qualification-rung-evidence.json
@@ -5,7 +5,7 @@
   "additionalProperties": false,
   "required": ["profile_id", "source", "scale", "live_edges", "status", "correctness", "phases", "metrics", "metric_sources", "failure"],
   "properties": {
-    "assembly_contract": {"const": "graphforge-progressive-rung-assembly/2"},
+    "assembly_contract": {"const": "graphforge-progressive-rung-assembly/3"},
     "profile_id": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{1,80}$"},
     "source": {"enum": ["progressive_profile", "canonical_ladder"]},
     "scale": {"type": "integer", "minimum": 1, "maximum": 26},
@@ -28,9 +28,10 @@
     },
     "metric_sources": {
       "type": "object", "additionalProperties": false,
-      "required": ["benchexec", "storage_attribution", "query_qualification"],
+      "required": ["benchexec", "graphforge_process", "storage_attribution", "query_qualification"],
       "properties": {
-        "benchexec": {"const": ["wall_seconds", "peak_rss_bytes", "physical_read_bytes", "physical_write_bytes"]},
+        "benchexec": {"const": ["wall_seconds", "physical_read_bytes", "physical_write_bytes"]},
+        "graphforge_process": {"const": ["peak_rss_bytes"]},
         "storage_attribution": {"const": ["retained_storage_bytes", "transient_peak_storage_bytes", "logical_read_bytes", "logical_write_bytes", "reader_calls", "publication_work_units"]},
         "query_qualification": {"const": ["live_edges", "correctness"]}
       }
@@ -119,7 +120,7 @@
       "if": {
         "properties": {
           "status": {"const": "passed"},
-          "assembly_contract": {"const": "graphforge-progressive-rung-assembly/2"}
+          "assembly_contract": {"const": "graphforge-progressive-rung-assembly/3"}
         },
         "required": ["status", "assembly_contract"]
       },

--- a/benchmarks/scripts/prepare-ovhc-agency-host.sh
+++ b/benchmarks/scripts/prepare-ovhc-agency-host.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Prepare OVHC-AGENCY (or equivalent) for local-linux-cgroups-v2 ladder admission.
+# Idempotent for controller enablement; does not reboot.
+
+set -euo pipefail
+
+if (( EUID != 0 )); then
+  echo "OVHC host setup requires root" >&2
+  exit 1
+fi
+
+workspace=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+"$workspace/scripts/provision-benchexec-user-delegation.sh"
+
+uid=${SUDO_UID:-1000}
+user_service="user.slice/user-${uid}.slice/user@${uid}.service"
+slice_path="/sys/fs/cgroup/${user_service}/benchexec.slice"
+
+mkdir -p "$slice_path"
+echo '+cpuset +cpu +io +memory +pids' >"/sys/fs/cgroup/${user_service}/cgroup.subtree_control"
+echo '+cpuset +cpu +io +memory +pids' >"${slice_path}/cgroup.subtree_control"
+
+echo "enabled cgroup controllers for ${user_service} and benchexec.slice"
+echo "run admission as the unprivileged user inside:"
+echo "  systemd-run --user --scope --slice=benchexec -p Delegate=yes -- ..."

--- a/benchmarks/tests/test_benchexec_authority.py
+++ b/benchmarks/tests/test_benchexec_authority.py
@@ -163,6 +163,24 @@ class BenchExecAuthorityTests(unittest.TestCase):
                 "/work/tmp/graphforge-certify-evidence.json",
             )
 
+    def test_tool_info_writes_certify_evidence_under_host_work_root(self):
+        class Task:
+            input_files_or_identifier = ("profile.json",)
+
+        with (
+            patch.dict(
+                "graphforge_bench.tools.graphforge_certify.os.environ",
+                {"GRAPHFORGE_HOST_WORK_ROOT": "/host/work"},
+                clear=False,
+            ),
+            patch("graphforge_bench.tools.graphforge_certify.os.path.ismount", return_value=False),
+            patch.object(Path, "mkdir"),
+        ):
+            self.assertEqual(
+                Tool().cmdline("graphforge-benchmark-certify", [], Task(), None)[-1],
+                "/host/work/tmp/graphforge-certify-evidence.json",
+            )
+
     def test_preserves_tree_authority_and_graphforge_telemetry(self):
         evidence = normalize_run(
             benchexec=result(),

--- a/benchmarks/tests/test_progressive_host_run.py
+++ b/benchmarks/tests/test_progressive_host_run.py
@@ -196,9 +196,7 @@ class ProgressiveHostRunTests(unittest.TestCase):
                 generator=generator,
                 benchexec_python=python,
             )
-            with patch(
-                "graphforge_bench.progressive_host_run.version", return_value="3.35"
-            ):
+            with patch("graphforge_bench.progressive_host_run.version", return_value="3.35"):
                 plan = build_plan(
                     root=ROOT,
                     output_dir=output,

--- a/benchmarks/tests/test_progressive_host_run.py
+++ b/benchmarks/tests/test_progressive_host_run.py
@@ -17,6 +17,7 @@ from graphforge_bench.progressive_host_run import (
     reclaim_rung_workspace,
     require_order,
     require_work_root,
+    resolve_host_benchexec_python,
 )
 from graphforge_bench.progressive_run import Executables
 from tests.test_progressive_run import passed_rung as local_passed_rung
@@ -215,6 +216,20 @@ class ProgressiveHostRunTests(unittest.TestCase):
                 sha256(ROOT / "profiles" / f"{HOST_PROFILE_ID}.json"),
             )
             self.assertNotIn("admitted_projection_sha256", plan["identities"])
+
+    def test_resolve_host_benchexec_python_requires_pystemd(self) -> None:
+        venv_python = ROOT / ".venv/bin/python"
+        self.assertTrue(venv_python.is_file())
+        with self.assertRaises(HostRunError):
+            resolve_host_benchexec_python(venv_python)
+        system = Path("/usr/bin/python3")
+        if system.is_file():
+            try:
+                resolved = resolve_host_benchexec_python(system)
+            except HostRunError:
+                self.skipTest("system BenchExec+pystemd unavailable")
+            else:
+                self.assertEqual(resolved, system.resolve())
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_progressive_host_run.py
+++ b/benchmarks/tests/test_progressive_host_run.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from graphforge_bench.progressive_host_run import (
+    HOST_PROFILE_ID,
+    HostRunError,
+    build_plan,
+    completed_prefix,
+    inventory_work_root,
+    load_host_capacity,
+    reclaim_rung_workspace,
+    require_order,
+    require_work_root,
+)
+from graphforge_bench.progressive_run import Executables
+from tests.test_progressive_run import passed_rung as local_passed_rung
+
+ROOT = Path(__file__).resolve().parents[1]
+WORK_PARENT = Path("/home/ubuntu/graphforge-ladder")
+COMMIT = "f013587f0123456789abcdef0123456789abcdef"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def host_capacity() -> dict:
+    return {
+        "schema": "graphforge-host-capacity/1",
+        "host_profile_id": HOST_PROFILE_ID,
+        "volume_bytes": 500 * 1024**3,
+        "reserved_headroom_bytes": 75 * 1024**3,
+        "physical_read_bytes_per_second": 10**9,
+        "physical_write_bytes_per_second": 10**9,
+        "reader_calls_per_second": 10**6,
+        "publication_work_per_second": 10**6,
+    }
+
+
+def passed_rung(scale: int) -> dict:
+    document = dict(local_passed_rung(18))
+    suffix = "local" if scale in (18, 19) else "provider"
+    source = "progressive_profile" if scale in (18, 19) else "canonical_ladder"
+    document["profile_id"] = f"graph500-s{scale}-{suffix}"
+    document["source"] = source
+    document["scale"] = scale
+    document["live_edges"] = (1 << scale) * 16
+    counts = dict(document["storage_attribution"]["counts"])
+    counts.update(
+        {
+            "source_nodes": 1 << scale,
+            "source_edges": 16 * (1 << scale),
+            "imported_nodes": 1 << scale,
+            "imported_edges": 16 * (1 << scale),
+        }
+    )
+    attribution = dict(document["storage_attribution"])
+    attribution["counts"] = counts
+    document["storage_attribution"] = attribution
+    return document
+
+
+def host_result(scale: int) -> dict:
+    suffix = "local" if scale in (18, 19) else "provider"
+    identities = {
+        "commit": COMMIT,
+        "host_profile_id": HOST_PROFILE_ID,
+        "host_profile_sha256": "a" * 64,
+        "profile_id": f"graph500-s{scale}-{suffix}",
+        "profile_sha256": "b" * 64,
+        "generator": "sha256:" + ("c" * 64),
+        "generator_executable_sha256": "d" * 64,
+        "gf_sha256": "e" * 64,
+        "certify_sha256": "f" * 64,
+        "benchexec_python_sha256": "1" * 64,
+        "benchexec_version": "3.35",
+    }
+    if scale >= 20:
+        identities["admitted_projection_sha256"] = "2" * 64
+    return {
+        "schema": "graphforge-progressive-host-run-result/1",
+        "rung": f"S{scale}",
+        "status": "passed",
+        "failure": None,
+        "identities": identities,
+        "artifacts": {
+            "plan_sha256": "3" * 64,
+            "benchexec_sha256": "4" * 64,
+            "graphforge_sha256": "5" * 64,
+            "rung_sha256": "6" * 64,
+        },
+        "claim": "engineering_evidence_only",
+    }
+
+
+class ProgressiveHostRunTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        WORK_PARENT.mkdir(parents=True, exist_ok=True)
+
+    def test_work_root_must_share_process_root_device(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            work = Path(temporary)
+            try:
+                require_work_root(work)
+            except HostRunError as error:
+                self.assertEqual(str(error), "work_root_invalid")
+            else:
+                self.assertEqual(work.stat().st_dev, Path("/").stat().st_dev)
+
+    def test_ordering_gates_and_s20_requires_capacity(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            output = Path(temporary) / "evidence"
+            output.mkdir()
+            require_order(ROOT, output, 18)
+            with self.assertRaisesRegex(HostRunError, "requires completed prefix"):
+                require_order(ROOT, output, 19)
+            (output / "s18-rung.json").write_text(json.dumps(passed_rung(18)), encoding="utf-8")
+            (output / "s18-result.json").write_text(json.dumps(host_result(18)), encoding="utf-8")
+            require_order(ROOT, output, 19)
+            (output / "s19-rung.json").write_text(json.dumps(passed_rung(19)), encoding="utf-8")
+            (output / "s19-result.json").write_text(json.dumps(host_result(19)), encoding="utf-8")
+            require_order(ROOT, output, 20)
+
+            python = ROOT / ".venv/bin/python"
+            payload = (ROOT / "runners/graph500-generator/src/main.rs").read_bytes()
+            gf = Path(temporary) / "gf"
+            certify = Path(temporary) / "certify"
+            generator = Path(temporary) / "generator"
+            for path in (gf, certify, generator):
+                path.write_bytes(payload)
+                path.chmod(0o755)
+            executables = Executables(
+                gf=gf,
+                certify=certify,
+                generator=generator,
+                benchexec_python=python,
+            )
+            with self.assertRaisesRegex(HostRunError, "host capacity is required"):
+                build_plan(
+                    root=ROOT,
+                    output_dir=output,
+                    scale=20,
+                    commit=COMMIT,
+                    executables=executables,
+                    capacity=None,
+                )
+
+    def test_host_capacity_schema_and_reclaim_inventory(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            root = Path(temporary)
+            capacity_path = root / "capacity.json"
+            capacity_path.write_text(json.dumps(host_capacity()), encoding="utf-8")
+            loaded = load_host_capacity(ROOT, capacity_path)
+            self.assertEqual(loaded["host_profile_id"], HOST_PROFILE_ID)
+            work = root / "work"
+            workspace = work / "workspace" / "s18"
+            workspace.mkdir(parents=True)
+            (workspace / "nodes.parquet").write_bytes(b"x")
+            reclaim_rung_workspace(work, 18)
+            inventory = inventory_work_root(work)
+            self.assertTrue(inventory["empty"])
+            self.assertEqual(inventory["host_profile_id"], HOST_PROFILE_ID)
+
+    def test_completed_prefix_rejects_gaps(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            output = Path(temporary)
+            (output / "s18-rung.json").write_text(json.dumps(passed_rung(18)), encoding="utf-8")
+            (output / "s18-result.json").write_text(json.dumps(host_result(18)), encoding="utf-8")
+            (output / "s20-rung.json").write_text(json.dumps(passed_rung(20)), encoding="utf-8")
+            (output / "s20-result.json").write_text(json.dumps(host_result(20)), encoding="utf-8")
+            with self.assertRaisesRegex(HostRunError, "out of order"):
+                completed_prefix(ROOT, output)
+
+    def test_build_plan_s18_binds_host_profile(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            output = Path(temporary)
+            python = ROOT / ".venv/bin/python"
+            self.assertTrue(python.is_file())
+            payload = (ROOT / "runners/graph500-generator/src/main.rs").read_bytes()
+            gf = Path(temporary) / "gf"
+            certify = Path(temporary) / "certify"
+            generator = Path(temporary) / "generator"
+            for path in (gf, certify, generator):
+                path.write_bytes(payload)
+                path.chmod(0o755)
+            executables = Executables(
+                gf=gf,
+                certify=certify,
+                generator=generator,
+                benchexec_python=python,
+            )
+            with patch(
+                "graphforge_bench.progressive_host_run.version", return_value="3.35"
+            ):
+                plan = build_plan(
+                    root=ROOT,
+                    output_dir=output,
+                    scale=18,
+                    commit=COMMIT,
+                    executables=executables,
+                    capacity=None,
+                )
+            self.assertEqual(plan["schema"], "graphforge-progressive-host-run-plan/1")
+            self.assertEqual(plan["rung"], "S18")
+            self.assertEqual(plan["execution"], "native_linux_benchexec_host")
+            self.assertEqual(plan["identities"]["host_profile_id"], HOST_PROFILE_ID)
+            self.assertEqual(plan["identities"]["profile_id"], "graph500-s18-local")
+            self.assertEqual(
+                plan["identities"]["host_profile_sha256"],
+                sha256(ROOT / "profiles" / f"{HOST_PROFILE_ID}.json"),
+            )
+            self.assertNotIn("admitted_projection_sha256", plan["identities"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_progressive_provider_plan.py
+++ b/benchmarks/tests/test_progressive_provider_plan.py
@@ -111,7 +111,7 @@ def storage_attribution(scale: int) -> dict:
 
 def rung(scale: int, *, source: str | None = None) -> dict:
     return {
-        "assembly_contract": "graphforge-progressive-rung-assembly/2",
+        "assembly_contract": "graphforge-progressive-rung-assembly/3",
         "profile_id": f"graph500-s{scale}-{'local' if scale in (18, 19) else 'provider'}",
         "source": source or ("progressive_profile" if scale in (18, 19) else "canonical_ladder"),
         "scale": scale,
@@ -145,10 +145,10 @@ def rung(scale: int, *, source: str | None = None) -> dict:
         "metric_sources": {
             "benchexec": [
                 "wall_seconds",
-                "peak_rss_bytes",
                 "physical_read_bytes",
                 "physical_write_bytes",
             ],
+            "graphforge_process": ["peak_rss_bytes"],
             "storage_attribution": [
                 "retained_storage_bytes",
                 "transient_peak_storage_bytes",

--- a/benchmarks/tests/test_progressive_qualification.py
+++ b/benchmarks/tests/test_progressive_qualification.py
@@ -144,7 +144,7 @@ def storage_attribution(scale: int, multiplier: int) -> dict:
 def rung(scale: int, *, rss: int = 1_000_000_000, wall: int = 100) -> dict:
     multiplier = 1 << max(0, scale - 18)
     return {
-        "assembly_contract": "graphforge-progressive-rung-assembly/2",
+        "assembly_contract": "graphforge-progressive-rung-assembly/3",
         "profile_id": f"graph500-s{scale}-evidence",
         "source": "canonical_ladder" if scale in {24, 25} else "progressive_profile",
         "scale": scale,
@@ -167,10 +167,10 @@ def rung(scale: int, *, rss: int = 1_000_000_000, wall: int = 100) -> dict:
         "metric_sources": {
             "benchexec": [
                 "wall_seconds",
-                "peak_rss_bytes",
                 "physical_read_bytes",
                 "physical_write_bytes",
             ],
+            "graphforge_process": ["peak_rss_bytes"],
             "storage_attribution": [
                 "retained_storage_bytes",
                 "transient_peak_storage_bytes",

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -936,9 +936,19 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         self.assertEqual(command[3:5], ["--full-access-dir", str(stage.resolve())])
         environment = execute.call_args.kwargs["env"]
         self.assertEqual(environment["PYTHONPATH"], str(ROOT / "harness"))
-        self.assertEqual(set(environment), {"HOME", "LANG", "LC_ALL", "PATH", "PYTHONPATH"})
+        required = {"HOME", "LANG", "LC_ALL", "PATH", "PYTHONPATH"}
+        allowed = required | {
+            "XDG_RUNTIME_DIR",
+            "DBUS_SESSION_BUS_ADDRESS",
+            "DBUS_SESSION_BUS_PID",
+            "USER",
+            "LOGNAME",
+        }
+        self.assertTrue(required <= set(environment))
+        self.assertTrue(set(environment) <= allowed)
         self.assertEqual(environment["HOME"], str(stage / "home"))
         self.assertIn("/usr/local/bin", environment["PATH"])
+        self.assertNotIn("GRAPHFORGE_HOST_WORK_ROOT", environment)
 
     def test_bench_home_uses_provider_volume_when_mounted(self) -> None:
         stage = self.base / "stage"

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -53,7 +53,7 @@ PHASES = [
 
 def passed_rung(scale: int) -> dict:
     return {
-        "assembly_contract": "graphforge-progressive-rung-assembly/2",
+        "assembly_contract": "graphforge-progressive-rung-assembly/3",
         "profile_id": f"graph500-s{scale}-local",
         "source": "progressive_profile",
         "scale": scale,
@@ -76,10 +76,10 @@ def passed_rung(scale: int) -> dict:
         "metric_sources": {
             "benchexec": [
                 "wall_seconds",
-                "peak_rss_bytes",
                 "physical_read_bytes",
                 "physical_write_bytes",
             ],
+            "graphforge_process": ["peak_rss_bytes"],
             "storage_attribution": [
                 "retained_storage_bytes",
                 "transient_peak_storage_bytes",
@@ -573,6 +573,27 @@ class ProgressiveRunControllerTests(unittest.TestCase):
                     with self.assertRaisesRegex(ControllerError, "bulk_ingest_capability_unproven"):
                         require_bulk_ingest_capability(invalid)
 
+    def test_rung_peak_rss_uses_process_vmhwm_not_cgroup_memory_peak(self) -> None:
+        receipts = authoritative_receipts(18)
+        gf = graphforge(18, receipts)
+        for index, phase in enumerate(gf["phases"]):
+            phase["peak_rss_bytes"] = 50_000_000 + index
+        gf["phases"][2]["peak_rss_bytes"] = 250_000_000
+        authority = benchexec(gf)
+        authority["authority"]["peak_rss_bytes"] = 4_000_000_000
+        rung = assemble_rung_evidence(root=ROOT, scale=18, graphforge=gf, benchexec=authority)
+        self.assertEqual(rung["assembly_contract"], "graphforge-progressive-rung-assembly/3")
+        self.assertEqual(rung["metrics"]["peak_rss_bytes"], 250_000_000)
+        self.assertEqual(rung["metric_sources"]["graphforge_process"], ["peak_rss_bytes"])
+        self.assertNotIn("peak_rss_bytes", rung["metric_sources"]["benchexec"])
+        missing = graphforge(18, receipts)
+        for phase in missing["phases"]:
+            phase["peak_rss_bytes"] = 0
+        with self.assertRaisesRegex(ControllerError, "VmHWM peak_rss_bytes is missing"):
+            assemble_rung_evidence(
+                root=ROOT, scale=18, graphforge=missing, benchexec=benchexec(missing)
+            )
+
     def test_named_authorities_assemble_true_passed_evidence_and_refuse_gaps(self) -> None:
         receipts = authoritative_receipts(18)
         gf = graphforge(18, receipts)
@@ -1046,6 +1067,35 @@ class ProgressiveRunControllerTests(unittest.TestCase):
                 _run_benchexec(stage, self.executables, plan["identities"])
             command = execute.call_args.args[0]
             self.assertNotIn("--memorylimit", command)
+
+    def test_host_durable_root_raises_benchexec_memory_ceiling(self) -> None:
+        stage = self.base / "host-stage"
+        stage.mkdir()
+        plan = build_plan(
+            root=ROOT,
+            output_dir=self.output,
+            scale=18,
+            commit=COMMIT,
+            executables=self.executables,
+        )
+        (stage / "bin").mkdir()
+        (stage / "benchmark.xml").write_text("fixture", encoding="utf-8")
+        work = Path("/home/ubuntu/graphforge-ladder")
+        with (
+            patch("graphforge_bench.progressive_run.subprocess.run") as execute,
+            patch.object(Path, "mkdir"),
+        ):
+            execute.return_value.returncode = 0
+            _run_benchexec(
+                stage,
+                self.executables,
+                plan["identities"],
+                durable_root=work,
+                home=work,
+            )
+        command = execute.call_args.args[0]
+        self.assertIn("--memorylimit", command)
+        self.assertEqual(command[command.index("--memorylimit") + 1], "96GB")
 
     def test_failed_result_schema_requires_closed_exact_identities(self) -> None:
         plan = build_plan(

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -158,6 +158,13 @@ are byte-identical, and 1x/2x/4x ordinal work remains a linear constant factor
 of candidates examined. A bounded RSS result does not pass if logical reads
 grow as expansion chunks multiplied by graph size.
 
+## OVHC-AGENCY host execution (#900 / #1087)
+
+The designated SUT is **OVHC-AGENCY** under profile `local-linux-cgroups-v2`.
+Use `make -C benchmarks progressive-host-ladder-run` with an ext4 work root
+under the process-root filesystem. Prefer that path over disposable Fly
+provider execution. See `benchmarks/README.md` (OVHC-AGENCY host ladder).
+
 ## Commands
 
 Always-on CI (SCALE-10 smoke + all reconciliation / determinism / bounded /


### PR DESCRIPTION
## Summary
- Add host-native progressive ladder controller for OVHC-AGENCY under `local-linux-cgroups-v2` (S18–S26) without Fly image digests or disposable provider mounts.
- Extend BenchExec staging to keep durable workspace paths on an ext4 work root that shares the process-root filesystem device.
- Document Makefile entry points, host capacity fixture, and cgroup prep script; keep optional Fly adapters intact.

Closes #1087

## Test plan
- [x] `PYTHONPATH=harness uv run --locked python -m unittest tests.test_progressive_host_run`
- [x] `PYTHONPATH=harness uv run --locked python -m unittest tests.test_progressive_run tests.test_benchexec_authority`
- [ ] CI Gate / exact-head green
- [ ] After merge: delegated local admission + S18 host ladder on OVHC-AGENCY


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791073059&installation_model_id=20486&pr_number=1088&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1088&signature=a63604df3ebd2745977eba8782db081350a0960840ea4d072423586831f23649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->