### PR TITLE
test(rel,exec): isolate differential traversal oracle from default builds

### DIFF
--- a/crates/graphforge-exec/BUILD.bazel
+++ b/crates/graphforge-exec/BUILD.bazel
@@ -25,6 +25,21 @@ gf_rust_library(
     deps = _EXEC_DEPS,
 )
 
+_EXEC_DIFFERENTIAL_DEPS = [
+    dep
+    for dep in _EXEC_DEPS
+    if dep != "//crates/graphforge-rel:graphforge_rel"
+] + ["//crates/graphforge-rel:graphforge_rel_differential"]
+
+gf_rust_library(
+    name = "graphforge_exec_differential",
+    crate_name = "graphforge_exec",
+    crate_features = ["differential-testing"],
+    testonly = True,
+    visibility = ["//visibility:private"],
+    deps = _EXEC_DIFFERENTIAL_DEPS,
+)
+
 gf_rust_test(
     name = "graphforge_exec_test",
     crate = ":graphforge_exec",
@@ -84,10 +99,12 @@ gf_rust_integration_test(
 gf_rust_integration_test(
     name = "differential_traversal",
     srcs = ["tests/differential_traversal.rs"],
-    crate = ":graphforge_exec",
+    crate = ":graphforge_exec_differential",
     data = _EXEC_TEST_DATA,
     size = "medium",
-    deps = _EXEC_TEST_DEPS,
+    deps = _EXEC_DIFFERENTIAL_DEPS + [
+        "//crates/graphforge-cypher:graphforge_cypher",
+    ],
 )
 
 gf_rust_integration_test(

--- a/crates/graphforge-exec/Cargo.toml
+++ b/crates/graphforge-exec/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 license-file.workspace = true
 repository.workspace = true
 
+[features]
+# Explicit opt-in for the independent fixed-hop differential oracle.
+differential-testing = ["graphforge-rel/differential-testing"]
+
 [dependencies]
 graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
 graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }
@@ -30,6 +34,10 @@ insta = { workspace = true, features = ["filters"] }
 tempfile = "3"
 tokio = { workspace = true }
 parquet = { workspace = true }
+
+[[test]]
+name = "differential_traversal"
+required-features = ["differential-testing"]
 
 [lints]
 workspace = true

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -4941,7 +4941,8 @@ pub struct ExecutionSession {
     /// invalidate its memoized state and loaded views — a same-session
     /// read → write → read must observe post-write adjacency.
     adjacency_provider: Arc<PersistentAdjacencyProvider>,
-    /// Doc-hidden differential-test strategy; production sessions leave false.
+    /// Differential-test strategy, absent from ordinary builds.
+    #[cfg(feature = "differential-testing")]
     relational_fixed_hop_reference: bool,
 }
 
@@ -5155,12 +5156,14 @@ impl ExecutionSession {
             mode,
             semantic_composition_fingerprint,
             adjacency_provider,
+            #[cfg(feature = "differential-testing")]
             relational_fixed_hop_reference: false,
         }
     }
 
     /// Use the relational fixed-hop implementation as an independent test
-    /// oracle. The public `GraphForge` facade never enables this strategy.
+    /// oracle. Available only with the non-default `differential-testing` feature.
+    #[cfg(feature = "differential-testing")]
     #[doc(hidden)]
     #[must_use]
     pub fn with_relational_fixed_hop_reference(mut self) -> Self {
@@ -5868,7 +5871,7 @@ impl ExecutionSession {
         // session cannot read persisted data, so reject scan plans up front
         // (mirroring `execute_create`'s write-target guard) and lower the rest
         // schema-only so pure computed/`RETURN` plans still run.
-        let mut lowerer = if self.dir.as_os_str().is_empty() {
+        let lowerer = if self.dir.as_os_str().is_empty() {
             if plan_reads_persisted_data(plan) {
                 return Err(GfError::Execution(
                     "execute_plan requires a project directory to read persisted nodes/edges; \
@@ -5885,9 +5888,12 @@ impl ExecutionSession {
                 self.mode,
             )
         };
-        if self.relational_fixed_hop_reference {
-            lowerer = lowerer.with_relational_fixed_hop_reference();
-        }
+        #[cfg(feature = "differential-testing")]
+        let lowerer = if self.relational_fixed_hop_reference {
+            lowerer.with_relational_fixed_hop_reference()
+        } else {
+            lowerer
+        };
         let logical = lowerer.lower_plan(plan)?;
 
         // Bind `$name` query parameters to their values, replacing the

--- a/crates/graphforge-exec/tests/differential_traversal.rs
+++ b/crates/graphforge-exec/tests/differential_traversal.rs
@@ -135,26 +135,29 @@ async fn differential(
     query: &str,
     shape: PlanShape,
 ) -> Vec<String> {
-    let plan = bind(query, rc);
+    let bound_query = bind(query, rc);
 
     build_adjacency_index(dir, TS).unwrap();
     let indexed_session = session(dir, rc);
-    let indexed_plan = indexed_session.explain_physical(&plan).await.unwrap();
-    let indexed = indexed_session.execute_plan(&plan).await.unwrap();
+    let indexed_plan = indexed_session
+        .explain_physical(&bound_query)
+        .await
+        .unwrap();
+    let indexed = indexed_session.execute_plan(&bound_query).await.unwrap();
 
     std::fs::remove_dir_all(dir.join("indexes")).unwrap();
     let plain_session = session(dir, rc);
-    let plain_plan = plain_session.explain_physical(&plan).await.unwrap();
-    let plain = plain_session.execute_plan(&plan).await.unwrap();
+    let plain_plan = plain_session.explain_physical(&bound_query).await.unwrap();
+    let plain = plain_session.execute_plan(&bound_query).await.unwrap();
 
     let relational = if matches!(shape, PlanShape::FixedHopProvider { .. }) {
         let reference = session(dir, rc).with_relational_fixed_hop_reference();
-        let reference_plan = reference.explain_physical(&plan).await.unwrap();
+        let reference_plan = reference.explain_physical(&bound_query).await.unwrap();
         assert!(
             !reference_plan.contains("ExpandExec"),
             "{query}: relational oracle unexpectedly used provider expansion:\n{reference_plan}"
         );
-        Some(reference.execute_plan(&plan).await.unwrap())
+        Some(reference.execute_plan(&bound_query).await.unwrap())
     } else {
         None
     };

--- a/crates/graphforge-rel/BUILD.bazel
+++ b/crates/graphforge-rel/BUILD.bazel
@@ -24,6 +24,16 @@ gf_rust_library(
     deps = _REL_DEPS,
 )
 
+# Only the differential traversal suite can depend on the reference switch.
+gf_rust_library(
+    name = "graphforge_rel_differential",
+    crate_name = "graphforge_rel",
+    crate_features = ["differential-testing"],
+    testonly = True,
+    visibility = ["//crates/graphforge-exec:__pkg__"],
+    deps = _REL_DEPS,
+)
+
 gf_rust_test(
     name = "graphforge_rel_test",
     crate = ":graphforge_rel",

--- a/crates/graphforge-rel/Cargo.toml
+++ b/crates/graphforge-rel/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 license-file.workspace = true
 repository.workspace = true
 
+[features]
+# Explicit opt-in for the independent fixed-hop differential oracle.
+differential-testing = []
+
 [dependencies]
 graphforge-core = { version = "0.5.2", path = "../graphforge-core" }
 graphforge-ir = { version = "0.5.2", path = "../graphforge-ir" }

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -117,8 +117,8 @@ pub struct GraphPlanLowerer<'a> {
     /// non-empty, so the no-ontology TCK plan is byte-identical.
     inference_rules: HashMap<u32, Vec<(String, String)>>,
     /// Test-only escape hatch that retains the relational fixed-hop lowering
-    /// as an independent semantic oracle. Production constructors leave this
-    /// disabled, so provider-backed expansion remains the sole default.
+    /// as an independent semantic oracle. Absent from ordinary builds.
+    #[cfg(feature = "differential-testing")]
     relational_fixed_hop_reference: bool,
 }
 
@@ -206,13 +206,14 @@ impl<'a> GraphPlanLowerer<'a> {
             read_dir,
             node_shapes: std::sync::RwLock::new(HashMap::new()),
             inference_rules: build_inference_rules(ontology),
+            #[cfg(feature = "differential-testing")]
             relational_fixed_hop_reference: false,
         }
     }
 
     /// Select the legacy relational fixed-hop lowering as a differential-test
-    /// oracle. This is deliberately doc-hidden and never enabled by production
-    /// API paths.
+    /// oracle. Available only with the non-default `differential-testing` feature.
+    #[cfg(feature = "differential-testing")]
     #[doc(hidden)]
     #[must_use]
     pub fn with_relational_fixed_hop_reference(mut self) -> Self {
@@ -899,6 +900,7 @@ impl<'a> GraphPlanLowerer<'a> {
                     &self.type_id_to_rel_name,
                     &self.inference_rules,
                     self.read_dir,
+                    #[cfg(feature = "differential-testing")]
                     self.relational_fixed_hop_reference,
                 );
             }
@@ -3729,7 +3731,7 @@ fn lower_expand(
     type_id_to_rel_name: &HashMap<u32, String>,
     inference_rules: &HashMap<u32, Vec<(String, String)>>,
     target: Option<(&Path, OntologyMode)>,
-    relational_reference: bool,
+    #[cfg(feature = "differential-testing")] relational_reference: bool,
 ) -> Result<LogicalPlan, LoweringError> {
     // Variable-length expand cannot be expressed in relational algebra; emit
     // the graphforge-plan Extension node whose physical execution (physical execution) performs an
@@ -3762,6 +3764,8 @@ fn lower_expand(
     // A project-backed fixed hop always uses the provider-backed Extension
     // node (#1248). The provider owns hit/miss/building fallback, keeping the
     // physical shape stable so a terminal LIMIT can cancel traversal work.
+    #[cfg(not(feature = "differential-testing"))]
+    let relational_reference = false;
     if !relational_reference
         && let Some(plan) = try_lower_provider_expand(
             src,

--- a/docs/development/bazel.md
+++ b/docs/development/bazel.md
@@ -113,6 +113,22 @@ python3 scripts/ci/cargo-bazel-drift-check.py
 python3 scripts/ci/bazel-migration-ledger-check.py
 ```
 
+### Differential traversal oracle
+
+Ordinary builds of `graphforge-rel` and `graphforge-exec` do not expose a
+reference-mode switch. The independent relational fixed-hop oracle requires the
+non-default `differential-testing` feature. Run its existing three-way corpus with:
+
+```bash
+cargo test -p graphforge-exec --features differential-testing --test differential_traversal
+bazelisk test //crates/graphforge-exec:differential_traversal
+```
+
+The Bazel target uses private/test-only feature variants and remains in
+`//:ci_rust_tests`. It verifies indexed and scan-built provider execution against
+the relational oracle, including physical-plan differences and result equality.
+Cargo selects this integration target when the explicit feature is enabled.
+
 ### Dependencies and features
 
 - Declare deps/features in Cargo manifests only; regenerate

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "b86739fcc00c0ff528956d8c6e28a5350455393d0b3cf75c84913efdad3a9ff2",
+  "sha256": "890639e5808d505c6f8cc21684c84716b278f4e6e075e9e2161682a75964f767",
   "entries": [
     {
       "name": "graphforge-api",
@@ -892,7 +892,9 @@
     {
       "name": "graphforge-exec",
       "version": "0.5.2",
-      "features": [],
+      "features": [
+        "differential-testing"
+      ],
       "dependencies": [
         {
           "name": "anyhow",
@@ -1643,7 +1645,9 @@
     {
       "name": "graphforge-rel",
       "version": "0.5.2",
-      "features": [],
+      "features": [
+        "differential-testing"
+      ],
       "dependencies": [
         {
           "name": "arrow-data",


### PR DESCRIPTION
The relational fixed-hop reference switch is absent from ordinary `graphforge-rel` and `graphforge-exec` builds. An explicit non-default `differential-testing` feature exposes it to the existing differential traversal corpus. Shared relational lowering for schema-only plans remains available.

Cargo selects the differential integration target with the explicit feature. Bazel uses restricted, test-only library variants for the same corpus, retained in `//:ci_rust_tests`. The corpus verifies real provider/reference physical-plan differences and identical results. One local test variable is renamed to pass the target's Clippy check.

Validation on the integrated main base `0f9212a7`:
- `cargo clippy --workspace -- -D warnings`: passed.
- External Rust compiler probes against fresh default-build artifacts reject both reference setters with `E0599`.
- `cargo test --locked -p graphforge-exec --features differential-testing --test differential_traversal`: 23 passed, no skips, after the final edit.
- Feature-enabled rel/exec library Clippy and differential-target Clippy with `-D warnings`: passed.
- `make pre-push-fast`, `make gate-registry-check`, formatting, diff checks, and Cargo/Bazel drift: passed.
- Bazel query confirms differential target membership in `//:ci_rust_tests`; required CI executes it.
- Independent LOW review found no actionable issues.

An additional executor `--all-targets` Clippy run failed on existing test-code diagnostics outside this change (199 library-test diagnostics and one persistent-adjacency test diagnostic). That broader check is not claimed green. The changed feature libraries and differential target pass their explicit checks. Dependency locks remain identical to current main.

Closes #1027

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791194082&installation_model_id=20486&pr_number=1131&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1131&signature=bebc9ec9ac39ffa5c2f7e10b8252c46e1cddaf30bf76fcc3267dd5fc142a8cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->