### PR TITLE
fix(build): separate Python extension and Rust test linkage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -535,6 +535,11 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
 
+      - name: Validate Python test and extension build modes
+        run: |
+          python3 scripts/ci/python-build-mode-check.py
+          python3 scripts/ci/test-python-build-mode-check.py
+
       - name: Run Clippy
         run: cargo clippy --workspace -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,9 @@ tantivy = { version = "=0.26.1", default-features = false, features = ["mmap", "
 lalrpop-util = "0.23"
 logos = "0.16"
 
-# Python binding. NOTE: the `extension-module` feature is scoped to the
-# `graphforge-bindings-py` crate (not enabled here), because it suppresses libpython
-# linkage for ALL crates that share this workspace dep — which would break
-# `cargo test`/embedded-Python use elsewhere.
+# Python binding. Distribution-only extension mode is an opt-in feature of
+# graphforge-bindings-py. It must not enter the default workspace feature graph:
+# Cargo unification would suppress libpython linkage for Rust test executables.
 pyo3 = { version = "0.28" }
 
 # Node binding

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,6 +27,20 @@ use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")
 
 crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
+# Bazel models the Python distribution cdylib. Keep its extension-only build
+# environment explicit instead of enabling a Cargo feature for all Rust tests.
+crate.annotation(
+    crate = "pyo3",
+    build_script_env = {"PYO3_BUILD_EXTENSION_MODULE": "1"},
+)
+crate.annotation(
+    crate = "pyo3-build-config",
+    build_script_env = {"PYO3_BUILD_EXTENSION_MODULE": "1"},
+)
+crate.annotation(
+    crate = "pyo3-ffi",
+    build_script_env = {"PYO3_BUILD_EXTENSION_MODULE": "1"},
+)
 crate.from_cargo(
     name = "crates",
     cargo_lockfile = "//:Cargo.lock",

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,8 @@ pre-push-fast:  ## Run fast checks only — format, lint, type, security, docstr
 	@echo "━━━ Bazelisk preflight + Cargo/Bazel drift ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@command -v bazelisk >/dev/null || (echo "bazelisk is required on PATH; see docs/development/bazel.md"; exit 1)
 	@python3 scripts/ci/cargo-bazel-drift-check.py
+	@python3 scripts/ci/python-build-mode-check.py
+	@python3 scripts/ci/test-python-build-mode-check.py
 	@echo "━━━ Public API BDD policy ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@python3 scripts/ci/api-bdd-policy.py --check-issues
 	@python3 scripts/ci/test-api-bdd-policy.py

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "037b1a5c1dc3799576a30eb1ae9e1e4892f4c81b0c5de82a3929bd4d7ebaebb1",
+  "checksum": "7c859f51d46c760db444076d608ec0dfd2143f694233968bab5e5a995296e66c",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -21369,7 +21369,6 @@
             "abi3-py313",
             "abi3-py314",
             "default",
-            "extension-module",
             "macros",
             "pyo3-macros"
           ],
@@ -21444,6 +21443,12 @@
             }
           ],
           "selects": {}
+        },
+        "build_script_env": {
+          "common": {
+            "PYO3_BUILD_EXTENSION_MODULE": "1"
+          },
+          "selects": {}
         }
       },
       "license": "MIT OR Apache-2.0",
@@ -21503,7 +21508,6 @@
             "abi3-py313",
             "abi3-py314",
             "default",
-            "extension-module",
             "resolve-config"
           ],
           "selects": {}
@@ -21543,6 +21547,12 @@
               "target": "target_lexicon"
             }
           ],
+          "selects": {}
+        },
+        "build_script_env": {
+          "common": {
+            "PYO3_BUILD_EXTENSION_MODULE": "1"
+          },
           "selects": {}
         }
       },
@@ -21602,8 +21612,7 @@
             "abi3-py312",
             "abi3-py313",
             "abi3-py314",
-            "default",
-            "extension-module"
+            "default"
           ],
           "selects": {}
         },
@@ -21642,6 +21651,12 @@
               "target": "pyo3_build_config"
             }
           ],
+          "selects": {}
+        },
+        "build_script_env": {
+          "common": {
+            "PYO3_BUILD_EXTENSION_MODULE": "1"
+          },
           "selects": {}
         },
         "links": "python"
@@ -31919,6 +31934,7 @@
             "Win32_System",
             "Win32_System_Console",
             "Win32_System_IO",
+            "Win32_System_Ioctl",
             "Win32_System_Memory",
             "Win32_System_Pipes",
             "Win32_System_SystemServices",

--- a/crates/graphforge-bindings-py/BUILD.bazel
+++ b/crates/graphforge-bindings-py/BUILD.bazel
@@ -32,8 +32,8 @@ filegroup(
 gf_rust_shared_library(
     name = "graphforge_bindings_py",
     crate_name = "graphforge_bindings_py",
-    # abi3-py310 + extension-module are selected via crate_universe feature
-    # unification from this package's Cargo.toml (see cargo-bazel-lock.json).
+    # ABI3 comes from Cargo.toml; extension-build mode is scoped explicitly to
+    # PyO3's Bazel build scripts in MODULE.bazel (see cargo-bazel-lock.json).
     # Mirror `.cargo/config.toml` apple rustflags so PyO3 extension-module
     # symbols resolve at Python load time (not link time).
     rustc_flags = select({

--- a/crates/graphforge-bindings-py/Cargo.toml
+++ b/crates/graphforge-bindings-py/Cargo.toml
@@ -11,6 +11,10 @@ repository.workspace = true
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+# Distribution builds opt in; ordinary Rust tests must link libpython.
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
 graphforge-api = { version = "0.5.2", path = "../graphforge-api" }
 graphforge-cli = { version = "0.5.2", path = "../graphforge-cli" }
@@ -24,11 +28,12 @@ arrow = { workspace = true, features = ["pyarrow"] }
 serde.workspace = true
 serde_json.workspace = true
 uuid = { workspace = true }
-# `extension-module` is enabled HERE only (a Python extension must not link
-# libpython); keeping it off the workspace dep avoids breaking other crates.
+# Keep extension mode out of the default dependency graph: Cargo unifies
+# dependency features across the workspace, including Rust test executables.
+# Maturin explicitly enables our extension-module feature for distribution.
 # `abi3-py310` builds a single stable-ABI wheel that installs on CPython 3.10+,
 # so one wheel per OS covers the whole py3.10–3.14 CI matrix.
-pyo3 = { workspace = true, features = ["extension-module", "abi3-py310"] }
+pyo3 = { workspace = true, features = ["abi3-py310"] }
 
 [lints]
 workspace = true

--- a/crates/graphforge-bindings-py/pyproject.toml
+++ b/crates/graphforge-bindings-py/pyproject.toml
@@ -45,5 +45,5 @@ python-source = "python"
 profile = "release"
 # Only build the Python extension module, not the whole workspace.
 # abi3-py310 → one stable-ABI wheel per OS covers the whole py3.10–3.14 matrix.
-features = ["pyo3/extension-module", "pyo3/abi3-py310"]
+features = ["extension-module"]
 include = ["python/graphforge/_project_skills/**/*"]

--- a/docs/development/bazel.md
+++ b/docs/development/bazel.md
@@ -118,6 +118,47 @@ python3 scripts/ci/bazel-migration-ledger-check.py
 - Do not hand-edit `@crates` labels to diverge from lock state — the drift
   check must stay green.
 
+### Python test and extension build modes
+
+Python Rust tests are executables and must link to libpython. Distribution
+extensions resolve Python symbols when loaded by the interpreter and must not
+link libpython on Unix. The same ABI3 (Python 3.10+) contract applies in both modes.
+
+| Build | Link mode |
+|---|---|
+| Ordinary `cargo test` / `cargo llvm-cov` | Default features retain ABI3 and link libpython |
+| `maturin build` / `maturin develop` | The binding's `pyproject.toml` explicitly selects its `extension-module` feature |
+| Bazel Python cdylib | `MODULE.bazel` scopes `PYO3_BUILD_EXTENSION_MODULE` to the PyO3 build scripts |
+
+Do not enable `pyo3/extension-module` in an unconditional Cargo dependency or
+default feature. Cargo unifies dependency features across the workspace, so
+that would break the binding's Rust tests and the ordinary workspace coverage
+command. Do not export `PYO3_BUILD_EXTENSION_MODULE` globally: PyO3 treats its
+presence as enabled, even if its value is `0`. A manual Cargo distribution
+build must opt in with `--features graphforge-bindings-py/extension-module`.
+
+For native Rust tests, select a supported interpreter with its shared development
+library available. On Linux, a managed interpreter's library directory also
+needs to be visible to the runtime loader (as on OVHC-AGENCY):
+
+```bash
+uv python install 3.12
+python_test_exe="$(uv python find 3.12)"
+python_test_libdir="$("$python_test_exe" -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
+PYO3_PYTHON="$python_test_exe" \
+  LD_LIBRARY_PATH="$python_test_libdir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+  CARGO_TARGET_DIR=target/python-tests \
+  cargo test -p graphforge-bindings-py --lib
+```
+
+`scripts/ci/python-build-mode-check.py` inspects the actual default and packaging
+Cargo feature graphs and the generated Bazel build-script environments. It runs
+in the fast local gate and required Rust Quality job before Clippy. Refresh the
+Cargo/Bazel lock and feature fingerprint after intentionally changing either
+mode. Test builds, a real native import, and inspection of the distribution
+artifact's dynamic dependencies remain required evidence when changing linkage;
+a successful cdylib build alone does not prove the Rust-test executable links.
+
 ### Tests, fixtures, and generated inputs
 
 - Unit tests: `gf_rust_test` next to the library.

--- a/scripts/ci/python-build-mode-check.py
+++ b/scripts/ci/python-build-mode-check.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Keep Python extension linkage separate from ordinary Cargo Rust tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Any
+
+import tomllib
+
+PYO3_CRATES = {"pyo3", "pyo3-ffi", "pyo3-build-config"}
+EXTENSION_ENV = "PYO3_BUILD_EXTENSION_MODULE"
+
+
+def validate_metadata(metadata: dict[str, Any], *, extension: bool) -> None:
+    """Inspect resolved features, including indirect/default feature activation."""
+    binding = [
+        package for package in metadata["packages"] if package["name"] == "graphforge-bindings-py"
+    ]
+    if len(binding) != 1 or not any(
+        "cdylib" in target["kind"] and target.get("test", False) for target in binding[0]["targets"]
+    ):
+        raise ValueError("Python binding Rust lib tests must remain enabled")
+    names = {package["id"]: package["name"] for package in metadata["packages"]}
+    found = set()
+    for node in metadata["resolve"]["nodes"]:
+        name = names[node["id"]]
+        if name not in PYO3_CRATES:
+            continue
+        found.add(name)
+        features = set(node["features"])
+        if ("extension-module" in features) != extension:
+            mode = "extension packaging" if extension else "ordinary Rust tests"
+            raise ValueError(f"{name}: incorrect extension-module feature for {mode}")
+        if "abi3-py310" not in features:
+            raise ValueError(f"{name}: Python 3.10+ ABI3 contract is missing")
+    if found != PYO3_CRATES:
+        raise ValueError(f"missing resolved PyO3 crates: {sorted(PYO3_CRATES - found)}")
+
+
+def validate_bazel(lock: dict[str, Any]) -> None:
+    """Require explicit extension mode in every generated PyO3 build script."""
+    found = set()
+    for crate in lock["crates"].values():
+        name = crate["name"]
+        if name not in PYO3_CRATES:
+            continue
+        found.add(name)
+        environment = crate.get("build_script_attrs", {}).get("build_script_env", {})
+        # PyO3 treats presence as enabled, even when a caller writes "0".
+        if EXTENSION_ENV not in environment.get("common", {}):
+            raise ValueError(f"{name}: Bazel distribution build lacks explicit extension mode")
+    if found != PYO3_CRATES:
+        raise ValueError("Bazel lock is missing PyO3 build scripts")
+
+
+def cargo_metadata(root: Path, features: list[str] | None = None) -> dict[str, Any]:
+    command = ["cargo", "metadata", "--format-version=1", "--locked"]
+    if features is not None:
+        command += ["--manifest-path", "crates/graphforge-bindings-py/Cargo.toml"]
+        if features:
+            command += ["--features", ",".join(features)]
+    return json.loads(subprocess.check_output(command, cwd=root, text=True))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    root = parser.parse_args().root.resolve()
+    if EXTENSION_ENV in os.environ:
+        raise SystemExit(f"unset {EXTENSION_ENV} for ordinary Rust-test/coverage validation")
+    try:
+        validate_metadata(cargo_metadata(root), extension=False)
+        packaging = tomllib.loads(
+            (root / "crates/graphforge-bindings-py/pyproject.toml").read_text(encoding="utf-8")
+        )
+        features = packaging["tool"]["maturin"].get("features", [])
+        validate_metadata(cargo_metadata(root, features), extension=True)
+        validate_bazel(json.loads((root / "cargo-bazel-lock.json").read_text(encoding="utf-8")))
+    except (ValueError, KeyError, subprocess.CalledProcessError) as error:
+        raise SystemExit(f"Python build-mode check failed: {error}") from error
+    print(
+        "Python build-mode configuration valid: Cargo tests, maturin extensions, Bazel extensions"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test-python-build-mode-check.py
+++ b/scripts/ci/test-python-build-mode-check.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Regression coverage for the Cargo-test versus Python-extension boundary."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRIPT = Path(__file__).with_name("python-build-mode-check.py")
+SPEC = importlib.util.spec_from_file_location("python_build_mode_check", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+CHECK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK)
+
+
+def metadata(*, extension: bool = False) -> dict:
+    return {
+        "packages": [{"id": name, "name": name} for name in CHECK.PYO3_CRATES]
+        + [
+            {
+                "id": "binding",
+                "name": "graphforge-bindings-py",
+                "targets": [{"kind": ["cdylib"], "test": True}],
+            }
+        ],
+        "resolve": {
+            "nodes": [
+                {
+                    "id": name,
+                    "features": ["abi3-py310"] + (["extension-module"] if extension else []),
+                }
+                for name in CHECK.PYO3_CRATES
+            ]
+        },
+    }
+
+
+def bazel_lock() -> dict:
+    return {
+        "crates": {
+            name: {
+                "name": name,
+                "build_script_attrs": {
+                    "build_script_env": {"common": {CHECK.EXTENSION_ENV: "1"}, "selects": {}}
+                },
+            }
+            for name in CHECK.PYO3_CRATES
+        }
+    }
+
+
+class BuildModeTests(unittest.TestCase):
+    def test_distinct_test_and_distribution_modes(self) -> None:
+        CHECK.validate_metadata(metadata(), extension=False)
+        CHECK.validate_metadata(metadata(extension=True), extension=True)
+        CHECK.validate_bazel(bazel_lock())
+
+    def test_unconditional_or_indirect_extension_feature_fails_tests(self) -> None:
+        # Resolved nodes expose both direct dependency features and default/alias
+        # feature activation; looking only at manifest spelling misses the latter.
+        for name in CHECK.PYO3_CRATES:
+            with self.subTest(crate=name):
+                graph = metadata()
+                next(node for node in graph["resolve"]["nodes"] if node["id"] == name)[
+                    "features"
+                ].append("extension-module")
+                with self.assertRaisesRegex(ValueError, "ordinary Rust tests"):
+                    CHECK.validate_metadata(graph, extension=False)
+
+    def test_packaging_must_enable_extension_and_keep_abi3(self) -> None:
+        with self.assertRaisesRegex(ValueError, "extension packaging"):
+            CHECK.validate_metadata(metadata(), extension=True)
+        graph = metadata(extension=True)
+        graph["resolve"]["nodes"][0]["features"].remove("abi3-py310")
+        with self.assertRaisesRegex(ValueError, "ABI3"):
+            CHECK.validate_metadata(graph, extension=True)
+
+    def test_missing_resolved_crates_fail_closed(self) -> None:
+        graph = metadata()
+        graph["resolve"]["nodes"].pop()
+        with self.assertRaisesRegex(ValueError, "missing resolved"):
+            CHECK.validate_metadata(graph, extension=False)
+
+    def test_disabling_binding_rust_tests_is_not_a_linkage_fix(self) -> None:
+        graph = metadata()
+        graph["packages"][-1]["targets"][0]["test"] = False
+        with self.assertRaisesRegex(ValueError, "Rust lib tests must remain enabled"):
+            CHECK.validate_metadata(graph, extension=False)
+
+    def test_bazel_requires_every_extension_build_script(self) -> None:
+        good = bazel_lock()
+        for name in CHECK.PYO3_CRATES:
+            with self.subTest(crate=name):
+                missing = copy.deepcopy(good)
+                missing["crates"][name]["build_script_attrs"].clear()
+                with self.assertRaisesRegex(ValueError, "lacks explicit extension mode"):
+                    CHECK.validate_bazel(missing)
+        missing = copy.deepcopy(good)
+        missing["crates"].pop("pyo3-ffi")
+        with self.assertRaisesRegex(ValueError, "missing PyO3"):
+            CHECK.validate_bazel(missing)
+
+    def test_bazel_extension_environment_is_enabled_by_presence(self) -> None:
+        lock = bazel_lock()
+        lock["crates"]["pyo3-ffi"]["build_script_attrs"]["build_script_env"]["common"][
+            CHECK.EXTENSION_ENV
+        ] = "0"
+        CHECK.validate_bazel(lock)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "7bff132d4c674e4bdc233fd065ffb378e9512889b36ca1316fdd40033b9a4e13",
+  "sha256": "0e8388776ea735062c4becc7eb3ef7200fbb16b15d36ceae80b74286a1326a4d",
   "entries": [
     {
       "name": "graphforge-api",
@@ -442,7 +442,9 @@
     {
       "name": "graphforge-bindings-py",
       "version": "0.5.2",
-      "features": [],
+      "features": [
+        "extension-module"
+      ],
       "dependencies": [
         {
           "name": "arrow",
@@ -487,8 +489,7 @@
           "name": "pyo3",
           "req": "^0.28",
           "features": [
-            "abi3-py310",
-            "extension-module"
+            "abi3-py310"
           ],
           "optional": false,
           "uses_default_features": true,


### PR DESCRIPTION
Ordinary workspace Rust tests currently fail to link the Python binding test executable because its unconditional PyO3 `extension-module` feature suppresses libpython linkage. Make extension mode an explicit packaging feature, keep ABI3 enabled by default, and give Bazel's distribution build the equivalent scoped PyO3 build-script environment. Existing Python Rust tests remain enabled.

Add a required Rust Quality / fast-gate regression check against resolved Cargo feature graphs, actual maturin configuration, and the generated Bazel environment. Document supported Python development/runtime linkage on OVHC-AGENCY. Regenerate the Cargo/Bazel lock and fingerprint; the generated lock also restores the already-resolved Windows `Win32_System_Ioctl` feature (present in Cargo metadata before this change), with no dependency version changes.

Closes #1102.

Validation on OVHC-AGENCY with managed CPython 3.12.13, its development libpython, an isolated Cargo target, and four Cargo jobs:

- `cargo test -p graphforge-bindings-py --lib`: 2 passed, 0 ignored. The Rust test executable links `libpython3.12.so.1.0`; its managed library directory must be on `LD_LIBRARY_PATH` for execution.
- `cargo test --workspace --no-run`: passed, all 101 test executables built without target exclusions. This checks workspace build compatibility, not execution of the entire workspace suite. Logs confirm all 20 workspace crates compiled from this worktree.
- `cargo clippy --workspace -- -D warnings`: passed.
- `maturin build --profile dev --manifest-path crates/graphforge-bindings-py/Cargo.toml --interpreter <managed Python 3.12> --out /tmp/graphforge-1102-wheels`: passed, produced a cp310-abi3 wheel. Installed its real native artifact in a clean Python environment with PyArrow; `GraphForge().execute("RETURN 42 AS answer").to_pylist()` returned `[{"answer": 42}]`. ELF inspection found no libpython `DT_NEEDED` entry.
- `bazelisk build --jobs=4 //:python_wheel_smoke`: passed (1,438 actions). Installed that wheel separately, verified the loaded native SHA against its generated artifact evidence, and repeated the real query and ELF dependency check successfully.
- New build-mode checker rejects the unchanged baseline's unconditional extension feature; all 7 regression tests pass. Cargo/Bazel drift, `make pre-push-fast`, `make gate-registry-check`, and final `cargo fmt --all -- --check` pass.

Merged head `c31f7132` passed exact-head CI Gate, including authoritative Bazel Rust tests, native Windows/macOS durability, bindings, and concurrency. `make pre-push-fast` and `make pre-push-preflight` also passed. The native build/import checks above preceded the final rebase, which added only the architecture ADR and lock consistency fix.

Additional local workspace execution completed successfully in two parts on the same PR head. The initial `cargo test --workspace` passed API unit tests, BDD/TCK, and integration targets through `fixed_hop_limit`; merge cleanup then removed its working directory before the next target could start. After restoring that exact checkout, every remaining API integration target passed, followed by `cargo test --workspace --exclude graphforge-api` and `cargo test -p graphforge-api --doc` (exit 0). No assertions failed or new test skips were introduced. Commands and results are retained on OVHC-AGENCY in `/tmp/gf-1109-workspace-run.log` and `/tmp/gf-1109-workspace-resume.log`. Tests ran as ubuntu with an isolated ext4-backed `/tmp` mount; the host mount was unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791155436&installation_model_id=20486&pr_number=1109&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1109&signature=23018f2654bb6031f848ea6c4eccd4101ab8c1246f8393b9e2b021d8adf65222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->