### PR TITLE
chore(rel): remove unused lowering entry points

### DIFF
--- a/crates/graphforge-api/tests/xor_scaling.rs
+++ b/crates/graphforge-api/tests/xor_scaling.rs
@@ -61,7 +61,9 @@ fn deterministic_work(plan: &GraphPlan) -> Work {
             )
         })
         .count();
-    let logical = graphforge_rel::lower(plan).expect("XOR benchmark query lowers");
+    let logical = graphforge_rel::GraphPlanLowerer::new(None, None)
+        .lower_plan(plan)
+        .expect("XOR benchmark query lowers");
     let mut logical_xor_nodes = 0;
     logical
         .apply(|node| {

--- a/crates/graphforge-rel/src/lib.rs
+++ b/crates/graphforge-rel/src/lib.rs
@@ -1,5 +1,10 @@
 //! GraphForge Graph IR → DataFusion relational lowering.
 //!
+//! Compiler consumers configure [`GraphPlanLowerer`] with their catalog, ontology,
+//! and project context, then call [`GraphPlanLowerer::lower_plan`]. DataFusion
+//! analysis and optimization use the consumer's execution session. Applications
+//! enter through the `graphforge-api` facade.
+//!
 //! # Milestone status
 //!
 //! - logical-plan lowering #574 — IR expression lowering to DataFusion `Expr`
@@ -29,40 +34,6 @@ use graphforge_ontology::OntologyHandle;
 /// Using a type alias means all downstream code (including `graphforge-exec`) works
 /// directly with the native DataFusion type without any wrapping overhead.
 pub type LogicalPlan = datafusion::logical_expr::LogicalPlan;
-
-/// Lower a [`GraphPlan`] to a DataFusion [`LogicalPlan`].
-///
-/// Delegates to [`GraphPlanLowerer`] with `catalog = None` and
-/// `ontology = None` (exploratory mode).  Scan operators (`NodeScan`,
-/// `Expand`) return [`GfError::Plan`] until #576 is complete.
-///
-/// # Errors
-///
-/// Returns [`GfError::Plan`] if any operator in the pipeline cannot be
-/// lowered (e.g. graph-native scan operators not yet implemented in #576).
-pub fn lower(plan: &GraphPlan) -> Result<LogicalPlan, GfError> {
-    GraphPlanLowerer::new(None, None).lower_plan(plan)
-}
-
-/// Lower a [`GraphPlan`] and run DataFusion's analyzer + optimizer over it.
-///
-/// Uses a transient [`SessionContext`](datafusion::prelude::SessionContext)
-/// with no registered catalog — the lowered plan is self-contained (scans use
-/// [`LogicalTableSource`](datafusion::logical_expr::logical_plan::LogicalTableSource)
-/// with static schemas), so optimisation needs no external state.  Lowering
-/// runs in exploratory mode (`catalog = None`, `ontology = None`).
-///
-/// # Errors
-///
-/// Returns [`GfError::Plan`] if lowering fails or the analyzer/optimizer
-/// rejects the plan (e.g. unresolved `$param` placeholders).
-pub fn lower_and_optimize(plan: &GraphPlan) -> Result<LogicalPlan, GfError> {
-    let lowered = lower(plan)?;
-    let ctx = datafusion::prelude::SessionContext::new();
-    ctx.state()
-        .optimize(&lowered)
-        .map_err(|e| GfError::Plan(e.to_string()))
-}
 
 /// Render a [`GraphPlan`]'s optimised DataFusion [`LogicalPlan`] as indented
 /// text (with per-node schemas) for the `explain` LogicalPlan stage.

--- a/crates/graphforge-rel/tests/expression_lowering_matrix.rs
+++ b/crates/graphforge-rel/tests/expression_lowering_matrix.rs
@@ -14,7 +14,8 @@ fn lower(query: &str) -> graphforge_rel::LogicalPlan {
     )
     .bind(&ast)
     .unwrap_or_else(|errors| panic!("bind failed for {query:?}: {errors:?}"));
-    graphforge_rel::lower(&plan)
+    graphforge_rel::GraphPlanLowerer::new(None, None)
+        .lower_plan(&plan)
         .unwrap_or_else(|error| panic!("lower failed for {query:?}: {error}"))
 }
 

--- a/docs/book/architecture/ast-and-planning.md
+++ b/docs/book/architecture/ast-and-planning.md
@@ -190,7 +190,9 @@ The AST version is internal only. The IR version is the cross-layer contract. Su
 
 ## Relational Lowering
 
-The relational lowering stage (`graphforge-rel`) translates graph IR operators into DataFusion `LogicalPlan` nodes:
+The relational lowering stage (`graphforge-rel`) translates graph IR operators into DataFusion `LogicalPlan` nodes. Compiler consumers configure `GraphPlanLowerer` with the catalog, ontology, and project context, then call `lower_plan`. The execution session owns DataFusion analysis and optimization; applications enter through the `graphforge-api` facade.
+
+The former context-free `graphforge_rel::lower` and `lower_and_optimize` convenience functions are removed for v0.6.0. Compiler tests that only need schema lowering use `GraphPlanLowerer::new(None, None).lower_plan(&plan)`; production lowering retains its explicit runtime context.
 
 - Simple scans, filters, projections, and aggregations lower cleanly to DataFusion relational operators
 - DataFusion then optimizes projections and filters and chooses physical scan strategies


### PR DESCRIPTION
Remove the unused context-free `graphforge_rel::lower` and `lower_and_optimize` entry points. The expression lowering matrix and XOR scaling regression now call the canonical `GraphPlanLowerer::new(None, None).lower_plan(...)` API directly. Production lowering and EXPLAIN retain their catalog, ontology, project context, and execution-session behavior.

Consumer audit: workspace source has exactly two test callers of `lower` and no caller of `lower_and_optimize`. All three published reverse dependencies [reported by crates.io](https://crates.io/api/v1/crates/graphforge-rel/reverse_dependencies?page=1&per_page=100) are first-party `graphforge-cypher`, `graphforge-exec`, and `graphforge-api`; their production consumers already use `GraphPlanLowerer` or contextual EXPLAIN functions. The supported application facade is `graphforge-api`, and no supported external caller of these wrappers was identified. Document the canonical compiler API and the v0.6.0 migration.

Validation:
- `cargo test -p graphforge-rel`: 232 unit tests, 2 expression-matrix tests, and 15 golden-plan tests passed; no snapshot changes.
- `cargo test -p graphforge-api --test xor_scaling`: passed, exercising real facade execution and deterministic lowering-work counts.
- `cargo clippy --workspace -- -D warnings`: passed.
- `make pre-push-fast`: passed on the integrated tree.
- `make gate-registry-check`: passed (14 tests).
- `cargo fmt --all -- --check` and `git diff --check`: passed.

Closes #1023.

Merged after exact-head CI passed at `234be9f80bbb862865f904268af48c04f2e17eed`, including the authoritative Bazel Rust suite, binding packaging, platform durability, concurrency matrix, and CI Gate. Issue #1023 is closed.
