### PR TITLE
fix(exec): stamp demand-capture epochs against deferred stream pollution

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -1927,10 +1927,14 @@ impl GraphForge {
     {
         let handle = self.runtime.handle().clone();
         if tokio::runtime::Handle::try_current().is_ok() {
+            let capture_session = graphforge_exec::demand::bound_capture_session();
             std::thread::scope(|s| {
-                s.spawn(|| handle.block_on(fut))
-                    .join()
-                    .map_err(|_| GfError::Execution("execution thread panicked".into()))?
+                s.spawn(|| {
+                    graphforge_exec::demand::set_bound_capture_session(capture_session);
+                    handle.block_on(fut)
+                })
+                .join()
+                .map_err(|_| GfError::Execution("execution thread panicked".into()))?
             })
         } else {
             handle.block_on(fut)
@@ -3846,10 +3850,14 @@ impl RuntimeGuard {
     {
         let handle = self.runtime.handle().clone();
         if tokio::runtime::Handle::try_current().is_ok() {
+            let capture_session = graphforge_exec::demand::bound_capture_session();
             std::thread::scope(|s| {
-                s.spawn(|| handle.block_on(fut))
-                    .join()
-                    .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+                s.spawn(|| {
+                    graphforge_exec::demand::set_bound_capture_session(capture_session);
+                    handle.block_on(fut)
+                })
+                .join()
+                .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
             })
         } else {
             handle.block_on(fut)

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -215,10 +215,11 @@ impl Drop for CaptureDisable {
 /// certification phases from mixing counters while leaving execution itself
 /// unchanged.
 ///
-/// Physical streams stamp [`capture_epoch`] at creation. Deferred drops or
-/// polls after a later [`reset`] must not mutate the next session: record
-/// paths ignore mismatched epochs so one-hop expand evidence cannot leak into
-/// a following optimized two-hop snapshot (Bazel CI failure mode).
+/// Physical plans stamp [`capture_epoch`] at optimize/construction time.
+/// Deferred partition `execute` or stream drops after a later [`reset`] must
+/// not mutate the next session: record paths ignore mismatched epochs so
+/// one-hop expand evidence cannot leak into a following optimized two-hop
+/// snapshot (Bazel CI failure mode).
 #[doc(hidden)]
 pub fn capture<T>(operation: impl FnOnce() -> T) -> (T, DemandSnapshot) {
     let _exclusive = CAPTURE_GUARD
@@ -446,6 +447,10 @@ impl QueryDemand {
             quiescent_waker: AtomicWaker::new(),
             capture_epoch: capture_epoch(),
         }
+    }
+
+    pub(crate) fn capture_epoch(&self) -> u64 {
+        self.capture_epoch
     }
 
     pub(crate) fn is_cancelled(&self) -> bool {
@@ -709,6 +714,10 @@ struct RssProbeExec {
     input: Arc<dyn ExecutionPlan>,
     ordinal: usize,
     operator: &'static str,
+    /// Epoch of the capture session that instrumented this plan node.
+    /// Stamped at optimize time so deferred partition `execute` cannot adopt a
+    /// later session's epoch.
+    capture_epoch: u64,
     props: Arc<PlanProperties>,
 }
 
@@ -719,6 +728,22 @@ impl RssProbeExec {
             input,
             ordinal,
             operator,
+            capture_epoch: capture_epoch(),
+        }
+    }
+
+    fn with_input(
+        &self,
+        input: Arc<dyn ExecutionPlan>,
+        ordinal: usize,
+        operator: &'static str,
+    ) -> Self {
+        Self {
+            props: Arc::clone(input.properties()),
+            input,
+            ordinal,
+            operator,
+            capture_epoch: self.capture_epoch,
         }
     }
 }
@@ -762,7 +787,11 @@ impl ExecutionPlan for RssProbeExec {
         let input = children
             .pop()
             .ok_or_else(|| DataFusionError::Internal("RSS probe needs one child".into()))?;
-        Ok(Arc::new(Self::new(input, self.ordinal, self.operator)))
+        Ok(Arc::new(self.with_input(
+            input,
+            self.ordinal,
+            self.operator,
+        )))
     }
 
     fn execute(
@@ -771,7 +800,7 @@ impl ExecutionPlan for RssProbeExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let stream = self.input.execute(partition, context)?;
-        let epoch = capture_epoch();
+        let epoch = self.capture_epoch;
         let before = current_rss_bytes();
         if session_active(epoch) {
             let mut capture = CAPTURE.lock().expect("demand stats lock");
@@ -1105,6 +1134,7 @@ struct ProbeExec {
     ordinal: usize,
     uniqueness: bool,
     input_side: bool,
+    capture_epoch: u64,
     props: Arc<PlanProperties>,
 }
 
@@ -1117,6 +1147,7 @@ impl ProbeExec {
     ) -> Self {
         let props = Arc::clone(input.properties());
         Self {
+            capture_epoch: capture_epoch(),
             input,
             ordinal,
             uniqueness,
@@ -1166,12 +1197,15 @@ impl ExecutionPlan for ProbeExec {
         let input = children
             .pop()
             .ok_or_else(|| DataFusionError::Internal("DemandProbeExec needs one child".into()))?;
-        Ok(Arc::new(Self::new(
+        let props = Arc::clone(input.properties());
+        Ok(Arc::new(Self {
             input,
-            self.ordinal,
-            self.uniqueness,
-            self.input_side,
-        )))
+            ordinal: self.ordinal,
+            uniqueness: self.uniqueness,
+            input_side: self.input_side,
+            capture_epoch: self.capture_epoch,
+            props,
+        }))
     }
 
     fn execute(
@@ -1186,7 +1220,7 @@ impl ExecutionPlan for ProbeExec {
             ordinal: self.ordinal,
             uniqueness: self.uniqueness,
             input_side: self.input_side,
-            capture_epoch: capture_epoch(),
+            capture_epoch: self.capture_epoch,
         }))
     }
 }
@@ -1550,6 +1584,39 @@ mod tests {
         assert_eq!(hop.input_rows, 0);
         assert_eq!(hop.candidates_generated, 0);
         assert_eq!(hop.projected_rows, 100);
+        assert!(second.operator_rss.is_empty());
+    }
+
+    #[test]
+    fn plan_stamped_epoch_ignores_later_global_epoch() {
+        static CAPTURE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+        let _guard = CAPTURE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let mut plan_epoch = 0_u64;
+        let ((), _first) = capture(|| {
+            plan_epoch = capture_epoch();
+            // Simulate FixedHopDemandRule / ExpandExec construction under this session.
+            record_input(plan_epoch, 1, 10);
+        });
+
+        let ((), second) = capture(|| {
+            let live = capture_epoch();
+            assert_ne!(live, plan_epoch);
+            record_emitted(live, 1, 1000);
+            // Deferred partition execute from the prior plan still carries plan_epoch.
+            record_input(plan_epoch, 1, 1024);
+            record_candidates(plan_epoch, 1, 4310);
+            record_emitted(plan_epoch, 1, 4300);
+            record_operator_rss(plan_epoch, 0, false);
+            record_operator_rss(plan_epoch, 0, true);
+        });
+
+        let hop = &second.hops[&1];
+        assert_eq!(hop.rows_emitted, 1000);
+        assert_eq!(hop.input_rows, 0);
+        assert_eq!(hop.candidates_generated, 0);
         assert!(second.operator_rss.is_empty());
     }
 

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -6,6 +6,7 @@
 //! the fixed-hop operators below that semantic boundary. Unknown and blocking
 //! operators are deliberately opaque: demand never crosses them.
 
+use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::pin::Pin;
@@ -194,11 +195,36 @@ pub struct DemandSnapshot {
     pub execution_batch_rows: u64,
 }
 
+/// Mirrored for lock-free plan stamping / optimizer probes. Authoritative
+/// enable+epoch+snapshot transitions happen under [`CAPTURE`].
 static CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
 static CAPTURE_EPOCH: AtomicU64 = AtomicU64::new(1);
 static CAPTURE_GUARD: Mutex<()> = Mutex::new(());
-static CAPTURE: LazyLock<Mutex<DemandSnapshot>> =
-    LazyLock::new(|| Mutex::new(DemandSnapshot::default()));
+
+thread_local! {
+    /// Capture session epoch bound to this thread (and inherited across
+    /// `GraphForge::block_on` worker threads). Concurrent tests that `execute`
+    /// while another capture is active keep `0` and must not stamp/instrument
+    /// into the live process-global session.
+    static BOUND_CAPTURE_SESSION: Cell<u64> = const { Cell::new(0) };
+}
+
+struct CaptureState {
+    enabled: bool,
+    epoch: u64,
+    snapshot: DemandSnapshot,
+}
+
+static CAPTURE: LazyLock<Mutex<CaptureState>> = LazyLock::new(|| {
+    Mutex::new(CaptureState {
+        enabled: false,
+        epoch: 1,
+        snapshot: DemandSnapshot::default(),
+    })
+});
+
+#[cfg(test)]
+static CAPTURE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 struct CaptureDisable;
 
@@ -206,6 +232,45 @@ impl Drop for CaptureDisable {
     fn drop(&mut self) {
         disable();
     }
+}
+
+struct CaptureScopeGuard {
+    previous: u64,
+}
+
+impl Drop for CaptureScopeGuard {
+    fn drop(&mut self) {
+        BOUND_CAPTURE_SESSION.set(self.previous);
+    }
+}
+
+fn enter_capture_scope(epoch: u64) -> CaptureScopeGuard {
+    let previous = BOUND_CAPTURE_SESSION.get();
+    BOUND_CAPTURE_SESSION.set(epoch);
+    CaptureScopeGuard { previous }
+}
+
+/// Epoch bound to the current thread's capture scope, if any.
+#[must_use]
+#[doc(hidden)]
+pub fn bound_capture_session() -> u64 {
+    BOUND_CAPTURE_SESSION.get()
+}
+
+/// Inherit a capture session onto the current thread (for `block_on` workers).
+#[doc(hidden)]
+pub fn set_bound_capture_session(epoch: u64) {
+    BOUND_CAPTURE_SESSION.set(epoch);
+}
+
+/// Epoch to stamp on physical plans for the active capture bound to this thread.
+pub(crate) fn stamp_capture_epoch() -> Option<u64> {
+    let bound = BOUND_CAPTURE_SESSION.get();
+    (bound != 0 && capture_enabled() && capture_epoch() == bound).then_some(bound)
+}
+
+fn may_instrument_demand() -> bool {
+    stamp_capture_epoch().is_some()
 }
 
 /// Run one ordinary operation with exclusive aggregate diagnostic capture.
@@ -220,6 +285,10 @@ impl Drop for CaptureDisable {
 /// not mutate the next session: record paths ignore mismatched epochs so
 /// one-hop expand evidence cannot leak into a following optimized two-hop
 /// snapshot (Bazel CI failure mode).
+///
+/// Epoch checks and snapshot mutations share one mutex so a deferred worker
+/// that observed the prior session cannot win a TOCTOU race against `reset`
+/// and append expand counters into the next capture (high-thread CI failure).
 #[doc(hidden)]
 pub fn capture<T>(operation: impl FnOnce() -> T) -> (T, DemandSnapshot) {
     let _exclusive = CAPTURE_GUARD
@@ -227,34 +296,56 @@ pub fn capture<T>(operation: impl FnOnce() -> T) -> (T, DemandSnapshot) {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     reset();
     let disable_on_exit = CaptureDisable;
+    let _scope = enter_capture_scope(capture_epoch());
     let result = operation();
     // Snapshot while this session is still the active epoch, then retire it so
     // any still-alive operator streams cannot append to the next capture.
     let captured = snapshot();
     drop(disable_on_exit);
-    CAPTURE_EPOCH.fetch_add(1, Ordering::SeqCst);
+    retire_epoch();
     (result, captured)
 }
 
 /// Reset and enable fixed-hop demand capture.
 #[doc(hidden)]
 pub fn reset() {
-    CAPTURE_EPOCH.fetch_add(1, Ordering::SeqCst);
-    *CAPTURE.lock().expect("demand stats lock") = DemandSnapshot::default();
+    let mut state = CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    state.epoch = state.epoch.saturating_add(1).max(1);
+    state.snapshot = DemandSnapshot::default();
+    state.enabled = true;
+    CAPTURE_EPOCH.store(state.epoch, Ordering::SeqCst);
     CAPTURE_ENABLED.store(true, Ordering::SeqCst);
 }
 
 /// Disable demand capture without discarding the last snapshot.
 #[doc(hidden)]
 pub fn disable() {
+    let mut state = CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    state.enabled = false;
     CAPTURE_ENABLED.store(false, Ordering::SeqCst);
+}
+
+fn retire_epoch() {
+    let mut state = CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    state.epoch = state.epoch.saturating_add(1).max(1);
+    CAPTURE_EPOCH.store(state.epoch, Ordering::SeqCst);
 }
 
 /// Copy the current fixed-hop demand counters.
 #[must_use]
 #[doc(hidden)]
 pub fn snapshot() -> DemandSnapshot {
-    CAPTURE.lock().expect("demand stats lock").clone()
+    CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .snapshot
+        .clone()
 }
 
 pub(crate) fn capture_enabled() -> bool {
@@ -268,12 +359,15 @@ pub(crate) fn capture_epoch() -> u64 {
     CAPTURE_EPOCH.load(Ordering::Acquire)
 }
 
-fn session_active(epoch: u64) -> bool {
-    capture_enabled() && CAPTURE_EPOCH.load(Ordering::Acquire) == epoch
+fn session_active_locked(state: &CaptureState, epoch: u64) -> bool {
+    state.enabled && state.epoch == epoch
 }
 
 pub(crate) fn session_active_for(epoch: u64) -> bool {
-    session_active(epoch)
+    let state = CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    session_active_locked(&state, epoch)
 }
 
 /// Preserve physical-plan and memory evidence after execution, including when
@@ -317,29 +411,36 @@ pub(crate) fn record_plan_completion(
     let mut sorts = Vec::new();
     visit(plan, &mut sorts);
     let completion_rss = current_rss_bytes();
-    let mut capture = CAPTURE.lock().expect("demand stats lock");
+    let mut state = CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !state.enabled {
+        return;
+    }
     // The physical plan can retain an RSS-probe stream after collection has
     // completed. Treat this ordinary collect-completion boundary as the
     // authoritative release observation for wrappers that have not dropped.
-    for operator in &mut capture.operator_rss {
+    for operator in &mut state.snapshot.operator_rss {
         if operator.after_bytes == 0 {
             operator.after_bytes = completion_rss;
             operator.peak_bytes = operator.peak_bytes.max(completion_rss);
         }
     }
-    capture.sorts = sorts;
-    capture.memory_reserved_before = memory_reserved_before as u64;
-    capture.memory_reserved_after = memory_reserved_after as u64;
-    capture.returned_batch_bytes = returned_batch_bytes as u64;
-    capture.execution_batch_rows = execution_batch_rows as u64;
+    state.snapshot.sorts = sorts;
+    state.snapshot.memory_reserved_before = memory_reserved_before as u64;
+    state.snapshot.memory_reserved_after = memory_reserved_after as u64;
+    state.snapshot.returned_batch_bytes = returned_batch_bytes as u64;
+    state.snapshot.execution_batch_rows = execution_batch_rows as u64;
 }
 
 fn with_hop(epoch: u64, edge_var: u32, update: impl FnOnce(&mut HopSnapshot)) {
-    if !session_active(epoch) {
+    let mut state = CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !session_active_locked(&state, epoch) {
         return;
     }
-    let mut capture = CAPTURE.lock().expect("demand stats lock");
-    update(capture.hops.entry(edge_var).or_default());
+    update(state.snapshot.hops.entry(edge_var).or_default());
 }
 
 pub(crate) fn record_input(epoch: u64, edge_var: u32, rows: usize) {
@@ -411,15 +512,21 @@ pub(crate) fn record_emitted(epoch: u64, edge_var: u32, rows: usize) {
 }
 
 fn record_filter(epoch: u64, ordinal: usize, uniqueness: bool, input: bool, rows: usize) {
-    if !session_active(epoch) {
+    let mut state = CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !session_active_locked(&state, epoch) {
         return;
     }
-    let mut capture = CAPTURE.lock().expect("demand stats lock");
-    let filter = capture.filters.entry(ordinal).or_insert(FilterSnapshot {
-        ordinal,
-        relationship_uniqueness: uniqueness,
-        ..FilterSnapshot::default()
-    });
+    let filter = state
+        .snapshot
+        .filters
+        .entry(ordinal)
+        .or_insert(FilterSnapshot {
+            ordinal,
+            relationship_uniqueness: uniqueness,
+            ..FilterSnapshot::default()
+        });
     if input {
         filter.input_rows += rows as u64;
     } else {
@@ -445,7 +552,8 @@ impl QueryDemand {
             max_in_flight_reads: AtomicUsize::new(0),
             produced_rows: AtomicUsize::new(0),
             quiescent_waker: AtomicWaker::new(),
-            capture_epoch: capture_epoch(),
+            // QueryDemand is only constructed from FixedHopDemandRule inside capture.
+            capture_epoch: stamp_capture_epoch().unwrap_or_else(capture_epoch),
         }
     }
 
@@ -458,8 +566,13 @@ impl QueryDemand {
     }
 
     fn cancel(&self) {
-        if !self.cancelled.swap(true, Ordering::AcqRel) && session_active(self.capture_epoch) {
-            CAPTURE.lock().expect("demand stats lock").cancellations += 1;
+        if !self.cancelled.swap(true, Ordering::AcqRel) {
+            let mut state = CAPTURE
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if session_active_locked(&state, self.capture_epoch) {
+                state.snapshot.cancellations += 1;
+            }
         }
     }
 
@@ -478,9 +591,14 @@ impl QueryDemand {
         let current = self.in_flight_reads.fetch_add(1, Ordering::AcqRel) + 1;
         self.max_in_flight_reads
             .fetch_max(current, Ordering::AcqRel);
-        if session_active(self.capture_epoch) {
-            let mut capture = CAPTURE.lock().expect("demand stats lock");
-            capture.max_in_flight_reads = capture.max_in_flight_reads.max(current as u64);
+        {
+            let mut state = CAPTURE
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if session_active_locked(&state, self.capture_epoch) {
+                state.snapshot.max_in_flight_reads =
+                    state.snapshot.max_in_flight_reads.max(current as u64);
+            }
         }
         if self.is_cancelled() {
             self.finish_read();
@@ -638,17 +756,20 @@ impl PhysicalOptimizerRule for FixedHopDemandRule {
         };
         let plan = crate::ordered_two_hop::try_rewrite_ordered_two_hop(plan)?;
         let Some(terminal) = find_terminal_demand(&plan) else {
-            if capture_enabled() {
+            if may_instrument_demand() {
                 let mut rss_ordinal = 0;
                 return instrument_operator_rss(plan, &mut rss_ordinal);
             }
             return Ok(plan);
         };
         if !contains_demand_expand(&plan) {
-            if capture_enabled() {
+            if may_instrument_demand() {
                 let mut rss_ordinal = 0;
                 return instrument_operator_rss(plan, &mut rss_ordinal);
             }
+            return Ok(plan);
+        }
+        if !may_instrument_demand() {
             return Ok(plan);
         }
         let demand = Arc::new(QueryDemand::new());
@@ -728,7 +849,7 @@ impl RssProbeExec {
             input,
             ordinal,
             operator,
-            capture_epoch: capture_epoch(),
+            capture_epoch: stamp_capture_epoch().unwrap_or_else(capture_epoch),
         }
     }
 
@@ -802,26 +923,31 @@ impl ExecutionPlan for RssProbeExec {
         let stream = self.input.execute(partition, context)?;
         let epoch = self.capture_epoch;
         let before = current_rss_bytes();
-        if session_active(epoch) {
-            let mut capture = CAPTURE.lock().expect("demand stats lock");
-            if let Some(operator) = capture
-                .operator_rss
-                .iter_mut()
-                .find(|operator| operator.ordinal == self.ordinal)
-            {
-                operator.before_bytes = match (operator.before_bytes, before) {
-                    (0, value) | (value, 0) => value,
-                    (left, right) => left.min(right),
-                };
-                operator.peak_bytes = operator.peak_bytes.max(before);
-            } else {
-                capture.operator_rss.push(OperatorRssSnapshot {
-                    ordinal: self.ordinal,
-                    operator: self.operator,
-                    before_bytes: before,
-                    peak_bytes: before,
-                    after_bytes: 0,
-                });
+        {
+            let mut state = CAPTURE
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if session_active_locked(&state, epoch) {
+                if let Some(operator) = state
+                    .snapshot
+                    .operator_rss
+                    .iter_mut()
+                    .find(|operator| operator.ordinal == self.ordinal)
+                {
+                    operator.before_bytes = match (operator.before_bytes, before) {
+                        (0, value) | (value, 0) => value,
+                        (left, right) => left.min(right),
+                    };
+                    operator.peak_bytes = operator.peak_bytes.max(before);
+                } else {
+                    state.snapshot.operator_rss.push(OperatorRssSnapshot {
+                        ordinal: self.ordinal,
+                        operator: self.operator,
+                        before_bytes: before,
+                        peak_bytes: before,
+                        after_bytes: 0,
+                    });
+                }
             }
         }
         Ok(Box::pin(RssProbeStream {
@@ -863,12 +989,15 @@ impl RecordBatchStream for RssProbeStream {
 }
 
 fn record_operator_rss(epoch: u64, ordinal: usize, released: bool) {
-    if !session_active(epoch) {
+    let rss = current_rss_bytes();
+    let mut state = CAPTURE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !session_active_locked(&state, epoch) {
         return;
     }
-    let rss = current_rss_bytes();
-    let mut capture = CAPTURE.lock().expect("demand stats lock");
-    if let Some(operator) = capture
+    if let Some(operator) = state
+        .snapshot
         .operator_rss
         .iter_mut()
         .find(|operator| operator.ordinal == ordinal)
@@ -1147,7 +1276,7 @@ impl ProbeExec {
     ) -> Self {
         let props = Arc::clone(input.properties());
         Self {
-            capture_epoch: capture_epoch(),
+            capture_epoch: stamp_capture_epoch().unwrap_or_else(capture_epoch),
             input,
             ordinal,
             uniqueness,
@@ -1420,7 +1549,6 @@ mod tests {
         };
 
         // Process-global capture must not interleave with other capture users.
-        static CAPTURE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
         let _guard = CAPTURE_TEST_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -1547,7 +1675,6 @@ mod tests {
 
     #[test]
     fn stale_capture_epoch_cannot_pollute_next_session() {
-        static CAPTURE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
         let _guard = CAPTURE_TEST_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -1589,7 +1716,6 @@ mod tests {
 
     #[test]
     fn plan_stamped_epoch_ignores_later_global_epoch() {
-        static CAPTURE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
         let _guard = CAPTURE_TEST_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -1618,6 +1744,76 @@ mod tests {
         assert_eq!(hop.input_rows, 0);
         assert_eq!(hop.candidates_generated, 0);
         assert!(second.operator_rss.is_empty());
+    }
+
+    #[test]
+    fn deferred_record_cannot_win_reset_toctou() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        let _guard = CAPTURE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let mut stale_epoch = 0_u64;
+        let ((), _first) = capture(|| {
+            stale_epoch = capture_epoch();
+            record_input(stale_epoch, 1, 1024);
+            record_candidates(stale_epoch, 1, 4310);
+            record_emitted(stale_epoch, 1, 4300);
+        });
+
+        // Hold CAPTURE so a deferred writer can pass an out-of-lock epoch check
+        // against the retired session, then observe reset under the same lock.
+        let barrier = Arc::new(Barrier::new(2));
+        let stale = stale_epoch;
+        let writer_barrier = Arc::clone(&barrier);
+        let writer = thread::spawn(move || {
+            // Wait until the main thread is inside the next capture session.
+            writer_barrier.wait();
+            record_input(stale, 1, 1024);
+            record_candidates(stale, 1, 4310);
+            record_emitted(stale, 1, 4300);
+            record_operator_rss(stale, 0, true);
+        });
+
+        let ((), second) = capture(|| {
+            let live = capture_epoch();
+            assert_ne!(live, stale_epoch);
+            record_emitted(live, 1, 1000);
+            barrier.wait();
+            // Give the deferred writer a chance to race against this session.
+            thread::yield_now();
+            thread::sleep(std::time::Duration::from_millis(10));
+        });
+        writer.join().expect("deferred writer");
+
+        let hop = &second.hops[&1];
+        assert_eq!(hop.rows_emitted, 1000);
+        assert_eq!(hop.input_rows, 0);
+        assert_eq!(hop.candidates_generated, 0);
+        assert!(second.operator_rss.is_empty());
+    }
+
+    #[test]
+    fn stamp_capture_epoch_requires_bound_session() {
+        let _guard = CAPTURE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        disable();
+        assert!(stamp_capture_epoch().is_none());
+        let ((), _captured) = capture(|| {
+            assert_eq!(stamp_capture_epoch(), Some(capture_epoch()));
+            // Unbound peer thread must not stamp the live session.
+            let live = capture_epoch();
+            let peer = std::thread::spawn(move || {
+                assert!(stamp_capture_epoch().is_none());
+                assert_ne!(bound_capture_session(), live);
+            });
+            peer.join().expect("peer");
+        });
+        assert!(stamp_capture_epoch().is_none());
     }
 
     #[test]

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -9,7 +9,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::task::{Context, Poll};
 
@@ -195,6 +195,7 @@ pub struct DemandSnapshot {
 }
 
 static CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
+static CAPTURE_EPOCH: AtomicU64 = AtomicU64::new(1);
 static CAPTURE_GUARD: Mutex<()> = Mutex::new(());
 static CAPTURE: LazyLock<Mutex<DemandSnapshot>> =
     LazyLock::new(|| Mutex::new(DemandSnapshot::default()));
@@ -213,6 +214,11 @@ impl Drop for CaptureDisable {
 /// threads. Serializing the complete operation prevents concurrent tests or
 /// certification phases from mixing counters while leaving execution itself
 /// unchanged.
+///
+/// Physical streams stamp [`capture_epoch`] at creation. Deferred drops or
+/// polls after a later [`reset`] must not mutate the next session: record
+/// paths ignore mismatched epochs so one-hop expand evidence cannot leak into
+/// a following optimized two-hop snapshot (Bazel CI failure mode).
 #[doc(hidden)]
 pub fn capture<T>(operation: impl FnOnce() -> T) -> (T, DemandSnapshot) {
     let _exclusive = CAPTURE_GUARD
@@ -221,13 +227,18 @@ pub fn capture<T>(operation: impl FnOnce() -> T) -> (T, DemandSnapshot) {
     reset();
     let disable_on_exit = CaptureDisable;
     let result = operation();
+    // Snapshot while this session is still the active epoch, then retire it so
+    // any still-alive operator streams cannot append to the next capture.
+    let captured = snapshot();
     drop(disable_on_exit);
-    (result, snapshot())
+    CAPTURE_EPOCH.fetch_add(1, Ordering::SeqCst);
+    (result, captured)
 }
 
 /// Reset and enable fixed-hop demand capture.
 #[doc(hidden)]
 pub fn reset() {
+    CAPTURE_EPOCH.fetch_add(1, Ordering::SeqCst);
     *CAPTURE.lock().expect("demand stats lock") = DemandSnapshot::default();
     CAPTURE_ENABLED.store(true, Ordering::SeqCst);
 }
@@ -247,6 +258,21 @@ pub fn snapshot() -> DemandSnapshot {
 
 pub(crate) fn capture_enabled() -> bool {
     CAPTURE_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Epoch of the active capture session. Physical streams must stamp this when
+/// created and pass it to record helpers so deferred work cannot pollute a
+/// newer session.
+pub(crate) fn capture_epoch() -> u64 {
+    CAPTURE_EPOCH.load(Ordering::Acquire)
+}
+
+fn session_active(epoch: u64) -> bool {
+    capture_enabled() && CAPTURE_EPOCH.load(Ordering::Acquire) == epoch
+}
+
+pub(crate) fn session_active_for(epoch: u64) -> bool {
+    session_active(epoch)
 }
 
 /// Preserve physical-plan and memory evidence after execution, including when
@@ -307,32 +333,35 @@ pub(crate) fn record_plan_completion(
     capture.execution_batch_rows = execution_batch_rows as u64;
 }
 
-fn with_hop(edge_var: u32, update: impl FnOnce(&mut HopSnapshot)) {
-    if !capture_enabled() {
+fn with_hop(epoch: u64, edge_var: u32, update: impl FnOnce(&mut HopSnapshot)) {
+    if !session_active(epoch) {
         return;
     }
     let mut capture = CAPTURE.lock().expect("demand stats lock");
     update(capture.hops.entry(edge_var).or_default());
 }
 
-pub(crate) fn record_input(edge_var: u32, rows: usize) {
-    with_hop(edge_var, |hop| {
+pub(crate) fn record_input(epoch: u64, edge_var: u32, rows: usize) {
+    with_hop(epoch, edge_var, |hop| {
         hop.input_batches += 1;
         hop.input_rows += rows as u64;
     });
 }
 
-pub(crate) fn record_candidates(edge_var: u32, rows: usize) {
-    with_hop(edge_var, |hop| hop.candidates_generated += rows as u64);
+pub(crate) fn record_candidates(epoch: u64, edge_var: u32, rows: usize) {
+    with_hop(epoch, edge_var, |hop| {
+        hop.candidates_generated += rows as u64
+    });
 }
 
 pub(crate) fn record_identity_projection(
+    epoch: u64,
     edge_var: u32,
     rows: usize,
     projected_columns: usize,
     metrics: &graphforge_storage::V4OrdinalLookupMetrics,
 ) {
-    with_hop(edge_var, |hop| {
+    with_hop(epoch, edge_var, |hop| {
         hop.projected_chunks = hop.projected_chunks.saturating_add(1);
         hop.projected_rows = hop.projected_rows.saturating_add(rows as u64);
         hop.projected_columns = hop
@@ -361,11 +390,12 @@ pub(crate) fn record_identity_projection(
 }
 
 pub(crate) fn record_materialization_projection(
+    epoch: u64,
     edge_var: u32,
     edge_columns: usize,
     node_columns: usize,
 ) {
-    with_hop(edge_var, |hop| {
+    with_hop(epoch, edge_var, |hop| {
         hop.edge_projected_columns = hop
             .edge_projected_columns
             .max(edge_columns.try_into().unwrap_or(u64::MAX));
@@ -375,12 +405,12 @@ pub(crate) fn record_materialization_projection(
     });
 }
 
-pub(crate) fn record_emitted(edge_var: u32, rows: usize) {
-    with_hop(edge_var, |hop| hop.rows_emitted += rows as u64);
+pub(crate) fn record_emitted(epoch: u64, edge_var: u32, rows: usize) {
+    with_hop(epoch, edge_var, |hop| hop.rows_emitted += rows as u64);
 }
 
-fn record_filter(ordinal: usize, uniqueness: bool, input: bool, rows: usize) {
-    if !capture_enabled() {
+fn record_filter(epoch: u64, ordinal: usize, uniqueness: bool, input: bool, rows: usize) {
+    if !session_active(epoch) {
         return;
     }
     let mut capture = CAPTURE.lock().expect("demand stats lock");
@@ -403,6 +433,7 @@ pub(crate) struct QueryDemand {
     max_in_flight_reads: AtomicUsize,
     produced_rows: AtomicUsize,
     quiescent_waker: AtomicWaker,
+    capture_epoch: u64,
 }
 
 impl QueryDemand {
@@ -413,6 +444,7 @@ impl QueryDemand {
             max_in_flight_reads: AtomicUsize::new(0),
             produced_rows: AtomicUsize::new(0),
             quiescent_waker: AtomicWaker::new(),
+            capture_epoch: capture_epoch(),
         }
     }
 
@@ -421,7 +453,7 @@ impl QueryDemand {
     }
 
     fn cancel(&self) {
-        if !self.cancelled.swap(true, Ordering::AcqRel) && capture_enabled() {
+        if !self.cancelled.swap(true, Ordering::AcqRel) && session_active(self.capture_epoch) {
             CAPTURE.lock().expect("demand stats lock").cancellations += 1;
         }
     }
@@ -433,19 +465,23 @@ impl QueryDemand {
 
     pub(crate) fn begin_read(self: &Arc<Self>, edge_var: u32) -> Option<ReadPermit> {
         if self.is_cancelled() {
-            with_hop(edge_var, |hop| hop.reads_after_cancel += 1);
+            with_hop(self.capture_epoch, edge_var, |hop| {
+                hop.reads_after_cancel += 1
+            });
             return None;
         }
         let current = self.in_flight_reads.fetch_add(1, Ordering::AcqRel) + 1;
         self.max_in_flight_reads
             .fetch_max(current, Ordering::AcqRel);
-        if capture_enabled() {
+        if session_active(self.capture_epoch) {
             let mut capture = CAPTURE.lock().expect("demand stats lock");
             capture.max_in_flight_reads = capture.max_in_flight_reads.max(current as u64);
         }
         if self.is_cancelled() {
             self.finish_read();
-            with_hop(edge_var, |hop| hop.reads_after_cancel += 1);
+            with_hop(self.capture_epoch, edge_var, |hop| {
+                hop.reads_after_cancel += 1
+            });
             return None;
         }
         Some(ReadPermit {
@@ -485,24 +521,33 @@ impl Drop for ReadPermit {
 /// Attributes storage observer events to one fixed-hop edge binding.
 pub(crate) struct HopReadObserver {
     edge_var: u32,
+    capture_epoch: u64,
 }
 
 impl HopReadObserver {
+    #[cfg(test)]
     pub(crate) fn new(edge_var: u32) -> Self {
-        Self { edge_var }
+        Self::with_epoch(edge_var, capture_epoch())
+    }
+
+    pub(crate) fn with_epoch(edge_var: u32, capture_epoch: u64) -> Self {
+        Self {
+            edge_var,
+            capture_epoch,
+        }
     }
 }
 
 impl graphforge_storage::io_stats::FilteredReadObserver for HopReadObserver {
     fn read_started(&self, table: graphforge_storage::io_stats::FilteredReadTable) {
-        with_hop(self.edge_var, |hop| match table {
+        with_hop(self.capture_epoch, self.edge_var, |hop| match table {
             graphforge_storage::io_stats::FilteredReadTable::Edge => hop.edge_reads_started += 1,
             graphforge_storage::io_stats::FilteredReadTable::Node => hop.node_reads_started += 1,
         });
     }
 
     fn rows_scanned(&self, table: graphforge_storage::io_stats::FilteredReadTable, rows: u64) {
-        with_hop(self.edge_var, |hop| match table {
+        with_hop(self.capture_epoch, self.edge_var, |hop| match table {
             graphforge_storage::io_stats::FilteredReadTable::Edge => hop.edge_rows_scanned += rows,
             graphforge_storage::io_stats::FilteredReadTable::Node => hop.node_rows_scanned += rows,
         });
@@ -514,7 +559,7 @@ impl graphforge_storage::io_stats::FilteredReadObserver for HopReadObserver {
         rows: u64,
         full: bool,
     ) {
-        with_hop(self.edge_var, |hop| match table {
+        with_hop(self.capture_epoch, self.edge_var, |hop| match table {
             graphforge_storage::io_stats::FilteredReadTable::Edge => {
                 hop.edge_reads_completed += 1;
                 hop.edge_rows_returned += rows;
@@ -529,7 +574,7 @@ impl graphforge_storage::io_stats::FilteredReadObserver for HopReadObserver {
     }
 
     fn read_failed(&self, table: graphforge_storage::io_stats::FilteredReadTable) {
-        with_hop(self.edge_var, |hop| match table {
+        with_hop(self.capture_epoch, self.edge_var, |hop| match table {
             graphforge_storage::io_stats::FilteredReadTable::Edge => hop.edge_reads_failed += 1,
             graphforge_storage::io_stats::FilteredReadTable::Node => hop.node_reads_failed += 1,
         });
@@ -543,7 +588,7 @@ impl graphforge_storage::io_stats::FilteredReadObserver for HopReadObserver {
         if table != graphforge_storage::io_stats::FilteredReadTable::Node {
             return;
         }
-        with_hop(self.edge_var, |hop| {
+        with_hop(self.capture_epoch, self.edge_var, |hop| {
             match pruning.strategy {
                 graphforge_storage::io_stats::FilteredReadStrategy::DenseRowSelection => {
                     hop.node_dense_row_selection_reads += 1;
@@ -726,8 +771,9 @@ impl ExecutionPlan for RssProbeExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let stream = self.input.execute(partition, context)?;
+        let epoch = capture_epoch();
         let before = current_rss_bytes();
-        if capture_enabled() {
+        if session_active(epoch) {
             let mut capture = CAPTURE.lock().expect("demand stats lock");
             if let Some(operator) = capture
                 .operator_rss
@@ -753,6 +799,7 @@ impl ExecutionPlan for RssProbeExec {
             schema: stream.schema(),
             inner: stream,
             ordinal: self.ordinal,
+            capture_epoch: epoch,
         }))
     }
 }
@@ -761,6 +808,7 @@ struct RssProbeStream {
     schema: SchemaRef,
     inner: SendableRecordBatchStream,
     ordinal: usize,
+    capture_epoch: u64,
 }
 
 impl Stream for RssProbeStream {
@@ -768,14 +816,14 @@ impl Stream for RssProbeStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let result = Pin::new(&mut self.inner).poll_next(cx);
-        record_operator_rss(self.ordinal, false);
+        record_operator_rss(self.capture_epoch, self.ordinal, false);
         result
     }
 }
 
 impl Drop for RssProbeStream {
     fn drop(&mut self) {
-        record_operator_rss(self.ordinal, true);
+        record_operator_rss(self.capture_epoch, self.ordinal, true);
     }
 }
 
@@ -785,8 +833,8 @@ impl RecordBatchStream for RssProbeStream {
     }
 }
 
-fn record_operator_rss(ordinal: usize, released: bool) {
-    if !capture_enabled() {
+fn record_operator_rss(epoch: u64, ordinal: usize, released: bool) {
+    if !session_active(epoch) {
         return;
     }
     let rss = current_rss_bytes();
@@ -1138,6 +1186,7 @@ impl ExecutionPlan for ProbeExec {
             ordinal: self.ordinal,
             uniqueness: self.uniqueness,
             input_side: self.input_side,
+            capture_epoch: capture_epoch(),
         }))
     }
 }
@@ -1148,6 +1197,7 @@ struct ProbeStream {
     ordinal: usize,
     uniqueness: bool,
     input_side: bool,
+    capture_epoch: u64,
 }
 
 impl Stream for ProbeStream {
@@ -1157,6 +1207,7 @@ impl Stream for ProbeStream {
         match Pin::new(&mut self.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(batch))) => {
                 record_filter(
+                    self.capture_epoch,
                     self.ordinal,
                     self.uniqueness,
                     self.input_side,
@@ -1341,11 +1392,12 @@ mod tests {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         reset();
-        record_input(12, 3);
-        record_candidates(12, 7);
-        record_emitted(12, 2);
-        record_filter(4, true, true, 7);
-        record_filter(4, true, false, 2);
+        let epoch = capture_epoch();
+        record_input(epoch, 12, 3);
+        record_candidates(epoch, 12, 7);
+        record_emitted(epoch, 12, 2);
+        record_filter(epoch, 4, true, true, 7);
+        record_filter(epoch, 4, true, false, 2);
 
         let observer = HopReadObserver::new(12);
         for table in [FilteredReadTable::Edge, FilteredReadTable::Node] {
@@ -1455,8 +1507,50 @@ mod tests {
         );
 
         disable();
-        record_input(12, 100);
+        record_input(epoch, 12, 100);
         assert_eq!(snapshot(), captured);
+    }
+
+    #[test]
+    fn stale_capture_epoch_cannot_pollute_next_session() {
+        static CAPTURE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+        let _guard = CAPTURE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let mut stale_epoch = 0_u64;
+        let ((), first) = capture(|| {
+            stale_epoch = capture_epoch();
+            record_input(stale_epoch, 1, 1024);
+            record_candidates(stale_epoch, 1, 4310);
+            record_emitted(stale_epoch, 1, 4300);
+        });
+        assert_eq!(first.hops[&1].rows_emitted, 4300);
+
+        let ((), second) = capture(|| {
+            let epoch = capture_epoch();
+            assert_ne!(epoch, stale_epoch);
+            record_identity_projection(
+                epoch,
+                1,
+                100,
+                1,
+                &graphforge_storage::V4OrdinalLookupMetrics::default(),
+            );
+            record_emitted(epoch, 1, 1000);
+            // Simulate a deferred one-hop expand drop from the prior session.
+            record_input(stale_epoch, 1, 1024);
+            record_candidates(stale_epoch, 1, 4310);
+            record_emitted(stale_epoch, 1, 4300);
+            record_operator_rss(stale_epoch, 0, true);
+        });
+
+        let hop = &second.hops[&1];
+        assert_eq!(hop.rows_emitted, 1000);
+        assert_eq!(hop.input_rows, 0);
+        assert_eq!(hop.candidates_generated, 0);
+        assert_eq!(hop.projected_rows, 100);
+        assert!(second.operator_rss.is_empty());
     }
 
     #[test]

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -350,7 +350,7 @@ pub(crate) fn record_input(epoch: u64, edge_var: u32, rows: usize) {
 
 pub(crate) fn record_candidates(epoch: u64, edge_var: u32, rows: usize) {
     with_hop(epoch, edge_var, |hop| {
-        hop.candidates_generated += rows as u64
+        hop.candidates_generated += rows as u64;
     });
 }
 
@@ -466,7 +466,7 @@ impl QueryDemand {
     pub(crate) fn begin_read(self: &Arc<Self>, edge_var: u32) -> Option<ReadPermit> {
         if self.is_cancelled() {
             with_hop(self.capture_epoch, edge_var, |hop| {
-                hop.reads_after_cancel += 1
+                hop.reads_after_cancel += 1;
             });
             return None;
         }
@@ -480,7 +480,7 @@ impl QueryDemand {
         if self.is_cancelled() {
             self.finish_read();
             with_hop(self.capture_epoch, edge_var, |hop| {
-                hop.reads_after_cancel += 1
+                hop.reads_after_cancel += 1;
             });
             return None;
         }

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -234,22 +234,6 @@ impl Drop for CaptureDisable {
     }
 }
 
-struct CaptureScopeGuard {
-    previous: u64,
-}
-
-impl Drop for CaptureScopeGuard {
-    fn drop(&mut self) {
-        BOUND_CAPTURE_SESSION.set(self.previous);
-    }
-}
-
-fn enter_capture_scope(epoch: u64) -> CaptureScopeGuard {
-    let previous = BOUND_CAPTURE_SESSION.get();
-    BOUND_CAPTURE_SESSION.set(epoch);
-    CaptureScopeGuard { previous }
-}
-
 /// Epoch bound to the current thread's capture scope, if any.
 #[must_use]
 #[doc(hidden)]
@@ -296,7 +280,8 @@ pub fn capture<T>(operation: impl FnOnce() -> T) -> (T, DemandSnapshot) {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     reset();
     let disable_on_exit = CaptureDisable;
-    let _scope = enter_capture_scope(capture_epoch());
+    // `reset` binds this thread to the live epoch (inherited across block_on
+    // workers). Concurrent unbound executes stamp epoch 0 and cannot record.
     let result = operation();
     // Snapshot while this session is still the active epoch, then retire it so
     // any still-alive operator streams cannot append to the next capture.
@@ -307,6 +292,10 @@ pub fn capture<T>(operation: impl FnOnce() -> T) -> (T, DemandSnapshot) {
 }
 
 /// Reset and enable fixed-hop demand capture.
+///
+/// Binds the new session to the calling thread so `demand::reset()` /
+/// `execute` / `disable` callers (and `explain` under an active reset) stamp
+/// the live epoch. Concurrent threads stay unbound and must not adopt it.
 #[doc(hidden)]
 pub fn reset() {
     let mut state = CAPTURE
@@ -317,6 +306,7 @@ pub fn reset() {
     state.enabled = true;
     CAPTURE_EPOCH.store(state.epoch, Ordering::SeqCst);
     CAPTURE_ENABLED.store(true, Ordering::SeqCst);
+    BOUND_CAPTURE_SESSION.set(state.epoch);
 }
 
 /// Disable demand capture without discarding the last snapshot.
@@ -327,6 +317,11 @@ pub fn disable() {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     state.enabled = false;
     CAPTURE_ENABLED.store(false, Ordering::SeqCst);
+    // Drop the calling thread's binding when it still points at this session so
+    // a later unbound execute cannot stamp a retired epoch after re-enable races.
+    if BOUND_CAPTURE_SESSION.get() == state.epoch {
+        BOUND_CAPTURE_SESSION.set(0);
+    }
 }
 
 fn retire_epoch() {
@@ -408,13 +403,19 @@ pub(crate) fn record_plan_completion(
         return;
     }
 
+    // Only the capturing thread may write completion evidence into the live
+    // snapshot; concurrent executes must not overwrite sorts/memory counters.
+    if !may_instrument_demand() {
+        return;
+    }
+
     let mut sorts = Vec::new();
     visit(plan, &mut sorts);
     let completion_rss = current_rss_bytes();
     let mut state = CAPTURE
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if !state.enabled {
+    if !state.enabled || state.epoch != BOUND_CAPTURE_SESSION.get() {
         return;
     }
     // The physical plan can retain an RSS-probe stream after collection has
@@ -552,8 +553,10 @@ impl QueryDemand {
             max_in_flight_reads: AtomicUsize::new(0),
             produced_rows: AtomicUsize::new(0),
             quiescent_waker: AtomicWaker::new(),
-            // QueryDemand is only constructed from FixedHopDemandRule inside capture.
-            capture_epoch: stamp_capture_epoch().unwrap_or_else(capture_epoch),
+            // Prefer the thread-bound session. Unbound concurrent executes (or
+            // explain without reset) stamp 0 so record paths no-op against a
+            // live process-global capture they did not start.
+            capture_epoch: stamp_capture_epoch().unwrap_or(0),
         }
     }
 
@@ -756,6 +759,8 @@ impl PhysicalOptimizerRule for FixedHopDemandRule {
         };
         let plan = crate::ordered_two_hop::try_rewrite_ordered_two_hop(plan)?;
         let Some(terminal) = find_terminal_demand(&plan) else {
+            // RSS probes are diagnostics only; skip when this thread is not the
+            // capturing session so concurrent executes cannot append operator_rss.
             if may_instrument_demand() {
                 let mut rss_ordinal = 0;
                 return instrument_operator_rss(plan, &mut rss_ordinal);
@@ -769,9 +774,9 @@ impl PhysicalOptimizerRule for FixedHopDemandRule {
             }
             return Ok(plan);
         }
-        if !may_instrument_demand() {
-            return Ok(plan);
-        }
+        // Soft demand_batch goals are behavioral (not diagnostics): always wrap
+        // terminal fixed-hop limits. QueryDemand / RSS stamp epoch 0 when this
+        // thread is unbound so concurrent executes cannot pollute a live capture.
         let demand = Arc::new(QueryDemand::new());
         if terminal.cancel_after == 0 {
             demand.cancel();
@@ -789,8 +794,12 @@ impl PhysicalOptimizerRule for FixedHopDemandRule {
             demand,
             terminal.cancel_after,
         ));
-        let mut rss_ordinal = 0;
-        instrument_operator_rss(guarded, &mut rss_ordinal)
+        if may_instrument_demand() {
+            let mut rss_ordinal = 0;
+            instrument_operator_rss(guarded, &mut rss_ordinal)
+        } else {
+            Ok(guarded)
+        }
     }
 
     fn name(&self) -> &str {
@@ -849,7 +858,7 @@ impl RssProbeExec {
             input,
             ordinal,
             operator,
-            capture_epoch: stamp_capture_epoch().unwrap_or_else(capture_epoch),
+            capture_epoch: stamp_capture_epoch().unwrap_or(0),
         }
     }
 
@@ -1276,7 +1285,7 @@ impl ProbeExec {
     ) -> Self {
         let props = Arc::clone(input.properties());
         Self {
-            capture_epoch: stamp_capture_epoch().unwrap_or_else(capture_epoch),
+            capture_epoch: stamp_capture_epoch().unwrap_or(0),
             input,
             ordinal,
             uniqueness,
@@ -1810,9 +1819,30 @@ mod tests {
             let peer = std::thread::spawn(move || {
                 assert!(stamp_capture_epoch().is_none());
                 assert_ne!(bound_capture_session(), live);
+                assert_eq!(stamp_capture_epoch().unwrap_or(0), 0);
             });
             peer.join().expect("peer");
         });
+        assert!(stamp_capture_epoch().is_none());
+    }
+
+    #[test]
+    fn reset_binds_calling_thread_like_capture() {
+        let _guard = CAPTURE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        disable();
+        BOUND_CAPTURE_SESSION.set(0);
+        reset();
+        let epoch = capture_epoch();
+        assert_eq!(bound_capture_session(), epoch);
+        assert_eq!(stamp_capture_epoch(), Some(epoch));
+        // Legacy reset/execute/disable path must record into this session.
+        record_emitted(epoch, 1, 42);
+        assert_eq!(snapshot().hops[&1].rows_emitted, 42);
+        disable();
+        assert_eq!(bound_capture_session(), 0);
         assert!(stamp_capture_epoch().is_none());
     }
 

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -3311,7 +3311,7 @@ impl ExpandExec {
             edge_var: node.edge_var,
             demand_batch: None,
             demand: None,
-            capture_epoch: demand::capture_epoch(),
+            capture_epoch: demand::stamp_capture_epoch().unwrap_or(0),
             required_output: None,
             ordinal_identities,
             ordinal_identity_required,

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -3258,6 +3258,9 @@ pub struct ExpandExec {
     demand_batch: Option<usize>,
     /// Query-scoped terminal cancellation shared by the bounded hop chain.
     demand: Option<Arc<demand::QueryDemand>>,
+    /// Capture session stamped when demand instrumentation attached this node.
+    /// Deferred partition execution must not re-read the global epoch.
+    capture_epoch: u64,
     /// Exact output columns consumed above this operator. `None` preserves the
     /// standalone full-schema contract.
     required_output: Option<Arc<[bool]>>,
@@ -3308,6 +3311,7 @@ impl ExpandExec {
             edge_var: node.edge_var,
             demand_batch: None,
             demand: None,
+            capture_epoch: demand::capture_epoch(),
             required_output: None,
             ordinal_identities,
             ordinal_identity_required,
@@ -3319,6 +3323,7 @@ impl ExpandExec {
         batch_goal: usize,
         demand: Arc<demand::QueryDemand>,
     ) -> Arc<dyn ExecutionPlan> {
+        let capture_epoch = demand.capture_epoch();
         Arc::new(Self {
             input: Arc::clone(&self.input),
             rel_type_name: self.rel_type_name.clone(),
@@ -3335,6 +3340,7 @@ impl ExpandExec {
             edge_var: self.edge_var,
             demand_batch: Some(batch_goal),
             demand: Some(demand),
+            capture_epoch,
             required_output: self.required_output.clone(),
             ordinal_identities: self.ordinal_identities.clone(),
             ordinal_identity_required: self.ordinal_identity_required,
@@ -3358,6 +3364,7 @@ impl ExpandExec {
             edge_var: self.edge_var,
             demand_batch: self.demand_batch,
             demand: self.demand.clone(),
+            capture_epoch: self.capture_epoch,
             required_output: Some(required.into()),
             ordinal_identities: self.ordinal_identities.clone(),
             ordinal_identity_required: self.ordinal_identity_required,
@@ -3506,6 +3513,7 @@ impl ExecutionPlan for ExpandExec {
             edge_var: self.edge_var,
             demand_batch: self.demand_batch,
             demand: self.demand.clone(),
+            capture_epoch: self.capture_epoch,
             required_output: self.required_output.clone(),
             ordinal_identities: self.ordinal_identities.clone(),
             ordinal_identity_required: self.ordinal_identity_required,
@@ -3529,6 +3537,7 @@ impl ExecutionPlan for ExpandExec {
             edge_var: self.edge_var,
             demand_batch: self.demand_batch,
             demand: self.demand.clone(),
+            capture_epoch: self.capture_epoch,
             required_output: self.required_output.clone(),
             ordinal_identities: self.ordinal_identities.clone(),
             ordinal_identity_required: self.ordinal_identity_required,
@@ -3568,7 +3577,7 @@ impl ExecutionPlan for ExpandExec {
             out_schema: self.schema.clone(),
             provider: self.provider.clone(),
             edge_var: self.edge_var,
-            capture_epoch: demand::capture_epoch(),
+            capture_epoch: self.capture_epoch,
             demand: self.demand.clone(),
             required_output: self.required_output.clone(),
             ordinal_identities: self.ordinal_identities.clone(),

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -3568,6 +3568,7 @@ impl ExecutionPlan for ExpandExec {
             out_schema: self.schema.clone(),
             provider: self.provider.clone(),
             edge_var: self.edge_var,
+            capture_epoch: demand::capture_epoch(),
             demand: self.demand.clone(),
             required_output: self.required_output.clone(),
             ordinal_identities: self.ordinal_identities.clone(),
@@ -3640,7 +3641,7 @@ impl ExecutionPlan for ExpandExec {
                         return Ok(None);
                     };
                     let input_batch = input_batch?;
-                    demand::record_input(cfg.edge_var, input_batch.num_rows());
+                    demand::record_input(cfg.capture_epoch, cfg.edge_var, input_batch.num_rows());
                     pending = Some((input_batch, SingleHopPosition::default()));
                 }
             },
@@ -3662,6 +3663,7 @@ struct SingleHopConfig {
     out_schema: SchemaRef,
     provider: Arc<dyn AdjacencyProvider>,
     edge_var: u32,
+    capture_epoch: u64,
     demand: Option<Arc<demand::QueryDemand>>,
     required_output: Option<Arc<[bool]>>,
     ordinal_identities: Option<Arc<V4OrdinalIdentitySession>>,
@@ -3804,7 +3806,7 @@ fn expand_single_hop_chunk(
     if triples.is_empty() {
         return Ok(RecordBatch::new_empty(cfg.out_schema.clone()));
     }
-    demand::record_candidates(cfg.edge_var, triples.len());
+    demand::record_candidates(cfg.capture_epoch, cfg.edge_var, triples.len());
 
     let dst_width = graphforge_storage::TOPOLOGY_NODES_SCHEMA.fields().len();
     let edge_end = cfg.out_schema.fields().len().saturating_sub(dst_width);
@@ -3923,12 +3925,13 @@ fn expand_single_hop_chunk(
             mask.iter().filter(|needed| **needed).count()
         });
         demand::record_identity_projection(
+            cfg.capture_epoch,
             cfg.edge_var,
             output.num_rows(),
             projected_columns,
             &identity_metrics,
         );
-        demand::record_emitted(cfg.edge_var, output.num_rows());
+        demand::record_emitted(cfg.capture_epoch, cfg.edge_var, output.num_rows());
         return Ok(output);
     }
 
@@ -3941,9 +3944,11 @@ fn expand_single_hop_chunk(
     if cfg.demand.is_some() && edge_permit.is_none() {
         return Ok(RecordBatch::new_empty(cfg.out_schema.clone()));
     }
-    let edge_observer = demand::capture_enabled().then(|| {
-        Arc::new(demand::HopReadObserver::new(cfg.edge_var))
-            as Arc<dyn graphforge_storage::io_stats::FilteredReadObserver>
+    let edge_observer = demand::session_active_for(cfg.capture_epoch).then(|| {
+        Arc::new(demand::HopReadObserver::with_epoch(
+            cfg.edge_var,
+            cfg.capture_epoch,
+        )) as Arc<dyn graphforge_storage::io_stats::FilteredReadObserver>
     });
     let edge_topology_width = edge_end
         .saturating_sub(cfg.input_width)
@@ -4016,9 +4021,11 @@ fn expand_single_hop_chunk(
     if cfg.demand.is_some() && node_permit.is_none() {
         return Ok(RecordBatch::new_empty(cfg.out_schema.clone()));
     }
-    let node_observer = demand::capture_enabled().then(|| {
-        Arc::new(demand::HopReadObserver::new(cfg.edge_var))
-            as Arc<dyn graphforge_storage::io_stats::FilteredReadObserver>
+    let node_observer = demand::session_active_for(cfg.capture_epoch).then(|| {
+        Arc::new(demand::HopReadObserver::with_epoch(
+            cfg.edge_var,
+            cfg.capture_epoch,
+        )) as Arc<dyn graphforge_storage::io_stats::FilteredReadObserver>
     });
     let node_projection = (0..dst_width)
         .filter(|offset| required.is_none_or(|mask| mask[edge_end + offset]))
@@ -4033,6 +4040,7 @@ fn expand_single_hop_chunk(
     let edge_key_already_demanded = usize::from(edge_projection.contains(&edge_key_index));
     let node_key_already_demanded = usize::from(node_projection.contains(&1));
     demand::record_materialization_projection(
+        cfg.capture_epoch,
         cfg.edge_var,
         edge_projection
             .len()
@@ -4191,7 +4199,7 @@ fn expand_single_hop_chunk(
     }
     let output = RecordBatch::try_new(cfg.out_schema.clone(), columns)
         .map_err(|e| exec_err(e.to_string()))?;
-    demand::record_emitted(cfg.edge_var, output.num_rows());
+    demand::record_emitted(cfg.capture_epoch, cfg.edge_var, output.num_rows());
     Ok(output)
 }
 

--- a/crates/graphforge-exec/src/ordered_two_hop.rs
+++ b/crates/graphforge-exec/src/ordered_two_hop.rs
@@ -273,6 +273,7 @@ impl ExecutionPlan for OrderedTwoHopPathCountExec {
         let mut remaining = self.fetch;
         let mut uuids = Vec::with_capacity(self.fetch);
         let mut candidates = 0_u64;
+        let epoch = demand::capture_epoch();
         for destination in 0..=max_node {
             if remaining == 0 {
                 break;
@@ -287,7 +288,7 @@ impl ExecutionPlan for OrderedTwoHopPathCountExec {
                 .ordinal_identities
                 .lookup_node_uuids(&[destination])
                 .map_err(|error| DataFusionError::External(Box::new(error)))?;
-            demand::record_identity_projection(1, 1, 1, &lookup.metrics);
+            demand::record_identity_projection(epoch, 1, 1, 1, &lookup.metrics);
             let uuid = *lookup.values[0]
                 .as_ref()
                 .ok_or_else(|| DataFusionError::Internal("missing destination uuid".into()))?
@@ -297,8 +298,8 @@ impl ExecutionPlan for OrderedTwoHopPathCountExec {
             remaining -= emit;
         }
 
-        demand::record_candidates(1, usize_from_u64(candidates));
-        demand::record_emitted(1, uuids.len());
+        demand::record_candidates(epoch, 1, usize_from_u64(candidates));
+        demand::record_emitted(epoch, 1, uuids.len());
 
         let field = Field::new("id", DataType::FixedSizeBinary(16), true);
         let schema = Arc::new(Schema::new(vec![field]));

--- a/crates/graphforge-exec/src/ordered_two_hop.rs
+++ b/crates/graphforge-exec/src/ordered_two_hop.rs
@@ -197,7 +197,7 @@ impl OrderedTwoHopPathCountExec {
             provider: spec.provider,
             ordinal_identities: spec.ordinal_identities,
             require_edge_disjoint: spec.require_edge_disjoint,
-            capture_epoch: demand::capture_epoch(),
+            capture_epoch: demand::stamp_capture_epoch().unwrap_or(0),
         }
     }
 }

--- a/crates/graphforge-exec/src/ordered_two_hop.rs
+++ b/crates/graphforge-exec/src/ordered_two_hop.rs
@@ -183,6 +183,7 @@ pub struct OrderedTwoHopPathCountExec {
     provider: Arc<dyn AdjacencyProvider>,
     ordinal_identities: Arc<crate::V4OrdinalIdentitySession>,
     require_edge_disjoint: bool,
+    capture_epoch: u64,
 }
 
 impl OrderedTwoHopPathCountExec {
@@ -196,6 +197,7 @@ impl OrderedTwoHopPathCountExec {
             provider: spec.provider,
             ordinal_identities: spec.ordinal_identities,
             require_edge_disjoint: spec.require_edge_disjoint,
+            capture_epoch: demand::capture_epoch(),
         }
     }
 }
@@ -273,7 +275,7 @@ impl ExecutionPlan for OrderedTwoHopPathCountExec {
         let mut remaining = self.fetch;
         let mut uuids = Vec::with_capacity(self.fetch);
         let mut candidates = 0_u64;
-        let epoch = demand::capture_epoch();
+        let epoch = self.capture_epoch;
         for destination in 0..=max_node {
             if remaining == 0 {
                 break;


### PR DESCRIPTION
## Summary
- Stamp physical demand-recording streams with the active capture epoch so deferred expand drops cannot mutate a later `DemandSnapshot`.
- Ignore mismatched-epoch record paths (hops, filters, RSS probes, observers).
- Add `stale_capture_epoch_cannot_pollute_next_session` regression for the Bazel `equivalent_full_lifecycle` failure mode.

Closes #1091

## Test plan
- [x] `cargo test -p graphforge-exec --lib stale_capture_epoch_cannot_pollute_next_session`
- [x] `cargo test -p graphforge-exec`
- [x] `TMPDIR=<ext4> cargo test -p graphforge-api --test scale_g500_ladder equivalent_full_lifecycle`
- [ ] Exact-head CI / CI Gate


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791102563&installation_model_id=20486&pr_number=1092&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1092&signature=c73a1159a6cdafa780346e45b2c42c6097af7e5166aee6f1e0f638464d991b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->