### PR TITLE
refactor(api): remove interim string-column batches

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -389,32 +389,6 @@ pub use provider_session::{OpenRouterProviderSession, OpenRouterProviderSessionC
 pub use search_index::SearchIndexOptions;
 
 // ---------------------------------------------------------------------------
-// RecordBatch (interim tabular result)
-// ---------------------------------------------------------------------------
-
-/// Minimal tabular result.  Replaced by Arrow `RecordBatch` when the read path
-/// lands (#717/#719).
-#[derive(Debug, Clone, Default)]
-pub struct RecordBatch {
-    /// Column names.
-    pub schema: Vec<String>,
-    /// One entry per column; each entry is the column's values as strings.
-    pub columns: Vec<Vec<String>>,
-}
-
-impl RecordBatch {
-    /// Return an empty batch with the given schema.
-    #[must_use]
-    pub fn empty(schema: Vec<String>) -> Self {
-        let ncols = schema.len();
-        Self {
-            schema,
-            columns: vec![vec![]; ncols],
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // GraphForge
 // ---------------------------------------------------------------------------
 
@@ -4819,11 +4793,7 @@ mod tests {
     }
 
     #[test]
-    fn facade_debug_empty_batch_and_procedure_width_contracts_are_exact() {
-        let empty = RecordBatch::empty(vec!["node_uuid".into(), "name".into()]);
-        assert_eq!(empty.schema, ["node_uuid", "name"]);
-        assert_eq!(empty.columns, [Vec::<String>::new(), Vec::new()]);
-
+    fn facade_debug_and_procedure_width_contracts_are_exact() {
         let graph = GraphForge::new(None).unwrap();
         let debug = format!("{graph:?}");
         for field in [

--- a/crates/graphforge-api/tests/bdd/api_steps.rs
+++ b/crates/graphforge-api/tests/bdd/api_steps.rs
@@ -18,7 +18,9 @@ async fn given_empty_graph(world: &mut GraphForgeWorld) {
     world.index_calls = 0;
     world.last_error = None;
     world.last_error_code = None;
-    world.last_result = None;
+    world.last_names = None;
+    world.last_count = None;
+    world.last_explanation = None;
     world.last_algorithm_result = None;
 }
 
@@ -1247,13 +1249,13 @@ async fn when_schema(world: &mut GraphForgeWorld) {
 
 #[when(regex = r#"^I call labels$"#)]
 async fn when_labels(world: &mut GraphForgeWorld) {
+    world.last_names = None;
+    world.last_count = None;
+    world.last_explanation = None;
     if let Some(forge) = &world.forge {
         match forge.labels() {
             Ok(labels) => {
-                world.last_result = Some(graphforge_api::RecordBatch {
-                    schema: vec!["label".into()],
-                    columns: vec![labels],
-                });
+                world.last_names = Some(labels);
             }
             Err(error) => world.last_error = Some(error.to_string()),
         }
@@ -1262,13 +1264,13 @@ async fn when_labels(world: &mut GraphForgeWorld) {
 
 #[when(regex = r#"^I call relationship_types$"#)]
 async fn when_rel_types(world: &mut GraphForgeWorld) {
+    world.last_names = None;
+    world.last_count = None;
+    world.last_explanation = None;
     if let Some(forge) = &world.forge {
         match forge.relationship_types() {
             Ok(relationship_types) => {
-                world.last_result = Some(graphforge_api::RecordBatch {
-                    schema: vec!["relationship_type".into()],
-                    columns: vec![relationship_types],
-                });
+                world.last_names = Some(relationship_types);
             }
             Err(error) => world.last_error = Some(error.to_string()),
         }
@@ -1277,13 +1279,13 @@ async fn when_rel_types(world: &mut GraphForgeWorld) {
 
 #[when(regex = r#"^I call node_count for label "([^"]+)"$"#)]
 async fn when_node_count(world: &mut GraphForgeWorld, label: String) {
+    world.last_names = None;
+    world.last_count = None;
+    world.last_explanation = None;
     if let Some(forge) = &world.forge {
         match forge.node_count(&label) {
             Ok(count) => {
-                world.last_result = Some(graphforge_api::RecordBatch {
-                    schema: vec!["node_count".into()],
-                    columns: vec![vec![count.to_string()]],
-                });
+                world.last_count = Some(count);
             }
             Err(error) => world.last_error = Some(error.to_string()),
         }
@@ -1346,12 +1348,12 @@ async fn when_neighbourhood(
 
 #[when(regex = r#"^I call explain on "([^"]+)"$"#)]
 async fn when_explain(world: &mut GraphForgeWorld, query: String) {
+    world.last_names = None;
+    world.last_count = None;
+    world.last_explanation = None;
     match graphforge_cypher::explain(&query) {
         Ok(s) => {
-            world.last_result = Some(graphforge_api::RecordBatch {
-                schema: vec!["plan".to_string()],
-                columns: vec![vec![s]],
-            });
+            world.last_explanation = Some(s);
         }
         Err(e) => world.last_error = Some(e.to_string()),
     }
@@ -1876,32 +1878,17 @@ async fn then_path_reaches_dispatch(world: &mut GraphForgeWorld) {
 }
 
 #[then(regex = r#"^the result is (\d+)$"#)]
-async fn then_result_is_n(world: &mut GraphForgeWorld, n: i64) {
-    let value = world
-        .last_result
-        .as_ref()
-        .and_then(|result| result.columns.first())
-        .and_then(|column| column.first())
-        .expect("integer result");
-    assert_eq!(value.parse::<i64>().unwrap(), n);
+async fn then_result_is_n(world: &mut GraphForgeWorld, n: u64) {
+    assert_eq!(world.last_count.expect("integer result"), n);
 }
 
 #[then(regex = r#"^the result is a non-empty string$"#)]
 async fn then_nonempty_string(world: &mut GraphForgeWorld) {
-    if let Some(rb) = &world.last_result {
-        let val = rb
-            .columns
-            .first()
-            .and_then(|c| c.first())
-            .map(|s| s.as_str())
-            .unwrap_or("");
-        assert!(!val.is_empty(), "expected non-empty string result");
-    } else {
-        panic!(
-            "no result stored — step failed? error: {:?}",
-            world.last_error
-        );
-    }
+    let explanation = world
+        .last_explanation
+        .as_deref()
+        .expect("explanation result");
+    assert!(!explanation.is_empty(), "expected non-empty string result");
 
     #[then(regex = r#"^a structured selector error is raised$"#)]
     async fn then_structured_selector_error(world: &mut GraphForgeWorld) {
@@ -1967,35 +1954,24 @@ async fn then_result_contains_title(world: &mut GraphForgeWorld, title: String) 
 
 #[then(regex = r#"^the result contains "([^"]+)"$"#)]
 async fn then_result_contains_text(world: &mut GraphForgeWorld, text: String) {
-    if let Some(rb) = &world.last_result {
-        let values = rb.columns.iter().flatten().collect::<Vec<_>>();
-        assert!(
-            values.iter().any(|value| value.contains(&text)),
-            "expected result to contain {text:?}\ngot:\n{}",
-            values
-                .iter()
-                .map(|value| value.as_str())
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
+    let values: Vec<&str> = if let Some(names) = &world.last_names {
+        names.iter().map(String::as_str).collect()
     } else {
-        panic!(
-            "no result stored — step failed? error: {:?}",
-            world.last_error
-        );
-    }
+        vec![world.last_explanation.as_deref().expect("text result")]
+    };
+    assert!(
+        values.iter().any(|value| value.contains(&text)),
+        "expected result to contain {text:?}\ngot:\n{}",
+        values.join("\n")
+    );
 }
 
 #[then(regex = r#"^the result is an empty list$"#)]
 async fn then_empty_list(world: &mut GraphForgeWorld) {
     assert!(
-        world
-            .last_result
-            .as_ref()
-            .and_then(|result| result.columns.first())
-            .is_some_and(Vec::is_empty),
+        world.last_names.as_ref().is_some_and(Vec::is_empty),
         "expected empty list, got {:?}",
-        world.last_result
+        world.last_names
     );
 }
 

--- a/crates/graphforge-api/tests/bdd/main.rs
+++ b/crates/graphforge-api/tests/bdd/main.rs
@@ -39,8 +39,12 @@ pub struct GraphForgeWorld {
     pub last_error: Option<String>,
     /// Stable public code for the last typed Rust facade error.
     pub last_error_code: Option<&'static str>,
-    /// Last interim `RecordBatch` returned by a stubbed When step (schema()/etc.).
-    pub last_result: Option<graphforge_api::RecordBatch>,
+    /// Last metadata collection returned by labels or relationship_types.
+    pub last_names: Option<Vec<String>>,
+    /// Last scalar returned by node_count.
+    pub last_count: Option<u64>,
+    /// Last explanation returned by explain.
+    pub last_explanation: Option<String>,
     /// Last Arrow-backed result returned by `execute()`.
     pub last_exec: Option<graphforge_api::ExecutionResult>,
     /// Most recent Arrow result returned by an analyst verb.

--- a/crates/graphforge-api/tests/bdd/tck_steps.rs
+++ b/crates/graphforge-api/tests/bdd/tck_steps.rs
@@ -29,7 +29,9 @@ async fn given_any_graph(world: &mut GraphForgeWorld) {
     crate::fixture::replace_with_fresh(&mut world.forge);
     world.nodes.clear();
     world.last_error = None;
-    world.last_result = None;
+    world.last_names = None;
+    world.last_count = None;
+    world.last_explanation = None;
     world.last_exec = None;
     world.params.clear();
 }
@@ -49,7 +51,9 @@ fn seed_graph(world: &mut GraphForgeWorld, create: &str) {
     world.forge = Some(forge);
     world.nodes.clear();
     world.last_error = None;
-    world.last_result = None;
+    world.last_names = None;
+    world.last_count = None;
+    world.last_explanation = None;
     world.last_exec = None;
     world.params.clear();
 }

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "87c96476a9ec9403f5d95afc57a2029979e6627903111fd3995329c93aec5a6b"
+EXPECTED_RUST_DIGEST = "932d8d9c7edf3f4aac04695933b01600e47a637f5aa332ca86ed53cb9989515d"
 EXPECTED_RELEASE_DIGEST = "84310d5de1f83e7080f71e7933470640be96cd1b32b0bc10b0584496380924b3"
 
 PYTHON_ONLY_METHODS = frozenset(

--- a/crates/graphforge-core/src/lib.rs
+++ b/crates/graphforge-core/src/lib.rs
@@ -979,10 +979,9 @@ pub enum ExplainStage {
 // GraphForge — public facade
 // ---------------------------------------------------------------------------
 //
-// The `GraphForge` engine facade and its interim `RecordBatch` result type live
-// in the top-level `graphforge-api` crate, not here: `graphforge-core` is the foundation crate
-// that every other crate depends on, so it cannot depend on the pipeline crates
-// (`graphforge-cypher`/`graphforge-rel`/`graphforge-exec`) the facade needs without a dependency cycle.
+// The `GraphForge` engine facade lives in the top-level `graphforge-api` crate.
+// Pipeline crates depend on `graphforge-core`, so core cannot depend on the
+// compiler and execution crates the facade needs without a dependency cycle.
 // See #716 / #583. `graphforge-core` keeps the shared value types below
 // ([`GfError`], [`OntologyMode`], [`NodeHandle`], [`RankOptions`], …) that the
 // facade composes.

--- a/docs/book/architecture/overview.md
+++ b/docs/book/architecture/overview.md
@@ -236,6 +236,12 @@ graphforge.query_id = "01J..."
 These annotations survive IPC serialization and Parquet round-trips, which is why Arrow is
 the correct contract for tabular results rather than a Polars or Python-specific result type.
 
+The unused string-column `graphforge_api::RecordBatch` interim type is removed
+for v0.6.0. Query results continue to expose Arrow batches through
+`ExecutionResult`; Rust table consumers use `arrow::record_batch::RecordBatch`.
+Metadata lists, counts, and explanations retain their public collection,
+scalar, and string return types.
+
 ### Control and construction plane (intentional non-Arrow returns)
 
 Not every public method is a tabular data operation. The Rust facade

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 376)
+        self.assertEqual(len(GATE.public_methods()), 375)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "87c96476a9ec9403f5d95afc57a2029979e6627903111fd3995329c93aec5a6b",
+  "public_method_digest": "932d8d9c7edf3f4aac04695933b01600e47a637f5aa332ca86ed53cb9989515d",
   "method_policy": {
     "receiver_defaults": {
       "GraphForge": "release-tested",
@@ -26,7 +26,6 @@
     "MultiOntologyError": "introspection",
     "PageToken": "introspection",
       "ProviderRerankedFindResult": "introspection",
-      "RecordBatch": "introspection",
       "ResolvedBeliefProjection": "introspection",
       "SearchIndexOptions": "introspection",
       "ExecutionResourcePolicy": "introspection"


### PR DESCRIPTION
The unused `graphforge_api::RecordBatch` defines a second, string-column batch vocabulary even though supported query and table paths already return Arrow. Remove it and migrate its only repository consumers: BDD fixtures now retain the actual metadata lists, `u64` counts, and explanation strings returned by public methods. Arrow-backed query/analyst results continue through their existing types. Document the v0.6.0 source cleanup.

Validation on OVHC-AGENCY using an isolated Cargo target and ext4-rooted TMPDIR:
- `cargo test -p graphforge-api --lib`: 677 passed, none ignored.
- `cargo test -p graphforge-api --test bdd`: 118 required API scenarios passed; all 3,897 TCK baseline scenarios passed, zero regressions.
- `cargo clippy --workspace -- -D warnings`, final `cargo fmt --all -- --check`, and `make gate-registry-check`: passed.
- `make pre-push-fast`: passed after rebasing onto the merged lock-consistency fix (#1103), including non-mutating locked resolution.
- Final surface inventory removes only `RecordBatch.empty`: 375 methods remain. Its digest is updated consistently in the Rust manifest and Python inventory assertion; all 12 policy tests and static classification pass. The final inventory-only commit does not change the Rust implementation tested above.
- Independent review of the complete final diff, including the inventory update, found no actionable issues. No new local native Python or Node conformance is claimed; those checks use the PR's native CI lanes.

Fixes #1024

Rebased unchanged after #1123 merged the independently verified process-global test-counter isolation fix. The previous failed run is documented in #1122; both original zero-read assertions remain intact. Final `make pre-push-fast` passed. Exact-head CI passed at `71d3bc2a84848f14972c84ee097b566d9b9adffb`, including authoritative Bazel Rust tests, binding conformance, platform durability, concurrency matrix, and CI Gate. Squash merged; issue #1024 is closed.
