### PR TITLE
docs(adr): define compiler-independent storage value contract

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -295,6 +295,10 @@ export default defineConfig({
                   label: '0024 Storage format exceptions',
                   slug: 'adr/0024-storage-format-exceptions',
                 },
+                {
+                  label: '0025 Storage value contract',
+                  slug: 'adr/0025-storage-value-contract',
+                },
               ],
             },
           ],

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -142,6 +142,7 @@ const PAGES = [
   'adr/0021-portable-project-v2.md',
   'adr/0023-composable-multi-ontology.md',
   'adr/0024-storage-format-exceptions.md',
+  'adr/0025-storage-value-contract.md',
   'releases/roadmap.md',
   'legal/licensing.md',
   'community/security.md',

--- a/docs/adr/0025-storage-value-contract.md
+++ b/docs/adr/0025-storage-value-contract.md
@@ -1,0 +1,181 @@
+# ADR 0025: Storage values have a compiler-independent contract
+
+**Status:** Accepted (decision; extraction not yet implemented)
+**Date:** 2026-09-04
+**Build target:** v0.6.0
+**Related:** issues #1013, #1011, #1012; ADRs 0008–0011, 0013, 0017, 0024
+
+## Context: the current dependency graph
+
+The compiler pipeline is a flow of work, not the Cargo dependency graph.
+`graphforge-storage` currently has production dependencies on both
+`graphforge-ir` and `graphforge-ontology`. In particular:
+
+- `graphforge-ir/src/expr.rs` owns `IrLiteral` and its custom serde encoding.
+  Storage's writer, property overlay, and GFDR journal use those values.
+- `graphforge-ir/src/catalog.rs` owns runtime IDs, the tag-bit conversion into
+  `graphforge_core::TypeId`, and `RuntimeCatalog`'s Arrow persistence schema.
+  Storage reads and writes that catalog and stores tagged IDs in topology.
+- Rel, exec, and storage independently construct or interpret heterogeneous
+  Arrow values (`__het_tag` and their variant payloads).
+- Storage also uses ontology handles and IR composition-binding adapters.
+  Moving value definitions alone will not remove every storage → IR edge.
+
+`IrVersion::CURRENT` is attached to result metadata in `graphforge-api`.
+It is not checked by `resolve_project_generation` on project open. Making that
+compiler version the durable-value compatibility gate would couple unrelated
+plan and storage evolution.
+
+## Decision and dependency graph
+
+Choose a small Rust **`graphforge-value`** contract crate. It depends on
+`graphforge-core`, Arrow, and serialization/error support; it must not depend
+on AST, IR, ontology, rel, exec, storage, or DataFusion. It is a leaf relative
+to those engine layers. Core remains below it and must not depend on it.
+
+The target **value-contract** edges (arrow means “depends on”) are:
+
+```text
+graphforge-ir       ─┐
+graphforge-ontology ─┤
+graphforge-rel      ─┤
+graphforge-exec     ─┼──> graphforge-value ──> graphforge-core
+graphforge-storage ─┤           │
+graphforge-api      ─┘           └──> Arrow + serde + error support
+```
+
+This graph does not replace the compiler pipeline or show every crate edge.
+Ontology-to-value conversion stays in ontology-facing adapters; conversion
+between DataFusion `ScalarValue` and the shared Arrow/value contract stays in
+rel/exec adapters. Neither may duplicate tag interpretation. Storage may still
+consume ontology/composition adapters where it validates semantic bindings;
+this ADR does not turn those APIs into compiler-independent APIs by assertion.
+
+### Ownership
+
+| Contract | Owner after extraction | Boundary |
+| --- | --- | --- |
+| Literal value variants currently named `IrLiteral`, including nested values and custom non-finite-float serde encoding | `graphforge-value` | A neutral value type; IR may re-export it as `IrLiteral` for source compatibility. `IrExpr`, arenas, operators, binder policy, and `IrVersion` stay in IR. Moving the Rust type must preserve serialized names and bytes. |
+| Ontology IDs versus runtime entity/relation IDs and their tagged carrier | Primitive ontology identity stays in core; checked tagged carrier/codec and runtime ID types live in `graphforge-value` | Private fields and checked construction prevent substitution; one encoder/decoder owns every tag bit. Ontology assignment validates its range before conversion. |
+| Heterogeneous Arrow values | `graphforge-value` | Construct, recognize, validate, encode, and decode the existing constant, nested, and per-expression dynamic layouts. This includes field names, types, null rules, tag selection, and schema-version recognition, not just constants. |
+| Persisted runtime catalog/value schemas | `graphforge-value` | Schema definitions, serialized carriers, and validation are shared. Runtime observation/interning policy can remain in IR, consuming those carriers. Storage owns Parquet I/O and generation publication, not a second schema definition. |
+| Topology tables, GFDR envelopes, generation manifests and participant inventory | `graphforge-storage` | Storage owns physical framing and open/replay admission, using the shared ID/value codecs. A contract crate does not own filesystem paths or publication. |
+| Canonical ontology documents, composition semantics and compiled ontology snapshots | `graphforge-ontology` and the existing workspace adapters | Durable source remains committed JSON; compiled Parquet is derived under ADR 0024. They consume checked identity/value types without moving ontology policy into the leaf. |
+
+The schema helpers must distinguish the existing layouts: dynamic list tags
+are per-expression payload indexes, not a global enum of value kinds. Preserve
+ADRs 0008–0011, including nested layouts and null semantics. Centralization must
+not accidentally assign one universal meaning to tags used by different schemas.
+
+## Versioning and compatibility
+
+Public package versions remain coordinated under ADR 0017. Four other version
+boundaries remain distinct:
+
+| Boundary | Rule |
+| --- | --- |
+| Graph IR / `IrVersion` | Describes the compiler-plan contract and result annotation. Changing it neither upgrades nor admits durable projects. |
+| Shared ID/value/catalog schemas | The contract crate names and validates each supported encoding independently of IR and package versions. Existing encodings are the initial contract; no new mandatory field or version metadata is added merely for extraction. |
+| Project container and participants | Storage validates the exact supported `FORMAT`, `CURRENT`, generation manifest and participant format contracts. Participant/schema compatibility cannot be inferred from a matching container alone. |
+| GFDR framing and typed payload | Preserve ADR 0024's run version, record version and payload schema ID. Moving `IrLiteral` must not silently alter the JSON encoded under the existing payload schema ID. |
+
+For #1011 and #1012, the chosen implementation is **encoding preserving**.
+Existing ontology IDs occupy the untagged low range below `2^30`; runtime
+entity IDs use bit 30 and runtime relation IDs use bit 31, with a local ID below
+`2^30`. Both tag bits set is invalid. The new carrier retains these integers,
+rejects invalid/out-of-range construction and decoding, and never renumbers
+catalog entries. Check the kind against the catalog/ontology at semantic
+admission; a syntactically valid integer alone does not prove a valid reference.
+
+Golden vectors must pin boundaries and invalid IDs, each heterogeneous layout
+and nested variant, and any moved literal/catalog serialization. Public Arrow
+results, Python/Node adapters, and receipts must retain their representations.
+Changing a Rust module path is not a reason to rewrite a committed generation.
+
+If an implementation cannot preserve an encoding, stop that refactor and make
+an explicit compatibility decision: assign a new applicable schema/format
+version and reject unsupported inputs, or separately specify and test a bounded
+migration through atomic generation publication. Never reinterpret old bytes
+under the same version. This ADR authorizes no migration feature.
+
+### Existing project-open and migration policy
+
+The [pre-v1 project compatibility policy](../book/architecture/project-format-compatibility.md)
+continues to apply. The current container marker is exactly
+`graphforge-project/v1\n`; its `v1` is a format marker, not product v1.0.
+The existing v0.5 generation protocol selects the canonical `CURRENT` record,
+authenticates its named manifest, validates paths, and holds the selected
+generation lease. It does not elect a generation by scanning directories.
+Unsupported layouts fail with `GF_UNSUPPORTED_PROJECT_FORMAT` before graph
+records are opened or project files are mutated. Malformed supported authority
+uses the existing corruption errors. An explicitly empty directory may be
+initialized; an unrecognized non-empty root may not.
+
+There is no pre-v1 importer, automatic upgrade, read-only compatibility view,
+identity conversion, or migration API for unsupported project layouts.
+Unsupported data must be re-created through supported construction/ingest.
+Within supported generations, the documented canonical Parquet bases,
+immutable full-snapshot fragments and typed GFDR payloads remain supported.
+The old routing-free/string-only GFDR prototype remains unsupported. Derived
+compiled ontology tables may be rebuilt from committed JSON; this is not a
+migration of authoritative graph data.
+
+### Required implementation admission checks
+
+The generic generation resolver remains a bounded container/manifest resolver;
+it must not become a full graph scan. Once the selected participant is opened,
+storage must use the shared schema recognizers and checked ID/value decoders at
+catalog, topology/property and GFDR decode boundaries. Catalog admission must
+reject invalid tags, duplicate/conflicting identities and unsupported carrier
+schemas before exposing them to query execution. Deferred/batched reads must
+validate values before returning or replaying each batch, not trust an open-time
+container check as proof of every row. Portable import must use the same checks
+before publication.
+
+Unknown value tags and schema drift need stable typed contract errors, mapped
+at storage boundaries to the existing unsupported-format or corruption error
+as appropriate. A malformed supported value is not a request to try an older
+codec. Persisted input must not panic, silently become null, or be repaired on
+open. Valid reopen/recovery tests and invalid-input tests must demonstrate that
+rejection leaves committed project authority unchanged. These are requirements
+for implementation, not claims that the current readers already enforce all of
+them.
+
+## Bounded implementation and evidence
+
+The decision unblocks existing work; it does not close that implementation:
+
+- **#1011** introduces the checked ID carrier in the leaf crate, replaces tag
+  logic in rel/storage/API, enforces ontology assignment bounds, and validates
+  persisted catalog/topology identity decoding. Its existing golden-vector and
+  public-representation criteria include valid reopen and invalid-ID rejection
+  without rewriting the project. Catalog carrier/schema changes needed for this
+  work must preserve the current encoding.
+- **#1012** owns the shared heterogeneous schema and codecs in that crate,
+  including the neutral literal representation needed by shared encode/decode.
+  This supersedes its original tentative “core or IR” location. Its existing
+  end-to-end write-back criterion must cross rel → exec → storage for every
+  supported variant, then reopen durable values; golden vectors pin the layouts
+  and any moved literal serde encoding. Unknown-tag/schema-drift cases exercise
+  the same helpers used by storage and import.
+- **#1008** consumes the resulting logical value/ID types for plan purity; it
+  does not move runtime environment authority into the value contract.
+
+No broad storage/ontology adapter rewrite is implied by these issues. Any
+remaining edge must be described honestly until separately justified work
+removes it. In particular, #1013 completes the architecture decision, not a
+claim that Cargo already implements the target value boundary. Its evidence is
+the inspected crate manifests and concrete reader/writer locations above,
+aligned architecture documentation, and the docs build/link gates. The follow-up
+issues require actual Rust/facade/binding evidence appropriate to their changed
+surface; logical plans alone are insufficient.
+
+## Alternatives rejected
+
+Formally making IR the durable contract would entrench the existing compiler
+and storage coupling and invite misuse of `IrVersion` on open. Putting all
+Arrow schemas in core would broaden the foundational crate's dependency surface
+and mix base identities with the evolving value wire contract. Duplicating
+storage-only DTOs with ad hoc conversions would keep multiple incompatible
+schema owners. The dedicated leaf keeps a single checked contract while
+allowing compiler plans and durable values to evolve independently.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ are not retained in this tree.
 | 0022 | [Multi-ontology semantics in portable project v2](0022-portable-v2-multi-ontology-compatibility.md) | `0022-portable-v2-multi-ontology-compatibility.md` |
 | 0023 | [Composable ontology modules and semantic bridges](0023-composable-multi-ontology.md) | `0023-composable-multi-ontology.md` |
 | 0024 | [Storage format exceptions for GFDR and compiled ontologies](0024-storage-format-exceptions.md) | `0024-storage-format-exceptions.md` |
+| 0025 | [Storage values have a compiler-independent contract](0025-storage-value-contract.md) | `0025-storage-value-contract.md` |
 
 ## Numbering
 

--- a/docs/book/architecture/overview.md
+++ b/docs/book/architecture/overview.md
@@ -150,12 +150,28 @@ Project = Graph (topology + properties)          ← graph layer
 
 ---
 
+## Crate dependencies and durable values
+
+The diagram above shows execution flow, not Cargo dependencies. Today storage
+also depends on IR and ontology: `IrLiteral`, tagged runtime IDs and the runtime
+catalog's persistence schema live in IR, and storage consumes ontology and
+composition adapters. `IrVersion` annotates results; it is not a project-open
+compatibility gate.
+
+[ADR 0025](../../adr/0025-storage-value-contract.md) chooses a compiler-independent
+`graphforge-value` crate above core for shared values, checked tagged IDs and
+Arrow/catalog codecs. That extraction is **Designed**, tracked by #1011 and
+#1012; the crate is not yet present. Compiler plans remain in IR, storage owns
+project admission and physical persistence, and existing encodings must be
+preserved. The [project compatibility policy](project-format-compatibility.md)
+remains separate from compiler-plan versioning.
+
 ## Rust Workspace Layout
 
 ```
 crates/
   graphforge-api/              # public Rust facade (lifecycle, Cypher, verbs, knowledge)
-  graphforge-core/             # engine facade helpers used by graphforge-api
+  graphforge-core/             # shared primitive types, identities, and errors
   graphforge-ast/              # AST + spans + syntax diagnostics
   graphforge-cypher/           # hand-written lexer + recursive-descent/Pratt parser
   graphforge-ontology/         # runtime ontology model, validation, migration
@@ -285,7 +301,7 @@ Shipped v0.5.0 expects these surfaces to stay green on `main`:
 - [Algorithm Verbs](algorithms.md) — full algorithm catalog across rank/cluster/paths/analyze/similar
 - [Execution Model](execution-model.md) — DataFusion integration, custom graph operators, Arrow result streams
 - [Storage](storage.md) — StorageProvider trait, Parquet provider
-- [ADR Index](../../adr/README.md) — contiguous decision log (`0001`–`0018`)
+- [ADR Index](../../adr/README.md) — contiguous decision log (`0001`–`0025`)
 - [ADR 0001: Rust Core](../../adr/0001-rust-core.md) — Rust core and binding strategy
 - [ADR 0002: RD+Pratt Parser](../../adr/0002-lr1-grammar.md) — Parser algorithm decision
 - [ADR 0003: Progressive Ontology](../../adr/0003-progressive-ontology.md) — exploration-first ontology modes

--- a/docs/book/architecture/project-format-compatibility.md
+++ b/docs/book/architecture/project-format-compatibility.md
@@ -52,6 +52,19 @@ plus bindings in the same generation. A missing or mismatched authority fails
 before publication; import never drops the bindings or fabricates composition
 state.
 
+## Shared value contract extraction for v0.6.0
+
+[ADR 0025](../../adr/0025-storage-value-contract.md) separates compiler IR
+versioning from persisted ID/value/catalog schemas. The current container
+marker is `graphforge-project/v1\n`, distinct from the product version.
+`IrVersion` is result metadata, not a project-open compatibility gate. The
+planned extraction in #1011/#1012 preserves current integer, Arrow and serde
+encodings; it introduces no automatic migration or mandatory new metadata for
+existing supported projects. Unknown versions and malformed values must fail
+through shared checked decoders without rewriting committed authority. The
+ADR identifies the required catalog/value admission and durable reopen tests;
+it does not claim those follow-up changes are already implemented.
+
 ## Knowledge-layer implementation boundary
 
 The knowledge layer starts from the v0.5 graph and project contracts on `main`.

--- a/docs/book/architecture/refactor-v0.5.md
+++ b/docs/book/architecture/refactor-v0.5.md
@@ -6,6 +6,15 @@
 
 This document is the authoritative reference for architectural decisions made before and during the v0.5 refactor. Treat this document as the primary constraint document for v0.5 architecture. When an implementation decision conflicts with something here, update this document first, then update the implementation.
 
+For the current storage/value boundary, [ADR 0025](../../adr/0025-storage-value-contract.md)
+supersedes this baseline's implicit coupling of durable values to Graph IR.
+The diagrams here describe workflow, not the complete Cargo graph: storage
+currently depends on IR and ontology. The `ir_version` examples below are
+compiler metadata, not implemented project-open admission rules; the
+[project format compatibility policy](project-format-compatibility.md) governs
+supported committed generations. Extraction of the chosen value contract is
+pending in #1011/#1012.
+
 **Product positioning:** GraphForge is a **Knowledge Analysis Workbench** — not a graph database and not merely a graph analytics engine. The graph is one asset inside a larger analytical project. The workbench is designed for analysts who build knowledge from uncertain, incomplete, or heterogeneous data over time.
 
 ---

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -19,6 +19,22 @@ pub trait StorageProvider: Send + Sync {
 
 ---
 
+## Value contract and current dependencies
+
+`graphforge-storage` currently depends on both `graphforge-ir` and
+`graphforge-ontology` in production. Its writer and GFDR journal consume
+`IrLiteral`; catalog and topology paths consume IR's runtime catalog and tagged
+IDs; ontology/composition adapters supply semantic binding validation. Storage
+is therefore not yet independent of compiler-owned value definitions.
+
+[ADR 0025](../../adr/0025-storage-value-contract.md) chooses `graphforge-value`
+for the shared value/ID/catalog encoding contract; extraction is pending in
+#1011 and #1012. Storage retains physical schemas, I/O, and project admission.
+Moving definitions must preserve existing bytes and public Arrow layouts.
+`graphforge.ir_version` metadata is descriptive and does not admit a project:
+container, participant and value compatibility use their own checked contracts.
+See [project format compatibility](project-format-compatibility.md).
+
 ## Provider Role: Parquet
 
 Parquet is the sole storage provider for the Rust core. It:

--- a/docs/engineering/adrs/README.md
+++ b/docs/engineering/adrs/README.md
@@ -61,3 +61,4 @@ Keeper set after #2730 (mirrors [`../../adr/README.md`](../../adr/README.md)):
 | 0022 | Multi-ontology semantics in portable project v2 | Accepted | [`../../adr/0022-portable-v2-multi-ontology-compatibility.md`](../../adr/0022-portable-v2-multi-ontology-compatibility.md) |
 | 0023 | Composable ontology modules and semantic bridges | Accepted | [`../../adr/0023-composable-multi-ontology.md`](../../adr/0023-composable-multi-ontology.md) |
 | 0024 | Storage format exceptions for GFDR and compiled ontologies | Accepted | [`../../adr/0024-storage-format-exceptions.md`](../../adr/0024-storage-format-exceptions.md) |
+| 0025 | Storage values have a compiler-independent contract | Accepted (extraction pending) | [`../../adr/0025-storage-value-contract.md`](../../adr/0025-storage-value-contract.md) |


### PR DESCRIPTION
Storage currently persists IR-owned literals and tagged IDs without an explicit independent value-version contract. ADR 0025 chooses a `graphforge-value` leaf above core, assigns value/ID/catalog ownership, and preserves existing integer, Arrow and serde encodings without making `IrVersion` a project-open gate.

The architecture pages now distinguish current Cargo dependencies from the target value contract. The ADR preserves the existing fail-closed pre-v1 compatibility/migration policy and assigns checked admission, golden vectors and durable reopen evidence to the bounded implementation in #1011/#1012. Those issue bodies have been aligned; extraction itself remains their work. The new ADR is included in both indexes and the published documentation navigation.

Validation:
- `npx --yes pnpm@10.26.2 docs:build` — passed, 109 pages.
- `npx --yes pnpm@10.26.2 docs:check-links` — passed, 13,789 hrefs, zero broken/stale links.
- `make gate-registry-check` — passed, 23 workflows and 14 tests.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

Documentation-only change; no native engine behavior or encoding changed. Findings were checked against the current manifests, IR value/catalog implementations, storage writer/GFDR readers and generation resolver, and API result metadata.

Closes #1013

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791152571&installation_model_id=20486&pr_number=1098&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1098&signature=d4afd95b1d1caaef2320505e2e7b81bda8390bdd361842de7fa685d7063df174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->