### PR TITLE
chore(exec): audit active kernels and remove blanket dead-code allowances

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -6419,6 +6419,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn prize_steiner_validates_property_types_before_kernel_dispatch() {
+        for prize in [
+            PropValue::Int(2),
+            PropValue::Int(-1),
+            PropValue::Int(i64::MAX),
+            PropValue::Null,
+            PropValue::Bool(true),
+            PropValue::Str("not a number".into()),
+        ] {
+            let valid = prize == PropValue::Int(2);
+            let graph = GraphForge::new(None).unwrap();
+            let node = graph
+                .add_node("Person", &HashMap::from([("prize".into(), prize.clone())]))
+                .unwrap();
+            let result = graph.paths(None, None, prize_steiner_options(&[&node], None, "prize"));
+            if valid {
+                assert_eq!(result.unwrap().num_rows(), 0);
+            } else {
+                assert!(result.is_err(), "invalid prize accepted: {prize:?}");
+            }
+            assert_eq!(graph.node_count("Person").unwrap(), 1);
+        }
+    }
+
     fn is_dag_options(directed: bool, via: Option<&str>) -> AnalyzeOptions {
         AnalyzeOptions {
             by: AnalyzeAlgorithm::IsDag,

--- a/crates/graphforge-exec/src/algorithm_cluster_spinglass.rs
+++ b/crates/graphforge-exec/src/algorithm_cluster_spinglass.rs
@@ -216,6 +216,7 @@ impl SpinglassGraph {
         finite(energy, "Spinglass energy is not finite")
     }
 
+    #[cfg(test)]
     pub(crate) fn move_delta(
         &self,
         component: &[usize],

--- a/crates/graphforge-exec/src/algorithm_embedding_node2vec.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_node2vec.rs
@@ -520,13 +520,6 @@ fn walk_task_chunks(total_walks: usize, threads: usize) -> Vec<(usize, usize)> {
     ranges
 }
 
-fn walk_task_ordinal(start_ordinal: usize, walk_ordinal: usize, walks_per_node: usize) -> usize {
-    start_ordinal
-        .checked_mul(walks_per_node)
-        .and_then(|value| value.checked_add(walk_ordinal))
-        .expect("validated walk task ordinals fit usize")
-}
-
 fn build_walk(
     graph: &AdjacencyGraph,
     options: &Node2VecOptions,
@@ -1000,9 +993,7 @@ mod tests {
     }
 
     #[test]
-    fn walk_task_ordinal_mapping_and_chunks_are_stable() {
-        assert_eq!(walk_task_ordinal(0, 0, 4), 0);
-        assert_eq!(walk_task_ordinal(2, 3, 4), 11);
+    fn walk_task_chunks_are_stable() {
         assert_eq!(walk_task_chunks(0, 4), Vec::<(usize, usize)>::new());
         assert_eq!(walk_task_chunks(5, 1), vec![(0, 5)]);
         assert_eq!(walk_task_chunks(5, 2), vec![(0, 3), (3, 5)]);

--- a/crates/graphforge-exec/src/algorithm_embedding_rng.rs
+++ b/crates/graphforge-exec/src/algorithm_embedding_rng.rs
@@ -53,6 +53,7 @@ impl EmbeddingRng {
         Self { state }
     }
 
+    #[cfg(test)]
     pub(crate) fn derived_state(&self) -> u64 {
         self.state
     }

--- a/crates/graphforge-exec/src/algorithm_paths_prize_steiner.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_prize_steiner.rs
@@ -10,25 +10,11 @@ use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum ResolvedNumber {
     Float64(f64),
-    Int64(i64),
-    UInt64(u64),
-    Null,
-    NonNumeric,
 }
 
 impl ResolvedNumber {
-    #[allow(
-        clippy::cast_precision_loss,
-        reason = "graph integer properties share the canonical Float64 algorithm cost domain"
-    )]
     fn finite_nonnegative(self, name: &str) -> Result<f64, AlgorithmError> {
-        let value = match self {
-            Self::Float64(value) => value,
-            Self::Int64(value) => value as f64,
-            Self::UInt64(value) => value as f64,
-            Self::Null => return Err(execution(format!("{name} is null"))),
-            Self::NonNumeric => return Err(execution(format!("{name} is not numeric"))),
-        };
+        let Self::Float64(value) = self;
         if !value.is_finite() || value < 0.0 {
             return Err(execution(format!("{name} must be finite and nonnegative")));
         }
@@ -563,9 +549,6 @@ mod tests {
             ResolvedNumber::Float64(f64::NAN),
             ResolvedNumber::Float64(f64::INFINITY),
             ResolvedNumber::Float64(-1.0),
-            ResolvedNumber::Int64(-1),
-            ResolvedNumber::Null,
-            ResolvedNumber::NonNumeric,
         ] {
             let mut invalid_nodes = nodes;
             invalid_nodes[1].prize = invalid;
@@ -578,7 +561,7 @@ mod tests {
             solve(
                 &[NodePrize {
                     node_uuid: uuid(1),
-                    prize: ResolvedNumber::UInt64(u64::MAX)
+                    prize: ResolvedNumber::Float64(18_446_744_073_709_551_616.0)
                 }],
                 &[],
                 &[1]

--- a/crates/graphforge-exec/src/algorithm_paths_random_walk.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_random_walk.rs
@@ -4,6 +4,9 @@
 //! tasks through the instance-owned private compute pool. Each walk keeps the
 //! exact serial RNG stream and choice ordering, and worker outputs merge by
 //! canonical task ordinal so the public row order remains byte-identical.
+//!
+//! The RNG contract is splitmix64-v1. Changing the generator, seed derivation,
+//! draw conversion, or choice ordering requires a new contract version.
 
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -11,10 +14,6 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use rayon::prelude::*;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
-
-/// Changing the generator, seed derivation, draw conversion, or choice ordering
-/// requires a new contract version.
-pub(crate) const RANDOM_WALK_RNG_CONTRACT: &str = "splitmix64-v1";
 
 /// Estimated transitions below which random_walk stays on the serial path (#553).
 ///
@@ -422,7 +421,6 @@ mod tests {
                 vec![uuid(2)],
             ]
         );
-        assert_eq!(RANDOM_WALK_RNG_CONTRACT, "splitmix64-v1");
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_paths_steiner.rs
+++ b/crates/graphforge-exec/src/algorithm_paths_steiner.rs
@@ -1,7 +1,7 @@
 //! Shared normalization for exact Steiner path algorithms.
 
 use graphforge_core::PathsOptions;
-use graphforge_core::algorithms::{Algorithm, AlgorithmResultSchema, PathAlgorithm};
+use graphforge_core::algorithms::PathAlgorithm;
 
 use crate::algorithm_dispatch::{AlgorithmControl, AlgorithmError};
 
@@ -35,23 +35,13 @@ impl SteinerKind {
 /// Canonical mandatory terminals consumed by a later Steiner kernel.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct NormalizedSteinerInvocation {
-    kind: SteinerKind,
     terminal_uuids: Vec<[u8; 16]>,
 }
 
 impl NormalizedSteinerInvocation {
-    pub(crate) const fn kind(&self) -> SteinerKind {
-        self.kind
-    }
-
     pub(crate) fn terminal_uuids(&self) -> &[[u8; 16]] {
         &self.terminal_uuids
     }
-}
-
-/// Return the dedicated non-null four-column schema for this Steiner kind.
-pub(crate) const fn steiner_schema(kind: SteinerKind) -> AlgorithmResultSchema {
-    Algorithm::Paths(kind.algorithm()).result_schema()
 }
 
 /// Normalize and validate one graph-layer Steiner invocation atomically.
@@ -100,10 +90,7 @@ pub(crate) fn normalize_steiner_invocation(
         }
     }
 
-    Ok(NormalizedSteinerInvocation {
-        kind,
-        terminal_uuids,
-    })
+    Ok(NormalizedSteinerInvocation { terminal_uuids })
 }
 
 fn validate_closed_options(
@@ -210,7 +197,6 @@ mod tests {
             &normalization_control,
         )
         .unwrap();
-        assert_eq!(normalized.kind(), SteinerKind::MinimumTree);
         assert_eq!(normalized.terminal_uuids(), &[uuid(1), uuid(2), uuid(3)]);
         assert_eq!(normalization_control.consume_states(4), Ok(4));
 
@@ -403,7 +389,8 @@ mod tests {
     #[test]
     fn schema_is_exact_non_null_single_tree_shape() {
         for kind in [SteinerKind::MinimumTree, SteinerKind::PrizeCollecting] {
-            let schema = steiner_schema(kind);
+            let schema =
+                graphforge_core::algorithms::Algorithm::Paths(kind.algorithm()).result_schema();
             assert_eq!(
                 schema
                     .fields

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -19,115 +19,53 @@
 
 pub mod adjacency;
 mod algorithm_analyze;
-#[allow(
-    dead_code,
-    reason = "issue 2106 provides the foundation for exact automorphism counting"
-)]
 pub(crate) mod algorithm_analyze_automorphism;
-#[allow(
-    dead_code,
-    reason = "issue 2111 provides the exact kernel before handler activation"
-)]
 pub(crate) mod algorithm_analyze_automorphism_count;
-#[allow(
-    dead_code,
-    reason = "issue 1223 registers the bipartite matching kernel"
-)]
 pub(crate) mod algorithm_analyze_bipartite;
-#[allow(dead_code, reason = "issue 1223 registers the Hopcroft-Karp kernel")]
 pub(crate) mod algorithm_analyze_bipartite_matching;
-#[allow(dead_code, reason = "issue 1214 registers the chromatic-number kernel")]
 pub(crate) mod algorithm_analyze_chromatic_number;
 pub(crate) mod algorithm_analyze_conductance;
-#[allow(dead_code, reason = "issue 1206 registers the dag-longest-path kernel")]
 pub(crate) mod algorithm_analyze_dag_longest_path;
-#[allow(
-    dead_code,
-    reason = "issue 1208 registers the weighted dag-longest-path kernel"
-)]
 pub(crate) mod algorithm_analyze_dag_longest_path_weighted;
-#[allow(dead_code, reason = "issue 1741 adds the shared DAG-family kernel")]
 pub(crate) mod algorithm_analyze_dag_topology;
-#[allow(dead_code, reason = "issue 1884 registers the dyad-census kernel")]
 pub(crate) mod algorithm_analyze_dyad_census;
-#[allow(dead_code, reason = "issue 1212 registers the edge-coloring kernel")]
 pub(crate) mod algorithm_analyze_edge_coloring;
-#[allow(
-    dead_code,
-    reason = "issue 2104 provides shared Euler construction before leaf activation"
-)]
 pub(crate) mod algorithm_analyze_euler;
-#[allow(dead_code, reason = "issue 1204 registers the find-cycles kernel")]
 pub(crate) mod algorithm_analyze_find_cycles;
-#[allow(dead_code, reason = "issue 1227 registers the Euler-circuit predicate")]
 pub(crate) mod algorithm_analyze_has_euler_circuit;
-#[allow(dead_code, reason = "issue 1228 registers the Euler-path predicate")]
 pub(crate) mod algorithm_analyze_has_euler_path;
-#[allow(dead_code, reason = "issue 1229 registers the planarity predicate")]
 pub(crate) mod algorithm_analyze_is_planar;
-#[allow(dead_code, reason = "issue 1217 registers the k1-coloring kernel")]
 pub(crate) mod algorithm_analyze_k1_coloring;
-#[allow(dead_code, reason = "issues 1230 and 1231 register this shared kernel")]
 pub(crate) mod algorithm_analyze_lowlink;
-#[allow(
-    dead_code,
-    reason = "issue 1221 registers the maximum-cardinality matching kernel"
-)]
 pub(crate) mod algorithm_analyze_max_cardinality_matching;
-#[allow(dead_code, reason = "#1198 dispatch integration registers this kernel")]
 pub(crate) mod algorithm_analyze_minimum_k_spanning_tree;
 pub(crate) mod algorithm_analyze_minimum_spanning_forest;
-#[allow(dead_code, reason = "issue 1234 registers the modularity kernel")]
 pub(crate) mod algorithm_analyze_modularity;
 pub(crate) mod algorithm_analyze_node_coloring;
 pub(crate) mod algorithm_analyze_transitivity;
-#[allow(dead_code, reason = "issue 1885 registers the triad-census kernel")]
 pub(crate) mod algorithm_analyze_triad_census;
-#[allow(dead_code, reason = "issue 1232 registers the triangle-count kernel")]
 pub(crate) mod algorithm_analyze_triangle_count;
 mod algorithm_cluster;
 pub(crate) mod algorithm_cluster_biconnected;
 pub(crate) mod algorithm_cluster_hdbscan;
 pub(crate) mod algorithm_cluster_kmeans;
 pub(crate) mod algorithm_cluster_max_cut;
-#[allow(dead_code)]
 pub(crate) mod algorithm_cluster_scc;
 pub(crate) mod algorithm_cluster_spectral;
-#[allow(dead_code)]
 pub(crate) mod algorithm_cluster_spinglass;
 pub(crate) mod algorithm_cluster_walktrap;
 pub(crate) mod algorithm_dispatch;
-#[allow(
-    dead_code,
-    reason = "embedding kernels consume this shared control foundation"
-)]
 pub(crate) mod algorithm_embedding_control;
 pub(crate) mod algorithm_embedding_fastrp;
 pub(crate) mod algorithm_embedding_graphsage;
 pub(crate) mod algorithm_embedding_hashgnn;
 mod algorithm_embedding_invocation;
-#[allow(
-    dead_code,
-    reason = "embedding leaf dispatches consume the shared typed option boundary"
-)]
 pub(crate) mod algorithm_embedding_options;
 pub use algorithm_embedding_options::validate_embedding_options;
 pub use algorithm_graph::AlgorithmProjectionFingerprint;
 pub(crate) mod algorithm_arrow_sink;
-#[allow(
-    dead_code,
-    reason = "Node2Vec activation consumes the deterministic walk corpus"
-)]
 pub(crate) mod algorithm_embedding_node2vec;
-#[allow(
-    dead_code,
-    reason = "embedding kernels consume this canonical output foundation"
-)]
 pub(crate) mod algorithm_embedding_output;
-#[allow(
-    dead_code,
-    reason = "embedding kernels consume this shared RNG foundation"
-)]
 pub(crate) mod algorithm_embedding_rng;
 pub(crate) mod algorithm_graph;
 pub(crate) mod algorithm_k_core;
@@ -135,50 +73,21 @@ pub(crate) mod algorithm_matching_blossom;
 pub(crate) mod algorithm_matching_state;
 pub(crate) mod algorithm_neighbors;
 pub(crate) mod algorithm_output;
-#[allow(
-    dead_code,
-    reason = "issues 1223 and 1233 consume the shared partition mapping"
-)]
 pub(crate) mod algorithm_partition;
 mod algorithm_paths;
-#[allow(dead_code, reason = "issue 1683 registers this kernel")]
 pub(crate) mod algorithm_paths_astar;
-#[allow(dead_code, reason = "issue 1691 registers this kernel")]
 pub(crate) mod algorithm_paths_bellman_ford;
-#[allow(dead_code, reason = "issue 1706 registers this kernel")]
 pub(crate) mod algorithm_paths_delta_stepping;
-#[allow(
-    dead_code,
-    reason = "issue 1220 registers the depth-first-search kernel"
-)]
 pub(crate) mod algorithm_paths_dfs;
-#[allow(dead_code, reason = "issue 1665 registers this kernel")]
 pub(crate) mod algorithm_paths_dijkstra;
-#[allow(dead_code, reason = "issue 1701 registers this kernel")]
 pub(crate) mod algorithm_paths_floyd_warshall;
-#[allow(
-    dead_code,
-    reason = "issue 2121 provides the Gomory-Hu kernel before activation"
-)]
 pub(crate) mod algorithm_paths_gomory_hu;
-#[allow(dead_code, reason = "issue 1209 registers both maximum-flow views")]
 pub(crate) mod algorithm_paths_max_flow;
-#[allow(dead_code, reason = "issue 1213 registers both min-cost flow views")]
 pub(crate) mod algorithm_paths_min_cost_flow;
-#[allow(dead_code, reason = "issue 1211 registers both minimum-cut views")]
 pub(crate) mod algorithm_paths_min_cut;
 pub(crate) mod algorithm_paths_min_steiner;
-#[allow(
-    dead_code,
-    reason = "production graph properties normalize to f64; exact scalar variants retain kernel boundary coverage"
-)]
 pub(crate) mod algorithm_paths_prize_steiner;
-#[allow(dead_code, reason = "issue 1222 registers the random-walk kernel")]
 pub(crate) mod algorithm_paths_random_walk;
-#[allow(
-    dead_code,
-    reason = "issue 2159 provides Steiner normalization before activation"
-)]
 pub(crate) mod algorithm_paths_steiner;
 pub(crate) mod algorithm_paths_transitive_closure;
 pub(crate) mod algorithm_paths_yens;

--- a/docs/development/executor-kernel-audit.md
+++ b/docs/development/executor-kernel-audit.md
@@ -1,0 +1,92 @@
+# Executor kernel dead-code audit (#1026)
+
+The audit covers all 43 module-wide `allow(dead_code)` declarations in
+`crates/graphforge-exec/src/lib.rs` at the start of #1026. Every module has
+production consumers. None is an abandoned or wholly test-only module, so all
+43 remain in production with their blanket allowances removed.
+
+The table records direct production consumers, excluding each module's own
+`#[cfg(test)] mod tests`. File names are relative to
+`crates/graphforge-exec/src/`. Analyze, cluster, and paths dispatchers invoke the
+kernels; shared foundation modules are also consumed by the named active kernels.
+The tracking column preserves issue numbers from the removed allowance comments;
+it records their historical rationale, not a claim that those issues remain open.
+The current cleanup is tracked by #1026.
+
+| Retained module | Direct production consumers | Tracking recorded in allowance |
+| --- | --- | --- |
+| `algorithm_analyze_automorphism` | `algorithm_analyze.rs`, `algorithm_analyze_automorphism_count.rs` | #2106 |
+| `algorithm_analyze_automorphism_count` | `algorithm_analyze.rs` | #2111 |
+| `algorithm_analyze_bipartite` | `algorithm_analyze.rs`, `algorithm_analyze_bipartite_matching.rs` | #1223 |
+| `algorithm_analyze_bipartite_matching` | `algorithm_analyze.rs` | #1223 |
+| `algorithm_analyze_chromatic_number` | `algorithm_analyze.rs` | #1214 |
+| `algorithm_analyze_dag_longest_path` | `algorithm_analyze.rs`, `algorithm_analyze_dag_longest_path_weighted.rs` | #1206 |
+| `algorithm_analyze_dag_longest_path_weighted` | `algorithm_analyze.rs` | #1208 |
+| `algorithm_analyze_dag_topology` | `algorithm_analyze.rs` | #1741 |
+| `algorithm_analyze_dyad_census` | `algorithm_analyze.rs` | #1884 |
+| `algorithm_analyze_edge_coloring` | `algorithm_analyze.rs` | #1212 |
+| `algorithm_analyze_euler` | `algorithm_analyze.rs`, `algorithm_analyze_has_euler_circuit.rs`, `algorithm_analyze_has_euler_path.rs` | #2104 |
+| `algorithm_analyze_find_cycles` | `algorithm_analyze.rs` | #1204 |
+| `algorithm_analyze_has_euler_circuit` | `algorithm_analyze.rs` | #1227 |
+| `algorithm_analyze_has_euler_path` | `algorithm_analyze.rs` | #1228 |
+| `algorithm_analyze_is_planar` | `algorithm_analyze.rs` | #1229 |
+| `algorithm_analyze_k1_coloring` | `algorithm_analyze.rs` | #1217 |
+| `algorithm_analyze_lowlink` | `algorithm_analyze.rs` | #1230, #1231 |
+| `algorithm_analyze_max_cardinality_matching` | `algorithm_analyze.rs` | #1221 |
+| `algorithm_analyze_minimum_k_spanning_tree` | `algorithm_analyze.rs` | #1198 |
+| `algorithm_analyze_modularity` | `algorithm_analyze.rs` | #1234 |
+| `algorithm_analyze_triad_census` | `algorithm_analyze.rs` | #1885 |
+| `algorithm_analyze_triangle_count` | `algorithm_analyze.rs` | #1232 |
+| `algorithm_cluster_scc` | `algorithm_cluster.rs` | None recorded |
+| `algorithm_cluster_spinglass` | `algorithm_cluster.rs` | None recorded |
+| `algorithm_embedding_control` | `algorithm_analyze.rs`, `algorithm_embedding_fastrp.rs`, `algorithm_embedding_graphsage.rs`, `algorithm_embedding_hashgnn.rs`, `algorithm_embedding_node2vec.rs`, `algorithm_embedding_output.rs` | None recorded |
+| `algorithm_embedding_options` | `algorithm_analyze.rs`, `algorithm_embedding_output.rs` | None recorded |
+| `algorithm_embedding_node2vec` | `algorithm_analyze.rs` | None recorded |
+| `algorithm_embedding_output` | `algorithm_analyze.rs`, `algorithm_embedding_fastrp.rs`, `algorithm_embedding_graphsage.rs`, `algorithm_embedding_hashgnn.rs`, `algorithm_embedding_node2vec.rs` | None recorded |
+| `algorithm_embedding_rng` | `algorithm_embedding_fastrp.rs`, `algorithm_embedding_graphsage.rs`, `algorithm_embedding_hashgnn.rs`, `algorithm_embedding_node2vec.rs` | None recorded |
+| `algorithm_partition` | `algorithm_analyze.rs`, `algorithm_analyze_bipartite.rs`, `algorithm_analyze_conductance.rs`, `algorithm_analyze_modularity.rs`, `algorithm_graph.rs` | #1223, #1233 |
+| `algorithm_paths_astar` | `algorithm_paths.rs` | #1683 |
+| `algorithm_paths_bellman_ford` | `algorithm_paths.rs` | #1691 |
+| `algorithm_paths_delta_stepping` | `algorithm_paths.rs` | #1706 |
+| `algorithm_paths_dfs` | `algorithm_paths.rs` | #1220 |
+| `algorithm_paths_dijkstra` | `algorithm_paths.rs`, `algorithm_paths_astar.rs`, `algorithm_paths_bellman_ford.rs`, `algorithm_paths_delta_stepping.rs`, `algorithm_paths_floyd_warshall.rs` | #1665 |
+| `algorithm_paths_floyd_warshall` | `algorithm_paths.rs` | #1701 |
+| `algorithm_paths_gomory_hu` | `algorithm_paths.rs` | #2121 |
+| `algorithm_paths_max_flow` | `algorithm_paths.rs`, `algorithm_paths_gomory_hu.rs`, `algorithm_paths_min_cut.rs` | #1209 |
+| `algorithm_paths_min_cost_flow` | `algorithm_paths.rs` | #1213 |
+| `algorithm_paths_min_cut` | `algorithm_paths.rs`, `algorithm_paths_gomory_hu.rs` | #1211 |
+| `algorithm_paths_prize_steiner` | `algorithm_paths.rs` | None recorded |
+| `algorithm_paths_random_walk` | `algorithm_paths.rs` | #1222 |
+| `algorithm_paths_steiner` | `algorithm_paths.rs` | #2159 |
+
+## Item-level disposition
+
+Removing the blanket allowances exposed seven unused-item diagnostics in a fresh
+executor compilation. The cleanup follows their actual use:
+
+- `SpinglassGraph::move_delta` remains behind `#[cfg(test)]` because the energy
+  delta regression uses it as an independent oracle for the production optimizer.
+- `EmbeddingRng::derived_state` remains behind `#[cfg(test)]` for deterministic
+  seed/state vectors. Production continues to use the same generator methods.
+- The unused `walk_task_ordinal` helper and its self-assertions are deleted.
+  Production task assignment and deterministic chunk/parallel walk tests remain.
+- The unused `RANDOM_WALK_RNG_CONTRACT` string and its self-assertion are deleted.
+  The splitmix64-v1 contract is documented at module level; exact seeded walk
+  vectors, weighted choices, and serial/parallel equivalence tests remain.
+- Prize-Steiner `ResolvedNumber` retains its production `Float64` representation.
+  Unconstructed integer/null/non-numeric variants are deleted. Production property
+  normalization already validates nulls, numeric types and exact integer conversion
+  before dispatch. A real API regression covers valid integers and invalid negative,
+  oversized, null, boolean and string prizes; kernel finite/nonnegative checks remain.
+- `NormalizedSteinerInvocation::kind`, its unused stored kind, and the unused
+  `steiner_schema` wrapper are deleted. The kind still validates options and terminal
+  requirements during normalization; schema tests exercise the canonical algorithm
+  schema directly.
+
+## Validation
+
+The acceptance gate is `cargo clippy --workspace -- -D warnings` plus executor
+unit tests. The changed property boundary also requires the focused API
+`prize_steiner_validates_property_types_before_kernel_dispatch` regression.
+Formatting and the repository fast gates apply to the final tree. Validation
+results belong to the focused PR; this inventory does not claim unrun checks.


### PR DESCRIPTION
All 43 executor modules hidden behind module-wide `allow(dead_code)` declarations have production callers. This change records the caller/tracking inventory, removes every blanket allowance, and resolves unused-item diagnostics. Two independent regression oracles remain under `cfg(test)`; unused helpers, stored state, and unreachable numeric variants are removed. No whole module was abandoned or test-only.

A real Rust API regression verifies integer prizes work and negative, oversized, null, boolean, and string prizes are rejected before kernel dispatch.

Validation on `fe98f80e092ea10f14c170971c4fa1b8cc662558`, based on current main `d1a172ba`:
- `cargo clippy --workspace -- -D warnings`: passed.
- `cargo test --locked -p graphforge-exec --lib`: 870 passed, 13 existing ignores.
- `cargo test --locked -p graphforge-api --lib prize_steiner_validates_property_types_before_kernel_dispatch`: 1 passed.
- `make pre-push-fast`, `make gate-registry-check`, `cargo fmt --all -- --check`, and `git diff --check`: passed.
- Independent LOW review verified the inventory, production callers, removed items, and retained test oracles; no actionable findings.

Closes #1026

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791192629&installation_model_id=20486&pr_number=1130&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1130&signature=8f40a3026a7ee344d00a63a4c20a53722e49cce693ee85314a631b2d6c6f448b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->