### PR TITLE
test(ontology): freeze canonical fingerprint compatibility

### DIFF
--- a/crates/graphforge-core/src/canonical.rs
+++ b/crates/graphforge-core/src/canonical.rs
@@ -3,6 +3,12 @@
 //! Domain owners define their registered schemas and logical-value encoders.
 //! This module owns the common bounded byte writer, closed fingerprint domains,
 //! SHA-256 envelope, and UUIDv8 projection.
+//!
+//! Ontology document `/1` digests intentionally retain their separate sorted-JSON
+//! grammar and domain prefixes in `graphforge-ontology::composition`. They must
+//! not be wrapped in this envelope: doing so changes persisted module, bridge,
+//! and composition identities. The compatibility decision is documented in
+//! `docs/book/architecture/canonical-fingerprints-v1.md`.
 
 use sha2::{Digest, Sha256};
 

--- a/crates/graphforge-ontology/src/composition/canonical.rs
+++ b/crates/graphforge-ontology/src/composition/canonical.rs
@@ -1,11 +1,21 @@
-//! JCS-style canonical JSON and module digests.
+//! Frozen ontology `/1` sorted-JSON grammar and domain-separated digests.
+//!
+//! This is intentionally distinct from `graphforge_core::canonical`'s binary
+//! `graphforge-canonical/1` envelope: replacing either grammar changes persisted
+//! identities. See `docs/book/architecture/canonical-fingerprints-v1.md`,
+//! "Ontology document compatibility boundary", for the byte rules and rationale.
 
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use super::identity::{BRIDGE_DIGEST_DOMAIN, MODULE_DIGEST_DOMAIN};
 
-/// Serialize a JSON [`Value`] with object keys sorted (RFC 8785 subset used by GraphForge).
+/// Serialize a JSON [`Value`] using the frozen ontology `/1` sorted-JSON grammar.
+///
+/// Object keys sort by Rust string order (UTF-8 bytes), arrays retain order,
+/// strings use `serde_json` escaping, and numbers use `serde_json::Number`'s
+/// spelling. No Unicode or floating-point normalization is performed. This is
+/// not full RFC 8785 JCS (which has different key ordering and number rules).
 pub fn canonical_json(value: &Value) -> Result<Vec<u8>, String> {
     fn write(value: &Value, output: &mut Vec<u8>) -> Result<(), String> {
         match value {
@@ -78,4 +88,60 @@ pub(crate) fn hex_lower(bytes: &[u8]) -> String {
             write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
             out
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::composition::identity::COMPOSITION_DOMAIN;
+
+    // Frozen before any encoder change for #1014. Expected hashes were computed
+    // independently with Python hashlib over the literal UTF-8 bytes and the
+    // NUL-terminated domain, not derived from the encoder under test.
+    #[test]
+    fn ontology_json_bytes_and_all_three_domains_match_frozen_vectors() {
+        let input = r#"{
+            "𐀀": 2, "\uE000": 1, "é": "e\u0301",
+            "n": [-0.0, 0.0, 1.0, 1e30, 1e-7, 18446744073709551615],
+            "a": [null, true, false, {"z": "é", "a": "quote\" slash/ newline\n"}]
+        }"#;
+        let canonical = concat!(
+            r#"{"a":[null,true,false,{"a":"quote\" slash/ newline\n","z":"é"}],"n":[-0.0,0.0,1.0,1e+30,1e-7,18446744073709551615],"é":"e"#,
+            "\u{301}",
+            "\",\"\u{e000}\":1,\"𐀀\":2}",
+        );
+        for (input, expected_bytes, expected_digests) in [
+            (
+                "{}",
+                "{}",
+                [
+                    "0ac9473099dfa8458a10862284a5f3d8cc8074352b1381532801787207e27acf",
+                    "adbf86344fa0d9b236b1922a37ff03e111c8646ac159f20874644f4105dadbc2",
+                    "c8dd8266bea2f0630c5990f5ca20f7b2cf953498fded20ea626cd3d9c6caf09f",
+                ],
+            ),
+            (
+                input,
+                canonical,
+                [
+                    "e71e871057cbf44aa5314d1df06312eb5cb99caa84e858676c0f4c78ee49d478",
+                    "d297a7cfeaadf9de85f0b00d2eea1882688dcc5a498a91ccacf077ce6b585568",
+                    "9caedae437e332f96314b220eee94773bc3b2e14b14c3a6483dac017de683c01",
+                ],
+            ),
+        ] {
+            let value: Value = serde_json::from_str(input).unwrap();
+            assert_eq!(canonical_json(&value).unwrap(), expected_bytes.as_bytes());
+            for (domain, expected) in [
+                MODULE_DIGEST_DOMAIN,
+                BRIDGE_DIGEST_DOMAIN,
+                COMPOSITION_DOMAIN,
+            ]
+            .into_iter()
+            .zip(expected_digests)
+            {
+                assert_eq!(domain_digest(domain, &value).unwrap(), expected);
+            }
+        }
+    }
 }

--- a/crates/graphforge-ontology/tests/bridge_sets.rs
+++ b/crates/graphforge-ontology/tests/bridge_sets.rs
@@ -372,6 +372,12 @@ fn deterministic_export_and_reopen() {
         )],
     );
     let digest_a = bridge_document_digest(&document).unwrap();
+    // Pin the existing document across register/adopt, JSON/YAML export/import,
+    // and snapshot reopen; equality with a recomputed hash alone misses drift.
+    assert_eq!(
+        digest_a,
+        "6e6013870946d3b4a07022ac4d210c1252dc233763fc98125ddfd57f1042fc9e"
+    );
     let id = inv.create_register(document.clone(), "c").unwrap();
     assert_eq!(id.canonical_digest, digest_a);
     inv.adopt(&BridgeSelector::Exact(id.clone()), 0, "a")

--- a/crates/graphforge-ontology/tests/composition_inventory.rs
+++ b/crates/graphforge-ontology/tests/composition_inventory.rs
@@ -60,6 +60,16 @@ fn fingerprint_stable_under_inventory_reorder() {
         ),
         vec![],
     );
+    // Pin existing authored documents as well as relative reorder stability.
+    // These hashes were independently computed over literal canonical JSON.
+    assert_eq!(
+        genealogy.id.canonical_digest,
+        "cdfae1502134b6ac5509efb01b1711d04ac0d7f3a6504de46628dca860609363"
+    );
+    assert_eq!(
+        provenance.id.canonical_digest,
+        "c3b7b56a3d1ae2c60c7de427865c68e963652bd363e9672fdc993ec98a56a3e9"
+    );
     let bridges = [BridgeSetId {
         bridge_id: "https://graphforge.dev/bridge/research-document".into(),
         authored_version: "1.0.0".into(),
@@ -91,6 +101,10 @@ fn fingerprint_stable_under_inventory_reorder() {
     .expect("reverse");
 
     assert_eq!(forward.fingerprint, reverse.fingerprint);
+    assert_eq!(
+        forward.fingerprint,
+        "82a22a7bb3512ea90074fb4ac100cdeef50ebfbf4c351c46e51a81aff715612c"
+    );
     assert_eq!(
         forward.modules.iter().map(|m| &m.id).collect::<Vec<_>>(),
         reverse.modules.iter().map(|m| &m.id).collect::<Vec<_>>()

--- a/docs/book/architecture/canonical-fingerprints-v1.md
+++ b/docs/book/architecture/canonical-fingerprints-v1.md
@@ -363,3 +363,87 @@ version:
 
 The epistemic layer adds record domains and schemas but continues to reference frozen knowledge-layer
 fingerprints by `(domain, version, sha256)`.
+
+## Ontology document compatibility boundary
+
+**Decision for v0.6.0 (#1014): retain the two existing byte grammars intentionally.**
+`graphforge-core::canonical` owns the bounded binary writer and `GFFP` envelope
+described above. `graphforge-ontology::composition::canonical` owns the existing
+sorted-JSON document grammar. Ontology module, bridge, and composition identities
+are not registered `graphforge-canonical/1` domains; they MUST NOT acquire a
+`GFFP` envelope or be re-encoded as Arrow records implicitly.
+
+Ontology `/1` digests are lowercase hexadecimal SHA-256 over the exact prefix
+followed immediately by the sorted-JSON bytes, with no additional lengths,
+envelope, or trailing delimiter:
+
+| Identity | Exact prefix (`\0` denotes one NUL byte) |
+|---|---|
+| Authored module document | `graphforge-ontology-module/1\0` |
+| Authored bridge document | `graphforge-ontology-bridge/1\0` |
+| Composition semantic document | `graphforge-ontology-composition/1\0` |
+
+Module and bridge documents are first serialized to `serde_json::Value` using
+their Rust document schemas, including the schemas' field omission/default
+rules. Composition builds the semantic object specified in the
+[multi-ontology contract](composable-multi-ontology.md#inventory-closure-and-composition-identity).
+The existing JSON encoder then applies these frozen rules recursively:
+
+- Objects sort keys by Rust string order, equivalent to lexicographic UTF-8 byte
+  order; they use `{`, `}`, `:`, and `,` without whitespace.
+- Arrays retain element order and use `[`, `]`, and `,` without whitespace.
+- Strings and keys use `serde_json` JSON escaping, preserving Unicode bytes
+  without normalization. Null and booleans use `null`, `true`, and `false`.
+- Numbers use `serde_json::Number` display spelling. Integer and floating-point
+  representations remain distinct: `1` differs from `1.0`, and `-0.0` is retained.
+  The pinned exponent spellings include `1e+30` and `1e-7`.
+
+Earlier descriptions called this grammar "JCS" or an "RFC 8785 subset". Those
+labels do not authorize changing the existing bytes to full RFC 8785 JCS. In
+particular, JCS sorts UTF-16 code units, which orders U+10000 before U+E000;
+ontology `/1` sorts U+E000 first. JCS number normalization also differs from the
+existing float spellings. Changing either rule changes document identities.
+
+The separation is required for compatibility, not a second implementation of
+the same contract. Ontology digests identify authored documents and qualified
+references, while core fingerprints encode typed logical values with explicit
+schema, lengths, versions, and bounds. Replacing the JSON encoder with core's
+writer/envelope would invalidate module and bridge references, compiled
+composition fingerprints, and portable import/export integrity checks. The
+core writer's limits also MUST NOT silently become new document admission
+rules. Domain owners retain their existing validation and limits.
+
+### Compatibility evidence and release impact
+
+The following executable vectors freeze the existing behavior:
+
+- `graphforge-core/src/canonical.rs`:
+  `envelope_hash_and_uuid_match_the_frozen_vector` checks exact core payload,
+  envelope, SHA-256, and UUIDv8 bytes.
+- `graphforge-ontology/src/composition/canonical.rs`:
+  `ontology_json_bytes_and_all_three_domains_match_frozen_vectors` checks exact
+  JSON bytes and all three ontology domain hashes, including empty objects,
+  nesting, escaping, Unicode ordering/non-normalization, float spelling, and
+  the maximum `u64`.
+- `graphforge-ontology/tests/composition_inventory.rs`:
+  `fingerprint_stable_under_inventory_reorder` pins two existing authored module
+  digests and the compiled composition fingerprint across inventory reordering.
+- `graphforge-ontology/tests/bridge_sets.rs`:
+  `deterministic_export_and_reopen` pins the existing bridge document digest
+  across registration/adoption, JSON and YAML export/import, and inventory
+  snapshot reopen. This is an inventory test, not disk recovery certification.
+
+The ontology hash constants were independently calculated with Python
+`hashlib.sha256` over literal canonical UTF-8 JSON and NUL-terminated prefixes,
+then verified against the unchanged Rust encoders. Together with the existing
+core vector, these are identity compatibility gates for encoder, schema, and
+serialization dependency changes; do not regenerate them merely to accept drift.
+
+This decision changes no identity or durable format and requires no migration
+for v0.6.0. A future convergence that changes bytes MUST first specify new
+domain/version identifiers, coexistence with `/1` readers, explicit migration of
+module and bridge references and dependent composition identities, portable
+format compatibility, and release impact. It MUST preserve reproduction of old
+digests and MUST NOT relabel old identities as the new contract. Sharing
+implementation primitives is permissible only if both grammars, prefixes,
+accepted inputs, and pinned outputs remain unchanged.

--- a/docs/book/architecture/composable-multi-ontology.md
+++ b/docs/book/architecture/composable-multi-ontology.md
@@ -10,6 +10,9 @@ This document is normative. **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, an
 opaque NFC string interpreted only by that ontology's declared version scheme;
 `canonical_digest` is lowercase SHA-256 over the domain-separated canonical
 module document. Two modules are the same only when all three fields match.
+The exact `/1` sorted-JSON grammar and intentional separation from the core
+binary fingerprint envelope are specified in the
+[ontology document compatibility boundary](canonical-fingerprints-v1.md#ontology-document-compatibility-boundary).
 
 `QualifiedSymbol` is `{ module, kind, local_id }`, where `kind` is exactly
 `entity`, `relation`, `property`, `constraint`, or `migration`, and `local_id`
@@ -37,7 +40,7 @@ dependencies fail before activation.
 `CompositionFingerprint` is lowercase SHA-256 of:
 
 ```text
-"graphforge-ontology-composition/1\0" || JCS({
+"graphforge-ontology-composition/1\0" || ontology_sorted_json_v1({
   modules: [exact module identities in closure order],
   bridges: [exact bridge identities in identity order],
   activation: [sorted scoped activation records]


### PR DESCRIPTION
Ontology document identities and core fingerprints use different byte grammars. Treating them as interchangeable would change persisted module and bridge references, compiled composition identities, and portable integrity checks. Document this as an intentional compatibility boundary for v0.6.0, preserving both existing encoders and requiring a versioned migration before any future identity-changing convergence.

Pin exact ontology JSON bytes and independently calculated SHA-256 vectors for module, bridge, and composition domains. Cover nested key ordering, Unicode ordering/non-normalization, escaping, number spellings, existing authored module documents, a compiled inventory, and the existing bridge register/adopt/export/import/reopen lifecycle. Retain the core's existing exact envelope/hash/UUID vector. Correct the prior “JCS subset” description to the actual frozen UTF-8-key/serde-number grammar. No production encoder statements, identity outputs, or durable formats change.

Validation:
- `CARGO_TARGET_DIR=/home/ubuntu/code/graphforge-target-1014 CARGO_BUILD_JOBS=4 cargo test -p graphforge-core -p graphforge-ontology`: 182 tests/doctests passed.
- `cargo fmt --all -- --check`: passed after final edits.
- `CARGO_TARGET_DIR=/home/ubuntu/code/graphforge-target-1014 CARGO_BUILD_JOBS=4 cargo clippy --workspace -- -D warnings`: passed.
- `make gate-registry-check`: passed (23 workflows, 14 tests).
- `make pre-push-fast`: passed, including Cargo/Bazel drift and multi-ontology contracts.

Rebased unchanged onto `610f05d1`, which includes the merged Python test-linkage and lock consistency fixes. Both `make pre-push-fast` and `make pre-push-preflight` pass on head `9a660515`; the earlier #1101/#1102 build blockers are resolved. Exact-head CI Gate and all applicable Rust, binding, native durability, concurrency, and tiny lifecycle checks passed at `9a660515`. Squash-merged as `c002585b`; issue #1014 is closed.

Closes #1014
