### PR TITLE
fix(bench): streamline native ladder execution and continuation

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-storage-qualification progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness ingest-ladder-bundle parity-gate progressive-host-ladder-plan progressive-host-ladder-run progressive-host-ladder-inventory progressive-host-ladder-reclaim
+.PHONY: install smoke smoke-python smoke-rust fly-adapter-static progressive-provider-attempt-static progressive-fly-transport-static local-admission progressive-qualification-list progressive-qualification-plan progressive-qualification-run progressive-qualification-project-s20 progressive-storage-qualification progressive-qualification-binaries progressive-provider-plan qualification-operator esc-readiness ingest-ladder-bundle parity-gate progressive-host-ladder-binaries progressive-host-ladder-plan progressive-host-ladder-run progressive-host-ladder-inventory progressive-host-ladder-reclaim
 
 install:
 	uv sync --locked
@@ -67,19 +67,14 @@ progressive-qualification-project-s20: install
 		--project-s20 --output-dir "$(OUTPUT_DIR)" \
 		--provider-capacity "$(PROVIDER_CAPACITY)"
 
+# Native host evidence is the release path. The module retains its explicit
+# image/result-anchor flags for optional historical provider bundles.
 progressive-storage-qualification: install
-	test -n "$(LOW_RUNG)" && test -n "$(HIGH_RUNG)" && test -n "$(EVIDENCE)"
-	test -n "$(COMMIT)" && test -n "$(IMAGE_DIGEST)"
-	test -n "$(LOW_RESULT_SHA256)" && test -n "$(HIGH_RESULT_SHA256)"
-	test -n "$(VOLUME_BYTES)" && test -n "$(RESERVED_HEADROOM_BYTES)"
+	test -n "$(LOW_RUNG)" && test -n "$(HIGH_RUNG)" && test -n "$(EVIDENCE)" && test -n "$(WORK_ROOT)"
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m \
 		graphforge_bench.progressive_storage_qualification \
 		"$(LOW_RUNG)" "$(HIGH_RUNG)" "$(EVIDENCE)" \
-		--commit "$(COMMIT)" --image-digest "$(IMAGE_DIGEST)" \
-		--low-result-sha256 "$(LOW_RESULT_SHA256)" \
-		--high-result-sha256 "$(HIGH_RESULT_SHA256)" \
-		--volume-bytes "$(VOLUME_BYTES)" \
-		--reserved-headroom-bytes "$(RESERVED_HEADROOM_BYTES)"
+		--work-root "$(WORK_ROOT)" --reserved-headroom-bytes "$(RESERVED_HEADROOM_BYTES)"
 
 # Safe control-plane admission only; this never provisions a provider.
 progressive-provider-plan: install
@@ -118,26 +113,32 @@ ingest-ladder-bundle: install
 # Host BenchExec must use system Python (BenchExec + pystemd). The harness venv
 # BenchExec cannot attach cgroups even inside a delegated systemd scope.
 BENCHEXEC_PYTHON ?= /usr/bin/python3
+HOST_TARGET_DIR ?= $(CURDIR)/../target-host-ladder
+MAXIMUM_SCALE ?= 26
+RESERVED_HEADROOM_BYTES ?= 80530636800
+HOST_LADDER_ARGS = --output-dir "$(OUTPUT_DIR)" --work-root "$(WORK_ROOT)" \
+	--gf "$(HOST_TARGET_DIR)/release/gf" \
+	--certify "$(HOST_TARGET_DIR)/release/graphforge-benchmark-certify" \
+	--generator "$(HOST_TARGET_DIR)/release/graphforge-benchmark-graph500-generator" \
+	--benchexec-python "$(BENCHEXEC_PYTHON)" \
+	--reserved-headroom-bytes "$(RESERVED_HEADROOM_BYTES)"
 
-progressive-host-ladder-plan: install progressive-qualification-binaries
-	test -n "$(RUNG)" && test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
-	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_host_run \
-		--rung "$(RUNG)" --output-dir "$(OUTPUT_DIR)" --work-root "$(WORK_ROOT)" --dry-run \
-		--gf "$(CURDIR)/../target/release/gf" \
-		--certify "$(CURDIR)/target/release/graphforge-benchmark-certify" \
-		--generator "$(CURDIR)/target/release/graphforge-benchmark-graph500-generator" \
-		--benchexec-python "$(BENCHEXEC_PYTHON)" \
-		$(if $(HOST_CAPACITY),--host-capacity "$(HOST_CAPACITY)",)
+progressive-host-ladder-binaries:
+	CARGO_TARGET_DIR="$(HOST_TARGET_DIR)" cargo build --locked --release --manifest-path ../Cargo.toml -p graphforge-cli
+	CARGO_TARGET_DIR="$(HOST_TARGET_DIR)" cargo build --locked --release --manifest-path Cargo.toml --bin graphforge-benchmark-certify --bin graphforge-benchmark-graph500-generator
 
-progressive-host-ladder-run: install progressive-qualification-binaries
-	test -n "$(RUNG)" && test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
+# Preview only the next admissible rung; later rungs need its real measurements.
+# Planning reads existing executables and never writes plans or projections.
+progressive-host-ladder-plan: install
+	test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
 	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_host_run \
-		--rung "$(RUNG)" --output-dir "$(OUTPUT_DIR)" --work-root "$(WORK_ROOT)" \
-		--gf "$(CURDIR)/../target/release/gf" \
-		--certify "$(CURDIR)/target/release/graphforge-benchmark-certify" \
-		--generator "$(CURDIR)/target/release/graphforge-benchmark-graph500-generator" \
-		--benchexec-python "$(BENCHEXEC_PYTHON)" \
-		$(if $(HOST_CAPACITY),--host-capacity "$(HOST_CAPACITY)",)
+		$(if $(RUNG),--rung "$(RUNG)",--maximum-scale "$(MAXIMUM_SCALE)") $(HOST_LADDER_ARGS) --dry-run
+
+# Resolve/build once, then sequentially advance, accept evidence, and reclaim.
+progressive-host-ladder-run: install progressive-host-ladder-binaries
+	test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"
+	PYTHONPATH=$(CURDIR)/harness uv run --locked python -m graphforge_bench.progressive_host_run \
+		$(if $(RUNG),--rung "$(RUNG)",--maximum-scale "$(MAXIMUM_SCALE)") $(HOST_LADDER_ARGS)
 
 progressive-host-ladder-inventory: install
 	test -n "$(OUTPUT_DIR)" && test -n "$(WORK_ROOT)"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -318,20 +318,37 @@ OUTPUT_DIR=$WORK_ROOT/evidence
 GRAPHFORGE_ADMISSION_EVIDENCE=$PWD/benchmarks/outputs/local-admission-evidence.json GRAPHFORGE_EXPECTED_UID=$(id -u) GRAPHFORGE_SYSTEMD_SCOPE_MODE=user GRAPHFORGE_SYSTEMD_SCOPE=gf-admit.scope   systemd-run --user --scope --slice=benchexec -p Delegate=yes --unit=gf-admit   "$PWD/benchmarks/scripts/run-delegated-local-admission.sh"
 ```
 
-Execute rungs sequentially. `WORK_ROOT` must share the process-root filesystem
-device with `/` (ext4 on OVHC-AGENCY). Do not use `/tmp` (tmpfs). Host runs
-default to `--benchexec-python /usr/bin/python3` (BenchExec + pystemd); the
-locked harness venv BenchExec cannot attach cgroups under a delegated scope.
-Product RSS remains the 4 GiB process VmHWM envelope; host BenchExec uses a
-raised cgroup kill ceiling so durable NVMe page cache does not false-OOM.
+Run the sequential ladder to the chosen maximum with one command. `WORK_ROOT`
+must share the process-root filesystem device with `/` (ext4 on OVHC-AGENCY);
+`/tmp` is tmpfs on this host. The command builds the three executables once in
+an isolated `HOST_TARGET_DIR`, resolves them once, and advances
+S18 → S19 → S20 → S22 → S24 → S25 → S26. Each rung uses native admission and
+ordinary BenchExec lifecycle/reopen evidence. A typed failure stops advancement
+and retains its artifacts; accepted rung datasets are reclaimed automatically.
 
 ```bash
-make -C benchmarks progressive-host-ladder-run   RUNG=S18 OUTPUT_DIR=$OUTPUT_DIR WORK_ROOT=$WORK_ROOT
-# after accepted evidence:
-make -C benchmarks progressive-host-ladder-reclaim   RUNG_SCALE=18 OUTPUT_DIR=$OUTPUT_DIR WORK_ROOT=$WORK_ROOT
-# S20+ also requires:
-#   HOST_CAPACITY=benchmarks/fixtures/progressive/ovhc-agency-host-capacity.json
+make -C benchmarks progressive-host-ladder-run \
+  MAXIMUM_SCALE=26 OUTPUT_DIR="$OUTPUT_DIR" WORK_ROOT="$WORK_ROOT" \
+  RESERVED_HEADROOM_BYTES=80530636800
 ```
+
+The reserve is 75 GiB by default. Before each launch, admission measures free
+space available to the current user on the actual work-root filesystem.
+S20+ projects storage and work from the declared adjacent completed rungs;
+throughput comes from their measured counters and elapsed time. No manual
+rate certificate or fixed provider volume limit applies. Product RSS remains
+the 4 GiB process VmHWM envelope, including its plateau check; the separate
+BenchExec cgroup kill ceiling accommodates durable page cache. A refused RSS
+projection is a real fix to investigate, not permission to relax that envelope.
+
+With existing binaries, `progressive-host-ladder-plan` previews the next rung
+without creating plans, projections, or an evidence directory. It accepts the
+same arguments as the run command, so preview → run works unchanged. Later
+rungs require actual measurements and cannot be fabricated by planning.
+`RUNG=S20` remains available to execute only the next selected rung. Existing
+passed evidence is validated before continuation; failed attempts are retained
+for diagnosis. Native execution has no Fly image, spend, or provider teardown
+requirement.
 
 Terminal teardown proof:
 
@@ -583,24 +600,19 @@ orchestration:
 
 ```bash
 make -C benchmarks progressive-storage-qualification \
-  LOW_RUNG=/evidence/s20-rung.json HIGH_RUNG=/evidence/s22-rung.json \
-  EVIDENCE=/evidence/g500-ladder-qualification.json \
-  COMMIT=$(git rev-parse HEAD) \
-  IMAGE_DIGEST=registry.fly.io/graphforge-bench@sha256:<64-hex-digest> \
-  LOW_RESULT_SHA256=<independently-recorded-s20-result-sha256> \
-  HIGH_RESULT_SHA256=<independently-recorded-s22-result-sha256> \
-  VOLUME_BYTES=536870912000 RESERVED_HEADROOM_BYTES=53687091200
+  LOW_RUNG="$OUTPUT_DIR/s20-rung.json" HIGH_RUNG="$OUTPUT_DIR/s22-rung.json" \
+  EVIDENCE="$OUTPUT_DIR/g500-ladder-qualification.json" \
+  WORK_ROOT="$WORK_ROOT" RESERVED_HEADROOM_BYTES=80530636800
 ```
 
-Each rung path must be accompanied by its canonical provider plan, BenchExec,
-GraphForge, and passed result files in the same evidence directory. The adapter
-first verifies each result against its independently supplied SHA-256 trust
-anchor, then verifies the result-owned artifact digests and exact
-commit/profile/image identities. The anchors must come from trusted transport
-metadata or an immutable manifest outside the evidence directory, never from
-the bundle being qualified. The adapter preserves integer numerators and
-denominators, recomputes all reconciliations, and emits `refuse` when the
-projected S26 lifecycle peak lacks the requested storage headroom.
+Each native rung path is accompanied by its plan, BenchExec, GraphForge, and
+passed result documents. The consumer verifies result-owned artifact digests,
+matching execution identities, and ordinary receipts, and checks that the two
+rung workspaces were reclaimed. Capacity is measured on `WORK_ROOT` with the
+specified reserve. The terminal inventory remains the independent whole-work-root
+cleanup record. Historical provider bundles retain the module's explicit
+image/result-anchor mode as optional tooling; native results require no external
+manifest or manual SHA certificate.
 
 ## Native local admission deployment
 

--- a/benchmarks/harness/graphforge_bench/native_rung.py
+++ b/benchmarks/harness/graphforge_bench/native_rung.py
@@ -1,0 +1,123 @@
+"""Validate one ordinary native rung for controller and evidence consumers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from graphforge_bench.progressive_qualification import PHASES
+from graphforge_bench.progressive_run import ControllerError, assemble_rung_evidence
+
+
+class NativeRungError(ControllerError):
+    """A native result or its ordinary lifecycle evidence is contradictory."""
+
+
+def _read(path: Path) -> dict[str, Any]:
+    try:
+        if path.is_symlink():
+            raise NativeRungError(f"linked evidence: {path.name}")
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError) as error:
+        raise NativeRungError(f"invalid evidence: {path.name}") from error
+    if not isinstance(value, dict):
+        raise NativeRungError(f"evidence is not an object: {path.name}")
+    return value
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def read_native_rung(root: Path, source: Path, scale: int) -> dict[str, Any]:
+    """Check hashes, immutable identities, exact phase success, and ordinary receipts.
+
+    Returns the original documents, so callers can consume the same validated
+    result and projection without maintaining a separate validation protocol.
+    """
+    documents = {}
+    for kind, schema in (
+        ("result", "progressive-host-run-result.json"),
+        ("plan", "progressive-host-run-plan.json"),
+        ("benchexec", "benchexec-run-evidence.json"),
+        ("graphforge", "certification-evidence.json"),
+        ("rung", "progressive-qualification-rung-evidence.json"),
+    ):
+        value = _read(source / f"s{scale}-{kind}.json")
+        error = next(
+            Draft202012Validator(_read(root / "schemas" / schema)).iter_errors(value), None
+        )
+        if error:
+            raise NativeRungError(f"S{scale} {kind} schema: {error.message}")
+        documents[kind] = value
+    result, plan, rung = (documents[kind] for kind in ("result", "plan", "rung"))
+    identities = result["identities"]
+    if (
+        result["status"] != "passed"
+        or result["rung"] != f"S{scale}"
+        or plan["rung"] != result["rung"]
+        or plan["identities"] != identities
+    ):
+        raise NativeRungError(f"S{scale} plan/result identity mismatch")
+    expected_artifacts = {
+        f"{kind}_sha256": _digest(source / f"s{scale}-{kind}.json")
+        for kind in ("plan", "benchexec", "graphforge", "rung")
+    }
+    if result["artifacts"] != expected_artifacts:
+        raise NativeRungError(f"S{scale} artifact digest mismatch")
+    profile = f"graph500-s{scale}-{'local' if scale < 20 else 'provider'}"
+    graphforge, benchexec = documents["graphforge"], documents["benchexec"]
+    if (
+        identities["profile_id"] != profile
+        or rung["profile_id"] != profile
+        or rung["scale"] != scale
+        or rung["status"] != "passed"
+        or not rung["correctness"]
+        or rung["phases"] != list(PHASES)
+        or benchexec["outcome"] != "passed"
+        or graphforge["status"] != "passed"
+        or benchexec["graphforge"] != graphforge
+        or [phase["phase"] for phase in graphforge["phases"]] != list(PHASES)
+        or any(phase["status"] != "passed" for phase in graphforge["phases"])
+        or graphforge["profile_id"] != profile
+    ):
+        raise NativeRungError(f"S{scale} lifecycle evidence contradicts success")
+    try:
+        derived = assemble_rung_evidence(
+            root=root,
+            scale=scale,
+            graphforge=graphforge,
+            benchexec=benchexec,
+            profile_id=profile,
+            source="progressive_profile" if scale < 20 else "canonical_ladder",
+        )
+    except (ValueError, KeyError, TypeError) as error:
+        raise NativeRungError(f"S{scale} ordinary lifecycle receipts invalid: {error}") from error
+    if derived != rung:
+        raise NativeRungError(f"S{scale} stored summary contradicts ordinary lifecycle receipts")
+    if scale == 26 and derived["live_edges"] < 1_000_000_000:
+        raise NativeRungError("S26 has fewer than one billion live persisted edges")
+    if scale >= 20:
+        path = source / f"s{scale}-projection.json"
+        projection = _read(path)
+        error = next(
+            Draft202012Validator(
+                _read(root / "schemas/progressive-qualification-evidence.json")
+            ).iter_errors(projection),
+            None,
+        )
+        sources = {20: [18, 19], 22: [19, 20], 24: [20, 22], 25: [22, 24], 26: [24, 25]}
+        if (
+            error
+            or _digest(path) != identities["admitted_projection_sha256"]
+            or projection["target"] != f"S{scale}"
+            or projection["decision"] != "admitted"
+            or projection["source_scales"] != sources[scale]
+        ):
+            raise NativeRungError(f"S{scale} admission projection mismatch")
+        documents["projection"] = projection
+    return documents

--- a/benchmarks/harness/graphforge_bench/progressive_host_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_host_run.py
@@ -87,8 +87,37 @@ def producer_files(root: Path) -> list[Path]:
 
 def producer_digest(root: Path, *, commit: str | None = None) -> str:
     """Bind producer behavior automatically; documentation changes are excluded."""
+    paths = set(producer_files(root))
+    if commit is not None:
+        package = root / "harness/graphforge_bench"
+        recorded_paths = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root.parent),
+                "ls-tree",
+                "-r",
+                "--name-only",
+                "-z",
+                commit,
+                "--",
+                "benchmarks/harness/graphforge_bench",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if recorded_paths.returncode:
+            raise HostRunError("host_prefix_producer_identity_mismatch")
+        # Legacy receipts have no stored producer digest. Enumerate their tree,
+        # not today's files, so deleted runtime helpers remain part of the hash.
+        paths = {path for path in paths if not path.is_relative_to(package)}
+        paths.update(
+            root.parent / name.decode("utf-8")
+            for name in recorded_paths.stdout.split(b"\0")
+            if name.endswith(b".py")
+        )
     digest = hashlib.sha256()
-    for path in producer_files(root):
+    for path in sorted(paths):
         relative = path.relative_to(root).as_posix()
         if commit is None:
             content = path.read_bytes()

--- a/benchmarks/harness/graphforge_bench/progressive_host_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_host_run.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping, Sequence
+import hashlib
 from importlib.metadata import PackageNotFoundError, version
 import json
 from pathlib import Path
@@ -20,6 +21,7 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
+from graphforge_bench.native_rung import read_native_rung
 from graphforge_bench.progressive_qualification import (
     QualificationError,
     load_profiles,
@@ -45,17 +47,62 @@ HOST_PROFILE_ID = "local-linux-cgroups-v2"
 LADDER = (18, 19, 20, 22, 24, 25, 26)
 LOCAL_SCALES = (18, 19)
 PROVIDER_SCALES = (20, 22, 24, 25, 26)
-CAPACITY_RATE_FIELDS = (
-    "physical_read_bytes_per_second",
-    "physical_write_bytes_per_second",
-    "reader_calls_per_second",
-    "publication_work_per_second",
-)
+DEFAULT_RESERVE_BYTES = 75 * 1024**3
 SYSTEM_BENCHEXEC_PYTHON = Path("/usr/bin/python3")
 
 
 class HostRunError(ControllerError):
     """Host-native ladder planning or execution refused."""
+
+    def __init__(self, code: str, *, rung: str | None = None, projection: Any = None):
+        super().__init__(code)
+        self.rung = rung
+        self.projection = projection
+
+
+def producer_files(root: Path) -> list[Path]:
+    """Hash the runtime package boundary, excluding docs, tests, and outputs.
+
+    Include all package sources rather than guessing an import closure: relative
+    imports, dynamic helpers, and executable admission fixtures are runtime code.
+    """
+    paths = set((root / "harness/graphforge_bench").rglob("*.py"))
+    paths.update(
+        root / name
+        for name in (
+            "definitions/graphforge-progressive-qualification-v1.xml",
+            "pyproject.toml",
+            "uv.lock",
+            "schemas/progressive-host-run-plan.json",
+            "schemas/progressive-host-run-result.json",
+            "schemas/progressive-qualification-profile.json",
+            "schemas/progressive-qualification-evidence.json",
+            "schemas/progressive-qualification-rung-evidence.json",
+            "schemas/certification-evidence.json",
+            "schemas/benchexec-run-evidence.json",
+        )
+    )
+    return sorted(paths)
+
+
+def producer_digest(root: Path, *, commit: str | None = None) -> str:
+    """Bind producer behavior automatically; documentation changes are excluded."""
+    digest = hashlib.sha256()
+    for path in producer_files(root):
+        relative = path.relative_to(root).as_posix()
+        if commit is None:
+            content = path.read_bytes()
+        else:
+            recorded = subprocess.run(
+                ["git", "-C", str(root.parent), "show", f"{commit}:benchmarks/{relative}"],
+                capture_output=True,
+                check=False,
+            )
+            if recorded.returncode:
+                raise HostRunError("host_prefix_producer_identity_mismatch")
+            content = recorded.stdout
+        digest.update(relative.encode("utf-8") + b"\0" + hashlib.sha256(content).digest())
+    return digest.hexdigest()
 
 
 def resolve_host_benchexec_python(candidate: Path | None = None) -> Path:
@@ -142,6 +189,21 @@ def load_host_capacity(root: Path, path: Path) -> Mapping[str, Any]:
     return document
 
 
+def measure_host_capacity(work_root: Path, reserved_headroom_bytes: int) -> dict[str, int]:
+    """Measure space available to this user on the actual work-root filesystem."""
+    if isinstance(reserved_headroom_bytes, bool) or reserved_headroom_bytes < 0:
+        raise HostRunError("work_root_capacity_invalid")
+    free = shutil.disk_usage(work_root).free
+    if free <= reserved_headroom_bytes:
+        raise HostRunError("work_root_capacity_refused")
+    return {"free_bytes": free, "reserved_headroom_bytes": reserved_headroom_bytes}
+
+
+def validated_host_rung(root: Path, output_dir: Path, scale: int) -> Mapping[str, Any]:
+    """Read the shared native receipt validation used by all native consumers."""
+    return read_native_rung(root, output_dir, scale)["rung"]
+
+
 def _passed_rung(root: Path, output_dir: Path, scale: int) -> Mapping[str, Any] | None:
     path = output_dir / f"s{scale}-rung.json"
     if not path.exists():
@@ -162,6 +224,7 @@ def _passed_rung(root: Path, output_dir: Path, scale: int) -> Mapping[str, Any] 
 def completed_prefix(root: Path, output_dir: Path) -> list[Mapping[str, Any]]:
     completed: list[Mapping[str, Any]] = []
     gap = False
+    shared_identity = None
     for scale in LADDER:
         rung = _passed_rung(root, output_dir, scale)
         if rung is None:
@@ -169,10 +232,16 @@ def completed_prefix(root: Path, output_dir: Path) -> list[Mapping[str, Any]]:
             continue
         if gap:
             raise HostRunError("rung evidence is out of order")
-        result = _json(output_dir / f"s{scale}-result.json")
-        _validate(root, "progressive-host-run-result.json", result)
-        if result.get("status") != "passed" or result.get("rung") != f"S{scale}":
-            raise HostRunError(f"S{scale} host result contradicts passed rung evidence")
+        validated_host_rung(root, output_dir, scale)
+        identities = _json(output_dir / f"s{scale}-result.json")["identities"]
+        shared = {
+            key: value
+            for key, value in identities.items()
+            if key not in {"profile_id", "profile_sha256", "admitted_projection_sha256"}
+        }
+        if shared_identity is not None and shared != shared_identity:
+            raise HostRunError("host_prefix_identity_mismatch")
+        shared_identity = shared
         completed.append(rung)
     return completed
 
@@ -196,17 +265,15 @@ def _admit_projection(
     profiles = load_profiles(root / "profiles" / "graph500")
     profile = next(item for item in profiles if item.scale == scale)
     completed = completed_prefix(root, output_dir)
-    rates = {name: int(capacity[name]) for name in CAPACITY_RATE_FIELDS}
     try:
-        evidence = project(profile, completed, rates)
+        evidence = project(profile, completed, native_capacity=capacity)
     except QualificationError as error:
         raise HostRunError("projection_refused") from error
     _validate(root, "progressive-qualification-evidence.json", evidence)
     if evidence.get("decision") != "admitted":
-        raise HostRunError("projection_refused")
-    path = output_dir / f"s{scale}-projection.json"
-    publish_json_no_clobber(path, evidence)
-    return evidence, _digest(path)
+        raise HostRunError("projection_refused", rung=f"S{scale}", projection=evidence)
+    encoded = (json.dumps(evidence, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    return evidence, hashlib.sha256(encoded).hexdigest()
 
 
 def build_plan(
@@ -217,6 +284,7 @@ def build_plan(
     commit: str,
     executables: Executables,
     capacity: Mapping[str, Any] | None,
+    projection: tuple[dict[str, Any], str] | None = None,
 ) -> dict[str, Any]:
     require_order(root, output_dir, scale)
     profile_path = _profile_path(root, scale)
@@ -234,6 +302,7 @@ def build_plan(
     host_profile_path = root / "profiles" / f"{HOST_PROFILE_ID}.json"
     identities: dict[str, Any] = {
         "commit": commit,
+        "producer_sha256": producer_digest(root),
         "host_profile_id": HOST_PROFILE_ID,
         "host_profile_sha256": _digest(host_profile_path),
         "profile_id": profile["id"],
@@ -248,7 +317,7 @@ def build_plan(
     if scale in PROVIDER_SCALES:
         if capacity is None:
             raise HostRunError("host capacity is required before S20+")
-        _, projection_digest = _admit_projection(root, output_dir, scale, capacity)
+        _, projection_digest = projection or _admit_projection(root, output_dir, scale, capacity)
         identities["admitted_projection_sha256"] = projection_digest
     plan = {
         "schema": PLAN_SCHEMA,
@@ -265,6 +334,8 @@ def build_plan(
         ],
         "claim": "engineering_evidence_only",
     }
+    if capacity is not None:
+        plan["work_root_capacity"] = dict(capacity)
     _validate(root, "progressive-host-run-plan.json", plan)
     return plan
 
@@ -457,13 +528,129 @@ def run(
     publish_json_no_clobber(result_path, passed)
 
 
+def execute_ladder(
+    *,
+    root: Path,
+    output_dir: Path,
+    work_root: Path,
+    maximum_scale: int,
+    executables: Executables,
+    commit: str,
+    reserved_headroom_bytes: int,
+    dry_run: bool = False,
+    rung: int | None = None,
+) -> list[dict[str, Any]]:
+    """Advance the existing ladder once, stopping before any successor on failure."""
+    completed = completed_prefix(root, output_dir)
+    next_index = len(completed)
+    if rung is not None:
+        require_order(root, output_dir, rung)
+        scales = [rung]
+    else:
+        scales = list(LADDER[next_index : LADDER.index(maximum_scale) + 1])
+    shared_identity = None
+    if completed:
+        previous = _json(output_dir / f"s{int(completed[0]['scale'])}-result.json")["identities"]
+        shared_identity = {
+            key: value
+            for key, value in previous.items()
+            if key not in {"profile_id", "profile_sha256", "admitted_projection_sha256"}
+        }
+        # Documentation-only checkout changes do not invalidate existing binaries.
+        # Continue with the original recorded commit after verifying all producer
+        # and input identities below, rather than relabelling old measurements.
+        commit = previous["commit"]
+        current_producer = producer_digest(root)
+        recorded_producer = previous.get("producer_sha256")
+        if recorded_producer is None:
+            recorded_producer = producer_digest(root, commit=commit)
+        if current_producer != recorded_producer:
+            raise HostRunError("host_prefix_producer_identity_mismatch")
+        expected = {
+            "host_profile_sha256": _digest(root / "profiles" / f"{HOST_PROFILE_ID}.json"),
+            "generator": "sha256:" + _digest(root / "runners/graph500-generator/src/main.rs"),
+            "gf_sha256": _digest(executables.gf),
+            "certify_sha256": _digest(executables.certify),
+            "generator_executable_sha256": _digest(executables.generator),
+            "benchexec_python_sha256": _digest(executables.benchexec_python),
+            "benchexec_version": version("BenchExec"),
+        }
+        if any(previous[key] != value for key, value in expected.items()):
+            raise HostRunError("host_prefix_identity_mismatch")
+        for accepted in completed:
+            accepted_scale = int(accepted["scale"])
+            identity = _json(output_dir / f"s{accepted_scale}-result.json")["identities"]
+            if identity["profile_sha256"] != _digest(_profile_path(root, accepted_scale)):
+                raise HostRunError("host_prefix_identity_mismatch", rung=f"S{accepted_scale}")
+        if not dry_run:
+            # Resume cleanup after a crash between passed-result publication and
+            # reclaim, including when the requested maximum is already complete.
+            for accepted in completed:
+                reclaim_rung_workspace(work_root, int(accepted["scale"]))
+
+    plans = []
+    for scale in scales:
+        try:
+            # An actual incomplete/failed attempt is immutable. A dry-run creates none.
+            if any(
+                (output_dir / f"s{scale}-{name}.json").exists()
+                for name in ("plan", "projection", "result", "rung", "graphforge", "benchexec")
+            ):
+                raise HostRunError("existing_attempt_requires_inspection")
+            capacity = measure_host_capacity(work_root, reserved_headroom_bytes)
+            projection = (
+                _admit_projection(root, output_dir, scale, capacity) if scale >= 20 else None
+            )
+            plan = build_plan(
+                root=root,
+                output_dir=output_dir,
+                scale=scale,
+                commit=commit,
+                executables=executables,
+                capacity=capacity,
+                projection=projection,
+            )
+            if shared_identity is not None and "producer_sha256" not in shared_identity:
+                plan["identities"].pop("producer_sha256", None)
+            current_shared = {
+                key: value
+                for key, value in plan["identities"].items()
+                if key not in {"profile_id", "profile_sha256", "admitted_projection_sha256"}
+            }
+            if shared_identity is not None and current_shared != shared_identity:
+                raise HostRunError("host_prefix_identity_mismatch")
+            shared_identity = current_shared
+            plans.append(plan)
+            if dry_run:
+                # Later projections require actual measurements from this next rung.
+                break
+            if projection is not None:
+                publish_json_no_clobber(output_dir / f"s{scale}-projection.json", projection[0])
+            publish_json_no_clobber(output_dir / f"s{scale}-plan.json", plan)
+            run(
+                root=root,
+                output_dir=output_dir,
+                work_root=work_root,
+                scale=scale,
+                plan=plan,
+                executables=executables,
+            )
+            validated_host_rung(root, output_dir, scale)
+            reclaim_rung_workspace(work_root, scale)
+        except HostRunError as error:
+            error.rung = error.rung or f"S{scale}"
+            raise
+        except (ControllerError, QualificationError, OSError, ValueError) as error:
+            code = "execution_io_failed" if isinstance(error, OSError) else str(error)
+            raise HostRunError(code, rung=f"S{scale}") from error
+    return plans
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
     action = parser.add_mutually_exclusive_group(required=True)
-    action.add_argument(
-        "--rung",
-        choices=tuple(f"S{scale}" for scale in LADDER),
-    )
+    action.add_argument("--rung", choices=tuple(f"S{scale}" for scale in LADDER))
+    action.add_argument("--maximum-scale", type=int, choices=LADDER)
     action.add_argument("--inventory", action="store_true")
     action.add_argument("--reclaim", type=int, choices=LADDER)
     parser.add_argument("--output-dir", type=Path, required=True)
@@ -471,12 +658,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--gf")
     parser.add_argument("--certify")
     parser.add_argument("--generator")
+    parser.add_argument("--benchexec-python", default=str(SYSTEM_BENCHEXEC_PYTHON))
+    parser.add_argument("--reserved-headroom-bytes", type=int, default=DEFAULT_RESERVE_BYTES)
     parser.add_argument(
-        "--benchexec-python",
-        default=str(SYSTEM_BENCHEXEC_PYTHON),
-        help="Python that provides BenchExec + pystemd (default: /usr/bin/python3)",
+        "--host-capacity",
+        type=Path,
+        help="legacy input: only reserve is used; space and rates are measured",
     )
-    parser.add_argument("--host-capacity", type=Path)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
     root = Path(__file__).resolve().parents[2]
@@ -488,16 +676,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(json.dumps(document, sort_keys=True))
             return 0 if document["empty"] else 2
         if args.reclaim is not None:
+            validated_host_rung(root, args.output_dir, args.reclaim)
             reclaim_rung_workspace(work_root, args.reclaim)
             return 0
         if not all((args.gf, args.certify, args.generator)):
             raise HostRunError("rung execution requires gf, certify, and generator")
-        scale = int(args.rung[1:])
-        capacity = None
-        if scale in PROVIDER_SCALES:
-            if args.host_capacity is None:
-                raise HostRunError("S20+ requires --host-capacity")
-            capacity = load_host_capacity(root, args.host_capacity)
+        reserve = args.reserved_headroom_bytes
+        if args.host_capacity is not None:
+            reserve = int(load_host_capacity(root, args.host_capacity)["reserved_headroom_bytes"])
         benchexec_python = resolve_host_benchexec_python(Path(args.benchexec_python))
         executables = resolve_executables(
             gf=args.gf,
@@ -505,36 +691,39 @@ def main(argv: Sequence[str] | None = None) -> int:
             generator=args.generator,
             benchexec_python=str(benchexec_python),
         )
-        plan = build_plan(
+        rung = int(args.rung[1:]) if args.rung else None
+        plans = execute_ladder(
             root=root,
             output_dir=args.output_dir,
-            scale=scale,
-            commit=repository_commit(root),
+            work_root=work_root,
+            maximum_scale=rung or args.maximum_scale,
+            rung=rung,
             executables=executables,
-            capacity=capacity,
+            commit=repository_commit(root),
+            reserved_headroom_bytes=reserve,
+            dry_run=args.dry_run,
         )
-        publish_json_no_clobber(args.output_dir / f"s{scale}-plan.json", plan)
-        if not args.dry_run:
-            run(
-                root=root,
-                output_dir=args.output_dir,
-                work_root=work_root,
-                scale=scale,
-                plan=plan,
-                executables=executables,
+        if args.dry_run:
+            print(
+                json.dumps(
+                    {"plans": plans, "maximum_scale": rung or args.maximum_scale}, sort_keys=True
+                )
             )
         return 0
-    except (HostRunError, ControllerError, QualificationError) as error:
-        print(
-            json.dumps(
-                {
-                    "schema": RESULT_SCHEMA,
-                    "status": "failed",
-                    "failure": str(error),
-                },
-                sort_keys=True,
-            )
-        )
+    except (ControllerError, QualificationError, OSError, ValueError) as error:
+        failed: dict[str, Any] = {
+            "schema": RESULT_SCHEMA,
+            "status": "failed",
+            "failure": "execution_io_failed" if isinstance(error, OSError) else str(error),
+        }
+        if isinstance(error, HostRunError):
+            failed["rung"] = error.rung
+            if error.projection is not None:
+                failed["failed_checks"] = [
+                    key for key, passed in error.projection["checks"].items() if not passed
+                ]
+                failed["projection"] = error.projection
+        print(json.dumps(failed, sort_keys=True))
         return 2
 
 

--- a/benchmarks/harness/graphforge_bench/progressive_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_qualification.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
@@ -183,6 +184,8 @@ def project(
     profile: Profile,
     completed: Sequence[Mapping[str, Any]],
     provider_capacity: Mapping[str, Any] | None = None,
+    *,
+    native_capacity: Mapping[str, int] | None = None,
 ) -> dict[str, Any]:
     """Project one provider rung from its two declared completed source scales."""
     if profile.execution != "provider" or profile.projection_sources is None:
@@ -234,6 +237,33 @@ def project(
     rss_high = _integer(high["metrics"], "peak_rss_bytes")
     rss_growth_fraction = (rss_high - rss_low) / max(1, rss_low)
     capacity = provider_capacity or {}
+    volume = VOLUME_LIMIT_BYTES
+    reserve = VOLUME_LIMIT_BYTES * 15 // 100
+    if native_capacity is not None:
+        volume = _integer(native_capacity, "free_bytes")
+        reserve = _integer(native_capacity, "reserved_headroom_bytes")
+        if volume <= 0 or reserve >= volume:
+            raise QualificationError("work_root_capacity_refused")
+        # Rates come from the same executed adjacent rungs, never operator estimates.
+        metric_rates = {
+            "physical_read_bytes_per_second": "physical_read_bytes",
+            "physical_write_bytes_per_second": "physical_write_bytes",
+            "reader_calls_per_second": "reader_calls",
+            "publication_work_per_second": "publication_work_units",
+        }
+        if any(_integer(item["metrics"], "wall_seconds") <= 0 for item in (low, high)):
+            raise QualificationError("measured throughput requires positive elapsed time")
+        observations = {}
+        for rate, metric in metric_rates.items():
+            positive = [
+                (_integer(item["metrics"], metric), _integer(item["metrics"], "wall_seconds"))
+                for item in (low, high)
+                if _integer(item["metrics"], metric) > 0
+            ]
+            # Cached zero-read runs do not measure zero device throughput.
+            observations[rate] = (
+                min(positive, key=lambda pair: Fraction(*pair)) if positive else None
+            )
     usable_seconds = int(WALL_LIMIT_SECONDS * (1 - TIME_HEADROOM))
     required_rates = {
         "physical_read_bytes_per_second": _ceil_ratio(
@@ -254,21 +284,35 @@ def project(
     work_headroom = measured_capacity and all(
         required * 5 <= capacity[name] * 4 for name, required in required_rates.items()
     )
+    if native_capacity is not None:
+        measured_capacity = all(
+            observation is not None or projected[metric_rates[rate]] == 0
+            for rate, observation in observations.items()
+        )
+        # Compare rational work/time directly; flooring subunit rates or rounding
+        # required demand up to one unit/second would create artificial blockers.
+        work_headroom = measured_capacity and all(
+            projected[metric_rates[rate]] == 0
+            or (
+                observation is not None
+                and projected[metric_rates[rate]] * observation[1] * 5
+                <= observation[0] * usable_seconds * 4
+            )
+            for rate, observation in observations.items()
+        )
     rss_growth = rss_high - rss_low
     checks = {
         "time_headroom": projected["wall_seconds"] <= WALL_LIMIT_SECONDS * 80 // 100,
         "rss_headroom": projected["peak_rss_bytes"] <= RSS_LIMIT_BYTES * 80 // 100,
-        "retained_storage_headroom": projected["retained_storage_bytes"]
-        <= VOLUME_LIMIT_BYTES * 85 // 100,
-        "transient_storage_headroom": projected["transient_peak_storage_bytes"]
-        <= VOLUME_LIMIT_BYTES * 85 // 100,
-        "storage_headroom": storage_peak <= VOLUME_LIMIT_BYTES * 85 // 100,
+        "retained_storage_headroom": projected["retained_storage_bytes"] <= volume - reserve,
+        "transient_storage_headroom": projected["transient_peak_storage_bytes"] <= volume - reserve,
+        "storage_headroom": storage_peak <= volume - reserve,
         "rss_bounded_or_plateaued": rss_growth <= rss_low * 10 // 100,
         "io_reader_publication_capacity_measured": measured_capacity,
         "io_reader_publication_headroom": work_headroom,
         "correctness": True,
     }
-    return {
+    evidence = {
         "schema": "graphforge-progressive-qualification-evidence/1",
         "target": f"S{profile.scale}",
         "source_scales": list(profile.projection_sources),
@@ -276,17 +320,21 @@ def project(
         "limits": {
             "wall_seconds": WALL_LIMIT_SECONDS,
             "rss_bytes": RSS_LIMIT_BYTES,
-            "volume_bytes": VOLUME_LIMIT_BYTES,
+            "volume_bytes": volume,
         },
         "headroom": {
             "time_fraction": TIME_HEADROOM,
             "rss_fraction": RSS_HEADROOM,
-            "storage_fraction": STORAGE_HEADROOM,
+            "storage_fraction": reserve / volume
+            if native_capacity is not None
+            else STORAGE_HEADROOM,
         },
         "projected": projected | {"storage_peak_bytes": storage_peak},
         "required_rates": required_rates,
         "provider_capacity": (
-            {name: capacity[name] for name in required_rates} if measured_capacity else None
+            {name: capacity[name] for name in required_rates}
+            if measured_capacity and native_capacity is None
+            else None
         ),
         "slopes_observed": {
             name: _integer(high["metrics"], name) - _integer(low["metrics"], name)
@@ -303,3 +351,14 @@ def project(
         "checks": checks,
         "claim": "engineering_evidence_only",
     }
+    if native_capacity is not None:
+        evidence["native_capacity"] = {
+            "free_bytes": volume,
+            "reserved_headroom_bytes": reserve,
+            "rate_source": "completed_adjacent_rungs",
+            "observed_rates": {
+                rate: {"work_units": pair[0], "wall_seconds": pair[1]} if pair else None
+                for rate, pair in observations.items()
+            },
+        }
+    return evidence

--- a/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
@@ -493,6 +493,52 @@ def build(
     )
 
 
+def build_native(
+    source_paths: Sequence[Path],
+    *,
+    work_root: Path,
+    reserved_headroom_bytes: int,
+) -> dict[str, Any]:
+    """Use retained ordinary host results and measured remaining work-root space."""
+    from graphforge_bench.progressive_host_run import (
+        measure_host_capacity,
+        require_work_root,
+        validated_host_rung,
+    )
+
+    if len(source_paths) != 2:
+        raise StorageQualificationError("exactly two adjacent observations are required")
+    work_root = require_work_root(work_root)
+    rungs = []
+    shared = None
+    for path in source_paths:
+        rung, _ = _read_digest(path)
+        scale = _integer(rung.get("scale"), "scale", positive=True)
+        if path.name != f"s{scale}-rung.json":
+            raise StorageQualificationError("native rung filename contradicts scale")
+        bound = validated_host_rung(BENCHMARK_ROOT, path.parent, scale)
+        result, _ = _read_digest(path.parent / f"s{scale}-result.json")
+        identities = {
+            key: value
+            for key, value in result["identities"].items()
+            if key not in {"profile_id", "profile_sha256", "admitted_projection_sha256"}
+        }
+        if shared is not None and identities != shared:
+            raise StorageQualificationError(
+                "native observations have different execution identities"
+            )
+        shared = identities
+        if (work_root / "workspace" / f"s{scale}").exists():
+            raise StorageQualificationError("native rung workspace has not been reclaimed")
+        rungs.append(bound)
+    capacity = measure_host_capacity(work_root, reserved_headroom_bytes)
+    return _build_qualification(
+        rungs,
+        volume_bytes=capacity["free_bytes"],
+        reserved_headroom_bytes=capacity["reserved_headroom_bytes"],
+    )
+
+
 def _build_qualification(
     source_rungs: Sequence[Mapping[str, Any]],
     *,
@@ -710,14 +756,14 @@ def validate(evidence: Mapping[str, Any]) -> None:
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("low", type=Path, help="lower-scale provider rung path")
-    parser.add_argument("high", type=Path, help="higher-scale provider rung path")
+    parser.add_argument("low", type=Path, help="lower-scale rung path")
+    parser.add_argument("high", type=Path, help="higher-scale rung path")
     parser.add_argument("output", type=Path)
-    parser.add_argument("--commit", required=True)
-    parser.add_argument("--image-digest", required=True)
+    parser.add_argument("--work-root", type=Path, help="native mode: measure this work root")
+    parser.add_argument("--commit")
+    parser.add_argument("--image-digest")
     parser.add_argument(
         "--low-result-sha256",
-        required=True,
         help=(
             "SHA-256 of the low provider result from trusted transport or an immutable "
             "manifest outside the evidence bundle"
@@ -725,30 +771,48 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument(
         "--high-result-sha256",
-        required=True,
         help=(
             "SHA-256 of the high provider result from trusted transport or an immutable "
             "manifest outside the evidence bundle"
         ),
     )
-    parser.add_argument("--volume-bytes", type=int, required=True)
+    parser.add_argument("--volume-bytes", type=int)
     parser.add_argument("--reserved-headroom-bytes", type=int, required=True)
     args = parser.parse_args(argv)
     try:
-        qualification = build(
-            [args.low, args.high],
-            provider_result_sha256=[
-                args.low_result_sha256,
-                args.high_result_sha256,
-            ],
-            expected_commit=args.commit,
-            expected_image_digest=args.image_digest,
-            volume_bytes=args.volume_bytes,
-            reserved_headroom_bytes=args.reserved_headroom_bytes,
-        )
+        if args.work_root is not None:
+            qualification = build_native(
+                [args.low, args.high],
+                work_root=args.work_root,
+                reserved_headroom_bytes=args.reserved_headroom_bytes,
+            )
+        else:
+            if not all(
+                (
+                    args.commit,
+                    args.image_digest,
+                    args.low_result_sha256,
+                    args.high_result_sha256,
+                    args.volume_bytes,
+                )
+            ):
+                raise StorageQualificationError(
+                    "provider mode requires commit/image/result anchors and volume"
+                )
+            qualification = build(
+                [args.low, args.high],
+                provider_result_sha256=[
+                    args.low_result_sha256,
+                    args.high_result_sha256,
+                ],
+                expected_commit=args.commit,
+                expected_image_digest=args.image_digest,
+                volume_bytes=args.volume_bytes,
+                reserved_headroom_bytes=args.reserved_headroom_bytes,
+            )
         publish_json_no_clobber(args.output, qualification)
         return 0
-    except (OSError, StorageQualificationError) as error:
+    except (OSError, ValueError) as error:
         parser.error(str(error))
 
 

--- a/benchmarks/schemas/progressive-host-run-plan.json
+++ b/benchmarks/schemas/progressive-host-run-plan.json
@@ -26,6 +26,7 @@
       ],
       "properties": {
         "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "producer_sha256": {"$ref": "#/$defs/digest"},
         "host_profile_id": {"const": "local-linux-cgroups-v2"},
         "host_profile_sha256": {"$ref": "#/$defs/digest"},
         "profile_id": {
@@ -47,6 +48,14 @@
         "benchexec_python_sha256": {"$ref": "#/$defs/digest"},
         "benchexec_version": {"type": "string", "pattern": "^[0-9]+(\\.[0-9]+)+$"},
         "admitted_projection_sha256": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "work_root_capacity": {
+      "type": "object", "additionalProperties": false,
+      "required": ["free_bytes", "reserved_headroom_bytes"],
+      "properties": {
+        "free_bytes": {"type": "integer", "minimum": 1},
+        "reserved_headroom_bytes": {"type": "integer", "minimum": 0}
       }
     },
     "limits": {

--- a/benchmarks/schemas/progressive-host-run-result.json
+++ b/benchmarks/schemas/progressive-host-run-result.json
@@ -39,6 +39,7 @@
       ],
       "properties": {
         "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "producer_sha256": {"$ref": "#/$defs/digest"},
         "host_profile_id": {"const": "local-linux-cgroups-v2"},
         "host_profile_sha256": {"$ref": "#/$defs/digest"},
         "profile_id": {

--- a/benchmarks/schemas/progressive-qualification-evidence.json
+++ b/benchmarks/schemas/progressive-qualification-evidence.json
@@ -28,14 +28,43 @@
         "correctness": {"const": true}
       }
     },
+    "native_capacity": {
+      "type": "object", "additionalProperties": false,
+      "required": ["free_bytes", "reserved_headroom_bytes", "rate_source", "observed_rates"],
+      "properties": {
+        "free_bytes": {"type": "integer", "minimum": 1},
+        "reserved_headroom_bytes": {"type": "integer", "minimum": 0},
+        "rate_source": {"const": "completed_adjacent_rungs"},
+        "observed_rates": {
+          "type": "object", "additionalProperties": false,
+          "required": ["physical_read_bytes_per_second", "physical_write_bytes_per_second", "reader_calls_per_second", "publication_work_per_second"],
+          "properties": {
+            "physical_read_bytes_per_second": {"$ref": "#/$defs/observation"},
+            "physical_write_bytes_per_second": {"$ref": "#/$defs/observation"},
+            "reader_calls_per_second": {"$ref": "#/$defs/observation"},
+            "publication_work_per_second": {"$ref": "#/$defs/observation"}
+          }
+        }
+      }
+    },
     "claim": {"const": "engineering_evidence_only"}
   },
   "allOf": [
     {
+      "if": {"not": {"required": ["native_capacity"]}},
+      "then": {"properties": {
+        "limits": {"properties": {"volume_bytes": {"const": 536870912000}}},
+        "headroom": {"properties": {"storage_fraction": {"const": 0.15}}}
+      }, "allOf": [{
+        "if": {"properties": {"decision": {"const": "admitted"}}},
+        "then": {"properties": {"provider_capacity": {"$ref": "#/$defs/rates"}}}
+      }]
+      }
+    },
+    {
       "if": {"properties": {"decision": {"const": "admitted"}}, "required": ["decision"]},
       "then": {
         "properties": {
-          "provider_capacity": {"$ref": "#/$defs/rates"},
           "checks": {
             "properties": {
               "time_headroom": {"const": true}, "rss_headroom": {"const": true},
@@ -70,14 +99,19 @@
     }
   ],
   "$defs": {
+    "observation": {"oneOf": [
+      {"type": "null"},
+      {"type": "object", "additionalProperties": false, "required": ["work_units", "wall_seconds"],
+       "properties": {"work_units": {"type": "integer", "minimum": 1}, "wall_seconds": {"type": "integer", "minimum": 1}}}
+    ]},
     "nonnegative": {"type": "integer", "minimum": 0},
     "limits": {
       "type": "object", "additionalProperties": false, "required": ["wall_seconds", "rss_bytes", "volume_bytes"],
-      "properties": {"wall_seconds": {"const": 14400}, "rss_bytes": {"const": 4294967296}, "volume_bytes": {"const": 536870912000}}
+      "properties": {"wall_seconds": {"const": 14400}, "rss_bytes": {"const": 4294967296}, "volume_bytes": {"type": "integer", "minimum": 1}}
     },
     "headroom": {
       "type": "object", "additionalProperties": false, "required": ["time_fraction", "rss_fraction", "storage_fraction"],
-      "properties": {"time_fraction": {"const": 0.2}, "rss_fraction": {"const": 0.2}, "storage_fraction": {"const": 0.15}}
+      "properties": {"time_fraction": {"const": 0.2}, "rss_fraction": {"const": 0.2}, "storage_fraction": {"type": "number", "minimum": 0, "maximum": 1}}
     },
     "projected": {
       "type": "object", "additionalProperties": false,

--- a/benchmarks/tests/host_run_fixture.py
+++ b/benchmarks/tests/host_run_fixture.py
@@ -1,0 +1,93 @@
+"""Ordinary bounded native receipts for host controller/consumer tests."""
+
+import json
+from pathlib import Path
+
+from graphforge_bench.progressive_run import Executables, assemble_rung_evidence
+from tests.test_progressive_run import authoritative_receipts, benchexec, graphforge
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def executables(base: Path) -> Executables:
+    paths = [base / name for name in ("gf", "certify", "generator")]
+    for path in paths:
+        path.write_bytes(b"bounded executable fixture")
+        path.chmod(0o755)
+    return Executables(*paths, ROOT / ".venv/bin/python")
+
+
+def write_host_bundle(output: Path, scale: int, plan: dict | None = None) -> None:
+    from graphforge_bench.progressive_host_run import producer_digest
+    from graphforge_bench.progressive_qualification import load_profiles, project
+    from tests.test_progressive_host_run import host_capacity, host_result, passed_rung, sha256
+
+    output.mkdir(parents=True, exist_ok=True)
+    result = host_result(scale)
+    if plan is None:
+        tools = executables(output.parent)
+        identities = result["identities"]
+        identities.update(
+            {
+                "producer_sha256": producer_digest(ROOT),
+                "host_profile_sha256": sha256(ROOT / "profiles/local-linux-cgroups-v2.json"),
+                "profile_sha256": sha256(
+                    ROOT
+                    / f"profiles/graph500/s{scale}-{'local' if scale < 20 else 'provider'}.json"
+                ),
+                "generator": "sha256:" + sha256(ROOT / "runners/graph500-generator/src/main.rs"),
+                "generator_executable_sha256": sha256(tools.generator),
+                "gf_sha256": sha256(tools.gf),
+                "certify_sha256": sha256(tools.certify),
+                "benchexec_python_sha256": sha256(tools.benchexec_python),
+            }
+        )
+    plan = plan or {
+        "schema": "graphforge-progressive-host-run-plan/1",
+        "rung": f"S{scale}",
+        "execution": "native_linux_benchexec_host",
+        "identities": result["identities"],
+        "limits": {"wall_seconds": 14400, "memory_bytes": 4294967296, "cores": 16},
+        "outputs": [
+            f"s{scale}-{name}.json"
+            for name in ("plan", "benchexec", "graphforge", "rung", "result")
+        ],
+        "claim": "engineering_evidence_only",
+    }
+    if scale >= 20 and not (output / f"s{scale}-projection.json").exists():
+        profile = next(p for p in load_profiles() if p.scale == scale)
+        projection = project(
+            profile, [passed_rung(s) for s in profile.projection_sources], host_capacity()
+        )
+        path = output / f"s{scale}-projection.json"
+        path.write_text(json.dumps(projection) + "\n")
+        plan["identities"]["admitted_projection_sha256"] = sha256(path)
+    receipts = authoritative_receipts(scale)
+    # This shared fixture includes retained construction staging as an owner.
+    # Keep its native union above every owner view and below their sum.
+    receipts["reopen_proof"][-1]["retained_storage_bytes"] = 500
+    receipts["reopen_proof"][-1]["transient_peak_storage_bytes"] = 600
+    gf = graphforge(scale, receipts)
+    gf["profile_id"] = plan["identities"]["profile_id"]
+    authority = benchexec(gf)
+    rung = assemble_rung_evidence(
+        root=ROOT,
+        scale=scale,
+        graphforge=gf,
+        benchexec=authority,
+        profile_id=plan["identities"]["profile_id"],
+        source="progressive_profile" if scale < 20 else "canonical_ladder",
+    )
+    for name, value in (
+        ("plan", plan),
+        ("graphforge", gf),
+        ("benchexec", authority),
+        ("rung", rung),
+    ):
+        (output / f"s{scale}-{name}.json").write_text(json.dumps(value) + "\n")
+    result["identities"] = plan["identities"]
+    result["artifacts"] = {
+        f"{name}_sha256": sha256(output / f"s{scale}-{name}.json")
+        for name in ("plan", "graphforge", "benchexec", "rung")
+    }
+    (output / f"s{scale}-result.json").write_text(json.dumps(result) + "\n")

--- a/benchmarks/tests/test_native_ladder_controller.py
+++ b/benchmarks/tests/test_native_ladder_controller.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+from collections import namedtuple
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from graphforge_bench.progressive_host_run import (
+    HostRunError,
+    completed_prefix,
+    execute_ladder,
+    measure_host_capacity,
+    validated_host_rung,
+)
+from tests.host_run_fixture import ROOT, executables, write_host_bundle
+from tests.test_progressive_host_run import COMMIT, WORK_PARENT, sha256
+
+
+class NativeLadderControllerTests(unittest.TestCase):
+    def test_plan_then_run_same_directory_and_automatic_advance(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            work = Path(temporary)
+            output = work / "evidence"
+            options = {
+                "root": ROOT,
+                "output_dir": output,
+                "work_root": work,
+                "maximum_scale": 20,
+                "executables": executables(work),
+                "commit": COMMIT,
+                "reserved_headroom_bytes": 1,
+            }
+            launched = []
+
+            def execute(**kwargs):
+                scale = kwargs["scale"]
+                launched.append(scale)
+                payload = work / "workspace" / f"s{scale}" / "payload"
+                payload.parent.mkdir(parents=True)
+                payload.write_bytes(b"dataset")
+                write_host_bundle(output, scale, kwargs["plan"])
+
+            with (
+                patch("graphforge_bench.progressive_host_run.version", return_value="3.35"),
+                patch("graphforge_bench.progressive_host_run.run", side_effect=execute),
+            ):
+                preview = execute_ladder(**options, dry_run=True)
+                self.assertEqual([p["rung"] for p in preview], ["S18"])
+                self.assertFalse(output.exists())
+                plans = execute_ladder(**options)
+            self.assertEqual(launched, [18, 19, 20])
+            self.assertEqual(len(plans), 3)
+            self.assertEqual(len(completed_prefix(ROOT, output)), 3)
+            self.assertFalse((work / "workspace/s20").exists())
+            projection = json.loads((output / "s20-projection.json").read_text())
+            self.assertEqual(
+                projection["native_capacity"]["rate_source"], "completed_adjacent_rungs"
+            )
+            self.assertNotIn("image_digest", plans[-1]["identities"])
+            self.assertEqual(
+                plans[-1]["identities"]["admitted_projection_sha256"],
+                sha256(output / "s20-projection.json"),
+            )
+
+    def test_s20_preview_never_publishes_projection(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            work = Path(temporary)
+            output = work / "evidence"
+            write_host_bundle(output, 18)
+            write_host_bundle(output, 19)
+            before = {p.name: p.read_bytes() for p in output.iterdir()}
+            with patch("graphforge_bench.progressive_host_run.version", return_value="3.35"):
+                plans = execute_ladder(
+                    root=ROOT,
+                    output_dir=output,
+                    work_root=work,
+                    maximum_scale=20,
+                    executables=executables(work),
+                    commit=COMMIT,
+                    reserved_headroom_bytes=1,
+                    dry_run=True,
+                )
+            self.assertEqual(plans[0]["rung"], "S20")
+            self.assertEqual(before, {p.name: p.read_bytes() for p in output.iterdir()})
+
+    def test_actual_work_root_free_space_and_reserve_refuse(self) -> None:
+        usage = namedtuple("usage", "total used free")
+        with patch(
+            "graphforge_bench.progressive_host_run.shutil.disk_usage",
+            return_value=usage(10**12, 10**12 - 100, 100),
+        ) as probe:
+            with self.assertRaisesRegex(HostRunError, "work_root_capacity_refused"):
+                measure_host_capacity(Path("/declared/work"), 100)
+            self.assertEqual(measure_host_capacity(Path("/declared/work"), 99)["free_bytes"], 100)
+            probe.assert_called_with(Path("/declared/work"))
+
+    def test_first_execution_failure_stops_and_retains_attempt(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            work = Path(temporary)
+            output = work / "evidence"
+            with (
+                patch("graphforge_bench.progressive_host_run.version", return_value="3.35"),
+                patch(
+                    "graphforge_bench.progressive_host_run.run",
+                    side_effect=HostRunError("benchexec_failed"),
+                ) as run,
+                self.assertRaisesRegex(HostRunError, "benchexec_failed"),
+            ):
+                execute_ladder(
+                    root=ROOT,
+                    output_dir=output,
+                    work_root=work,
+                    maximum_scale=26,
+                    executables=executables(work),
+                    commit=COMMIT,
+                    reserved_headroom_bytes=1,
+                )
+            self.assertEqual(run.call_count, 1)
+            self.assertTrue((output / "s18-plan.json").exists())
+            self.assertFalse((output / "s19-plan.json").exists())
+
+    def test_receipts_cannot_be_removed_even_with_refreshed_artifact_hash(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            output = Path(temporary)
+            write_host_bundle(output, 18)
+            gf_path = output / "s18-graphforge.json"
+            gf = json.loads(gf_path.read_text())
+            for phase in gf["phases"]:
+                phase["receipts"] = []
+            gf_path.write_text(json.dumps(gf))
+            result_path = output / "s18-result.json"
+            result = json.loads(result_path.read_text())
+            result["artifacts"]["graphforge_sha256"] = sha256(gf_path)
+            result_path.write_text(json.dumps(result))
+            with self.assertRaises(ValueError):
+                validated_host_rung(ROOT, output, 18)
+
+    def test_native_projection_uses_free_capacity_and_preserves_rss_refusal(self) -> None:
+        from graphforge_bench.progressive_qualification import load_profiles, project
+        from tests.test_progressive_host_run import passed_rung
+
+        profile = next(p for p in load_profiles() if p.scale == 20)
+        low, high = passed_rung(18), passed_rung(19)
+        for rung in (low, high):
+            rung["metrics"]["reader_calls"] = 8000
+            rung["metrics"]["publication_work_units"] = 9000
+        capacity = {"free_bytes": 1000, "reserved_headroom_bytes": 399}
+        accepted = project(profile, [low, high], native_capacity=capacity)
+        self.assertEqual(accepted["decision"], "admitted")
+        self.assertEqual(accepted["limits"]["volume_bytes"], 1000)
+        self.assertIsNone(accepted["provider_capacity"])
+        self.assertEqual(
+            accepted["native_capacity"]["observed_rates"]["physical_read_bytes_per_second"],
+            {"work_units": 600, "wall_seconds": 10},
+        )
+        rejected = project(
+            profile, [low, high], native_capacity=capacity | {"reserved_headroom_bytes": 401}
+        )
+        self.assertEqual(rejected["decision"], "refused")
+        self.assertFalse(rejected["checks"]["storage_headroom"])
+        high["metrics"]["peak_rss_bytes"] = 111
+        rss = project(profile, [low, high], native_capacity=capacity)
+        self.assertEqual(rss["decision"], "refused")
+        self.assertFalse(rss["checks"]["rss_bounded_or_plateaued"])
+
+    def test_cli_resolves_executables_once_for_maximum_scale(self) -> None:
+        from contextlib import redirect_stdout
+        import io
+
+        from graphforge_bench.progressive_host_run import main
+
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            work = Path(temporary)
+            tools = executables(work)
+            with (
+                patch(
+                    "graphforge_bench.progressive_host_run.resolve_host_benchexec_python",
+                    return_value=tools.benchexec_python,
+                ),
+                patch(
+                    "graphforge_bench.progressive_host_run.resolve_executables", return_value=tools
+                ) as resolve,
+                patch(
+                    "graphforge_bench.progressive_host_run.execute_ladder", return_value=[]
+                ) as execute,
+                redirect_stdout(io.StringIO()),
+            ):
+                code = main(
+                    [
+                        "--maximum-scale",
+                        "26",
+                        "--work-root",
+                        str(work),
+                        "--output-dir",
+                        str(work / "evidence"),
+                        "--gf",
+                        str(tools.gf),
+                        "--certify",
+                        str(tools.certify),
+                        "--generator",
+                        str(tools.generator),
+                    ]
+                )
+            self.assertEqual(code, 0)
+            resolve.assert_called_once()
+            self.assertEqual(execute.call_args.kwargs["maximum_scale"], 26)
+
+    def test_native_storage_consumer_uses_ordinary_receipts_without_cloud_identity(self) -> None:
+        from graphforge_bench.progressive_storage_qualification import (
+            StorageQualificationError,
+            build_native,
+        )
+
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            work = Path(temporary)
+            output = work / "evidence"
+            write_host_bundle(output, 20)
+            write_host_bundle(output, 22)
+            paths = [output / "s20-rung.json", output / "s22-rung.json"]
+            qualification = build_native(paths, work_root=work, reserved_headroom_bytes=1)
+            self.assertEqual(qualification["schema"], "graphforge-g500-ladder-qualification/3")
+            retained = work / "workspace" / "s20"
+            retained.mkdir(parents=True)
+            with self.assertRaisesRegex(StorageQualificationError, "not been reclaimed"):
+                build_native(paths, work_root=work, reserved_headroom_bytes=1)
+
+    def test_zero_cached_reads_and_fractional_rates_do_not_invent_capacity_refusals(self) -> None:
+        from graphforge_bench.progressive_qualification import load_profiles, project
+        from tests.test_progressive_host_run import passed_rung
+
+        profile = next(p for p in load_profiles() if p.scale == 20)
+        capacity = {"free_bytes": 10**12, "reserved_headroom_bytes": 1}
+        for low_reads, high_reads, low_time, high_time in (
+            (16384, 0, 195, 599),
+            (0, 16384, 195, 599),
+            (0, 0, 195, 599),
+            (1, 2, 3, 3),
+        ):
+            with self.subTest(observations=(low_reads, high_reads, low_time, high_time)):
+                low, high = passed_rung(18), passed_rung(19)
+                for rung, reads, seconds in (
+                    (low, low_reads, low_time),
+                    (high, high_reads, high_time),
+                ):
+                    rung["metrics"].update(physical_read_bytes=reads, wall_seconds=seconds)
+                evidence = project(profile, [low, high], native_capacity=capacity)
+                self.assertTrue(evidence["checks"]["io_reader_publication_headroom"])
+                observed = evidence["native_capacity"]["observed_rates"][
+                    "physical_read_bytes_per_second"
+                ]
+                if low_reads == high_reads == 0:
+                    self.assertIsNone(observed)
+                elif low_reads == 1:
+                    self.assertEqual(observed, {"work_units": 1, "wall_seconds": 3})
+        low, high = passed_rung(18), passed_rung(19)
+        low["metrics"].update(physical_read_bytes=1, wall_seconds=10000)
+        high["metrics"].update(physical_read_bytes=2, wall_seconds=10000)
+        insufficient = project(profile, [low, high], native_capacity=capacity)
+        self.assertFalse(insufficient["checks"]["io_reader_publication_headroom"])
+
+    def test_resume_reclaims_accepted_final_rung_without_rerunning_or_changing_identity(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            work = Path(temporary)
+            output = work / "evidence"
+            write_host_bundle(output, 18)
+            tools = executables(work)
+            retained = work / "workspace/s18"
+            retained.mkdir(parents=True)
+            (retained / "payload").write_bytes(b"accepted before interruption")
+            before = {p.name: p.read_bytes() for p in output.iterdir()}
+            args = {
+                "root": ROOT,
+                "output_dir": output,
+                "work_root": work,
+                "maximum_scale": 18,
+                "executables": tools,
+                "commit": "a" * 40,
+                "reserved_headroom_bytes": 1,
+            }
+            with patch("graphforge_bench.progressive_host_run.run") as run:
+                self.assertEqual(execute_ladder(**args, dry_run=True), [])
+                self.assertTrue(retained.exists())
+                self.assertEqual(execute_ladder(**args), [])
+                run.assert_not_called()
+            self.assertFalse(retained.exists())
+            self.assertEqual(before, {p.name: p.read_bytes() for p in output.iterdir()})
+
+    def test_changed_binary_refuses_resume_before_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            work = Path(temporary)
+            output = work / "evidence"
+            write_host_bundle(output, 18)
+            tools = executables(work)
+            tools.gf.write_bytes(b"different binary")
+            retained = work / "workspace/s18"
+            retained.mkdir(parents=True)
+            with self.assertRaisesRegex(HostRunError, "host_prefix_identity_mismatch"):
+                execute_ladder(
+                    root=ROOT,
+                    output_dir=output,
+                    work_root=work,
+                    maximum_scale=18,
+                    executables=tools,
+                    commit=COMMIT,
+                    reserved_headroom_bytes=1,
+                )
+            self.assertTrue(retained.exists())
+
+    def test_nested_graphforge_and_phase_success_contradictions_are_rejected(self) -> None:
+        for mutation in ("nested", "phase_order"):
+            with (
+                self.subTest(mutation=mutation),
+                tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary,
+            ):
+                output = Path(temporary)
+                write_host_bundle(output, 18)
+                gf_path = output / "s18-graphforge.json"
+                bx_path = output / "s18-benchexec.json"
+                gf, bx = json.loads(gf_path.read_text()), json.loads(bx_path.read_text())
+                if mutation == "nested":
+                    bx["graphforge"]["profile_id"] = "different-profile"
+                else:
+                    gf["phases"].reverse()
+                    bx["graphforge"] = gf
+                    gf_path.write_text(json.dumps(gf))
+                bx_path.write_text(json.dumps(bx))
+                result_path = output / "s18-result.json"
+                result = json.loads(result_path.read_text())
+                result["artifacts"].update(
+                    graphforge_sha256=sha256(gf_path), benchexec_sha256=sha256(bx_path)
+                )
+                result_path.write_text(json.dumps(result))
+                with self.assertRaisesRegex(ValueError, "contradicts success"):
+                    validated_host_rung(ROOT, output, 18)
+
+    def test_projection_refusal_identifies_rung_and_keeps_actionable_measurements(self) -> None:
+        from contextlib import redirect_stdout
+        import io
+
+        from graphforge_bench.progressive_host_run import main
+
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            work = Path(temporary)
+            output = work / "evidence"
+            write_host_bundle(output, 18)
+            write_host_bundle(output, 19)
+            tools = executables(work)
+            stream = io.StringIO()
+            with (
+                patch(
+                    "graphforge_bench.progressive_host_run.resolve_host_benchexec_python",
+                    return_value=tools.benchexec_python,
+                ),
+                patch(
+                    "graphforge_bench.progressive_host_run.measure_host_capacity",
+                    return_value={"free_bytes": 100, "reserved_headroom_bytes": 1},
+                ),
+                patch("graphforge_bench.progressive_host_run.run") as run,
+                redirect_stdout(stream),
+            ):
+                code = main(
+                    [
+                        "--maximum-scale",
+                        "26",
+                        "--work-root",
+                        str(work),
+                        "--output-dir",
+                        str(output),
+                        "--gf",
+                        str(tools.gf),
+                        "--certify",
+                        str(tools.certify),
+                        "--generator",
+                        str(tools.generator),
+                        "--dry-run",
+                    ]
+                )
+            self.assertEqual(code, 2)
+            failure = json.loads(stream.getvalue())
+            self.assertEqual(failure["rung"], "S20")
+            self.assertEqual(failure["failure"], "projection_refused")
+            self.assertIn("storage_headroom", failure["failed_checks"])
+            self.assertGreater(failure["projection"]["projected"]["storage_peak_bytes"], 100)
+            run.assert_not_called()
+            self.assertFalse((output / "s20-plan.json").exists())
+            self.assertFalse((output / "s20-projection.json").exists())
+
+    def test_actual_producer_change_refuses_but_documentation_change_can_resume(self) -> None:
+        import shutil
+
+        from graphforge_bench.progressive_host_run import producer_files
+
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            base = Path(temporary)
+            work = base / "work"
+            output = work / "evidence"
+            write_host_bundle(output, 18)
+            tools = executables(work)
+            copied_root = base / "checkout/benchmarks"
+            copied = [
+                *producer_files(ROOT),
+                ROOT / "profiles/local-linux-cgroups-v2.json",
+                ROOT / "profiles/graph500/s18-local.json",
+                ROOT / "runners/graph500-generator/src/main.rs",
+            ]
+            for source in copied:
+                destination = copied_root / source.relative_to(ROOT)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, destination)
+            (copied_root / "README.md").write_text("Unrelated documentation correction.\n")
+            args = {
+                "root": copied_root,
+                "output_dir": output,
+                "work_root": work,
+                "maximum_scale": 18,
+                "executables": tools,
+                "commit": "a" * 40,
+                "reserved_headroom_bytes": 1,
+            }
+            self.assertEqual(execute_ladder(**args), [])
+            producer = copied_root / "harness/graphforge_bench/progressive_host_run.py"
+            producer.write_text(
+                producer.read_text().replace(
+                    "DEFAULT_RESERVE_BYTES = 75", "DEFAULT_RESERVE_BYTES = 74"
+                )
+            )
+            with self.assertRaisesRegex(HostRunError, "host_prefix_producer_identity_mismatch"):
+                execute_ladder(**args)
+            shutil.copyfile(ROOT / producer.relative_to(copied_root), producer)
+            helper = copied_root / "harness/graphforge_bench/new_runtime/helper.py"
+            helper.parent.mkdir()
+            helper.write_text("def changed_runtime_helper(): return 1\n")
+            with self.assertRaisesRegex(HostRunError, "host_prefix_producer_identity_mismatch"):
+                execute_ladder(**args)

--- a/benchmarks/tests/test_native_ladder_controller.py
+++ b/benchmarks/tests/test_native_ladder_controller.py
@@ -19,6 +19,75 @@ from tests.test_progressive_host_run import COMMIT, WORK_PARENT, sha256
 
 
 class NativeLadderControllerTests(unittest.TestCase):
+    def test_legacy_resume_detects_deleted_runtime_helper(self) -> None:
+        import shutil
+        import subprocess
+
+        from graphforge_bench.progressive_host_run import producer_digest, producer_files
+
+        with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
+            base = Path(temporary)
+            work = base / "work"
+            output = work / "evidence"
+            write_host_bundle(output, 18)
+            tools = executables(work)
+            repository = base / "checkout"
+            copied_root = repository / "benchmarks"
+            for source in [
+                *producer_files(ROOT),
+                ROOT / "profiles/local-linux-cgroups-v2.json",
+                ROOT / "profiles/graph500/s18-local.json",
+                ROOT / "runners/graph500-generator/src/main.rs",
+            ]:
+                destination = copied_root / source.relative_to(ROOT)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, destination)
+            helper = copied_root / "harness/graphforge_bench/retired_runtime.py"
+            helper.write_text("value = 1\n")
+
+            def git(*arguments: str) -> str:
+                return (
+                    subprocess.check_output(
+                        ["git", "-C", str(repository), *arguments], stderr=subprocess.STDOUT
+                    )
+                    .decode()
+                    .strip()
+                )
+
+            git("init", "-q")
+            git("add", ".")
+            git(
+                "-c",
+                "user.name=Codex",
+                "-c",
+                "user.email=codex@openai.com",
+                "commit",
+                "-qm",
+                "original producer",
+            )
+            commit = git("rev-parse", "HEAD")
+            original = producer_digest(copied_root)
+            plan = json.loads((output / "s18-plan.json").read_text())
+            plan["identities"].pop("producer_sha256")
+            plan["identities"]["commit"] = commit
+            write_host_bundle(output, 18, plan)
+            options = {
+                "root": copied_root,
+                "output_dir": output,
+                "work_root": work,
+                "maximum_scale": 18,
+                "executables": tools,
+                "commit": commit,
+                "reserved_headroom_bytes": 1,
+            }
+            (copied_root / "README.md").write_text("Documentation-only change.\n")
+            self.assertEqual(execute_ladder(**options), [])
+            helper.unlink()
+            self.assertEqual(producer_digest(copied_root, commit=commit), original)
+            self.assertNotEqual(producer_digest(copied_root), original)
+            with self.assertRaisesRegex(HostRunError, "host_prefix_producer_identity_mismatch"):
+                execute_ladder(**options)
+
     def test_plan_then_run_same_directory_and_automatic_advance(self) -> None:
         with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
             work = Path(temporary)

--- a/benchmarks/tests/test_progressive_host_run.py
+++ b/benchmarks/tests/test_progressive_host_run.py
@@ -20,6 +20,7 @@ from graphforge_bench.progressive_host_run import (
     resolve_host_benchexec_python,
 )
 from graphforge_bench.progressive_run import Executables
+from tests.host_run_fixture import write_host_bundle
 from tests.test_progressive_run import passed_rung as local_passed_rung
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -122,11 +123,9 @@ class ProgressiveHostRunTests(unittest.TestCase):
             require_order(ROOT, output, 18)
             with self.assertRaisesRegex(HostRunError, "requires completed prefix"):
                 require_order(ROOT, output, 19)
-            (output / "s18-rung.json").write_text(json.dumps(passed_rung(18)), encoding="utf-8")
-            (output / "s18-result.json").write_text(json.dumps(host_result(18)), encoding="utf-8")
+            write_host_bundle(output, 18)
             require_order(ROOT, output, 19)
-            (output / "s19-rung.json").write_text(json.dumps(passed_rung(19)), encoding="utf-8")
-            (output / "s19-result.json").write_text(json.dumps(host_result(19)), encoding="utf-8")
+            write_host_bundle(output, 19)
             require_order(ROOT, output, 20)
 
             python = ROOT / ".venv/bin/python"
@@ -172,8 +171,7 @@ class ProgressiveHostRunTests(unittest.TestCase):
     def test_completed_prefix_rejects_gaps(self) -> None:
         with tempfile.TemporaryDirectory(dir=WORK_PARENT) as temporary:
             output = Path(temporary)
-            (output / "s18-rung.json").write_text(json.dumps(passed_rung(18)), encoding="utf-8")
-            (output / "s18-result.json").write_text(json.dumps(host_result(18)), encoding="utf-8")
+            write_host_bundle(output, 18)
             (output / "s20-rung.json").write_text(json.dumps(passed_rung(20)), encoding="utf-8")
             (output / "s20-result.json").write_text(json.dumps(host_result(20)), encoding="utf-8")
             with self.assertRaisesRegex(HostRunError, "out of order"):

--- a/docs/development/g500-certification.md
+++ b/docs/development/g500-certification.md
@@ -1,5 +1,7 @@
 # Billion-live-edge certification
 
+## Current native OVHC-AGENCY execution
+
 The current #745 release outcome reuses the #900 native **OVHC-AGENCY** ladder
 and its [host runbook](../../benchmarks/README.md).
 Use the [streaming generator](../../benchmarks/runners/graph500-generator/README.md):
@@ -9,10 +11,33 @@ tuples, including self-loops and repeated endpoint pairs, and GraphForge stores
 each as a distinct edge record. These are not unique undirected edges. The
 generator never filters or replenishes tuples to reach a target-live count.
 
+The native host runs through `local-linux-cgroups-v2`.
+After the one-time native host preparation described in `benchmarks/README.md`,
+run as the unprivileged user:
+
+```bash
+make -C benchmarks progressive-host-ladder-run MAXIMUM_SCALE=26 \
+  WORK_ROOT="$HOME/graphforge-ladder" \
+  OUTPUT_DIR="$HOME/graphforge-ladder/evidence" \
+  RESERVED_HEADROOM_BYTES=80530636800
+```
+
+The command builds once and advances the existing sequential ladder, using
+actual work-root free capacity, the declared reserve, and adjacent-rung measured
+throughput. The first execution or projection failure stops the command. Preserve
+its evidence and fix the underlying cause, including RSS/IO or recovery defects.
+Successful rungs retain ordinary public lifecycle receipts and reclaim their
+datasets before the next admission. Run `progressive-host-ladder-inventory`
+with the same work/evidence arguments to record independent terminal cleanup.
+`progressive-host-ladder-plan` previews only the next admissible rung, reads
+existing binaries, and writes no immutable artifacts. Implementation closure
+for #1087 does not claim the actual host outcomes retained by #900/#745.
+
 ## Historical cloud certification workflow
 
-The cloud workflow and target-live client below are retained for historical
-reference. They do not authorize or define the current native host run.
+The following describes the earlier standalone cloud workflow. It is not a
+prerequisite for the native host command above.
+
 
 Issue #745 certifies the complete persisted GraphForge lifecycle on an explicitly
 provisioned Linux evidence host. The workflow is manual, protected by the

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -176,9 +176,14 @@ grow as expansion chunks multiplied by graph size.
 ## OVHC-AGENCY host execution (#900 / #1087)
 
 The designated SUT is **OVHC-AGENCY** under profile `local-linux-cgroups-v2`.
-Use `make -C benchmarks progressive-host-ladder-run` with an ext4 work root
-under the process-root filesystem. Prefer that path over disposable Fly
-provider execution. See `benchmarks/README.md` (OVHC-AGENCY host ladder).
+Use `make -C benchmarks progressive-host-ladder-run MAXIMUM_SCALE=26
+WORK_ROOT=... OUTPUT_DIR=... RESERVED_HEADROOM_BYTES=80530636800` on the
+admitted ext4 work root. It builds/resolves once, advances sequentially, stops
+on the first typed failure, and reclaims accepted rung data. Planning is
+read-only. S20+ uses measured free disk space and adjacent-rung throughput;
+manual capacity rates and Fly image identities are not required. RSS limits
+and plateau checks remain unchanged. See the native command and terminal
+inventory in `benchmarks/README.md`.
 
 ## Historical reference-client commands
 
@@ -323,15 +328,10 @@ rung documents with:
 
 ```bash
 make -C benchmarks progressive-storage-qualification \
-  LOW_RUNG=build/s20-rung.json \
-  HIGH_RUNG=build/s22-rung.json \
-  EVIDENCE=build/g500-ladder-qualification.json \
-  COMMIT=$(git rev-parse HEAD) \
-  IMAGE_DIGEST=registry.fly.io/graphforge-bench@sha256:<64-hex-digest> \
-  LOW_RESULT_SHA256=<independently-recorded-s20-result-sha256> \
-  HIGH_RESULT_SHA256=<independently-recorded-s22-result-sha256> \
-  VOLUME_BYTES=536870912000 \
-  RESERVED_HEADROOM_BYTES=53687091200
+  LOW_RUNG="$OUTPUT_DIR/s20-rung.json" \
+  HIGH_RUNG="$OUTPUT_DIR/s22-rung.json" \
+  EVIDENCE="$OUTPUT_DIR/g500-ladder-qualification.json" \
+  WORK_ROOT="$WORK_ROOT" RESERVED_HEADROOM_BYTES=80530636800
 ```
 
 ## CI placement


### PR DESCRIPTION
The native ladder previously left immutable evidence during dry-run, retained a provider disk limit on OVHC-AGENCY, and required repeated per-rung invocations. It now advances the canonical ladder up to `--maximum-scale`, builds/resolves executables once, uses measured work-root free space and the declared reserve, and stops at the first typed failure.

Closes #1087. Actual S18–S26 host outcomes remain tracked by #900.

Dry-run is read-only. Continuation validates retained results, artifact hashes, executable/input identities, and runtime producer content before reclaiming accepted datasets. Documentation-only changes can resume valid recorded work; runtime producer changes cannot. Shared native-rung validation lets storage qualification consume ordinary host receipts. Existing RSS, time, disk-headroom, adjacent-rung projection, and lifecycle correctness limits remain enforced. Measured throughput handles zero-work cached observations without inventing capacity.

Validation on OVHC-AGENCY:

- All 327 Python harness tests passed against the integrated compliant generator, including dry-run then run, ordered advancement, exact rational throughput, capacity refusal, resume identity, tampered evidence, cleanup recovery, and legacy-receipt runtime deletion using a real temporary Git repository.
- Fast checks and gate registry passed; documentation and links passed before the unchanged integration.
- Independently reviewed code and the runbook integration. Rebased onto current main after #1117 merged; the final independent review found and fixed legacy producer deletion before merge. Historical runtime files are enumerated from the recorded Git tree, so deletion cannot evade legacy resume validation.

#1112 owns the parity adapter that consumes this shared validator. This PR does not claim completion of the host scale ladder.

Final exact-head CI Gate and all applicable checks passed at `a93c23de7a37a887ba57374d48ce3aaa599d061d`. Squash-merged as `2f3b453215b4d40f5b8b2b881e37b78b3512467f`; #1087 is closed.
