### PR TITLE
refactor(core): centralize deterministic UUIDv5 derivation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,6 +240,7 @@ jobs:
         run: |
           scripts/ci/check-domain-dependencies.py
           scripts/ci/test-domain-dependencies.py
+          python3 scripts/ci/test-uuid-derivation-policy.py
 
       - name: Test crates.io publish plan helper
         if: steps.policy-suites.outputs.crate_publish == 'true'

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ pre-push-fast:  ## Run fast checks only — format, lint, type, security, docstr
 	@python3 scripts/ci/cargo-bazel-drift-check.py
 	@python3 scripts/ci/python-build-mode-check.py
 	@python3 scripts/ci/test-python-build-mode-check.py
+	@python3 scripts/ci/test-uuid-derivation-policy.py
 	@echo "━━━ Public API BDD policy ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@python3 scripts/ci/api-bdd-policy.py --check-issues
 	@python3 scripts/ci/test-api-bdd-policy.py

--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -85,9 +85,9 @@ fn eligible_delta_operations(
             ),
             _ => return Ok(None),
         };
-        let operation_uuid = Uuid::new_v5(
+        let operation_uuid = graphforge_core::uuid::composite_delta_operation(
             &request.context.operation_uuid.0,
-            format!("graphforge-composite-delta-operation/1/{index}").as_bytes(),
+            index,
         );
         operations.push(graphforge_storage::GraphDeltaOp {
             operation_uuid,
@@ -285,24 +285,23 @@ impl GraphForge {
             // Select the storage route from explicit typed input before the
             // private workspace is mutated. Capacity exhaustion deliberately
             // falls back to canonical full-Parquet publication.
-            let prepared_delta = if !optimistic
-                && let Some(operations) = eligible_delta_operations(request)?
-            {
-                let delta_request = graphforge_storage::GraphDeltaPublishRequest {
-                    transaction_uuid,
-                    generation_uuid,
-                    run_uuid: Uuid::new_v5(&transaction_uuid, b"graphforge-composite-delta-run/1"),
-                    operations,
-                    limits: graphforge_storage::GraphDeltaJournalLimits::default(),
+            let prepared_delta =
+                if !optimistic && let Some(operations) = eligible_delta_operations(request)? {
+                    let delta_request = graphforge_storage::GraphDeltaPublishRequest {
+                        transaction_uuid,
+                        generation_uuid,
+                        run_uuid: graphforge_core::uuid::composite_delta_run(&transaction_uuid),
+                        operations,
+                        limits: graphforge_storage::GraphDeltaJournalLimits::default(),
+                    };
+                    match graphforge_storage::prepare_graph_delta(parent, &delta_request) {
+                        Ok(prepared) => Some(prepared),
+                        Err(error) if error.code() == "GF_RESOURCE_LIMIT" => None,
+                        Err(error) => return Err(error),
+                    }
+                } else {
+                    None
                 };
-                match graphforge_storage::prepare_graph_delta(parent, &delta_request) {
-                    Ok(prepared) => Some(prepared),
-                    Err(error) if error.code() == "GF_RESOURCE_LIMIT" => None,
-                    Err(error) => return Err(error),
-                }
-            } else {
-                None
-            };
             let property_inventory =
                 crate::property_inventory_for_hydrated_generation(parent, &self.dir)?;
             apply_graph_mutations(

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -198,6 +198,7 @@ pub use graphforge_core::embedding_options::{
     GraphSageOptions, HashGnnOptions, Node2VecOptions,
 };
 pub use graphforge_core::manifest::{MANIFEST_FILE, ONTOLOGY_FILE, ProjectManifest};
+pub use graphforge_core::uuid::hub_clone_operation;
 pub use graphforge_core::{
     AnalyzeOptions, ApiErrorCode, ClusterOptions, EdgeHandle, FindOptions, GfError, NodeHandle,
     NodeSelector, OntologyFormat, OntologyMode, PathsOptions, ProjectErrorCode, PropValue,

--- a/crates/graphforge-api/src/portable.rs
+++ b/crates/graphforge-api/src/portable.rs
@@ -482,10 +482,8 @@ impl GraphForge {
         project_root: &Path,
         request: &PortableImportRequest,
     ) -> Result<PortableImportResult, GfError> {
-        let generation_uuid = Uuid::new_v5(
-            &request.operation_id.0,
-            b"graphforge-portable-import-generation/1",
-        );
+        let generation_uuid =
+            graphforge_core::uuid::portable_import_generation(&request.operation_id.0);
         let receipt = graphforge_storage::import_portable_project_file(
             &request.input,
             project_root,
@@ -519,10 +517,8 @@ impl GraphForge {
         request: &PortableV2ImportRequest,
         cancelled: Option<&AtomicBool>,
     ) -> Result<PortableV2ImportResult, graphforge_storage::PortableV2Error> {
-        let generation_uuid = Uuid::new_v5(
-            &request.operation_id.0,
-            b"graphforge-portable-v2-import-generation/1",
-        );
+        let generation_uuid =
+            graphforge_core::uuid::portable_v2_import_generation(&request.operation_id.0);
         let receipt = graphforge_storage::import_complete_portable_v2(
             &request.input,
             project_root,

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -3299,10 +3299,8 @@ fn run_integrated_certification_with_edge_factor(
     let phase = Instant::now();
     let interrupted = root.join("interrupted-target");
     let interrupted_operation = uuidv7(0x746);
-    let interrupted_generation = Uuid::new_v5(
-        &interrupted_operation,
-        b"graphforge-portable-v2-import-generation/1",
-    );
+    let interrupted_generation =
+        graphforge_core::uuid::portable_v2_import_generation(&interrupted_operation);
     let interrupted_cancelled = AtomicBool::new(false);
     let supported_capabilities = [
         "epistemic",

--- a/crates/graphforge-cli/src/hub_clone.rs
+++ b/crates/graphforge-cli/src/hub_clone.rs
@@ -1177,14 +1177,9 @@ fn run_clone_job(
             .map(|verified| (verified, Some(object.length), None))
         },
     )?;
-    let operation_id = OperationId(uuid::Uuid::new_v5(
-        &uuid::Uuid::NAMESPACE_URL,
-        format!(
-            "{}:{}",
-            canonical_name(&identity),
-            verified.immutable_version
-        )
-        .as_bytes(),
+    let operation_id = OperationId(graphforge_api::hub_clone_operation(
+        &canonical_name(&identity),
+        &verified.immutable_version,
     ));
     profile.handoff(
         ComponentKind::PortableVerify,

--- a/crates/graphforge-core/src/uuid.rs
+++ b/crates/graphforge-core/src/uuid.rs
@@ -1,4 +1,4 @@
-//! UUIDv7 generation and Arrow/Parquet serialisation helpers.
+//! UUID generation, deterministic derivation, and Arrow/Parquet serialisation helpers.
 //!
 //! All write paths (CREATE, MERGE, batch ingest, provenance) mint UUIDv7
 //! identifiers for new first-class objects.  Centralising generation here keeps
@@ -32,6 +32,49 @@ pub const PROVENANCE_NAMESPACE: Uuid = Uuid::from_bytes([
 #[must_use]
 pub fn new_v5(namespace: &Uuid, name: &[u8]) -> Uuid {
     Uuid::new_v5(namespace, name)
+}
+
+/// Derive the portable-v1 imported generation from its caller-owned operation.
+/// The versioned name is a persisted compatibility contract.
+#[must_use]
+pub fn portable_import_generation(operation: &Uuid) -> Uuid {
+    new_v5(operation, b"graphforge-portable-import-generation/1")
+}
+
+/// Derive the portable-v2 imported generation in a separate versioned domain.
+#[must_use]
+pub fn portable_v2_import_generation(operation: &Uuid) -> Uuid {
+    new_v5(operation, b"graphforge-portable-v2-import-generation/1")
+}
+
+/// Derive one composite delta operation using its original mutation index.
+/// The slash separates the versioned domain from the unambiguous decimal index.
+#[must_use]
+pub fn composite_delta_operation(operation: &Uuid, index: usize) -> Uuid {
+    new_v5(
+        operation,
+        format!("graphforge-composite-delta-operation/1/{index}").as_bytes(),
+    )
+}
+
+/// Derive the composite delta run from its transaction identity.
+#[must_use]
+pub fn composite_delta_run(transaction: &Uuid) -> Uuid {
+    new_v5(transaction, b"graphforge-composite-delta-run/1")
+}
+
+/// Derive a hub clone operation using the historical URL namespace and name.
+///
+/// `repository` must be the validated canonical `owner/repository` identity
+/// (whose slugs cannot contain `:`), and `immutable_version` the verified package
+/// version. The colon therefore separates the components unambiguously. Preserve
+/// this legacy domain: adding a new prefix would change existing retry identities.
+#[must_use]
+pub fn hub_clone_operation(repository: &str, immutable_version: &str) -> Uuid {
+    new_v5(
+        &Uuid::NAMESPACE_URL,
+        format!("{repository}:{immutable_version}").as_bytes(),
+    )
 }
 
 /// Convert a [`Uuid`] into its 16-byte big-endian form, suitable for an Arrow
@@ -96,6 +139,82 @@ mod tests {
         assert_eq!(first, new_v5(&namespace, b"graphforge"));
         assert_ne!(first, new_v5(&namespace, b"GraphForge"));
         assert_eq!(first.get_version_num(), 5);
+    }
+
+    #[test]
+    fn persisted_derivation_golden_vectors() {
+        // Frozen from the original namespace/name pairs, independently calculated
+        // with Python uuid.uuid5. Compare bytes to protect persisted identities.
+        let operation = Uuid::parse_str("00112233-4455-6677-8899-aabbccddeeff").unwrap();
+        let version_a = format!("sha256:{}", "a".repeat(64));
+        let version_b = format!("sha256:{}", "b".repeat(64));
+        let vectors = [
+            (
+                portable_import_generation(&operation),
+                "02abd337-e93c-56a3-bf8f-dadbb5b1e8d5",
+            ),
+            (
+                portable_v2_import_generation(&operation),
+                "167a58d3-52f2-533e-b3c4-01d743d7537d",
+            ),
+            (
+                composite_delta_operation(&operation, 0),
+                "bf613aba-38a4-5ae7-8982-1675caa13e7c",
+            ),
+            (
+                composite_delta_operation(&operation, 1),
+                "dcffd77e-a011-5480-8fb3-8493d22ff8be",
+            ),
+            (
+                composite_delta_operation(&operation, 10),
+                "de381822-c256-5bf9-904f-25692a6b6c7e",
+            ),
+            (
+                composite_delta_run(&operation),
+                "d230eba6-b8a4-549e-b032-888112a9fc62",
+            ),
+            (
+                hub_clone_operation("curatelabs/demo", &version_a),
+                "e6caa879-f226-55fc-9d67-41c15b8f9658",
+            ),
+            (
+                hub_clone_operation("curatelabs/demo", &version_b),
+                "db3c36b4-97ee-57bb-ac63-995c79fb577b",
+            ),
+            (
+                hub_clone_operation("curatelabs/other", &version_a),
+                "29ea96be-d350-5026-a85b-32cbf5b835cc",
+            ),
+            (
+                new_v5(&PROVENANCE_NAMESPACE, b"graphforge"),
+                "59a64d29-3fe8-5c2c-ad21-1f285e53d758",
+            ),
+        ];
+        let mut unique = std::collections::HashSet::new();
+        for (actual, expected) in vectors {
+            assert_eq!(
+                actual.as_bytes(),
+                Uuid::parse_str(expected).unwrap().as_bytes()
+            );
+            assert!(unique.insert(actual), "derivation domains collided");
+        }
+        let other_operation = Uuid::from_bytes([7; 16]);
+        assert_ne!(
+            portable_import_generation(&operation),
+            portable_import_generation(&other_operation)
+        );
+        assert_ne!(
+            portable_v2_import_generation(&operation),
+            portable_v2_import_generation(&other_operation)
+        );
+        assert_ne!(
+            composite_delta_operation(&operation, 0),
+            composite_delta_operation(&other_operation, 0)
+        );
+        assert_ne!(
+            composite_delta_run(&operation),
+            composite_delta_run(&other_operation)
+        );
     }
 
     #[test]

--- a/scripts/ci/classify-policy-suites.sh
+++ b/scripts/ci/classify-policy-suites.sh
@@ -132,6 +132,7 @@ while IFS= read -r -d '' path; do
       cli_publish=true
       ;;
     scripts/ci/check-domain-dependencies.py | scripts/ci/test-domain-dependencies.py | \
+      scripts/ci/test-uuid-derivation-policy.py | \
       docs/adr/0014-* | Cargo.toml | crates/*/Cargo.toml)
       domain_dependencies=true
       ;;

--- a/scripts/ci/test-uuid-derivation-policy.py
+++ b/scripts/ci/test-uuid-derivation-policy.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Keep direct UUIDv5 construction inside the shared core identity module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+SHARED = Path("crates/graphforge-core/src/uuid.rs")
+DERIVATION = re.compile(r"(?:\b(?:[A-Za-z_]\w*\s*::\s*)+|>\s*::\s*)(?:new_v5|from_sha1_bytes)\b")
+
+
+def violations(path: Path, source: str) -> list[str]:
+    """Reject associated constructors, including aliased types and split paths."""
+    if path == SHARED:
+        return []
+    result = []
+    for match in DERIVATION.finditer(source):
+        spelling = re.sub(r"\s+", "", match.group())
+        if spelling == "graphforge_core::uuid::new_v5":
+            continue
+        if spelling == "crate::uuid::new_v5" and path.parts[:2] == ("crates", "graphforge-core"):
+            continue
+        line = source.count("\n", 0, match.start()) + 1
+        result.append(f"{path}:{line}: use graphforge_core::uuid, found {spelling}")
+    return result
+
+
+def main() -> None:
+    """Exercise the guard, then scan all first-party Rust sources and fixtures."""
+    caller = Path("crates/graphforge-api/src/example.rs")
+    for expression in (
+        "Uuid::new_v5(&namespace, name)",
+        "uuid::Uuid::new_v5(&namespace, name)",
+        "use uuid::Uuid as Identity; Identity :: new_v5(&namespace, name)",
+        "Uuid\n::\nnew_v5(&namespace, name)",
+        "<uuid::Uuid>::new_v5(&namespace, name)",
+        "let derive = Uuid::new_v5; derive(&namespace, name)",
+        "uuid::Builder::from_sha1_bytes(digest)",
+    ):
+        assert violations(caller, expression), expression
+        assert not violations(SHARED, expression), expression
+    for expression in (
+        "graphforge_core::uuid::new_v5(&namespace, name)",
+        "use graphforge_core::uuid::new_v5; new_v5(&namespace, name)",
+        "Uuid::now_v7()",
+        "Uuid::from_bytes(bytes)",
+    ):
+        assert not violations(caller, expression), expression
+    assert violations(caller, "crate::uuid::new_v5(&namespace, name)")
+    failures = [
+        failure
+        for path in sorted((ROOT / "crates").rglob("*.rs"))
+        for failure in violations(path.relative_to(ROOT), path.read_text(encoding="utf-8"))
+    ]
+    assert not failures, "\n".join(failures)
+    print("UUID derivation policy and mutation tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Deterministic UUIDv5 names for portable imports, composite delta operations/runs, and hub clone retries were constructed directly in API and CLI callers. Centralize these persisted identity contracts in `graphforge-core::uuid` and route CLI access through the Rust facade. Preserve every existing namespace, separator, index encoding, and resulting UUID.

Ten frozen golden vectors compare the exact UUID bytes for all existing domains, multiple operation indices, provenance namespace, and hub repository/version inputs. A focused source-policy regression rejects direct UUIDv5/SHA-1 UUID construction outside the shared module, including aliased and qualified associated constructors; repository-policy CI and `make pre-push-fast` run it.

Validation:
- `cargo test -p graphforge-core`: 48 passed, including the golden vectors.
- `cargo clippy --workspace -- -D warnings`: passed.
- `make pre-push-fast`: passed.
- `make gate-registry-check`: passed (14 tests).
- `python3 scripts/ci/test-uuid-derivation-policy.py`, `bash scripts/ci/test-classify-policy-suites.sh`, `python3 scripts/ci/check-domain-dependencies.py`, and `python3 scripts/ci/test-ci-storage-policy.py`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Real Rust facade tests from the workspace-built API test binary, with `TMPDIR` on the host ext4 root: `portable::tests::` 10 passed; `composite_publish::tests::` 18 passed, including import and delta-publication reopen.

Closes #1028.

Rebased unchanged onto current main after #1104 merged. Final `make pre-push-fast` passed. Exact-head CI passed at `08435ee40a493f5d5af182513e418d2aee696c2c`, including authoritative Bazel Rust tests, binding packaging, platform durability, concurrency matrix, and CI Gate. Squash merged; issue #1028 is closed.
