### PR TITLE
test(api): isolate composite endpoint I/O proof

### DIFF
--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -1513,6 +1513,23 @@ mod tests {
 
     #[test]
     fn composite_endpoint_resolution_uses_index_without_topology_decode() {
+        // Process-global I/O counters require isolation from parallel API tests.
+        const CHILD: &str = "GRAPHFORGE_COMPOSITE_ENDPOINT_IO_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("composite_publish::tests::composite_endpoint_resolution_uses_index_without_topology_decode")
+                .arg("--nocapture")
+                .env(CHILD, "1")
+                .status()
+                .unwrap();
+            assert!(
+                status.success(),
+                "isolated composite endpoint I/O proof failed"
+            );
+            return;
+        }
+
         let directory = tempfile::tempdir().unwrap();
         let existing = uuid7(180);
         let mut seed =


### PR DESCRIPTION
The composite endpoint test resets and asserts process-global storage I/O counters inside the parallel API unit process. Another test can increment those counters during the measurement, causing a false topology-decode failure; this blocked #1108’s integration run. Run this proof in an isolated exact-test child, following the existing public add-edge test pattern. Preserve the real index/writer setup, both zero-read assertions, and edge construction.

Validation:
- A channel-synchronized scratch probe using the real storage crate confirmed an unrelated thread’s `read_nodes` changes the coordinator’s full-read counter from 0 to 1. The CI log does not identify which reader contributed to its failure.
- Focused endpoint tests: 10 passed, including the isolated composite proof.
- Parallel API unit suite (`--test-threads=4`): 681 passed, none ignored; the child proof ran in that suite.
- `cargo clippy --locked --workspace -j 4 -- -D warnings`: passed.
- `make pre-push-fast`, `make gate-registry-check` (14 tests), final formatting, and diff checks: passed.

Closes #1122. Unblocks #1024 / PR #1108.

Exact-head CI passed at `36029af7a968bff236adf3874f3ad7e3ba78c47f`, including authoritative Bazel Rust tests, native binding packaging, platform durability, concurrency matrix, and CI Gate. Squash merged; issue #1122 is closed.
