### PR TITLE
docs: limit unfinished agent work and prioritize merging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,15 @@ Every change follows:
 
 Narrow sub-issues may split a canonical issue only to satisfy existing acceptance criteria, isolate a verified blocker, or separate an XL independently reviewable concern. They must be native sub-issues, block the canonical issue, avoid overlap, and never expand scope. The canonical issue remains the close gate.
 
+### Finish and merge before starting more work
+
+- Limit a coordinated agent team's work in progress to **three unmerged changes total**, across all agents and worktrees. Count open PRs (including drafts) and implemented local branches without PRs. Multiple branches for one concern count once; unrelated contributors' and automated dependency PRs do not consume these slots.
+- Before starting or delegating implementation, inspect the live PR queue and existing local work. If the team is at or above the limit, review, test, fix, and merge existing changes before starting another concern. Preserve inherited work; do not close PRs or hide work in local branches to satisfy the limit.
+- The coordinating agent owns integration. Prioritize a PR that can meet the merge gate now, respecting live dependencies, and merge it as soon as the gate passes and merge authorization exists. Do not wait for the milestone or the rest of the batch to finish. Recheck the queue after each merge and before assigning more implementation.
+- Refresh and run final integration CI for the next merge candidate first. After it merges, refresh the next candidate against current `main`. Avoid rebasing and restarting CI across the entire queue after every merge. Start dependent implementation after its prerequisite merges; use waiting time for review, diagnosis, or acceptance-test planning.
+- When a shared build or CI defect blocks the queue, prioritize its root-cause fix. A bounded fix needed to unblock an existing change may temporarily exceed the limit; identify the blocked PRs and drain the queue after the fix lands. This exception does not permit unrelated new work.
+- Delegate review and validation of existing changes before opening more implementation streams. Report progress in merged outcomes and concrete remaining blockers; a completed branch or green draft is still unfinished work.
+
 ## Architecture
 
 Rust owns behavior. Python and Node are thin bindings—never fallback engines.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -185,7 +185,9 @@ and [testing.md](testing.md) for command recipes and suite layout.
 
 ### PR Size Guidelines
 
-Keep PRs small and focused. CI tools work best with small, reviewable diffs.
+Keep each PR focused on one issue and one concern, with the tests needed to
+prove its acceptance criteria. Size is advisory: split XL work or independently
+reviewable concerns when the review benefit justifies another CI cycle.
 
 **Good:**
 - Single feature or bug fix
@@ -196,15 +198,20 @@ Keep PRs small and focused. CI tools work best with small, reviewable diffs.
 - Multiple unrelated changes
 - Refactoring + new feature + bug fixes combined
 
-**Example — breaking up a Rust feature:**
+For example, a bounded Cypher feature may need parser, IR, lowering, execution,
+and regression-test changes in one PR to demonstrate working behavior. Do not
+split solely at crate boundaries or defer a change's acceptance tests to a
+later PR. When a split is justified, each PR must have independently verifiable
+acceptance criteria, and dependencies must be explicit.
 
-```
-PR 1: "graphforge-cypher: add WITH clause grammar and AST node"
-PR 2: "graphforge-ir: add WithOp graph IR operator"
-PR 3: "graphforge-rel: lower WITH to DataFusion logical plan"
-PR 4: "graphforge-exec: integrate WITH in execution pipeline"
-PR 5: "tests: WITH clause unit + integration + TCK"
-```
+### Merge cadence
+
+Finish and merge reviewed work before starting more implementation. Coordinated
+agent teams have a limit of three unmerged changes across all agents, including
+draft PRs and implemented local branches. The coordinating agent owns the merge
+queue; prioritize existing PRs and shared CI blockers, and integrate dependent
+changes in order. See [the work-in-progress rules in AGENTS.md](../../AGENTS.md#finish-and-merge-before-starting-more-work)
+for counting, the bounded blocker exception, and handling an inherited backlog.
 
 ### No Bandaid Fixes
 


### PR DESCRIPTION
Agent implementation has accumulated faster than integration, producing stale PRs and repeated CI cycles. Limit the coordinated team to three unmerged concerns (including drafts and implemented local branches), assign the coordinator responsibility for prompt merging, and refresh integration candidates sequentially. Prioritize existing work and shared blockers before starting another concern.

Align the contributor guide and remove its five-PR example that separated a feature from its acceptance tests. Required merge and correctness gates remain intact.

Validation: `git diff --check` passed; `make gate-registry-check` passed (23 workflows validated, 14 tests). Reviewed both documents against the issue acceptance criteria.

Closes #1120

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791165566&installation_model_id=20486&pr_number=1121&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1121&signature=5900845df3f30a39d1312f39104d0087e9069e0bc8b9dbd222540c670d5688cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->