### PR TITLE
fix(bench): preserve workflow receipt failures

### DIFF
--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -527,7 +527,7 @@ impl PhaseExecutor for PublicProcessExecutor {
                 };
                 peak_rss_bytes = max_optional(peak_rss_bytes, execution.peak_rss_bytes);
                 receipts.extend(execution.receipts);
-                if execution.exit_code != Some(0) {
+                if execution.exit_code != Some(0) || execution.failure.is_some() {
                     return Ok(Execution {
                         exit_code: execution.exit_code,
                         duration_ms: millis(started.elapsed()),
@@ -2382,6 +2382,60 @@ mod tests {
         assert_eq!(fs::read_to_string(state).unwrap().trim(), "5");
         drop(fixture_writer);
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn public_workflow_preserves_zero_exit_receipt_failures() {
+        for reject_second in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let script = root.path().join("command.sh");
+            let calls = root.path().join("calls");
+            fs::write(
+                &script,
+                format!(
+                    r#"state="$1"
+n=0
+[ ! -f "$state" ] || n=$(cat "$state")
+n=$((n + 1))
+printf '%s\n' "$n" > "$state"
+if [ "{reject_second}" = true ] && [ "$n" = 2 ]; then
+    printf '%s\n' '{{"contract":"unknown/1"}}'
+else
+    printf '%s\n' '{{"contract":"graphforge-import-session/1","outcome":"begun"}}'
+fi
+"#
+                ),
+            )
+            .unwrap();
+            let mut profile = shell_ingest_profile(&script);
+            let PhaseAction::GraphForgeCliWorkflow { commands } = &mut profile.phases[2].action
+            else {
+                panic!("ingest workflow");
+            };
+            for args in commands {
+                args.insert(1, calls.to_string_lossy().into_owned());
+                args.insert(2, "--json".into());
+            }
+            let execution = PublicProcessExecutor::default()
+                .execute(&profile, &profile.phases[2])
+                .unwrap();
+            assert_eq!(execution.exit_code, Some(0));
+            assert_eq!(
+                execution.failure,
+                reject_second.then_some(FailureKind::EvidenceInvalid)
+            );
+            assert_eq!(execution.receipts.len(), if reject_second { 1 } else { 5 });
+            assert!(execution.receipts.iter().all(|receipt| {
+                receipt["contract"] == "graphforge-import-session/1"
+                    && receipt["outcome"] == "begun"
+            }));
+            assert_eq!(
+                fs::read_to_string(calls).unwrap().trim(),
+                if reject_second { "2" } else { "5" },
+                "a rejected receipt must prevent all later child commands"
+            );
+        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
A public-command workflow could report success after a child exited zero with an invalid JSON receipt: the child execution carried `EvidenceInvalid`, but workflow aggregation checked only the exit code and continued. Stop on either a nonzero exit or a recorded execution failure, preserving the original exit code, failure classification, prior receipts, cleanup details, timing, and RSS.

A real child-process regression proves valid zero-exit receipt sequences succeed, while an invalid second receipt stops the workflow after exactly two commands and retains only the preceding valid receipt. It failed before the fix (`None` instead of `EvidenceInvalid`) and passes afterward. Existing nonzero-exit handling remains covered.

Validation:
- All 25 certifier tests passed; all-targets certifier Clippy with `-D warnings` passed.
- Fresh CLI/certifier/generator binaries completed the real ten-phase tiny lifecycle, retaining 2 recount, 2 query, and 4 reopened-query receipts with matching source/imported results.
- Fast checks, 14 gate-registry tests, and final formatting/diff checks passed.

This is the independent gate defect blocking #1119/#1124. Updating the new adjacency-probe receipt field remains in #1124; this change does not relax receipt validation or resource thresholds.

Closes #1125. Exact-head CI run 33950728612 passed at `78f76ee3bb28d02aae82b6c8829a3d9f2b7f5a88`, with successful CI Gate, CLEAN merge state, and no unresolved review threads. Squash merged as `6a937da07a6ee9eb5ae5b2b4247f7432a5e7211a`; issue #1125 is closed.
