### PR TITLE
refactor(storage): consolidate directory capability validation

### DIFF
--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -109,6 +109,80 @@ pub struct FileSpaceUsage {
     pub allocated_bytes: u64,
 }
 
+/// Stage of a failed retained-directory validation. Policy owners may preserve
+/// their own diagnostics without duplicating native identity checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectoryValidationStage {
+    /// Named path metadata could not be read.
+    NamedMetadata,
+    /// Retained handle metadata could not be read.
+    RetainedMetadata,
+    /// Named path identity could not be read.
+    NamedIdentity,
+    /// Retained handle identity could not be read.
+    RetainedIdentity,
+    /// A path/handle is not an ordinary directory or its identity changed.
+    IdentityChanged,
+}
+
+/// Native validation failure with a typed stage and original I/O diagnostic.
+#[derive(Debug)]
+pub struct DirectoryValidationError {
+    stage: DirectoryValidationStage,
+    source: io::Error,
+}
+
+impl DirectoryValidationError {
+    fn new(stage: DirectoryValidationStage, source: io::Error) -> Self {
+        Self { stage, source }
+    }
+
+    /// Return the failing native operation for a caller's policy mapping.
+    #[must_use]
+    pub fn stage(&self) -> DirectoryValidationStage {
+        self.stage
+    }
+
+    /// Preserve the existing native I/O error and kind for generic consumers.
+    #[must_use]
+    pub fn into_io_error(self) -> io::Error {
+        self.source
+    }
+}
+
+impl std::fmt::Display for DirectoryValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.source, formatter)
+    }
+}
+
+impl std::error::Error for DirectoryValidationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// Directory handle opened with this crate's native no-follow and sharing policy.
+/// Private construction prevents an arbitrary `File` from claiming that policy.
+#[derive(Debug)]
+pub struct OpenedDirectoryHandle {
+    file: File,
+}
+
+impl OpenedDirectoryHandle {
+    /// Borrow the native handle for metadata, volume queries, or cooperative locks.
+    #[must_use]
+    pub fn as_file(&self) -> &File {
+        &self.file
+    }
+
+    /// Transfer the raw handle to a caller that owns its validation policy.
+    #[must_use]
+    pub fn into_file(self) -> File {
+        self.file
+    }
+}
+
 /// Retained directory capability whose children are opened without following
 /// links or reparse points.
 #[derive(Debug)]
@@ -179,18 +253,80 @@ impl StableDirectory {
         Ok(directory)
     }
 
-    /// Require that the named path still identifies this retained directory.
-    pub fn revalidate_named(&self) -> io::Result<()> {
-        let metadata = std::fs::symlink_metadata(&self.path)?;
-        if !metadata.is_dir() || is_link_or_reparse(&metadata) {
-            return Err(io::Error::other(
-                "stable directory path is linked or special",
+    /// Adopt an already retained handle and expected identity, validating both
+    /// the named path and the handle before issuing a directory capability.
+    pub fn from_retained_handle(
+        path: PathBuf,
+        handle: OpenedDirectoryHandle,
+        identity: FileIdentity,
+    ) -> Result<Self, DirectoryValidationError> {
+        let directory = Self {
+            path,
+            file: handle.file,
+            identity,
+        };
+        directory.revalidate_named_detailed()?;
+        Ok(directory)
+    }
+
+    /// Borrow the retained handle for native volume queries and cooperative locks.
+    /// Callers must revalidate around namespace-sensitive operations.
+    #[must_use]
+    pub fn as_file(&self) -> &File {
+        &self.file
+    }
+
+    /// Return the named path associated with this capability.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Transfer the policy-proven native handle for adoption by another capability.
+    #[must_use]
+    pub fn into_handle(self) -> OpenedDirectoryHandle {
+        OpenedDirectoryHandle { file: self.file }
+    }
+
+    /// Require that the named path and retained handle still identify this
+    /// ordinary directory, returning a typed failure stage for policy adapters.
+    pub fn revalidate_named_detailed(&self) -> Result<(), DirectoryValidationError> {
+        use DirectoryValidationStage as Stage;
+        let named = std::fs::symlink_metadata(&self.path)
+            .map_err(|error| DirectoryValidationError::new(Stage::NamedMetadata, error))?;
+        let retained = self
+            .file
+            .metadata()
+            .map_err(|error| DirectoryValidationError::new(Stage::RetainedMetadata, error))?;
+        if !named.is_dir() || is_link_or_reparse(&named) || !retained.is_dir() {
+            return Err(DirectoryValidationError::new(
+                Stage::IdentityChanged,
+                io::Error::other("stable directory path is linked or special"),
             ));
         }
-        if path_identity(&self.path)? != self.identity {
-            return Err(io::Error::other("stable directory identity changed"));
+        let named_identity = path_identity(&self.path)
+            .map_err(|error| DirectoryValidationError::new(Stage::NamedIdentity, error))?;
+        if named_identity != self.identity {
+            return Err(DirectoryValidationError::new(
+                Stage::IdentityChanged,
+                io::Error::other("stable directory identity changed"),
+            ));
+        }
+        let retained_identity = file_identity(&self.file)
+            .map_err(|error| DirectoryValidationError::new(Stage::RetainedIdentity, error))?;
+        if retained_identity != self.identity {
+            return Err(DirectoryValidationError::new(
+                Stage::IdentityChanged,
+                io::Error::other("stable directory identity changed"),
+            ));
         }
         Ok(())
+    }
+
+    /// Require that the named path still identifies this retained directory.
+    pub fn revalidate_named(&self) -> io::Result<()> {
+        self.revalidate_named_detailed()
+            .map_err(DirectoryValidationError::into_io_error)
     }
 
     /// Open one real child directory relative to this capability.
@@ -556,6 +692,13 @@ impl StableDirectory {
     pub fn identity(&self) -> FileIdentity {
         self.identity
     }
+}
+
+/// Open a directory handle using the platform's no-follow and sharing policy.
+/// The caller must validate directory kind and retained/named identity before
+/// treating it as authority; prefer `StableDirectory::open` for a capability.
+pub fn open_directory_handle(path: &Path) -> io::Result<OpenedDirectoryHandle> {
+    stable_open_directory(path).map(|file| OpenedDirectoryHandle { file })
 }
 
 fn validate_child_name(name: &OsStr) -> io::Result<()> {
@@ -1250,16 +1393,20 @@ fn verify_space_usage_metadata(metadata: &std::fs::Metadata) -> io::Result<()> {
     Ok(())
 }
 
+/// Whether metadata denotes a symlink or native reparse point.
 #[cfg(windows)]
-fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+#[must_use]
+pub fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
     use std::os::windows::fs::MetadataExt as _;
     const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
     metadata.file_type().is_symlink()
         || (metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT) != 0
 }
 
+/// Whether metadata denotes a symlink or native reparse point.
 #[cfg(not(windows))]
-fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+#[must_use]
+pub fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
     metadata.file_type().is_symlink()
 }
 
@@ -2828,6 +2975,66 @@ mod windows {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retained_directory_adoption_checks_handle_and_named_identity() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let first_identity = path_identity(first.path()).unwrap();
+        let wrong_handle = open_directory_handle(second.path()).unwrap();
+
+        // The named directory is genuine and matches the claimed identity;
+        // only the retained handle is wrong. Named-only validation would pass.
+        let failure = StableDirectory::from_retained_handle(
+            first.path().to_path_buf(),
+            wrong_handle,
+            first_identity,
+        )
+        .unwrap_err();
+        assert_eq!(failure.stage(), DirectoryValidationStage::IdentityChanged);
+        assert_eq!(failure.into_io_error().kind(), io::ErrorKind::Other);
+
+        let retained = StableDirectory::from_retained_handle(
+            first.path().to_path_buf(),
+            open_directory_handle(first.path()).unwrap(),
+            first_identity,
+        )
+        .unwrap();
+        retained.revalidate_named_detailed().unwrap();
+        retained.try_clone().unwrap().revalidate_named().unwrap();
+        assert_eq!(file_identity(retained.as_file()).unwrap(), first_identity);
+        assert_eq!(
+            file_identity(&retained.into_handle().into_file()).unwrap(),
+            first_identity
+        );
+    }
+
+    #[test]
+    fn retained_directory_adoption_rejects_regular_handle_and_missing_name() {
+        let root = tempfile::tempdir().unwrap();
+        let identity = path_identity(root.path()).unwrap();
+        let regular = root.path().join("regular");
+        std::fs::write(&regular, b"unchanged").unwrap();
+        let failure = StableDirectory::from_retained_handle(
+            root.path().to_path_buf(),
+            OpenedDirectoryHandle {
+                file: File::open(&regular).unwrap(),
+            },
+            identity,
+        )
+        .unwrap_err();
+        assert_eq!(failure.stage(), DirectoryValidationStage::IdentityChanged);
+        assert_eq!(std::fs::read(regular).unwrap(), b"unchanged");
+
+        let failure = StableDirectory::from_retained_handle(
+            root.path().join("missing"),
+            open_directory_handle(root.path()).unwrap(),
+            identity,
+        )
+        .unwrap_err();
+        assert_eq!(failure.stage(), DirectoryValidationStage::NamedMetadata);
+        assert_eq!(failure.into_io_error().kind(), io::ErrorKind::NotFound);
+    }
 
     #[cfg(windows)]
     #[allow(unsafe_code)]

--- a/crates/graphforge-storage/src/directory_capability_conformance.rs
+++ b/crates/graphforge-storage/src/directory_capability_conformance.rs
@@ -99,7 +99,10 @@ fn named_directory_replacement<D: DirectoryContract>() {
         // No FILE_SHARE_DELETE: Windows prevents the replacement rather than
         // allowing a rename and discovering it on the next revalidation.
         let failure = std::fs::rename(&directory, &displaced).unwrap_err();
-        assert_eq!(failure.kind(), std::io::ErrorKind::PermissionDenied);
+        // Rust does not map ERROR_SHARING_VIOLATION to PermissionDenied;
+        // pin the native refusal caused by the retained no-delete-share handle.
+        const ERROR_SHARING_VIOLATION: i32 = 32;
+        assert_eq!(failure.raw_os_error(), Some(ERROR_SHARING_VIOLATION), "{failure:?}");
         child.revalidate().unwrap();
         assert_eq!(
             std::fs::read(directory.join("authority")).unwrap(),

--- a/crates/graphforge-storage/src/directory_capability_conformance.rs
+++ b/crates/graphforge-storage/src/directory_capability_conformance.rs
@@ -1,0 +1,179 @@
+// Shared adversarial cases for the filesystem and lifecycle capabilities.
+//
+// Before consolidation these cases exercise the two independent implementations.
+// Lifecycle retains ancestor authority; a standalone StableDirectory validates
+// only its own named directory, so that distinction is asserted explicitly.
+
+use std::path::Path;
+
+use graphforge_filesystem::StableDirectory;
+
+use super::LifecycleDirectory;
+
+trait DirectoryContract: Sized {
+    fn open(path: &Path) -> Result<Self, String>;
+    fn child(&self, name: &str) -> Result<Self, String>;
+    fn revalidate(&self) -> Result<(), String>;
+}
+
+impl DirectoryContract for StableDirectory {
+    fn open(path: &Path) -> Result<Self, String> {
+        Self::open(path).map_err(|error| error.to_string())
+    }
+
+    fn child(&self, name: &str) -> Result<Self, String> {
+        self.open_child_directory(name.as_ref())
+            .map_err(|error| error.to_string())
+    }
+
+    fn revalidate(&self) -> Result<(), String> {
+        self.revalidate_named().map_err(|error| error.to_string())
+    }
+}
+
+impl DirectoryContract for LifecycleDirectory {
+    fn open(path: &Path) -> Result<Self, String> {
+        Self::open(path, "IDENTITY", "conformance_open").map_err(|error| error.to_string())
+    }
+
+    fn child(&self, name: &str) -> Result<Self, String> {
+        Self::open_child(
+            self,
+            name.as_ref(),
+            &self.path.join(name),
+            "IDENTITY",
+            "conformance_child",
+        )
+        .map_err(|error| error.to_string())
+    }
+
+    fn revalidate(&self) -> Result<(), String> {
+        self.revalidate("IDENTITY", "conformance_revalidation")
+            .map_err(|error| error.to_string())
+    }
+}
+
+fn real_directory_and_regular_file<D: DirectoryContract>() {
+    let root = tempfile::tempdir().unwrap();
+    let directory = root.path().join("directory");
+    std::fs::create_dir(&directory).unwrap();
+    std::fs::write(root.path().join("regular"), b"unchanged").unwrap();
+    let parent = D::open(root.path()).unwrap();
+    let child = parent.child("directory").unwrap();
+    child.revalidate().unwrap();
+    assert!(parent.child("regular").is_err());
+    assert!(D::open(&root.path().join("regular")).is_err());
+    assert_eq!(
+        std::fs::read(root.path().join("regular")).unwrap(),
+        b"unchanged"
+    );
+}
+
+#[test]
+fn both_capabilities_accept_real_directories_and_reject_files() {
+    real_directory_and_regular_file::<StableDirectory>();
+    real_directory_and_regular_file::<LifecycleDirectory>();
+}
+
+fn named_directory_replacement<D: DirectoryContract>() {
+    let root = tempfile::tempdir().unwrap();
+    let directory = root.path().join("directory");
+    let displaced = root.path().join("displaced");
+    std::fs::create_dir(&directory).unwrap();
+    std::fs::write(directory.join("authority"), b"original").unwrap();
+    let parent = D::open(root.path()).unwrap();
+    let child = parent.child("directory").unwrap();
+    #[cfg(unix)]
+    {
+        std::fs::rename(&directory, &displaced).unwrap();
+        std::fs::create_dir(&directory).unwrap();
+        assert!(child.revalidate().is_err());
+        assert_eq!(
+            std::fs::read(displaced.join("authority")).unwrap(),
+            b"original"
+        );
+        assert!(!directory.join("authority").exists());
+    }
+    #[cfg(windows)]
+    {
+        // No FILE_SHARE_DELETE: Windows prevents the replacement rather than
+        // allowing a rename and discovering it on the next revalidation.
+        let failure = std::fs::rename(&directory, &displaced).unwrap_err();
+        assert_eq!(failure.kind(), std::io::ErrorKind::PermissionDenied);
+        child.revalidate().unwrap();
+        assert_eq!(
+            std::fs::read(directory.join("authority")).unwrap(),
+            b"original"
+        );
+        assert!(!displaced.exists());
+    }
+}
+
+#[test]
+fn both_capabilities_fail_closed_on_named_directory_replacement() {
+    named_directory_replacement::<StableDirectory>();
+    named_directory_replacement::<LifecycleDirectory>();
+}
+
+#[cfg(unix)]
+fn link_directory(source: &Path, target: &Path) {
+    std::os::unix::fs::symlink(source, target).unwrap();
+}
+
+#[cfg(windows)]
+fn link_directory(source: &Path, target: &Path) {
+    // Junctions exercise reparse rejection without requiring symlink privilege.
+    let result = std::process::Command::new("cmd")
+        .args(["/C", "mklink", "/J"])
+        .arg(target)
+        .arg(source)
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "junction creation failed: {result:?}"
+    );
+}
+
+fn linked_directory<D: DirectoryContract>() {
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::write(outside.path().join("authority"), b"outside").unwrap();
+    let linked = root.path().join("linked");
+    link_directory(outside.path(), &linked);
+    let parent = D::open(root.path()).unwrap();
+    assert!(D::open(&linked).is_err());
+    assert!(parent.child("linked").is_err());
+    assert_eq!(
+        std::fs::read(outside.path().join("authority")).unwrap(),
+        b"outside"
+    );
+}
+
+#[test]
+fn both_capabilities_reject_link_or_reparse_directory_opens() {
+    linked_directory::<StableDirectory>();
+    linked_directory::<LifecycleDirectory>();
+}
+
+#[cfg(unix)]
+fn ancestor_replacement<D: DirectoryContract>(retains_ancestors: bool) {
+    let root = tempfile::tempdir().unwrap();
+    let parent_path = root.path().join("parent");
+    let displaced = root.path().join("displaced");
+    std::fs::create_dir(&parent_path).unwrap();
+    std::fs::create_dir(parent_path.join("child")).unwrap();
+    let parent = D::open(&parent_path).unwrap();
+    let child = parent.child("child").unwrap();
+    std::fs::rename(&parent_path, &displaced).unwrap();
+    link_directory(&displaced, &parent_path);
+    assert!(parent.revalidate().is_err());
+    assert_eq!(child.revalidate().is_err(), retains_ancestors);
+}
+
+#[cfg(unix)]
+#[test]
+fn same_ancestor_attack_exposes_the_lifecycle_policy_boundary() {
+    ancestor_replacement::<StableDirectory>(false);
+    ancestor_replacement::<LifecycleDirectory>(true);
+}

--- a/crates/graphforge-storage/src/directory_capability_conformance.rs
+++ b/crates/graphforge-storage/src/directory_capability_conformance.rs
@@ -40,7 +40,7 @@ impl DirectoryContract for LifecycleDirectory {
         Self::open_child(
             self,
             name.as_ref(),
-            &self.path.join(name),
+            &self.path().join(name),
             "IDENTITY",
             "conformance_child",
         )

--- a/crates/graphforge-storage/src/filesystem_admission.rs
+++ b/crates/graphforge-storage/src/filesystem_admission.rs
@@ -1678,6 +1678,10 @@ fn unsupported(phase: &'static str, cause: &'static str) -> GfError {
 mod tests {
     use super::*;
 
+    mod directory_capability_conformance {
+        include!("directory_capability_conformance.rs");
+    }
+
     fn canonical_tempdir() -> tempfile::TempDir {
         let base = std::env::temp_dir().canonicalize().unwrap();
         tempfile::tempdir_in(base).unwrap()

--- a/crates/graphforge-storage/src/filesystem_admission.rs
+++ b/crates/graphforge-storage/src/filesystem_admission.rs
@@ -21,6 +21,8 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use graphforge_core::{GfError, ProjectErrorCode};
+use graphforge_filesystem::is_link_or_reparse;
+
 use sha2::{Digest as _, Sha256};
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use sysinfo::Disks;
@@ -133,7 +135,7 @@ impl ProjectLifecycleAdmission {
         }
         self.project
             .revalidate("IDENTITY", "project_identity_changed")?;
-        if self.project.identity.volume_serial != self.parent.identity.volume_serial {
+        if self.project.identity().volume_serial != self.parent.identity().volume_serial {
             return Err(unsupported("IDENTITY", "project_cross_volume"));
         }
         Ok(())
@@ -185,7 +187,7 @@ impl ProjectLifecycleAdmission {
             lifecycle_lock,
             ..
         } = self;
-        let project_identity = project.identity;
+        let project_identity = project.identity();
         drop(project);
 
         let named = std::fs::symlink_metadata(&root)
@@ -200,7 +202,7 @@ impl ProjectLifecycleAdmission {
         }
         std::fs::remove_dir_all(&root)
             .map_err(|_| unsupported("REMOVE", "project_remove_failed"))?;
-        complete_namespace_barrier(&parent.path)
+        complete_namespace_barrier(parent.path())
             .map_err(|_| unsupported("REMOVE", "parent_namespace_barrier_failed"))?;
         parent.revalidate("REMOVE", "parent_identity_changed")?;
         if let Some(lock) = &lifecycle_lock {
@@ -227,7 +229,7 @@ impl ProjectRootIdentity {
             .revalidate("IDENTITY", "parent_identity_changed")?;
         self.project
             .revalidate("IDENTITY", "project_identity_changed")?;
-        if self.project.identity.volume_serial != self.parent.identity.volume_serial {
+        if self.project.identity().volume_serial != self.parent.identity().volume_serial {
             return Err(unsupported("IDENTITY", "project_cross_volume"));
         }
         Ok(())
@@ -247,8 +249,8 @@ impl ProjectRootIdentity {
         self.revalidate_identity()?;
         let admission =
             admit_project_lifecycle(&self.root, self.mode, ProjectRootRequirement::Existing)?;
-        if admission.parent.identity != self.parent.identity
-            || admission.project.identity != self.project.identity
+        if admission.parent.identity() != self.parent.identity()
+            || admission.project.identity() != self.project.identity()
         {
             return Err(unsupported("IDENTITY", "project_identity_changed"));
         }
@@ -404,39 +406,56 @@ where
 
 #[derive(Debug)]
 struct LifecycleDirectory {
-    path: PathBuf,
-    handle: File,
-    identity: graphforge_filesystem::FileIdentity,
-    ancestors: Vec<RetainedDirectory>,
+    directory: graphforge_filesystem::StableDirectory,
+    ancestors: Vec<graphforge_filesystem::StableDirectory>,
 }
 
-#[derive(Debug)]
-struct RetainedDirectory {
-    path: PathBuf,
-    handle: File,
-    identity: graphforge_filesystem::FileIdentity,
+fn lifecycle_directory_error(
+    error: &graphforge_filesystem::DirectoryValidationError,
+    phase: &'static str,
+    cause: &'static str,
+) -> GfError {
+    if error.stage() == graphforge_filesystem::DirectoryValidationStage::RetainedIdentity {
+        unsupported("IDENTITY", "opened_identity_unavailable")
+    } else {
+        unsupported(phase, cause)
+    }
 }
 
 impl LifecycleDirectory {
+    fn path(&self) -> &Path {
+        self.directory.path()
+    }
+
+    fn handle(&self) -> &File {
+        self.directory.as_file()
+    }
+
+    fn identity(&self) -> graphforge_filesystem::FileIdentity {
+        self.directory.identity()
+    }
+
     fn from_handle(
         path: PathBuf,
-        handle: File,
+        handle: graphforge_filesystem::OpenedDirectoryHandle,
         phase: &'static str,
         cause: &'static str,
     ) -> Result<Self, GfError> {
-        let opened = handle.metadata().map_err(|_| unsupported(phase, cause))?;
-        let identity = file_identity(&handle)?;
+        let opened = handle
+            .as_file()
+            .metadata()
+            .map_err(|_| unsupported(phase, cause))?;
+        let identity = file_identity(handle.as_file())?;
         if !opened.is_dir() {
             return Err(unsupported(phase, cause));
         }
-        let directory = Self {
-            path,
-            handle,
-            identity,
+        let directory =
+            graphforge_filesystem::StableDirectory::from_retained_handle(path, handle, identity)
+                .map_err(|error| lifecycle_directory_error(&error, phase, cause))?;
+        Ok(Self {
+            directory,
             ancestors: Vec::new(),
-        };
-        directory.revalidate(phase, cause)?;
-        Ok(directory)
+        })
     }
 
     fn open(path: &Path, phase: &'static str, cause: &'static str) -> Result<Self, GfError> {
@@ -444,11 +463,15 @@ impl LifecycleDirectory {
         if is_link_or_reparse(&named) || !named.is_dir() {
             return Err(unsupported(phase, cause));
         }
-        let handle = open_directory_handle(path).map_err(|_| unsupported(phase, cause))?;
+        let handle = graphforge_filesystem::open_directory_handle(path)
+            .map_err(|_| unsupported(phase, cause))?;
         let identity =
             graphforge_filesystem::path_identity(path).map_err(|_| unsupported(phase, cause))?;
-        let opened = handle.metadata().map_err(|_| unsupported(phase, cause))?;
-        if !opened.is_dir() || file_identity(&handle)? != identity {
+        let opened = handle
+            .as_file()
+            .metadata()
+            .map_err(|_| unsupported(phase, cause))?;
+        if !opened.is_dir() || file_identity(handle.as_file())? != identity {
             return Err(unsupported(phase, cause));
         }
         Self::from_handle(path.to_path_buf(), handle, phase, cause)
@@ -463,20 +486,11 @@ impl LifecycleDirectory {
     ) -> Result<Self, GfError> {
         let handle = open_child_directory_handle(parent, name, path)
             .map_err(|_| unsupported(phase, cause))?;
-        let opened = handle.metadata().map_err(|_| unsupported(phase, cause))?;
-        let identity = file_identity(&handle)?;
-        if !opened.is_dir() {
-            return Err(unsupported(phase, cause));
-        }
-        let directory = Self {
-            path: path.to_path_buf(),
-            handle,
-            identity,
-            ancestors: parent.retained_ancestry(phase, cause)?,
-        };
+        let mut directory = Self::from_handle(path.to_path_buf(), handle, phase, cause)?;
+        directory.ancestors = parent.retained_ancestry(phase, cause)?;
         directory.revalidate(phase, cause)?;
         parent.revalidate(phase, "ancestor_identity_changed")?;
-        if directory.identity.volume_serial != parent.identity.volume_serial {
+        if directory.identity().volume_serial != parent.identity().volume_serial {
             return Err(unsupported(phase, "child_cross_volume"));
         }
         Ok(directory)
@@ -484,76 +498,34 @@ impl LifecycleDirectory {
 
     fn revalidate(&self, phase: &'static str, cause: &'static str) -> Result<(), GfError> {
         for ancestor in &self.ancestors {
-            ancestor.revalidate(phase, "ancestor_identity_changed")?;
+            ancestor.revalidate_named_detailed().map_err(|error| {
+                lifecycle_directory_error(&error, phase, "ancestor_identity_changed")
+            })?;
         }
-        let named = std::fs::symlink_metadata(&self.path).map_err(|_| unsupported(phase, cause))?;
-        let opened = self
-            .handle
-            .metadata()
-            .map_err(|_| unsupported(phase, cause))?;
-        if is_link_or_reparse(&named)
-            || !named.is_dir()
-            || !opened.is_dir()
-            || graphforge_filesystem::path_identity(&self.path)
-                .map_err(|_| unsupported(phase, cause))?
-                != self.identity
-            || file_identity(&self.handle)? != self.identity
-        {
-            return Err(unsupported(phase, cause));
-        }
-        Ok(())
+        self.directory
+            .revalidate_named_detailed()
+            .map_err(|error| lifecycle_directory_error(&error, phase, cause))
     }
 
     fn retained_ancestry(
         &self,
         phase: &'static str,
         cause: &'static str,
-    ) -> Result<Vec<RetainedDirectory>, GfError> {
+    ) -> Result<Vec<graphforge_filesystem::StableDirectory>, GfError> {
         let mut retained = Vec::with_capacity(self.ancestors.len() + 1);
         for ancestor in &self.ancestors {
-            retained.push(ancestor.try_clone(phase, cause)?);
+            retained.push(
+                ancestor
+                    .try_clone()
+                    .map_err(|_| unsupported(phase, cause))?,
+            );
         }
-        retained.push(RetainedDirectory {
-            path: self.path.clone(),
-            handle: self
-                .handle
+        retained.push(
+            self.directory
                 .try_clone()
                 .map_err(|_| unsupported(phase, cause))?,
-            identity: self.identity,
-        });
+        );
         Ok(retained)
-    }
-}
-
-impl RetainedDirectory {
-    fn try_clone(&self, phase: &'static str, cause: &'static str) -> Result<Self, GfError> {
-        Ok(Self {
-            path: self.path.clone(),
-            handle: self
-                .handle
-                .try_clone()
-                .map_err(|_| unsupported(phase, cause))?,
-            identity: self.identity,
-        })
-    }
-
-    fn revalidate(&self, phase: &'static str, cause: &'static str) -> Result<(), GfError> {
-        let named = std::fs::symlink_metadata(&self.path).map_err(|_| unsupported(phase, cause))?;
-        let opened = self
-            .handle
-            .metadata()
-            .map_err(|_| unsupported(phase, cause))?;
-        if is_link_or_reparse(&named)
-            || !named.is_dir()
-            || !opened.is_dir()
-            || graphforge_filesystem::path_identity(&self.path)
-                .map_err(|_| unsupported(phase, cause))?
-                != self.identity
-            || file_identity(&self.handle)? != self.identity
-        {
-            return Err(unsupported(phase, cause));
-        }
-        Ok(())
     }
 }
 
@@ -577,13 +549,13 @@ impl LifecycleLock {
         parent: &LifecycleDirectory,
         target_name: &std::ffi::OsStr,
     ) -> Result<Self, GfError> {
-        let name = lifecycle_lock_name(&parent.path, target_name);
-        let path = parent.path.join(&name);
+        let name = lifecycle_lock_name(parent.path(), target_name);
+        let path = parent.path().join(&name);
         let file = open_lifecycle_lock_file(parent, &name)
             .map_err(|_| unsupported("LOCK", "lifecycle_lock_open_failed"))?;
         file.sync_all()
             .map_err(|_| unsupported("LOCK", "lifecycle_lock_flush_failed"))?;
-        complete_namespace_barrier(&parent.path)
+        complete_namespace_barrier(parent.path())
             .map_err(|_| unsupported("LOCK", "parent_namespace_barrier_failed"))?;
         crate::file_lock::lock_exclusive(&file)
             .map_err(|_| unsupported("LOCK", "lifecycle_lock_failed"))?;
@@ -593,7 +565,7 @@ impl LifecycleLock {
             path,
             file,
             identity,
-            parent_identity: parent.identity,
+            parent_identity: parent.identity(),
         };
         lock.revalidate()?;
         Ok(lock)
@@ -656,7 +628,7 @@ fn open_lifecycle_lock_file(parent: &LifecycleDirectory, name: &str) -> std::io:
 
     let open_existing = || {
         openat(
-            &parent.handle,
+            parent.handle(),
             name,
             OFlags::RDWR | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
             Mode::empty(),
@@ -667,7 +639,7 @@ fn open_lifecycle_lock_file(parent: &LifecycleDirectory, name: &str) -> std::io:
     match open_existing() {
         Ok(file) => Ok(file),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => match openat(
-            &parent.handle,
+            parent.handle(),
             name,
             OFlags::RDWR
                 | OFlags::CREATE
@@ -699,7 +671,7 @@ fn open_lifecycle_lock_file(parent: &LifecycleDirectory, name: &str) -> std::io:
         .create(true)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_WRITE_THROUGH)
-        .open(parent.path.join(name))
+        .open(parent.path().join(name))
 }
 
 #[cfg(all(not(unix), not(windows)))]
@@ -751,7 +723,7 @@ fn filesystem_durability_preflight_resolved(
     let started = Instant::now();
     let _probe_lock = lock_probe_parent(parent, target_name)?;
     let parent_metadata = parent
-        .handle
+        .handle()
         .metadata()
         .map_err(|_| unsupported("CLASSIFY", "parent_metadata_unavailable"))?;
     if !parent_metadata.is_dir() {
@@ -764,19 +736,19 @@ fn filesystem_durability_preflight_resolved(
         let target = LifecycleDirectory::open_child(
             parent,
             target_name,
-            &parent.path.join(target_name),
+            &parent.path().join(target_name),
             "CLASSIFY",
             "target_identity_unavailable",
         )?;
-        if target.identity.volume_serial != parent.identity.volume_serial {
+        if target.identity().volume_serial != parent.identity().volume_serial {
             return Err(unsupported("CLASSIFY", "target_cross_volume"));
         }
     }
     hit(fault, ProbeFault::Classify, "CLASSIFY")?;
     let filesystem_class = classify_supported_local_volume(parent)?;
 
-    let probe_name = stable_probe_name(&parent.path, target_name);
-    let probe_root = parent.path.join(&probe_name);
+    let probe_name = stable_probe_name(parent.path(), target_name);
+    let probe_root = parent.path().join(&probe_name);
     if child_metadata(parent, std::ffi::OsStr::new(&probe_name)).is_ok() {
         let stale = open_probe_directory(parent, &probe_name, &probe_root)?;
         cleanup_probe(parent, stale, ProbeFault::None)?;
@@ -855,7 +827,7 @@ fn lock_probe_parent(
     _target_name: &std::ffi::OsStr,
 ) -> Result<ProbeParentLock, GfError> {
     let handle = parent
-        .handle
+        .handle()
         .try_clone()
         .map_err(|_| unsupported("LOCK", "parent_open_failed"))?;
     crate::file_lock::lock_exclusive(&handle)
@@ -868,7 +840,7 @@ fn lock_probe_parent(
     parent: &LifecycleDirectory,
     target_name: &std::ffi::OsStr,
 ) -> Result<named_lock::NamedLockGuard, GfError> {
-    let name = stable_probe_name(&parent.path, target_name);
+    let name = stable_probe_name(parent.path(), target_name);
     let lock = named_lock::NamedLock::create(&format!("GraphForge.{name}"))
         .map_err(|_| unsupported("LOCK", "parent_lock_create_failed"))?;
     lock.lock()
@@ -906,7 +878,7 @@ fn resolve_project_path(root: &Path) -> Result<ResolvedProjectPath, GfError> {
     // from the process root; namespace ancestors above it are not mutated by
     // GraphForge and are therefore outside the durability contract.
     let parent = LifecycleDirectory::open(parent_path, "CLASSIFY", "parent_identity_unavailable")?;
-    let root = parent.path.join(&target_name);
+    let root = parent.path().join(&target_name);
     if let Ok(metadata) = child_metadata(&parent, &target_name)
         && is_link_or_reparse(&metadata)
     {
@@ -971,7 +943,7 @@ fn classify_supported_local_volume(parent: &LifecycleDirectory) -> Result<String
 fn classify_supported_local_volume_platform(
     parent: &LifecycleDirectory,
 ) -> Result<String, GfError> {
-    let stat = rustix::fs::fstatfs(&parent.handle)
+    let stat = rustix::fs::fstatfs(parent.handle())
         .map_err(|_| unsupported("CLASSIFY", "native_volume_query_failed"))?;
     let class = stat
         .f_fstypename
@@ -993,7 +965,7 @@ fn classify_supported_local_volume_platform(
     if (flags & u32::try_from(libc::MNT_RDONLY).unwrap_or(u32::MAX)) != 0 {
         return Err(unsupported("CLASSIFY", "volume_read_only"));
     }
-    reject_removable_volume(&parent.path)?;
+    reject_removable_volume(parent.path())?;
     Ok(class)
 }
 
@@ -1001,7 +973,7 @@ fn classify_supported_local_volume_platform(
 fn classify_supported_local_volume_platform(
     parent: &LifecycleDirectory,
 ) -> Result<String, GfError> {
-    let stat = rustix::fs::fstatfs(&parent.handle)
+    let stat = rustix::fs::fstatfs(parent.handle())
         .map_err(|_| unsupported("CLASSIFY", "native_volume_query_failed"))?;
     let class = match u64::try_from(stat.f_type).unwrap_or_default() {
         0xEF53 => "ext",
@@ -1009,12 +981,12 @@ fn classify_supported_local_volume_platform(
         0x9123_683E => "btrfs",
         _ => return Err(unsupported("CLASSIFY", "filesystem_class_unproven")),
     };
-    let vfs = rustix::fs::fstatvfs(&parent.handle)
+    let vfs = rustix::fs::fstatvfs(parent.handle())
         .map_err(|_| unsupported("CLASSIFY", "native_volume_query_failed"))?;
     if vfs.f_flag.contains(rustix::fs::StatVfsMountFlags::RDONLY) {
         return Err(unsupported("CLASSIFY", "volume_read_only"));
     }
-    reject_removable_volume(&parent.path)?;
+    reject_removable_volume(parent.path())?;
     Ok(class.into())
 }
 
@@ -1022,7 +994,7 @@ fn classify_supported_local_volume_platform(
 fn classify_supported_local_volume_platform(
     parent: &LifecycleDirectory,
 ) -> Result<String, GfError> {
-    let information = graphforge_filesystem::windows_volume_information(&parent.path)
+    let information = graphforge_filesystem::windows_volume_information(parent.path())
         .map_err(|_| unsupported("CLASSIFY", "native_volume_query_failed"))?;
     classify_windows_volume(
         &information.filesystem_name,
@@ -1073,30 +1045,40 @@ fn reject_removable_volume(parent: &Path) -> Result<(), GfError> {
 }
 
 struct ProbeDirectory {
-    path: PathBuf,
-    handle: File,
-    identity: graphforge_filesystem::FileIdentity,
+    directory: graphforge_filesystem::StableDirectory,
+}
+
+fn probe_directory_error(
+    error: &graphforge_filesystem::DirectoryValidationError,
+    phase: &'static str,
+) -> GfError {
+    use graphforge_filesystem::DirectoryValidationStage as Stage;
+    match error.stage() {
+        Stage::NamedMetadata => unsupported(phase, "private_directory_missing"),
+        Stage::RetainedMetadata => unsupported(phase, "private_directory_handle_unreadable"),
+        Stage::NamedIdentity => unsupported(phase, "private_directory_identity_unavailable"),
+        Stage::RetainedIdentity => unsupported("IDENTITY", "opened_identity_unavailable"),
+        Stage::IdentityChanged => unsupported(phase, "private_directory_identity_changed"),
+    }
 }
 
 impl ProbeDirectory {
+    fn path(&self) -> &Path {
+        self.directory.path()
+    }
+
+    fn handle(&self) -> &File {
+        self.directory.as_file()
+    }
+
+    fn identity(&self) -> graphforge_filesystem::FileIdentity {
+        self.directory.identity()
+    }
+
     fn revalidate(&self, phase: &'static str) -> Result<(), GfError> {
-        let named = std::fs::symlink_metadata(&self.path)
-            .map_err(|_| unsupported(phase, "private_directory_missing"))?;
-        let opened = self
-            .handle
-            .metadata()
-            .map_err(|_| unsupported(phase, "private_directory_handle_unreadable"))?;
-        if is_link_or_reparse(&named)
-            || !named.is_dir()
-            || !opened.is_dir()
-            || graphforge_filesystem::path_identity(&self.path)
-                .map_err(|_| unsupported(phase, "private_directory_identity_unavailable"))?
-                != self.identity
-            || file_identity(&self.handle)? != self.identity
-        {
-            return Err(unsupported(phase, "private_directory_identity_changed"));
-        }
-        Ok(())
+        self.directory
+            .revalidate_named_detailed()
+            .map_err(|error| probe_directory_error(&error, phase))
     }
 }
 
@@ -1113,61 +1095,42 @@ fn open_probe_directory(
     let handle = open_child_directory_handle(parent, std::ffi::OsStr::new(name), path)
         .map_err(|_| unsupported("CREATE", "private_directory_open_failed"))?;
     let opened = handle
+        .as_file()
         .metadata()
         .map_err(|_| unsupported("CREATE", "private_directory_handle_unreadable"))?;
     let identity = graphforge_filesystem::path_identity(path)
         .map_err(|_| unsupported("CREATE", "private_directory_identity_unavailable"))?;
-    if !opened.is_dir() || file_identity(&handle)? != identity {
+    if !opened.is_dir() || file_identity(handle.as_file())? != identity {
         return Err(unsupported(
             "CREATE",
             "private_directory_substituted_during_open",
         ));
     }
     parent.revalidate("CREATE", "parent_identity_changed")?;
-    Ok(ProbeDirectory {
-        path: path.to_path_buf(),
+    let directory = graphforge_filesystem::StableDirectory::from_retained_handle(
+        path.to_path_buf(),
         handle,
         identity,
-    })
+    )
+    .map_err(|error| probe_directory_error(&error, "CREATE"))?;
+    Ok(ProbeDirectory { directory })
 }
 
-#[cfg(unix)]
 fn open_child_directory_handle(
     parent: &LifecycleDirectory,
     name: &std::ffi::OsStr,
-    _path: &Path,
-) -> std::io::Result<File> {
-    use rustix::fs::{Mode, OFlags, openat};
-
-    openat(
-        &parent.handle,
-        name,
-        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
-        Mode::empty(),
-    )
-    .map(File::from)
-    .map_err(std::io::Error::from)
-}
-
-#[cfg(windows)]
-fn open_child_directory_handle(
-    _parent: &LifecycleDirectory,
-    _name: &std::ffi::OsStr,
     path: &Path,
-) -> std::io::Result<File> {
-    open_directory_handle(path)
-}
-
-#[cfg(all(not(unix), not(windows)))]
-fn open_child_directory_handle(
-    _parent: &LifecycleDirectory,
-    _name: &std::ffi::OsStr,
-    _path: &Path,
-) -> std::io::Result<File> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "child directory handles are unsupported",
-    ))
+) -> std::io::Result<graphforge_filesystem::OpenedDirectoryHandle> {
+    if parent.path().join(name) != path {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "child path does not match retained parent and name",
+        ));
+    }
+    parent
+        .directory
+        .open_child_directory(name)
+        .map(graphforge_filesystem::StableDirectory::into_handle)
 }
 
 #[cfg(unix)]
@@ -1179,8 +1142,8 @@ fn child_metadata(
     use std::os::unix::fs::MetadataExt as _;
 
     let stat =
-        statat(&parent.handle, name, AtFlags::SYMLINK_NOFOLLOW).map_err(std::io::Error::from)?;
-    let path_metadata = std::fs::symlink_metadata(parent.path.join(name))?;
+        statat(parent.handle(), name, AtFlags::SYMLINK_NOFOLLOW).map_err(std::io::Error::from)?;
+    let path_metadata = std::fs::symlink_metadata(parent.path().join(name))?;
     #[cfg(target_os = "linux")]
     let stat_device = stat.st_dev;
     #[cfg(not(target_os = "linux"))]
@@ -1196,7 +1159,7 @@ fn child_metadata(
     parent: &LifecycleDirectory,
     name: &std::ffi::OsStr,
 ) -> std::io::Result<std::fs::Metadata> {
-    std::fs::symlink_metadata(parent.path.join(name))
+    std::fs::symlink_metadata(parent.path().join(name))
 }
 
 #[cfg(unix)]
@@ -1207,7 +1170,7 @@ fn create_private_child_directory(
 ) -> std::io::Result<()> {
     use rustix::fs::{Mode, mkdirat};
 
-    mkdirat(&parent.handle, name, Mode::RUSR | Mode::WUSR | Mode::XUSR)
+    mkdirat(parent.handle(), name, Mode::RUSR | Mode::WUSR | Mode::XUSR)
         .map_err(std::io::Error::from)
 }
 
@@ -1231,39 +1194,9 @@ fn create_private_child_directory(
     Ok(())
 }
 
-#[cfg(unix)]
 pub(crate) fn open_directory_handle(path: &Path) -> std::io::Result<File> {
-    use rustix::fs::{Mode, OFlags, open};
-
-    let handle = open(
-        path,
-        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
-        Mode::empty(),
-    )?;
-    Ok(File::from(handle))
-}
-
-#[cfg(windows)]
-pub(crate) fn open_directory_handle(path: &Path) -> std::io::Result<File> {
-    use std::os::windows::fs::OpenOptionsExt as _;
-
-    const FILE_SHARE_READ: u32 = 0x0000_0001;
-    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
-    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
-    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    OpenOptions::new()
-        .read(true)
-        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
-        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)
-}
-
-#[cfg(all(not(unix), not(windows)))]
-pub(crate) fn open_directory_handle(_path: &Path) -> std::io::Result<File> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "directory identity handles are unsupported",
-    ))
+    graphforge_filesystem::open_directory_handle(path)
+        .map(graphforge_filesystem::OpenedDirectoryHandle::into_file)
 }
 
 fn create_private_probe_directory(
@@ -1286,11 +1219,11 @@ fn run_probe(
     fault: ProbeFault,
 ) -> Result<(), GfError> {
     probe.revalidate("CREATE")?;
-    if parent.identity.volume_serial != probe.identity.volume_serial {
+    if parent.identity().volume_serial != probe.identity().volume_serial {
         return Err(unsupported("CREATE", "private_directory_cross_volume"));
     }
 
-    let lock_path = probe.path.join("lock");
+    let lock_path = probe.path().join("lock");
     let mut lock = create_new_file(probe, "lock")?;
     lock.write_all(PROBE_BYTES_A)
         .map_err(|_| unsupported("WRITE", "lock_file_write_failed"))?;
@@ -1298,7 +1231,7 @@ fn run_probe(
     lock.sync_all()
         .map_err(|_| unsupported("FILE_FLUSH", "lock_file_flush_failed"))?;
     hit(fault, ProbeFault::FileFlush, "FILE_FLUSH")?;
-    verify_stable_identity(&lock, &lock_path, &parent.path)?;
+    verify_stable_identity(&lock, &lock_path, parent.path())?;
 
     crate::file_lock::lock_exclusive(&lock)
         .map_err(|_| unsupported("LOCK", "exclusive_lock_failed"))?;
@@ -1309,7 +1242,7 @@ fn run_probe(
         let _ = crate::file_lock::unlock(&contender);
         return Err(unsupported("LOCK", "exclusive_lock_not_enforced"));
     }
-    verify_stable_identity(&lock, &lock_path, &parent.path)?;
+    verify_stable_identity(&lock, &lock_path, parent.path())?;
     crate::file_lock::unlock(&lock).map_err(|_| unsupported("LOCK", "exclusive_unlock_failed"))?;
 
     crate::file_lock::lock_shared(&lock).map_err(|_| unsupported("LOCK", "shared_lock_failed"))?;
@@ -1329,7 +1262,7 @@ fn run_probe(
 
     let (target, target_identity, target_path) = replace_probe_file(probe, fault)?;
     probe.revalidate("NAMESPACE_DURABILITY")?;
-    complete_namespace_barrier(&probe.path)
+    complete_namespace_barrier(probe.path())
         .map_err(|_| unsupported("NAMESPACE_DURABILITY", "probe_namespace_barrier_failed"))?;
     hit(
         fault,
@@ -1356,7 +1289,7 @@ fn run_probe(
     if bytes != PROBE_BYTES_B {
         return Err(unsupported("IDENTITY", "replacement_bytes_mismatch"));
     }
-    verify_stable_identity(&published, &target_path, &parent.path)?;
+    verify_stable_identity(&published, &target_path, parent.path())?;
     drop(target);
     complete_namespace_barrier_handle(parent)
         .map_err(|_| unsupported("NAMESPACE_DURABILITY", "parent_namespace_barrier_failed"))
@@ -1374,16 +1307,16 @@ fn replace_probe_file(
         .map_err(|_| unsupported("REPLACE", "initial_file_flush_failed"))?;
     drop(initial);
     graphforge_filesystem::install_new_file(
-        &probe.handle,
+        probe.handle(),
         std::ffi::OsStr::new("initial"),
         std::ffi::OsStr::new("published"),
     )
     .map_err(|_| unsupported("REPLACE", "atomic_create_failed"))?;
 
-    let target_path = probe.path.join("published");
+    let target_path = probe.path().join("published");
     let target = open_regular_non_link(probe, "published")?;
     let target_identity = file_identity(&target)?;
-    let replacement_path = probe.path.join("replacement");
+    let replacement_path = probe.path().join("replacement");
     let mut replacement = create_new_file(probe, "replacement")?;
     replacement
         .write_all(PROBE_BYTES_B)
@@ -1398,7 +1331,7 @@ fn replace_probe_file(
         let target_before = graphforge_filesystem::path_identity(&target_path)
             .map_err(|_| unsupported("REPLACE", "target_identity_unavailable"))?;
         graphforge_filesystem::replace_file(
-            &probe.handle,
+            probe.handle(),
             std::ffi::OsStr::new("replacement"),
             std::ffi::OsStr::new("published"),
         )
@@ -1412,7 +1345,7 @@ fn replace_probe_file(
         ))
     } else {
         graphforge_filesystem::replace_file(
-            &probe.handle,
+            probe.handle(),
             std::ffi::OsStr::new("replacement"),
             std::ffi::OsStr::new("published"),
         )
@@ -1445,7 +1378,7 @@ fn create_new_file(probe: &ProbeDirectory, name: &str) -> Result<File, GfError> 
 }
 
 fn open_regular_non_link(probe: &ProbeDirectory, name: &str) -> Result<File, GfError> {
-    let path = probe.path.join(name);
+    let path = probe.path().join(name);
     let metadata = std::fs::symlink_metadata(&path)
         .map_err(|_| unsupported("IDENTITY", "path_metadata_failed"))?;
     if is_link_or_reparse(&metadata)
@@ -1475,7 +1408,7 @@ fn open_probe_file(probe: &ProbeDirectory, name: &str, create: bool) -> std::io:
     if create {
         flags |= OFlags::CREATE | OFlags::EXCL;
     }
-    openat(&probe.handle, name, flags, Mode::RUSR | Mode::WUSR)
+    openat(probe.handle(), name, flags, Mode::RUSR | Mode::WUSR)
         .map(File::from)
         .map_err(std::io::Error::from)
 }
@@ -1494,7 +1427,7 @@ fn open_probe_file(probe: &ProbeDirectory, name: &str, create: bool) -> std::io:
     if create {
         options.create_new(true);
     }
-    options.open(probe.path.join(name))
+    options.open(probe.path().join(name))
 }
 
 #[cfg(all(not(unix), not(windows)))]
@@ -1534,7 +1467,7 @@ fn cleanup_probe(
     hit(fault, ProbeFault::Cleanup, "CLEANUP")?;
     probe.revalidate("CLEANUP")?;
     let mut entries = Vec::new();
-    for entry in std::fs::read_dir(&probe.path)
+    for entry in std::fs::read_dir(probe.path())
         .map_err(|_| unsupported("CLEANUP", "private_directory_unreadable"))?
     {
         if entries.len() >= usize::try_from(MAX_PROBE_FILES).unwrap_or(usize::MAX) {
@@ -1572,8 +1505,8 @@ fn cleanup_probe(
             .map_err(|_| unsupported("CLEANUP", "private_entry_remove_failed"))?;
     }
     probe.revalidate("CLEANUP")?;
-    let path = probe.path.clone();
-    drop(probe.handle);
+    let path = probe.path().to_path_buf();
+    drop(probe);
     std::fs::remove_dir(path)
         .map_err(|_| unsupported("CLEANUP", "private_directory_remove_failed"))?;
     complete_namespace_barrier_handle(parent)
@@ -1583,11 +1516,11 @@ fn cleanup_probe(
 fn complete_namespace_barrier_handle(parent: &LifecycleDirectory) -> std::io::Result<()> {
     #[cfg(unix)]
     {
-        parent.handle.sync_all()
+        parent.handle().sync_all()
     }
     #[cfg(not(unix))]
     {
-        complete_namespace_barrier(&parent.path)
+        complete_namespace_barrier(parent.path())
     }
 }
 
@@ -1617,19 +1550,6 @@ fn complete_namespace_barrier(_path: &Path) -> std::io::Result<()> {
         std::io::ErrorKind::Unsupported,
         "namespace durability barrier is unsupported",
     ))
-}
-
-#[cfg(windows)]
-fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt as _;
-    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-    metadata.file_type().is_symlink()
-        || (metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT) != 0
-}
-
-#[cfg(not(windows))]
-fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
-    metadata.file_type().is_symlink()
 }
 
 fn file_identity(file: &File) -> Result<graphforge_filesystem::FileIdentity, GfError> {
@@ -1780,7 +1700,7 @@ mod tests {
                 )
                 .unwrap();
                 admission.revalidate_identity().unwrap();
-                (admission.created_root(), admission.project.identity)
+                (admission.created_root(), admission.project.identity())
             }));
         }
         barrier.wait();
@@ -2010,14 +1930,14 @@ mod tests {
             ProjectRootRequirement::CreateIfMissing,
         )
         .unwrap();
-        let expected = admission.project.identity;
+        let expected = admission.project.identity();
 
         let identity = admission.into_identity().unwrap();
         identity.revalidate_identity().unwrap();
         assert_eq!(identity.root(), root);
         let readmitted = identity.readmit().unwrap();
 
-        assert_eq!(readmitted.project.identity, expected);
+        assert_eq!(readmitted.project.identity(), expected);
         readmitted.revalidate_identity().unwrap();
     }
 
@@ -2209,7 +2129,7 @@ mod tests {
 
         let resolved = resolve_project_path(&target).unwrap();
 
-        assert_eq!(resolved.parent.path, storage_parent);
+        assert_eq!(resolved.parent.path(), storage_parent);
         assert!(
             resolved.parent.ancestors.is_empty(),
             "namespace above the storage parent is outside GraphForge's contract"

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -70,6 +70,7 @@ const PAGES = [
   'book/architecture/overview.md',
   'book/architecture/graphforge-vs-neo4j-gds.md',
   'book/architecture/storage.md',
+  'book/architecture/directory-capabilities.md',
   'book/architecture/concurrency-recovery.md',
   'book/architecture/project-format-compatibility.md',
   'book/architecture/portable-project-v2.md',

--- a/docs/book/architecture/directory-capabilities.md
+++ b/docs/book/architecture/directory-capabilities.md
@@ -1,0 +1,67 @@
+# Directory capability and lifecycle admission boundary
+
+Issue #1017 consolidates directory identity checks while retaining storage's
+additional lifecycle policy. This is a native filesystem boundary, independent
+of query semantics or project-format migration.
+
+## Threat model before consolidation
+
+`graphforge-filesystem::StableDirectory` and storage's private
+`LifecycleDirectory` currently both retain a directory handle and its native
+volume/file identity. Their platform opens are identical: Unix uses
+`RDONLY | DIRECTORY | NOFOLLOW | CLOEXEC` with `openat` for child lookup;
+Windows uses read access, `FILE_FLAG_BACKUP_SEMANTICS`,
+`FILE_FLAG_OPEN_REPARSE_POINT`, and read/write sharing without
+`FILE_SHARE_DELETE`. Unsupported platforms reject directory admission.
+
+| Threat or operation | StableDirectory | LifecycleDirectory |
+| --- | --- | --- |
+| Named directory replaced | Revalidation compares named identity with captured identity | Same, also rereads retained-handle metadata/identity |
+| Final component is a symlink/reparse point or regular file | Rejects on open and revalidation | Rejects on open and revalidation |
+| Child lookup | Checks a single plain name; Unix lookup is relative to retained parent; Windows reopens named path and checks parent before/after | Unix lookup is relative to retained parent; Windows reopens named path; lifecycle callers provide a validated target name and parent is rechecked afterward |
+| Ancestor replaced by a link back to the same child inode | A standalone child validates only its own path, so its unchanged identity remains valid | Retains parent ancestry and rejects the substituted ancestor |
+| Child crosses a volume boundary | Generic capability permits it | Lifecycle policy rejects it |
+| Directory rename while retained on Windows | OS denies deletion/rename sharing | Same |
+| Native identity | Full Windows file ID/volume serial or Unix device/inode | Same shared identity primitives |
+| Namespace durability | `sync` reopens a write handle on Windows and checks identity before flushing | NTFS admission uses the existing write-through publication protocol; its namespace barrier only revalidates the ordinary directory, never claims directory flush durability |
+
+These are compatible mechanisms with additional admission policy, not two
+incompatible authority models. Ancestor retention, same-volume restrictions,
+filesystem classification, lifecycle locks, private probe creation, and platform
+namespace barriers belong to storage. Exact no-link directory opens and
+retained/named identity checks belong to the filesystem capability.
+
+## Shared adversarial evidence
+
+`filesystem_admission::tests::directory_capability_conformance` applies the
+same cases to both original implementations before their consolidation:
+
+- open a real directory and reject a regular file without changing its bytes;
+- substitute a retained named directory on Unix and reject revalidation;
+- require Windows to deny rename of a retained directory, leaving it valid;
+- reject final-component symlinks on Unix and junction/reparse points on Windows
+  on both direct open and parent-relative child open, preserving outside data;
+- on Unix, replace a parent by a symlink back to its displaced directory and
+  explicitly distinguish the standalone capability's unchanged-child identity
+  from lifecycle's retained-ancestor policy.
+
+The tests live under the existing admission test prefix so the Linux, macOS,
+and Windows admission lanes execute them. Windows junction creation is required
+and checked; the suite does not skip link cases when a privilege is unavailable.
+The Unix-only ancestor mutation reflects Windows' different no-delete-sharing
+semantics, which the named-directory replacement case checks directly.
+
+## Consolidation requirements
+
+Lifecycle admission becomes a policy wrapper over `StableDirectory`, retaining
+ancestor capabilities and its existing same-volume and barrier rules. One
+filesystem revalidation protocol must check both named and retained directory
+kind/identity and reject final-component links/reparse points. Storage may map
+those failures into its existing phase/cause diagnostics; it must not reimplement
+the native checks. Strengthening retained-handle validation in the generic
+capability is intentional. No relaxed directory acceptance, fallback reopen, or
+new claim of Windows directory-flush durability is permitted.
+
+The existing admission evidence and recovery tests remain the behavioral gate.
+The shared cases prove capability behavior; they do not by themselves certify
+power-loss recovery or filesystem durability.

--- a/docs/book/architecture/directory-capabilities.md
+++ b/docs/book/architecture/directory-capabilities.md
@@ -7,7 +7,7 @@ of query semantics or project-format migration.
 ## Threat model before consolidation
 
 `graphforge-filesystem::StableDirectory` and storage's private
-`LifecycleDirectory` currently both retain a directory handle and its native
+`LifecycleDirectory` both retained a directory handle and its native
 volume/file identity. Their platform opens are identical: Unix uses
 `RDONLY | DIRECTORY | NOFOLLOW | CLOEXEC` with `openat` for child lookup;
 Windows uses read access, `FILE_FLAG_BACKUP_SEMANTICS`,
@@ -51,16 +51,42 @@ and checked; the suite does not skip link cases when a privilege is unavailable.
 The Unix-only ancestor mutation reflects Windows' different no-delete-sharing
 semantics, which the named-directory replacement case checks directly.
 
-## Consolidation requirements
+The test-only baseline was committed before replacing either mechanism. At
+`edbf4336`, the [Windows native lane](https://github.com/CurateLabs/graphforge/actions/runs/33927328124/job/101199483840)
+passed all 24 admission tests (including the three applicable shared cases) and
+25 filesystem tests; the [macOS native lane](https://github.com/CurateLabs/graphforge/actions/runs/33927328124/job/101199483884)
+also passed. Linux passed the four shared cases, all 27 admission tests and all
+15 filesystem tests before consolidation. The host's `/tmp` was tmpfs, so Linux
+durable-admission tests used an explicit `TMPDIR` on the host's admitted ext4
+volume.
 
-Lifecycle admission becomes a policy wrapper over `StableDirectory`, retaining
-ancestor capabilities and its existing same-volume and barrier rules. One
-filesystem revalidation protocol must check both named and retained directory
-kind/identity and reject final-component links/reparse points. Storage may map
-those failures into its existing phase/cause diagnostics; it must not reimplement
-the native checks. Strengthening retained-handle validation in the generic
-capability is intentional. No relaxed directory acceptance, fallback reopen, or
-new claim of Windows directory-flush durability is permitted.
+## Consolidated implementation
+
+Lifecycle admission is a policy wrapper over `StableDirectory`, retaining
+ancestor capabilities and its existing same-volume and barrier rules.
+`ProbeDirectory` also delegates its directory validation to the same capability.
+The duplicate `RetainedDirectory` type, directory-open flags, link/reparse
+predicate, and storage directory revalidation bodies are removed.
+
+`StableDirectory::revalidate_named_detailed` is the sole native directory
+revalidation protocol: it checks named and retained metadata, ordinary directory
+kind, link/reparse status, and named/retained identity against the captured
+identity. Typed failure stages let storage preserve its phase/cause diagnostics;
+the ordinary I/O adapter retains the native error kind. Initial admission still
+performs its policy-specific prechecks before adopting a retained handle.
+Adoption accepts an opaque `OpenedDirectoryHandle` constructed by the shared
+native open primitive, not an arbitrary `File`: metadata and identity alone
+cannot prove that a Windows handle denies delete sharing.
+
+The stronger retained-handle check is intentional. Lifecycle child opening now
+also uses the capability's validated single-component name and before/after
+parent checks; ancestry cloning revalidates the capability before and after
+cloning. These additional checks can reject a concurrent substitution earlier.
+The retained-ancestor rule remains storage policy: a standalone child still
+validates its own identity, while lifecycle validates the retained ancestry.
+No filesystem class, same-volume restriction, cooperative lock, probe evidence
+field, or namespace barrier changes. In particular, admission does not call the
+generic Windows directory `sync` operation or claim directory-flush durability.
 
 The existing admission evidence and recovery tests remain the behavioral gate.
 The shared cases prove capability behavior; they do not by themselves certify

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -7,6 +7,9 @@
 
 ## Overview
 
+The native directory authority, lifecycle policy, and adversarial checks are
+documented in [Directory capabilities](directory-capabilities.md).
+
 GraphForge uses a **pluggable storage provider** model. No provider is the semantic owner of the query language. All providers implement a common Rust trait and are selected at runtime based on the use case.
 
 ```rust


### PR DESCRIPTION
Storage lifecycle admission and the filesystem capability maintained separate directory identity protocols. Admission and its private probes now delegate to `StableDirectory`; the duplicate retained-directory type and native open/revalidation implementations are removed. Storage retains ancestor authority, same-volume admission, phase/cause diagnostics, locks, and existing Unix/Windows namespace barriers.

The shared protocol validates both named and retained directory metadata/identity. An opaque opened-directory handle preserves the native no-follow/sharing policy when storage adopts a handle. Child opening and ancestry cloning additionally revalidate the shared capability around their operations.

Shared adversarial cases were run against both original implementations before deletion: real directories/files, named replacement, symlink/junction child opens, and the intentional Unix ancestor-policy distinction. The test-only baseline `edbf4336` passed the complete [Windows native lane](https://github.com/CurateLabs/graphforge/actions/runs/33927328124/job/101199483840) and [macOS native lane](https://github.com/CurateLabs/graphforge/actions/runs/33927328124/job/101199483884); Linux admission 27 and filesystem 15 also passed before consolidation. New retained-handle tests reject mismatched identities and ordinary-file handles while preserving native missing-name errors.

Validation of consolidation (native sources are unchanged by the rebase onto the merged ADR/lock fix):

- Filesystem library: 17 passed. Storage library: 933 passed, 0 failed, 2 unchanged existing ignores (subprocess helper and manual scale test).
- `cargo clippy -p graphforge-filesystem -p graphforge-storage -- -D warnings` passed using isolated `CARGO_TARGET_DIR=/home/ubuntu/code/graphforge-target-1017` and `CARGO_BUILD_JOBS=8`.
- `make pre-push-fast` passed after rebasing onto the merged lock consistency fix.
- Docs build 109 pages; link check 13668 links; gate registry 14 tests; Cargo/Bazel drift; final formatting and diff checks passed.

On OVHC-AGENCY, `/tmp` is tmpfs; an existing storage test hardcodes `/tmp` and bypasses `TMPDIR`. The initial full run therefore failed that admission case. The complete storage suite passed unchanged as `ubuntu` in a private mount namespace with an ext4 directory bound to `/tmp`; the host mount was unchanged:

```sh
sudo -n unshare --mount --propagation private -- sh -c \
  'mount --bind /home/ubuntu/code/graphforge-target-1017/tmp /tmp && exec runuser -u ubuntu -- /home/ubuntu/code/graphforge-target-1017/debug/deps/graphforge_storage-f8df7c7eab2f4012'
```

Closes #1017.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate directory capability validation into `StableDirectory` typed stages and opaque handles
> - Introduces `DirectoryValidationStage` and `DirectoryValidationError` in [lib.rs](https://github.com/CurateLabs/graphforge/pull/1105/files#diff-6fd9fdbbd7d4f9f52cb005fd818a3c8b0e9182e3994e4b6734f9ecad1d8a8c74) so validation failures report which native stage failed while preserving the original I/O error kind.
> - Adds opaque `OpenedDirectoryHandle` and public `open_directory_handle` so directory adoption requires a handle opened through the crate's native no-follow/sharing policy instead of an arbitrary `File`.
> - Extends `StableDirectory` validation to check named metadata, retained-handle metadata, directory kind, link/reparse status, named identity, and retained identity; revalidating clones and transferring handles now enforce these checks.
> - Refactors `LifecycleDirectory`, `ProbeDirectory`, and admission routines in [filesystem_admission.rs](https://github.com/CurateLabs/graphforge/pull/1105/files#diff-d2d62df986a9ff36f6197d5ea2ef471b4b8a79dffff8513a95019410496c24c0) to delegate opening, child opening, cloning, and revalidation to `StableDirectory`, removing duplicate storage-owned platform open and link/reparse helpers.
> - Adds shared adversarial conformance tests in [directory_capability_conformance.rs](https://github.com/CurateLabs/graphforge/pull/1105/files#diff-19d01573b39acdfd1031a121827e308b4015fd05bf225a40755b596e07e07902) covering real directories, regular files, link/junction rejection, and named/ancestor replacement for both directory implementations.
> - Behavioral Change: `open_child_directory_handle` now rejects paths that do not equal the retained parent path plus the requested child name before opening; retained-directory adoption fails closed for non-directory handles and mismatched identities.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01fad5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->