### PR TITLE
ci(bench): remove unused provider image build from required PR checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1200,18 +1200,6 @@ jobs:
             tests.test_progressive_run \
             tests.test_qualification_operator
 
-      - name: Build immutable progressive qualification image
-        shell: bash
-        run: |
-          set -euo pipefail
-          source_sha=$(git rev-parse HEAD)
-          image="graphforge-progressive-qualification:${source_sha}"
-          docker build --platform linux/amd64 \
-            --build-arg "GRAPHFORGE_COMMIT=${source_sha}" \
-            --file containers/graphforge-progressive-qualification/Dockerfile \
-            --tag "$image" .
-          test "$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$image")" = "$source_sha"
-
       - name: Cargo feature drift check (fail-closed)
         run: |
           python3 scripts/ci/cargo-bazel-drift-check.py

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -434,6 +434,26 @@ real `/work` mount. The host
 must separately pass native Linux cgroups-v2 admission. The runner has no
 laptop fallback and never calls a provider API.
 
+Build the optional provider image explicitly from the repository root when
+preparing provider execution:
+
+```bash
+set -euo pipefail
+source_sha=$(git rev-parse HEAD)
+image="graphforge-progressive-qualification:${source_sha}"
+docker build --platform linux/amd64 \
+  --build-arg "GRAPHFORGE_COMMIT=${source_sha}" \
+  --file containers/graphforge-progressive-qualification/Dockerfile \
+  --tag "$image" .
+test "$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$image")" = "$source_sha"
+```
+
+This builds and verifies a local image. Provider publication and execution use
+the existing operator authorization. Required PR CI retains the static image
+contract, offline provider tests, and real tiny lifecycle through ordinary
+executables; it does not build an unused provider image. OVHC-AGENCY uses those
+native executables directly.
+
 A successful rung emits exactly `sN-plan.json`, `sN-benchexec.json`,
 `sN-graphforge.json`, `sN-rung.json`, and `sN-result.json`, all scoped to
 engineering evidence. The canonical order remains S18, S19, S20, S22, S24,


### PR DESCRIPTION
The required Bazel job built a provider image that no subsequent CI step consumed. In [run 33927431253](https://github.com/CurateLabs/graphforge/actions/runs/33927431253/job/101198952955), that build took 13m33s of the 16m43s job before authoritative Rust checks.

Remove that build from required PR CI and document its explicit manual build/revision-check command. Static image checks, offline provider tests, the real tiny public lifecycle producer, authoritative Bazel Rust tests, and binding packaging checks remain in the workflow. The optional image and native OVHC-AGENCY execution code are unchanged.

Validation passed:
- `python3 scripts/ci/test-ci-storage-policy.py`
- `python3 scripts/ci/test-progressive-qualification-image.py` and `python3 scripts/ci/test-fly-filesystem-safety-contract.py` (2 tests each)
- Existing seven offline provider/controller suites: 123 tests
- `make gate-registry-check` (registry valid, 14 tests)
- `make pre-push-fast` and `git diff --check`

Exact-head CI passed at `3e5b4e4299e46ed1f0b85bdd594e3488a295214a` ([CI Gate](https://github.com/CurateLabs/graphforge/actions/runs/33930353407/job/101209680419)). The [Bazel job](https://github.com/CurateLabs/graphforge/actions/runs/33930353407/job/101207674216) started at 23:41:12 UTC and reached authoritative Rust tests at 23:41:45; those tests passed in 17 seconds. The retained real tiny lifecycle producer passed from 23:42:02 to 23:44:09, and binding packaging passed at 23:44:09. Offline provider tests also passed. No local native rebuild was needed for these workflow/documentation changes.

Closes #1113.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791157030&installation_model_id=20486&pr_number=1114&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1114&signature=90f2e06b883b7ad7ad2bdde553191b9cde50e57fe4d0db284f238a60dd96291a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
