### PR TITLE
fix(exec): preserve structured errors across DataFusion

### DIFF
--- a/crates/graphforge-api/src/checkpoint_graph_diff.rs
+++ b/crates/graphforge-api/src/checkpoint_graph_diff.rs
@@ -102,7 +102,7 @@ fn streamed_logical_rows(
             checkpoint(cancellation)?;
             let next = graph.block_on(async { Ok(stream.next().await) })?;
             let Some(batch) = next else { break };
-            let batch = batch.map_err(|error| GfError::Execution(error.to_string()))?;
+            let batch = batch.map_err(GfError::from_execution_error)?;
             page_count += batch.num_rows();
             records.extend(logical_rows(std::slice::from_ref(&batch), cancellation)?);
         }

--- a/crates/graphforge-api/src/graph_inspection.rs
+++ b/crates/graphforge-api/src/graph_inspection.rs
@@ -130,7 +130,7 @@ async fn inspection_from_node_stream(
     while let Some(batch) = stream.next().await {
         accumulate_node_batch(
             &mut inspection,
-            &batch.map_err(|error| GfError::Execution(error.to_string()))?,
+            &batch.map_err(GfError::from_execution_error)?,
         )?;
     }
     Ok(inspection)
@@ -143,7 +143,7 @@ async fn inspection_from_relationship_stream(
     while let Some(batch) = stream.next().await {
         accumulate_relationship_batch(
             &mut inspection,
-            &batch.map_err(|error| GfError::Execution(error.to_string()))?,
+            &batch.map_err(GfError::from_execution_error)?,
         )?;
     }
     Ok(inspection)

--- a/crates/graphforge-core/src/error_conversion.rs
+++ b/crates/graphforge-core/src/error_conversion.rs
@@ -1,0 +1,39 @@
+//! Recover GraphForge's structured errors at foreign error boundaries.
+
+use std::error::Error;
+
+use crate::GfError;
+
+impl GfError {
+    /// Preserve a GraphForge source when a planner wraps it in another error.
+    ///
+    /// Foreign failures without a GraphForge source retain the existing
+    /// `GF_PLAN` classification and diagnostic. Source traversal uses Rust's
+    /// error identity, never diagnostic text.
+    #[must_use]
+    pub fn from_plan_error(error: impl Error + 'static) -> Self {
+        Self::recover_source(&error).unwrap_or_else(|| Self::Plan(error.to_string()))
+    }
+
+    /// Preserve a GraphForge source when execution wraps it in another error.
+    ///
+    /// This also handles shared foreign errors: cloning the GraphForge value
+    /// retains its typed code, variant, message, and source span without needing
+    /// exclusive ownership of an upstream error. Foreign failures without a
+    /// GraphForge source retain `GF_EXECUTION` and their existing diagnostic.
+    #[must_use]
+    pub fn from_execution_error(error: impl Error + 'static) -> Self {
+        Self::recover_source(&error).unwrap_or_else(|| Self::Execution(error.to_string()))
+    }
+
+    fn recover_source(error: &(dyn Error + 'static)) -> Option<Self> {
+        let mut source = Some(error);
+        while let Some(error) = source {
+            if let Some(original) = error.downcast_ref::<Self>() {
+                return Some(original.clone());
+            }
+            source = error.source();
+        }
+        None
+    }
+}

--- a/crates/graphforge-core/src/lib.rs
+++ b/crates/graphforge-core/src/lib.rs
@@ -101,7 +101,7 @@ pub enum OntologyMode {
 /// Compiler stages, I/O, discovery, and other subsystems also expose dedicated
 /// error types. Boundary adapters classify them as needed; [`GfError::code`]
 /// supplies stable public codes rather than a one-to-one variant/exception map.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum GfError {
     /// Feature exists in the API but has not been implemented yet.
     #[error("not implemented: {0}")]
@@ -183,6 +183,8 @@ pub enum GfError {
     #[error("ontology error: {0}")]
     Ontology(String),
 }
+
+mod error_conversion;
 
 impl GfError {
     /// Return the stable public error code for this failure.

--- a/crates/graphforge-exec/src/error_conversion_tests.rs
+++ b/crates/graphforge-exec/src/error_conversion_tests.rs
@@ -1,0 +1,329 @@
+//! Real DataFusion error propagation must retain GraphForge's public identity.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::common::Diagnostic;
+use datafusion::error::DataFusionError;
+use datafusion::execution::TaskContext;
+use datafusion::execution::context::{QueryPlanner, SessionState};
+use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::logical_expr::{Volatility, col, create_udf};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+};
+use datafusion::prelude::SessionContext;
+use futures::StreamExt;
+use graphforge_core::{ApiErrorCode, GfError, ProjectErrorCode, Span};
+use graphforge_ir::{GraphPlan, RuntimeCatalog};
+use graphforge_storage::GraphCatalog;
+use tempfile::TempDir;
+
+use super::ExecutionSession;
+
+#[test]
+fn datafusion_error_source_preserves_binder_span_through_shared_context() {
+    let original = GfError::Bind {
+        msg: "undeclared variable".into(),
+        span: Span { start: 7, end: 14 },
+    };
+    let wrapped = Arc::new(DataFusionError::Context(
+        "physical operator".into(),
+        Box::new(DataFusionError::External(Box::new(original.clone()))),
+    ));
+    // Two consumers preclude using exclusive Arc ownership to recover the error.
+    for _ in 0..2 {
+        let recovered = GfError::from_plan_error(DataFusionError::Shared(Arc::clone(&wrapped)));
+        assert_eq!(recovered.code(), "GF_PARSE");
+        assert_eq!(recovered.to_string(), original.to_string());
+        let GfError::Bind { msg, span } = recovered else {
+            panic!("binder variant was lost");
+        };
+        assert_eq!(msg, "undeclared variable");
+        assert_eq!(span, Span { start: 7, end: 14 });
+    }
+}
+
+#[test]
+fn datafusion_error_source_preserves_typed_resource_failure() {
+    let original = resource_failure();
+    let expected = original.to_string();
+    let recovered = GfError::from_execution_error(DataFusionError::External(Box::new(original)));
+    assert_eq!(recovered.code(), "GF_RESOURCE_LIMIT");
+    assert_eq!(recovered.to_string(), expected);
+    assert!(matches!(
+        recovered,
+        GfError::Api {
+            code: ApiErrorCode::ResourceLimit,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn datafusion_error_source_does_not_classify_diagnostic_text() {
+    let foreign = DataFusionError::Execution("GF_RESOURCE_LIMIT is just text".into());
+    let expected = foreign.to_string();
+    let recovered = GfError::from_execution_error(foreign);
+    assert_eq!(recovered.code(), "GF_EXECUTION");
+    assert!(matches!(recovered, GfError::Execution(ref message) if message == &expected));
+    let foreign = DataFusionError::Plan("missing column".into());
+    let expected = foreign.to_string();
+    let recovered = GfError::from_plan_error(foreign);
+    assert!(matches!(recovered, GfError::Plan(ref message) if message == &expected));
+}
+
+fn resource_failure() -> GfError {
+    GfError::Api {
+        code: ApiErrorCode::ResourceLimit,
+        message: "bounded operator exhausted its budget".into(),
+    }
+}
+
+async fn failing_dataframe() -> datafusion::dataframe::DataFrame {
+    let context = SessionContext::new();
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "input",
+            DataType::Int64,
+            false,
+        )])),
+        vec![Arc::new(Int64Array::from(vec![1, 2]))],
+    )
+    .unwrap();
+    let function = create_udf(
+        "graphforge_structured_failure",
+        vec![DataType::Int64],
+        DataType::Int64,
+        Volatility::Volatile,
+        Arc::new(|_| Err(super::to_df_err(resource_failure()))),
+    );
+    context
+        .read_batch(batch)
+        .unwrap()
+        .select(vec![function.call(vec![col("input")])])
+        .unwrap()
+}
+
+// Inject only the physical planner result. The actual ExecutionSession entry
+// points still perform lowering, planning, collecting and stream wrapping, so
+// reverting a production conversion makes these tests fail.
+#[derive(Debug)]
+enum BoundaryPlanner {
+    Physical(Arc<dyn ExecutionPlan>),
+    Failure(GfError),
+}
+
+#[async_trait]
+impl QueryPlanner for BoundaryPlanner {
+    async fn create_physical_plan(
+        &self,
+        _logical_plan: &LogicalPlan,
+        _session_state: &SessionState,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        match self {
+            Self::Physical(physical) => Ok(Arc::clone(physical)),
+            Self::Failure(error) => Err(DataFusionError::Context(
+                "test physical planner".into(),
+                Box::new(super::to_df_err(error.clone())),
+            )),
+        }
+    }
+}
+
+fn boundary_session(planner: BoundaryPlanner) -> (TempDir, ExecutionSession) {
+    let dir = TempDir::new().unwrap();
+    let catalog = GraphCatalog::open(dir.path(), None, &RuntimeCatalog::new()).unwrap();
+    let mut session = ExecutionSession::new(catalog, None).unwrap();
+    let state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_query_planner(Arc::new(planner))
+        .build();
+    session.ctx = SessionContext::new_with_state(state);
+    (dir, session)
+}
+
+fn assert_resource_failure(error: GfError) {
+    assert_eq!(error.code(), "GF_RESOURCE_LIMIT");
+    assert_eq!(error.to_string(), resource_failure().to_string());
+    assert!(matches!(
+        error,
+        GfError::Api {
+            code: ApiErrorCode::ResourceLimit,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn datafusion_error_source_survives_session_collect() {
+    let physical = failing_dataframe()
+        .await
+        .create_physical_plan()
+        .await
+        .unwrap();
+    let (_dir, session) = boundary_session(BoundaryPlanner::Physical(physical));
+    let plan = GraphPlan::builder("openCypher").build();
+    let failure = session
+        .execute_plan(&plan)
+        .await
+        .expect_err("physical UDF must fail through the production collecting boundary");
+    assert_resource_failure(failure);
+}
+
+#[tokio::test]
+async fn datafusion_error_source_survives_session_stream_poll() {
+    let physical = failing_dataframe()
+        .await
+        .create_physical_plan()
+        .await
+        .unwrap();
+    let (_dir, session) = boundary_session(BoundaryPlanner::Physical(physical));
+    let plan = GraphPlan::builder("openCypher").build();
+    let mut stream = session
+        .execute_plan_stream(&plan, &HashMap::new())
+        .await
+        .unwrap();
+    let failure = stream
+        .next()
+        .await
+        .expect("physical failure batch")
+        .expect_err("physical UDF must fail");
+    // The production session stream is DataFusion-typed; consumers recover the
+    // original source after QueryEvidenceStream has finalized its evidence.
+    assert_resource_failure(GfError::from_execution_error(failure));
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn datafusion_error_source_survives_session_planning_for_collect_and_stream() {
+    let original = GfError::Bind {
+        msg: "physical planner preserved source".into(),
+        span: Span { start: 3, end: 9 },
+    };
+    let (_dir, session) = boundary_session(BoundaryPlanner::Failure(original.clone()));
+    let plan = GraphPlan::builder("openCypher").build();
+    let collecting = session.execute_plan(&plan).await.unwrap_err();
+    let streaming = match session.execute_plan_stream(&plan, &HashMap::new()).await {
+        Err(error) => error,
+        Ok(_) => panic!("physical planning must fail before opening a stream"),
+    };
+    for recovered in [collecting, streaming] {
+        assert_eq!(recovered.code(), "GF_PARSE");
+        assert_eq!(recovered.to_string(), original.to_string());
+        assert!(matches!(
+            recovered,
+            GfError::Bind {
+                span: Span { start: 3, end: 9 },
+                ..
+            }
+        ));
+    }
+}
+
+// A physical operator may fail when execute() opens its stream, before polling.
+#[derive(Debug)]
+struct StreamStartFailure {
+    properties: Arc<PlanProperties>,
+}
+
+impl DisplayAs for StreamStartFailure {
+    fn fmt_as(&self, _format: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("StreamStartFailure")
+    }
+}
+
+impl ExecutionPlan for StreamStartFailure {
+    fn name(&self) -> &str {
+        "StreamStartFailure"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        assert!(children.is_empty());
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        Err(super::to_df_err(resource_failure()))
+    }
+}
+
+#[tokio::test]
+async fn datafusion_error_source_survives_session_stream_initialization() {
+    let empty = datafusion::physical_plan::empty::EmptyExec::new(Arc::new(Schema::empty()));
+    let physical = Arc::new(StreamStartFailure {
+        properties: Arc::clone(empty.properties()),
+    });
+    let (_dir, session) = boundary_session(BoundaryPlanner::Physical(physical));
+    let plan = GraphPlan::builder("openCypher").build();
+    let failure = match session.execute_plan_stream(&plan, &HashMap::new()).await {
+        Err(error) => error,
+        Ok(_) => panic!("opening the physical stream must fail"),
+    };
+    assert_resource_failure(failure);
+}
+
+#[test]
+fn datafusion_error_source_preserves_project_code_through_arrow_and_diagnostic() {
+    let original = GfError::Project {
+        code: ProjectErrorCode::ProjectCorrupt,
+        message: "selected graph authority failed authentication".into(),
+    };
+    let wrapped = DataFusionError::ArrowError(
+        Box::new(arrow::error::ArrowError::ExternalError(Box::new(
+            original.clone(),
+        ))),
+        None,
+    )
+    .with_diagnostic(Diagnostic::new_error("physical read failed", None));
+    let recovered = GfError::from_execution_error(wrapped);
+    assert_eq!(recovered.code(), "GF_PROJECT_CORRUPT");
+    assert_eq!(recovered.to_string(), original.to_string());
+    assert!(matches!(
+        recovered,
+        GfError::Project {
+            code: ProjectErrorCode::ProjectCorrupt,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn datafusion_collection_preserves_only_the_primary_source() {
+    let primary = DataFusionError::Collection(vec![
+        super::to_df_err(resource_failure()),
+        DataFusionError::Execution("secondary".into()),
+    ]);
+    assert_resource_failure(GfError::from_execution_error(primary));
+
+    // DataFusion exposes the first collection member through Error::source.
+    // A secondary GraphForge diagnostic must not replace a foreign primary.
+    let foreign_primary = DataFusionError::Collection(vec![
+        DataFusionError::Plan("primary failure".into()),
+        super::to_df_err(resource_failure()),
+    ]);
+    let expected = foreign_primary.to_string();
+    let recovered = GfError::from_plan_error(foreign_primary);
+    assert!(matches!(recovered, GfError::Plan(message) if message == expected));
+}

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -1058,7 +1058,7 @@ fn summary_batch(schema: &SchemaRef, tally: &CreateTally) -> Result<RecordBatch,
             Arc::new(UInt64Array::from(vec![tally.labels_added])),
         ],
     )
-    .map_err(|e| GfError::Execution(e.to_string()))
+    .map_err(GfError::from_execution_error)
 }
 
 /// Running CREATE side-effect tallies accumulated across input batches (#601):
@@ -1128,12 +1128,12 @@ fn merge_computed(
         return Ok(());
     };
     for (name, array) in cols {
-        let scalar = ScalarValue::try_from_array(array, row)
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+        let scalar =
+            ScalarValue::try_from_array(array, row).map_err(GfError::from_execution_error)?;
         if scalar.is_null() {
             continue;
         }
-        let lit = scalar_to_ir_literal(&scalar).map_err(|e| GfError::Execution(e.to_string()))?;
+        let lit = scalar_to_ir_literal(&scalar).map_err(GfError::from_execution_error)?;
         props.insert(name.clone(), lit);
     }
     Ok(())
@@ -1328,8 +1328,7 @@ fn emit_batch_creates(
     for spec in cfg.nodes.iter().filter(|s| !s.is_reference) {
         append_created_node_output_cols(spec, n, computed, &recorder, &mut out_cols)?;
     }
-    RecordBatch::try_new(cfg.out_schema.clone(), out_cols)
-        .map_err(|e| GfError::Execution(e.to_string()))
+    RecordBatch::try_new(cfg.out_schema.clone(), out_cols).map_err(GfError::from_execution_error)
 }
 
 fn append_created_node_output_cols(
@@ -1365,7 +1364,7 @@ fn append_created_node_output_cols(
     for uuid in uuids {
         uuid_b
             .append_value(uuid)
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
     }
     out_cols.push(Arc::new(uuid_b.finish()));
     out_cols.push(Arc::new(UInt64Array::from(node_ids.to_vec())));
@@ -1377,7 +1376,7 @@ fn append_created_node_output_cols(
         out_cols.push(
             scalar
                 .to_array_of_size(rows)
-                .map_err(|e| GfError::Execution(e.to_string()))?,
+                .map_err(GfError::from_execution_error)?,
         );
     }
     if let Some(cols) = computed.get(&spec.var) {
@@ -1669,7 +1668,7 @@ fn delete_summary_batch(
             Arc::new(UInt64Array::from(vec![edges])),
         ],
     )
-    .map_err(|e| GfError::Execution(e.to_string()))
+    .map_err(GfError::from_execution_error)
 }
 
 // ---------------------------------------------------------------------------
@@ -1682,7 +1681,7 @@ fn count_summary_batch(schema: &SchemaRef, count: u64) -> Result<RecordBatch, Gf
         schema.clone(),
         vec![Arc::new(UInt64Array::from(vec![count]))],
     )
-    .map_err(|e| GfError::Execution(e.to_string()))
+    .map_err(GfError::from_execution_error)
 }
 
 /// Resolve a write target's input-column locations: the identity UUID column and
@@ -1968,7 +1967,7 @@ fn accumulate_set_batch(
         let values = phys
             .evaluate(batch)
             .and_then(|cv| cv.into_array(n))
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
         let id_col = batch.column(col.uuid_idx);
         for row in 0..n {
             if id_col.is_null(row) {
@@ -1976,10 +1975,9 @@ fn accumulate_set_batch(
             }
             let uuid =
                 graphforge_core::uuid::to_bytes(&fixed_binary_uuid(batch, col.uuid_idx, row)?);
-            let scalar = ScalarValue::try_from_array(&values, row)
-                .map_err(|e| GfError::Execution(e.to_string()))?;
-            let lit =
-                scalar_to_ir_literal(&scalar).map_err(|e| GfError::Execution(e.to_string()))?;
+            let scalar =
+                ScalarValue::try_from_array(&values, row).map_err(GfError::from_execution_error)?;
+            let lit = scalar_to_ir_literal(&scalar).map_err(GfError::from_execution_error)?;
             let stem = col.stem_for_row(batch, row, mode, type_map)?;
             acc.record(col.is_edge, stem, uuid, col.prop_name.clone(), lit);
         }
@@ -3185,7 +3183,7 @@ impl V4OrdinalIdentityResolver {
             .lock()
             .expect("ordinal identity handle poisoned")
             .revalidate_for_session()
-            .map_err(|error| GfError::Execution(error.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
         Ok(V4OrdinalIdentityPin {
             session: Some(Arc::new(V4OrdinalIdentitySession {
                 handle,
@@ -3216,7 +3214,7 @@ impl V4OrdinalIdentitySession {
             .lock()
             .expect("ordinal identity handle poisoned")
             .lookup_node_uuids_pinned(requested)
-            .map_err(|error| GfError::Execution(error.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
         if self.attribution_available.swap(false, Ordering::AcqRel) {
             lookup.metrics.revalidation_calls = self.revalidation.calls;
             lookup.metrics.revalidation_bytes = self.revalidation.bytes_read;
@@ -3703,7 +3701,7 @@ fn unused_expand_column(field: &Field, rows: usize) -> Result<ArrayRef, GfError>
             FixedSizeBinaryArray::try_from_iter(
                 (0..rows).map(|_| vec![0_u8; usize::try_from(*width).unwrap_or(0)]),
             )
-            .map_err(|error| GfError::Execution(error.to_string()))?,
+            .map_err(GfError::from_execution_error)?,
         ),
         DataType::UInt64 => Arc::new(UInt64Array::from(vec![0_u64; rows])),
         DataType::UInt32 => Arc::new(UInt32Array::from(vec![0_u32; rows])),
@@ -5301,11 +5299,11 @@ impl ExecutionSession {
             .state()
             .create_physical_plan(&logical)
             .await
-            .map_err(|e| GfError::Plan(e.to_string()))?;
+            .map_err(GfError::from_plan_error)?;
 
         let batches = collect(Arc::clone(&physical), self.ctx.task_ctx())
             .await
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
 
         let schema = batches
             .first()
@@ -5462,10 +5460,10 @@ impl ExecutionSession {
             .state()
             .create_physical_plan(&logical)
             .await
-            .map_err(|e| GfError::Plan(e.to_string()))?;
+            .map_err(GfError::from_plan_error)?;
         let batches = collect(physical, self.ctx.task_ctx())
             .await
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
         let mut frontier = write_driver::Frontier { df_schema, batches };
 
         // Phase loop: buffer every effect, then one staged commit.
@@ -5534,7 +5532,7 @@ impl ExecutionSession {
         write_driver::commit_statement(&mut wctx, &self.dir)?;
         self.catalog
             .refresh_property_inventory(&self.dir)
-            .map_err(|error| GfError::Execution(error.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
         self.adjacency_provider.invalidate();
 
         let c = wctx.counters;
@@ -5749,7 +5747,7 @@ impl ExecutionSession {
             returned_batch_bytes,
             task_ctx.session_config().batch_size(),
         );
-        let mut batches = collected.map_err(|e| GfError::Execution(e.to_string()))?;
+        let mut batches = collected.map_err(GfError::from_execution_error)?;
 
         // DataFusion's collect may return zero batches for an empty stream.
         // Public callers (and DF54-era optimistic publish tests) index
@@ -5806,28 +5804,26 @@ impl ExecutionSession {
             };
             let vars = graphforge_rel::VarMap::new();
             let lowerer = graphforge_rel::ExprLowerer::new(&exprs, self.ontology.as_ref(), &vars);
-            let expr = lowerer
-                .lower(expr)
-                .map_err(|error| GfError::Plan(error.to_string()))?;
+            let expr = lowerer.lower(expr).map_err(GfError::from_plan_error)?;
             let logical = LogicalPlanBuilder::empty(true)
                 .project(vec![expr.alias("__gf_row_count")])
                 .and_then(LogicalPlanBuilder::build)
-                .map_err(|error| GfError::Plan(error.to_string()))?;
+                .map_err(GfError::from_plan_error)?;
             let logical = bind_query_params(logical, params)?;
             let physical = self
                 .ctx
                 .state()
                 .create_physical_plan(&logical)
                 .await
-                .map_err(|error| GfError::Plan(error.to_string()))?;
+                .map_err(GfError::from_plan_error)?;
             let batches = collect(physical, self.ctx.task_ctx())
                 .await
-                .map_err(|error| GfError::Execution(error.to_string()))?;
+                .map_err(GfError::from_execution_error)?;
             let batch = batches.first().ok_or_else(|| {
                 GfError::Execution(format!("{keyword} expression returned no row"))
             })?;
             let value = ScalarValue::try_from_array(batch.column(0), 0)
-                .map_err(|error| GfError::Execution(error.to_string()))?;
+                .map_err(GfError::from_execution_error)?;
             let count = match value {
                 ScalarValue::Int64(Some(value)) => u64::try_from(value).ok(),
                 ScalarValue::UInt64(Some(value)) => Some(value),
@@ -5870,7 +5866,7 @@ impl ExecutionSession {
         let memory_reserved_before = task_ctx.memory_pool().reserved();
         let stream =
             datafusion::physical_plan::execute_stream(Arc::clone(&physical), Arc::clone(&task_ctx))
-                .map_err(|e| GfError::Execution(e.to_string()))?;
+                .map_err(GfError::from_execution_error)?;
         let schema = stream.schema();
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             schema,
@@ -5920,7 +5916,7 @@ impl ExecutionSession {
                 .state()
                 .create_physical_plan(&logical)
                 .await
-                .map_err(|e| GfError::Plan(e.to_string()))?;
+                .map_err(GfError::from_plan_error)?;
             return Ok(datafusion::physical_plan::displayable(physical.as_ref())
                 .indent(false)
                 .to_string());
@@ -5982,7 +5978,7 @@ impl ExecutionSession {
             .state()
             .create_physical_plan(&logical)
             .await
-            .map_err(|e| GfError::Plan(e.to_string()))?;
+            .map_err(GfError::from_plan_error)?;
         Ok((physical, fallback_schema))
     }
 
@@ -6056,7 +6052,7 @@ fn bind_query_params(
         .collect();
     logical
         .with_param_values(values)
-        .map_err(|e| GfError::Plan(e.to_string()))
+        .map_err(GfError::from_plan_error)
 }
 
 // ---------------------------------------------------------------------------
@@ -6071,6 +6067,9 @@ const _: fn() = || {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod error_conversion_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -451,14 +451,13 @@ impl Frontier {
             .first()
             .map_or_else(|| Arc::clone(self.df_schema.inner()), RecordBatch::schema);
         let input = arrow::compute::concat_batches(&schema, &self.batches)
-            .map_err(|error| GfError::Execution(error.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
         let indices = UInt64Array::from(indices.to_vec());
         let columns = input
             .columns()
             .iter()
             .map(|column| {
-                arrow::compute::take(column, &indices, None)
-                    .map_err(|error| GfError::Execution(error.to_string()))
+                arrow::compute::take(column, &indices, None).map_err(GfError::from_execution_error)
             })
             .collect::<Result<Vec<_>, _>>()?;
         self.batches = vec![
@@ -467,7 +466,7 @@ impl Frontier {
                 columns,
                 &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(indices.len())),
             )
-            .map_err(|error| GfError::Execution(error.to_string()))?,
+            .map_err(GfError::from_execution_error)?,
         ];
         Ok(())
     }
@@ -518,7 +517,7 @@ impl Frontier {
             }
             rebuilt.push(
                 RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
-                    .map_err(|e| GfError::Execution(e.to_string()))?,
+                    .map_err(GfError::from_execution_error)?,
             );
         }
         self.batches = rebuilt;
@@ -539,7 +538,7 @@ impl Frontier {
             schema_fields.push((Some(qualifier), Arc::new(Field::new(name, data_type, true))));
         }
         self.df_schema = DFSchema::new_with_metadata(schema_fields, HashMap::new())
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
         Ok(())
     }
 
@@ -573,7 +572,7 @@ impl Frontier {
             for u in &uuids[range.clone()] {
                 uuid_b
                     .append_value(u)
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
             }
             Ok(vec![
                 Arc::new(uuid_b.finish()) as ArrayRef,
@@ -620,7 +619,7 @@ impl Frontier {
             for u in &uuids[range.clone()] {
                 uuid_b
                     .append_value(u)
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
             }
             let mut cols: Vec<ArrayRef> = vec![
                 Arc::new(uuid_b.finish()) as ArrayRef,
@@ -633,7 +632,7 @@ impl Frontier {
                 cols.push(
                     scalar
                         .to_array_of_size(rows)
-                        .map_err(|e| GfError::Execution(e.to_string()))?,
+                        .map_err(GfError::from_execution_error)?,
                 );
             }
             for (name, _) in &spec.computed_properties {
@@ -693,7 +692,7 @@ impl Frontier {
             for row in selected {
                 uuid_builder
                     .append_value(row.uuid)
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
             }
             let mut columns: Vec<ArrayRef> = vec![
                 Arc::new(uuid_builder.finish()),
@@ -714,10 +713,9 @@ impl Frontier {
                 });
                 let values = values
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 columns.push(
-                    ScalarValue::iter_to_array(values)
-                        .map_err(|error| GfError::Execution(error.to_string()))?,
+                    ScalarValue::iter_to_array(values).map_err(GfError::from_execution_error)?,
                 );
             }
             Ok(columns)
@@ -756,7 +754,7 @@ impl Frontier {
             );
         }
         self.df_schema = DFSchema::new_with_metadata(logical_fields, HashMap::new())
-            .map_err(|error| GfError::Execution(error.to_string()))?;
+            .map_err(GfError::from_execution_error)?;
 
         self.batches = self
             .batches
@@ -772,7 +770,7 @@ impl Frontier {
                     fields[*index] = fields[*index].clone().with_name(replacement);
                 }
                 RecordBatch::try_new(Arc::new(Schema::new(fields)), batch.columns().to_vec())
-                    .map_err(|error| GfError::Execution(error.to_string()))
+                    .map_err(GfError::from_execution_error)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -819,13 +817,13 @@ impl Frontier {
             for row in range {
                 uuid_b
                     .append_value(uuids[row])
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 src_b
                     .append_value(src_uuids[row])
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 dst_b
                     .append_value(dst_uuids[row])
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 name_b.append_option(rel_names[row].as_deref());
             }
             Ok(vec![
@@ -872,13 +870,13 @@ impl Frontier {
             for row in range.clone() {
                 uuid_b
                     .append_value(identities.uuids[row])
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 src_b
                     .append_value(identities.src_uuids[row])
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 dst_b
                     .append_value(identities.dst_uuids[row])
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 name_b.append_option(identities.rel_names[row].as_deref());
             }
             let mut columns: Vec<ArrayRef> = vec![
@@ -891,7 +889,7 @@ impl Frontier {
                 columns.push(
                     graphforge_rel::expr::ir_literal_to_scalar(lit)
                         .to_array_of_size(rows)
-                        .map_err(|e| GfError::Execution(e.to_string()))?,
+                        .map_err(GfError::from_execution_error)?,
                 );
             }
             for (name, _) in &spec.computed_properties {
@@ -942,13 +940,13 @@ impl Frontier {
             for row in selected {
                 edge_builder
                     .append_value(row.uuid)
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 src_builder
                     .append_value(row.src_uuid)
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 dst_builder
                     .append_value(row.dst_uuid)
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 type_builder.append_value(&row.rel_type);
             }
             let mut columns: Vec<ArrayRef> = vec![
@@ -967,10 +965,9 @@ impl Frontier {
                         )
                     })
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 columns.push(
-                    ScalarValue::iter_to_array(values)
-                        .map_err(|error| GfError::Execution(error.to_string()))?,
+                    ScalarValue::iter_to_array(values).map_err(GfError::from_execution_error)?,
                 );
             }
             Ok(columns)
@@ -1040,7 +1037,7 @@ impl Frontier {
             columns[index] = Arc::new(list);
             rebuilt.push(
                 RecordBatch::try_new(batch.schema(), columns)
-                    .map_err(|e| GfError::Execution(e.to_string()))?,
+                    .map_err(GfError::from_execution_error)?,
             );
             offset += batch.num_rows();
         }
@@ -1360,7 +1357,7 @@ fn bind_expr_params(
         ))
     })
     .map(|transformed| transformed.data)
-    .map_err(|e| GfError::Plan(e.to_string()))
+    .map_err(GfError::from_plan_error)
 }
 
 /// Run the statement's write ops in clause order against the shared frontier
@@ -1443,15 +1440,15 @@ pub(crate) async fn run_terminal_suffix(
         .state()
         .create_physical_plan(logical)
         .await
-        .map_err(|e| GfError::Plan(e.to_string()))?;
+        .map_err(GfError::from_plan_error)?;
     let (input_schema, input_batches) = terminal_input(frontier);
     let input = MemorySourceConfig::try_new_from_batches(input_schema, input_batches)
-        .map_err(|e| GfError::Plan(e.to_string()))?;
+        .map_err(GfError::from_plan_error)?;
     let physical = replace_empty_input(physical, input)?;
     let schema = physical.schema();
     let mut batches = datafusion::physical_plan::collect(physical, session.task_ctx())
         .await
-        .map_err(|e| GfError::Execution(e.to_string()))?;
+        .map_err(GfError::from_execution_error)?;
     if batches.is_empty() {
         batches.push(RecordBatch::new_empty(Arc::clone(&schema)));
     }
@@ -1488,7 +1485,7 @@ fn terminal_global_count(
                 let index = frontier
                     .df_schema
                     .index_of_column(column)
-                    .map_err(|error| GfError::Plan(error.to_string()))?;
+                    .map_err(GfError::from_plan_error)?;
                 frontier
                     .batches
                     .iter()
@@ -1507,7 +1504,7 @@ fn terminal_global_count(
     let schema = Arc::clone(logical.schema().inner());
     RecordBatch::try_new(schema, counts)
         .map(Some)
-        .map_err(|error| GfError::Execution(error.to_string()))
+        .map_err(GfError::from_execution_error)
 }
 
 fn terminal_input(frontier: &Frontier) -> (SchemaRef, Vec<RecordBatch>) {
@@ -1532,7 +1529,7 @@ fn replace_empty_input(
         .map(|child| replace_empty_input(Arc::clone(child), Arc::clone(&input)))
         .collect::<Result<Vec<_>, _>>()?;
     plan.with_new_children(children)
-        .map_err(|e| GfError::Plan(e.to_string()))
+        .map_err(GfError::from_plan_error)
 }
 
 /// CREATE phase: mint per frontier row into the shared writer, then extend
@@ -1602,8 +1599,8 @@ fn run_create_phase(
     let mut computed_batches = Vec::with_capacity(frontier.batches.len());
     for batch in &frontier.batches {
         // Evaluate any row-dependent property values against this batch (#814).
-        let computed = crate::eval_create_computed(&cfg, batch)
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+        let computed =
+            crate::eval_create_computed(&cfg, batch).map_err(GfError::from_execution_error)?;
         write_batch_creates(
             &cfg,
             &mut ctx.writer,
@@ -1766,7 +1763,7 @@ fn resolve_merge_node_properties_by_row(
         let expr = bind_expr_params(expr.clone(), env.params)?;
         let (expr, eval_schema) = positional_eval_expr(expr, &frontier.df_schema)?;
         let expr = create_physical_expr(&expr, &eval_schema, &ExecutionProps::new())
-            .map_err(|error| GfError::Plan(error.to_string()))?;
+            .map_err(GfError::from_plan_error)?;
         physical.push((name, expr));
     }
     let mut resolved_rows = Vec::with_capacity(frontier.num_rows());
@@ -1777,18 +1774,17 @@ fn resolve_merge_node_properties_by_row(
                 expr.evaluate(batch)
                     .and_then(|value| value.into_array(batch.num_rows()))
                     .map(|values| ((*name).clone(), values))
-                    .map_err(|error| GfError::Execution(error.to_string()))
+                    .map_err(GfError::from_execution_error)
             })
             .collect::<Result<Vec<_>, _>>()?;
         for row in 0..batch.num_rows() {
             let mut resolved = spec.clone();
             for (name, values) in &evaluated {
                 let scalar = ScalarValue::try_from_array(values, row)
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 resolved.properties.push((
                     name.clone(),
-                    scalar_to_ir_literal(&scalar)
-                        .map_err(|error| GfError::Execution(error.to_string()))?,
+                    scalar_to_ir_literal(&scalar).map_err(GfError::from_execution_error)?,
                 ));
             }
             resolved.computed_properties.clear();
@@ -1821,7 +1817,7 @@ fn positional_eval_expr(expr: DfExpr, schema: &DFSchema) -> Result<(DfExpr, DFSc
                 format!("__gf_eval_{index}"),
             ))))
         })
-        .map_err(|error| GfError::Plan(error.to_string()))?
+        .map_err(GfError::from_plan_error)?
         .data;
     let fields = schema
         .as_arrow()
@@ -1840,8 +1836,8 @@ fn positional_eval_expr(expr: DfExpr, schema: &DFSchema) -> Result<(DfExpr, DFSc
             )
         })
         .collect();
-    let schema = DFSchema::new_with_metadata(fields, HashMap::new())
-        .map_err(|error| GfError::Plan(error.to_string()))?;
+    let schema =
+        DFSchema::new_with_metadata(fields, HashMap::new()).map_err(GfError::from_plan_error)?;
     Ok((expr, schema))
 }
 
@@ -2092,7 +2088,7 @@ fn resolve_merge_edge_properties_by_row(
         let expr = bind_expr_params(expr.clone(), env.params)?;
         let (expr, eval_schema) = positional_eval_expr(expr, &frontier.df_schema)?;
         let expr = create_physical_expr(&expr, &eval_schema, &ExecutionProps::new())
-            .map_err(|error| GfError::Plan(error.to_string()))?;
+            .map_err(GfError::from_plan_error)?;
         physical.push((name, expr));
     }
     let mut resolved_rows = Vec::with_capacity(frontier.num_rows());
@@ -2103,18 +2099,17 @@ fn resolve_merge_edge_properties_by_row(
                 expr.evaluate(batch)
                     .and_then(|value| value.into_array(batch.num_rows()))
                     .map(|values| ((*name).clone(), values))
-                    .map_err(|error| GfError::Execution(error.to_string()))
+                    .map_err(GfError::from_execution_error)
             })
             .collect::<Result<Vec<_>, _>>()?;
         for row in 0..batch.num_rows() {
             let mut resolved = spec.clone();
             for (name, values) in &evaluated {
                 let scalar = ScalarValue::try_from_array(values, row)
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 resolved.properties.push((
                     name.clone(),
-                    scalar_to_ir_literal(&scalar)
-                        .map_err(|error| GfError::Execution(error.to_string()))?,
+                    scalar_to_ir_literal(&scalar).map_err(GfError::from_execution_error)?,
                 ));
             }
             resolved.computed_properties.clear();
@@ -2381,15 +2376,15 @@ fn collect_delete_expr_targets(
             &frontier.df_schema,
             &ExecutionProps::new(),
         )
-        .map_err(|error| GfError::Plan(error.to_string()))?;
+        .map_err(GfError::from_plan_error)?;
         for batch in &frontier.batches {
             let values = physical
                 .evaluate(batch)
                 .and_then(|value| value.into_array(batch.num_rows()))
-                .map_err(|error| GfError::Execution(error.to_string()))?;
+                .map_err(GfError::from_execution_error)?;
             for row in 0..batch.num_rows() {
                 let value = ScalarValue::try_from_array(&values, row)
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 collect_delete_scalar(&value, nodes, edges)?;
             }
         }
@@ -2423,7 +2418,7 @@ fn collect_delete_scalar(
                 if let Some(column) = values.column_by_name(field) {
                     found_path = true;
                     let nested = ScalarValue::try_from_array(column, 0)
-                        .map_err(|error| GfError::Execution(error.to_string()))?;
+                        .map_err(GfError::from_execution_error)?;
                     collect_delete_scalar(&nested, nodes, edges)?;
                 }
             }
@@ -2449,8 +2444,8 @@ fn collect_delete_list(
     edges: &mut HashSet<[u8; 16]>,
 ) -> Result<(), GfError> {
     for row in 0..items.len() {
-        let item = ScalarValue::try_from_array(items, row)
-            .map_err(|error| GfError::Execution(error.to_string()))?;
+        let item =
+            ScalarValue::try_from_array(items, row).map_err(GfError::from_execution_error)?;
         collect_delete_scalar(&item, nodes, edges)?;
     }
     Ok(())
@@ -2770,7 +2765,7 @@ fn run_set_phase_masked(
         let df_expr = bind_expr_params(df_expr, env.params)?;
         let (df_expr, eval_schema) = positional_eval_expr(df_expr, &frontier.df_schema)?;
         let phys = create_physical_expr(&df_expr, &eval_schema, &ExecutionProps::new())
-            .map_err(|e| GfError::Plan(e.to_string()))?;
+            .map_err(GfError::from_plan_error)?;
 
         let mut overlay = Vec::with_capacity(frontier.batches.len());
         let mut offset = 0usize;
@@ -2779,7 +2774,7 @@ fn run_set_phase_masked(
             let values = phys
                 .evaluate(batch)
                 .and_then(|cv| cv.into_array(n))
-                .map_err(|e| GfError::Execution(e.to_string()))?;
+                .map_err(GfError::from_execution_error)?;
             let selected = mask.map(|mask| &mask[offset..offset + n]);
             let overlay_values = if let Some(selected) = selected {
                 let selection = BooleanArray::from(selected.to_vec());
@@ -2799,9 +2794,9 @@ fn run_set_phase_masked(
                         },
                         |index| Ok(Arc::clone(batch.column(index))),
                     )
-                    .map_err(|error| GfError::Execution(error.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 arrow::compute::kernels::zip::zip(&selection, &values, &previous)
-                    .map_err(|error| GfError::Execution(error.to_string()))?
+                    .map_err(GfError::from_execution_error)?
             } else {
                 Arc::clone(&values)
             };
@@ -2821,7 +2816,7 @@ fn run_set_phase_masked(
                     ));
                 }
                 let scalar = ScalarValue::try_from_array(&values, row)
-                    .map_err(|e| GfError::Execution(e.to_string()))?;
+                    .map_err(GfError::from_execution_error)?;
                 let stem = col.stem_for_row(batch, row, env.mode, &env.type_map)?;
                 if scalar.is_null() {
                     let present = property_is_present(
@@ -2852,8 +2847,7 @@ fn run_set_phase_masked(
                     }
                     continue;
                 }
-                let lit =
-                    scalar_to_ir_literal(&scalar).map_err(|e| GfError::Execution(e.to_string()))?;
+                let lit = scalar_to_ir_literal(&scalar).map_err(GfError::from_execution_error)?;
                 let pending = if is_edge {
                     ctx.writer.contains_pending_edge(&uuid)
                 } else {
@@ -2958,14 +2952,14 @@ fn run_set_map_phase_with_input(
         let df_expr = bind_expr_params(df_expr, env.params)?;
         let (df_expr, eval_schema) = positional_eval_expr(df_expr, &frontier.df_schema)?;
         let phys = create_physical_expr(&df_expr, &eval_schema, &ExecutionProps::new())
-            .map_err(|e| GfError::Plan(e.to_string()))?;
+            .map_err(GfError::from_plan_error)?;
         let mut overlays: HashMap<String, Vec<ArrayRef>> = HashMap::new();
 
         for batch in &frontier.batches {
             let values = phys
                 .evaluate(batch)
                 .and_then(|cv| cv.into_array(batch.num_rows()))
-                .map_err(|e| GfError::Execution(e.to_string()))?;
+                .map_err(GfError::from_execution_error)?;
             let maps = values
                 .as_any()
                 .downcast_ref::<StructArray>()
@@ -3047,12 +3041,12 @@ fn run_set_map_phase_with_input(
                 let mut null_keys = HashSet::new();
                 for (field, column) in maps.fields().iter().zip(maps.columns()) {
                     let scalar = ScalarValue::try_from_array(column, row)
-                        .map_err(|e| GfError::Execution(e.to_string()))?;
+                        .map_err(GfError::from_execution_error)?;
                     if scalar.is_null() {
                         null_keys.insert(field.name().clone());
                     } else {
-                        let value = scalar_to_ir_literal(&scalar)
-                            .map_err(|e| GfError::Execution(e.to_string()))?;
+                        let value =
+                            scalar_to_ir_literal(&scalar).map_err(GfError::from_execution_error)?;
                         updates.insert(field.name().clone(), value);
                     }
                 }
@@ -3110,8 +3104,7 @@ fn decode_tagged_map_updates(
     maps: &StructArray,
     row: usize,
 ) -> Result<HashMap<String, graphforge_ir::IrLiteral>, GfError> {
-    let tagged = ScalarValue::try_from_array(maps, row)
-        .map_err(|error| GfError::Execution(error.to_string()))?;
+    let tagged = ScalarValue::try_from_array(maps, row).map_err(GfError::from_execution_error)?;
     let decoded = graphforge_rel::expr::decode_het_scalar(&tagged)
         .ok_or_else(|| GfError::Execution("SET source is not a map".into()))?;
     let ScalarValue::Struct(values) = decoded else {
@@ -3119,14 +3112,13 @@ fn decode_tagged_map_updates(
     };
     let mut updates = HashMap::new();
     for (field, column) in values.fields().iter().zip(values.columns()) {
-        let tagged_value = ScalarValue::try_from_array(column, 0)
-            .map_err(|error| GfError::Execution(error.to_string()))?;
+        let tagged_value =
+            ScalarValue::try_from_array(column, 0).map_err(GfError::from_execution_error)?;
         let value = graphforge_rel::expr::decode_het_scalar(&tagged_value).unwrap_or(tagged_value);
         if !value.is_null() {
             updates.insert(
                 field.name().clone(),
-                scalar_to_ir_literal(&value)
-                    .map_err(|error| GfError::Execution(error.to_string()))?,
+                scalar_to_ir_literal(&value).map_err(GfError::from_execution_error)?,
             );
         }
     }
@@ -3337,7 +3329,7 @@ fn run_remove_phase(
                 ScalarValue::try_from(&overlay_type)
                     .unwrap_or(ScalarValue::Null)
                     .to_array_of_size(batch.num_rows())
-                    .map_err(|e| GfError::Execution(e.to_string()))?,
+                    .map_err(GfError::from_execution_error)?,
             );
         }
         frontier.overlay_property(item.target, &item.prop_name, overlay)?;
@@ -3538,7 +3530,7 @@ pub(crate) fn statement_summary_batch(c: &WriteCounters) -> Result<RecordBatch, 
             Arc::new(UInt64Array::from(vec![c.properties_removed])),
         ],
     )
-    .map_err(|e| GfError::Execution(e.to_string()))
+    .map_err(GfError::from_execution_error)
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/book/architecture/execution-model.md
+++ b/docs/book/architecture/execution-model.md
@@ -77,6 +77,36 @@ GraphPlan (Graph IR)
 
 ---
 
+## Error identity across DataFusion
+
+A GraphForge operator wraps its `GfError` as a downcastable
+`DataFusionError::External`. Planning, execution, and facade stream consumers
+recover that error through the standard Rust error source chain, including
+DataFusion context and shared wrappers. They preserve its variant, typed code,
+message, and span rather than classifying display text. The original error is
+cloned when a shared upstream failure cannot be exclusively owned. For a
+multi-error wrapper, recovery follows that wrapper's designated source; it does
+not search other branches for a preferred classification.
+
+| Boundary input | Public result |
+| --- | --- |
+| Wrapped `GfError::Parse` or `Bind` | Original variant and span; `GF_PARSE` / binding `ParseError` |
+| Wrapped `GfError::Api` or `Project` | Original closed typed code, such as `GF_RESOURCE_LIMIT` or `GF_PROJECT_CORRUPT` |
+| Any other wrapped `GfError` | Original variant and existing public code |
+| Foreign planner error without a GraphForge source | Existing `GfError::Plan` / `GF_PLAN` classification and diagnostic |
+| Foreign execution error without a GraphForge source | Existing `GfError::Execution` / `GF_EXECUTION` classification and diagnostic |
+
+This corrects the v0.6 error boundary: an owned GraphForge resource, validation,
+or project error no longer becomes a generic execution/plan error solely
+because DataFusion transported it. No new public code is introduced, and
+foreign errors keep their existing fallback classification. Raw Arrow batch
+streams retain DataFusion's error type and downcastable source until a facade
+consumer converts them. Parser/binder kind retention and lowering-kind mapping
+remain the separate work tracked by #1018; this boundary does not claim that
+already flattened errors can be reconstructed.
+
+---
+
 ## Custom Graph Execution Nodes
 
 GraphForge registers custom `ExecutionPlan` implementations with DataFusion for operators


### PR DESCRIPTION
GraphForge errors wrapped by DataFusion currently lose their typed code, variant, and span when planning or execution converts them back through display text. Recover the original `GfError` through its standard error source chain at plan, collect, write, and facade stream-consumption boundaries; unrelated foreign errors retain their existing classification and diagnostic.

The regression suite executes the production `ExecutionSession` boundaries with failing physical plans, including collect, planning, stream start, stream polling, shared/context wrappers, Arrow diagnostics, and a multi-error wrapper's designated source. The broader stage-kind and Python/Node error matrix remains in #1018.

Validation:
- `cargo test -p graphforge-exec`: 975 passed; 16 existing ignored tests unchanged. Nine focused error-conversion tests passed with none ignored.
- `cargo test -p graphforge-api --lib graph_inspection`: 4 passed, including persistent reopen.
- `cargo test -p graphforge-api --lib checkpoint_graph_diff`: 3 passed.
- `make pre-push-fast`: passed.
- `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`, and `make gate-registry-check`: passed.

Native tests used isolated `CARGO_TARGET_DIR=/home/ubuntu/code/graphforge-1028-target` and an ext4-rooted `TMPDIR` on OVHC-AGENCY.

Fixes #1097

Integrated onto current main after #1100. The sole rebase conflict preserves the corrected public error documentation from #1107 and adds this change’s `Clone` derivation. Final local checks and exact-head CI passed at `5a806163e59e76bebb65fd17abf800b4f58a9211`, including authoritative Bazel Rust tests, binding packaging, platform durability, concurrency matrix, and CI Gate. Squash merged; #1097 is closed and parent #1018 remains open.
