### PR TITLE
fix(exec): bound recount RSS and preserve lazy index recovery

### DIFF
--- a/crates/graphforge-api/src/belief_projection.rs
+++ b/crates/graphforge-api/src/belief_projection.rs
@@ -434,10 +434,10 @@ impl GraphForge {
                 .expect("runtime catalog poisoned")
                 .clone(),
         ));
-        projected.adjacency_provider = Arc::new(graphforge_exec::PersistentAdjacencyProvider::new(
-            projected.dir.clone(),
+        projected.adjacency_provider = Arc::new(crate::adjacency_provider_for_graph(
+            &projected.dir,
             projected.ontology_mode,
-        ));
+        )?);
         let current = self.generation_for_read()?;
         if current.generation_uuid() != source_generation_uuid {
             return Err(transaction_conflict(

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -1288,6 +1288,105 @@ mod tests {
     }
 
     #[test]
+    fn initial_import_publishes_label_encoding_and_reopen_avoids_legacy_scan() {
+        const CHILD: &str = "GF_TEST_IMPORT_ENCODING_REOPEN";
+        if std::env::var_os(CHILD).is_none() {
+            // Storage read counters are process-global: isolate this admission
+            // measurement from unrelated API tests running concurrently.
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "import_session::tests::initial_import_publishes_label_encoding_and_reopen_avoids_legacy_scan",
+                    "--nocapture",
+                ])
+                .env(CHILD, "1")
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+        let (directory, project, graph) = fixture();
+        let initial_nodes = [Uuid::now_v7(), Uuid::now_v7()];
+        let mut session = graph
+            .begin_import_session(OperationId(Uuid::now_v7()), ImportSessionLimits::default())
+            .unwrap();
+        session
+            .append_arrow(BulkInputKind::Node, &[nodes(&initial_nodes)])
+            .unwrap();
+        session
+            .append_arrow(
+                BulkInputKind::Edge,
+                &[edges(Uuid::now_v7(), initial_nodes[0], initial_nodes[1])],
+            )
+            .unwrap();
+        session.validate(&graph).unwrap();
+        session.commit(&graph, None).unwrap();
+        let inventory = graphforge_storage::resolve_project_generation(&project)
+            .unwrap()
+            .graph_files_inventory()
+            .unwrap()
+            .unwrap();
+        let marked = inventory
+            .files
+            .iter()
+            .any(|entry| entry.relative_path == "topology/runtime_entity_label_encoding.json");
+        drop(graph);
+        let before = graphforge_storage::io_stats::snapshot();
+        let reopened = GraphForge::new(project.to_str()).unwrap();
+        let reads = graphforge_storage::io_stats::snapshot();
+        assert_eq!(
+            reads.node_full_reads - before.node_full_reads,
+            0,
+            "committed encoding marker={marked}; reopen decoded {} node rows for legacy reconciliation",
+            reads.node_full_rows
+        );
+        assert!(
+            marked,
+            "the encoding guarantee must be part of committed authority"
+        );
+        assert_eq!(reopened.node_count("Person").unwrap(), 2);
+        let appended = reopened;
+        let package = directory.path().join("marked.gfpb");
+        appended
+            .export_portable_v2(
+                &crate::PortableV2ExportRequest {
+                    selection: crate::PortableSelection::Current,
+                    output_path: package.clone(),
+                    representation: graphforge_storage::PortableV2Output::Bundle,
+                    profile: graphforge_storage::PortableV2SelectionProfile::Complete,
+                    subset: None,
+                    limits: graphforge_storage::PortableV2Limits::default(),
+                },
+                None,
+                |_| {},
+            )
+            .unwrap();
+        let imported = directory.path().join("imported");
+        GraphForge::import_portable_v2(
+            &imported,
+            &crate::PortableV2ImportRequest {
+                input: package,
+                operation_id: OperationId(Uuid::now_v7()),
+                limits: graphforge_storage::PortableV2Limits::default(),
+            },
+            None,
+        )
+        .unwrap();
+        let before = graphforge_storage::io_stats::snapshot();
+        let portable = GraphForge::new(imported.to_str()).unwrap();
+        assert_eq!(
+            graphforge_storage::io_stats::snapshot().node_full_reads - before.node_full_reads,
+            0
+        );
+        assert_eq!(portable.node_count("Person").unwrap(), 2);
+    }
+
+    #[test]
     fn arrow_session_resumes_stages_and_publishes_one_generation() {
         let (_directory, project, graph) = fixture();
         let node_ids = [Uuid::now_v7(), Uuid::now_v7()];

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -1921,53 +1921,56 @@ impl GraphForge {
             ));
         }
 
-        let cleanup_result = (|| -> Result<(), GfError> {
-            let entries = std::fs::read_dir(&self.dir)
-                .map_err(|e| GfError::Storage(format!("failed to read in-memory project: {e}")))?;
-            let mut first_error = None;
+        let cleanup_result = self
+            .adjacency_provider
+            .reset_graph(|| -> Result<(), GfError> {
+                let entries = std::fs::read_dir(&self.dir).map_err(|e| {
+                    GfError::Storage(format!("failed to read in-memory project: {e}"))
+                })?;
+                let mut first_error = None;
 
-            for entry in entries {
-                let entry = match entry {
-                    Ok(entry) => entry,
-                    Err(error) => {
+                for entry in entries {
+                    let entry = match entry {
+                        Ok(entry) => entry,
+                        Err(error) => {
+                            first_error.get_or_insert_with(|| {
+                                GfError::Storage(format!(
+                                    "failed to inspect in-memory project entry: {error}"
+                                ))
+                            });
+                            continue;
+                        }
+                    };
+                    let path = entry.path();
+                    let file_type = match entry.file_type() {
+                        Ok(file_type) => file_type,
+                        Err(error) => {
+                            first_error.get_or_insert_with(|| {
+                                GfError::Storage(format!(
+                                    "failed to inspect in-memory project entry {}: {error}",
+                                    path.display()
+                                ))
+                            });
+                            continue;
+                        }
+                    };
+                    let result = if file_type.is_dir() && !file_type.is_symlink() {
+                        std::fs::remove_dir_all(&path)
+                    } else {
+                        std::fs::remove_file(&path)
+                    };
+                    if let Err(error) = result {
                         first_error.get_or_insert_with(|| {
                             GfError::Storage(format!(
-                                "failed to inspect in-memory project entry: {error}"
-                            ))
-                        });
-                        continue;
-                    }
-                };
-                let path = entry.path();
-                let file_type = match entry.file_type() {
-                    Ok(file_type) => file_type,
-                    Err(error) => {
-                        first_error.get_or_insert_with(|| {
-                            GfError::Storage(format!(
-                                "failed to inspect in-memory project entry {}: {error}",
+                                "failed to remove in-memory project entry {}: {error}",
                                 path.display()
                             ))
                         });
-                        continue;
                     }
-                };
-                let result = if file_type.is_dir() && !file_type.is_symlink() {
-                    std::fs::remove_dir_all(&path)
-                } else {
-                    std::fs::remove_file(&path)
-                };
-                if let Err(error) = result {
-                    first_error.get_or_insert_with(|| {
-                        GfError::Storage(format!(
-                            "failed to remove in-memory project entry {}: {error}",
-                            path.display()
-                        ))
-                    });
                 }
-            }
 
-            first_error.map_or(Ok(()), Err)
-        })();
+                first_error.map_or(Ok(()), Err)
+            });
 
         // These registries describe the fixture, not only its remaining files.
         // Reset them even when filesystem cleanup is partial so callers never
@@ -7317,6 +7320,52 @@ mod tests {
         let parent = tempfile::tempdir().unwrap();
         let result = GraphForge::new(parent.path().join("missing/project").to_str());
         assert!(matches!(result, Err(GfError::Storage(_))));
+    }
+
+    #[test]
+    fn clear_repopulation_does_not_reuse_private_adjacency_at_same_generation() {
+        use graphforge_exec::AdjacencyProvider;
+        let graph = GraphForge::new(None).unwrap();
+        graph
+            .execute("CREATE (:Person)-[:KNOWS]->(:Person)")
+            .unwrap();
+        let retained = graph
+            .adjacency_provider
+            .adjacency("KNOWS", graphforge_ir::Direction::Out)
+            .unwrap();
+        let generation =
+            graphforge_storage::generation::read_topology_generation(&graph.dir).unwrap();
+        graph.clear().unwrap();
+        graph
+            .execute("CREATE (:Person)-[:KNOWS]->(:Person)-[:KNOWS]->(:Person)")
+            .unwrap();
+        assert_eq!(
+            graphforge_storage::generation::read_topology_generation(&graph.dir).unwrap(),
+            generation
+        );
+        let count = graph
+            .execute("MATCH ()-[r]->() RETURN count(r) AS n")
+            .unwrap();
+        let count = count.batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(count.value(0), 2);
+        assert_eq!(
+            graph
+                .execute("MATCH ()-[r:KNOWS]->() RETURN r")
+                .unwrap()
+                .batches
+                .iter()
+                .map(|batch| batch.num_rows())
+                .sum::<usize>(),
+            2
+        );
+        // The old view has not touched a shard yet. Its first lazy read must
+        // still see the old graph after a different CSR has been published.
+        assert_eq!(retained.neighbors(1).unwrap().len(), 1);
+        assert!(retained.neighbors(2).unwrap().is_empty());
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -630,10 +630,7 @@ impl GraphForge {
             uuid_membership_index: Mutex::new(None),
             ordinal_identities,
             clock: Mutex::new(Arc::new(system_time_micros)),
-            adjacency_provider: Arc::new(graphforge_exec::PersistentAdjacencyProvider::new(
-                dir.clone(),
-                ontology_mode,
-            )),
+            adjacency_provider: Arc::new(adjacency_provider_for_graph(&dir, ontology_mode)?),
             adjacency_visibility: Arc::new(std::sync::RwLock::new(())),
             embedding_refresh_scheduler: Arc::new(Mutex::new(
                 embedding_refresh::initialize_embedding_refresh_scheduler(&dir)?,
@@ -825,6 +822,7 @@ impl GraphForge {
         )?);
         let runtime = build_runtime(&resource_policy)?;
 
+        let adjacency_provider = adjacency_provider_for_graph(&dir, ontology_mode)?;
         let graph = Self {
             identity: GraphIdentity::new(),
             path: Some(container_dir),
@@ -839,10 +837,7 @@ impl GraphForge {
             uuid_membership_index: Mutex::new(None),
             ordinal_identities,
             clock: Mutex::new(Arc::new(system_time_micros)),
-            adjacency_provider: Arc::new(graphforge_exec::PersistentAdjacencyProvider::new(
-                dir.clone(),
-                ontology_mode,
-            )),
+            adjacency_provider: Arc::new(adjacency_provider),
             adjacency_visibility: Arc::new(std::sync::RwLock::new(())),
             embedding_refresh_scheduler: Arc::new(Mutex::new(
                 embedding_refresh::initialize_embedding_refresh_scheduler(&dir)?,
@@ -1397,10 +1392,7 @@ impl GraphForge {
         let adjacency_provider = if execution_mode == self.ontology_mode {
             Arc::clone(&self.adjacency_provider)
         } else {
-            Arc::new(graphforge_exec::PersistentAdjacencyProvider::new(
-                self.dir.clone(),
-                execution_mode,
-            ))
+            Arc::new(adjacency_provider_for_graph(&self.dir, execution_mode)?)
         };
         let session = ExecutionSession::new_with_target_provider_resources_and_identity(
             catalog,
@@ -3373,10 +3365,8 @@ impl GraphForge {
             // reads by it (exploratory `_exploratory.parquet` vs typed
             // `topology/edges/<REL>.parquet`); rebuild it so the adjacency path
             // matches the new mode.
-            self.adjacency_provider = Arc::new(graphforge_exec::PersistentAdjacencyProvider::new(
-                self.dir.clone(),
-                self.ontology_mode,
-            ));
+            self.adjacency_provider =
+                Arc::new(adjacency_provider_for_graph(&self.dir, self.ontology_mode)?);
         }
         Ok(())
     }
@@ -3905,6 +3895,21 @@ fn ordinal_identity_resolver(
     Ok(Arc::new(graphforge_exec::V4OrdinalIdentityResolver::new(
         ordinal_identity_handle(generation, graph_root)?,
     )))
+}
+
+fn adjacency_provider_for_graph(
+    dir: &Path,
+    mode: OntologyMode,
+) -> Result<graphforge_exec::PersistentAdjacencyProvider, GfError> {
+    let provider = graphforge_exec::PersistentAdjacencyProvider::new(dir.to_path_buf(), mode);
+    // A pinned view must not mutate its generation. Writable workspaces also
+    // have concurrent readers that enumerate graph files, so lazy build temps
+    // must stay outside those trees. Each provider owns a unique cache root.
+    let artifacts = tempfile::Builder::new()
+        .prefix("graphforge-adjacency-cache-")
+        .tempdir()
+        .map_err(|error| GfError::Storage(format!("cannot create adjacency cache: {error}")))?;
+    Ok(provider.with_rebuild_root(artifacts))
 }
 
 fn hydrate_graph_workspace(

--- a/crates/graphforge-api/src/ontology_composition_lifecycle.rs
+++ b/crates/graphforge-api/src/ontology_composition_lifecycle.rs
@@ -485,9 +485,10 @@ impl GraphForge {
             .expect("composition binding lock poisoned") =
             Some(std::sync::Arc::new(published_binding));
         self.ontology_mode = configuration.ontology_mode.execution_mode();
-        self.adjacency_provider = std::sync::Arc::new(
-            graphforge_exec::PersistentAdjacencyProvider::new(self.dir.clone(), self.ontology_mode),
-        );
+        self.adjacency_provider = std::sync::Arc::new(crate::adjacency_provider_for_graph(
+            &self.dir,
+            self.ontology_mode,
+        )?);
         Ok(CompositionChangeReceipt {
             project_generation_uuid: *self
                 .current_generation_uuid

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -695,6 +695,19 @@ mod tests {
             child_receipt.generation_uuid
         );
         let child_inventory = resolved_child.graph_files_inventory().unwrap().unwrap();
+        let marker_path = "topology/runtime_entity_label_encoding.json";
+        let parent_marker = first_inventory
+            .files
+            .iter()
+            .find(|entry| entry.relative_path == marker_path)
+            .unwrap();
+        let child_marker = child_inventory
+            .files
+            .iter()
+            .find(|entry| entry.relative_path == marker_path)
+            .unwrap();
+        assert_eq!(parent_marker.content_sha256, child_marker.content_sha256);
+        assert_eq!(parent_marker.byte_length, child_marker.byte_length);
         assert!(first_inventory.files.iter().any(|parent_entry| {
             child_inventory.files.iter().any(|child_entry| {
                 parent_entry.content_sha256 == child_entry.content_sha256

--- a/crates/graphforge-api/src/same_process_concurrency_tests.rs
+++ b/crates/graphforge-api/src/same_process_concurrency_tests.rs
@@ -113,6 +113,25 @@ fn assert_equal(phase: &str, results: &[Fingerprints]) {
 }
 
 #[test]
+fn lazy_rank_keeps_graph_workspace_inventory_unchanged() {
+    let project = tempfile::tempdir().unwrap();
+    seed(project.path());
+    let graph = GraphForge::new(project.path().to_str()).unwrap();
+    let before = graphforge_storage::capture_graph_files(&graph.dir)
+        .unwrap()
+        .0;
+    assert!(!graphforge_storage::adjacency::adjacency_dir(&graph.dir).exists());
+    graph.rank("Person", RankOptions::default()).unwrap();
+    assert_eq!(
+        graphforge_storage::capture_graph_files(&graph.dir)
+            .unwrap()
+            .0,
+        before,
+        "read-time cache publication must be outside the graph workspace scanned by concurrent readers"
+    );
+}
+
+#[test]
 fn independent_instances_and_one_instance_reads_are_deterministic() {
     let first = tempfile::tempdir().expect("phase=independent first tempdir");
     let second = tempfile::tempdir().expect("phase=independent second tempdir");

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -192,9 +192,10 @@ impl GraphForge {
                 &catalog,
             )?;
         }
-        self.adjacency_provider = std::sync::Arc::new(
-            graphforge_exec::PersistentAdjacencyProvider::new(self.dir.clone(), self.ontology_mode),
-        );
+        self.adjacency_provider = std::sync::Arc::new(crate::adjacency_provider_for_graph(
+            &self.dir,
+            self.ontology_mode,
+        )?);
         Ok(())
     }
 
@@ -228,9 +229,10 @@ impl GraphForge {
         self.ontology = None;
         self.ontology_document = None;
         self.ontology_mode = OntologyMode::Exploratory;
-        self.adjacency_provider = std::sync::Arc::new(
-            graphforge_exec::PersistentAdjacencyProvider::new(self.dir.clone(), self.ontology_mode),
-        );
+        self.adjacency_provider = std::sync::Arc::new(crate::adjacency_provider_for_graph(
+            &self.dir,
+            self.ontology_mode,
+        )?);
         Ok(())
     }
 }

--- a/crates/graphforge-api/tests/algorithm_public_surface.rs
+++ b/crates/graphforge-api/tests/algorithm_public_surface.rs
@@ -134,6 +134,15 @@ fn persisted_public_rank_is_exact_after_repeat_and_reopen_and_unavailable_is_sta
     graph
         .execute("CREATE (:Person {name:'a'})-[:KNOWS]->(:Person {name:'b'})")
         .unwrap();
+    graph
+        .index_search(
+            "Person",
+            graphforge_api::SearchIndexOptions::Text {
+                properties: Some(vec!["name".into()]),
+                rebuild: false,
+            },
+        )
+        .unwrap();
 
     let options = RankOptions {
         by: RankAlgorithm::Degree,
@@ -144,6 +153,12 @@ fn persisted_public_rank_is_exact_after_repeat_and_reopen_and_unavailable_is_sta
     let first = graph.rank("Person", options.clone()).unwrap();
     let repeated = graph.rank("Person", options.clone()).unwrap();
     assert_eq!(first, repeated);
+    // Inspection opens a read-only generation and traverses relationships.
+    // Repeating it must not discover an adjacency cache written into that
+    // generation by the preceding read.
+    assert_eq!(graph.labels().unwrap(), ["Person"]);
+    assert_eq!(graph.relationship_types().unwrap(), ["KNOWS"]);
+    assert_eq!(graph.schema().unwrap().num_rows(), 2);
     assert_eq!(
         first
             .schema()
@@ -172,6 +187,33 @@ fn persisted_public_rank_is_exact_after_repeat_and_reopen_and_unavailable_is_sta
     assert!((scores.value(0) - 1.0).abs() < f64::EPSILON);
     assert!(scores.value(1).abs() < f64::EPSILON);
 
+    graph
+        .checkpoint(graphforge_api::CheckpointRequest {
+            name: "rank-source".into(),
+            description: None,
+            idempotency_key: graphforge_api::OperationId(uuid::Uuid::from_u128(1094)),
+            actor_uuid: None,
+        })
+        .unwrap();
+    {
+        let view = graph.open_checkpoint("rank-source").unwrap();
+        assert_eq!(
+            view.inspect_adjacency().unwrap().state,
+            graphforge_storage::adjacency::AdjacencyFreshnessState::Missing
+        );
+        assert_eq!(view.rank("Person", options.clone()).unwrap(), first);
+        assert_eq!(graph.labels().unwrap(), ["Person"]);
+        assert_eq!(graph.schema().unwrap().num_rows(), 2);
+        assert_eq!(
+            graph
+                .open_checkpoint("rank-source")
+                .unwrap()
+                .rank("Person", options.clone())
+                .unwrap(),
+            first
+        );
+    }
+
     let unavailable = || {
         graph
             .analyze(
@@ -190,4 +232,6 @@ fn persisted_public_rank_is_exact_after_repeat_and_reopen_and_unavailable_is_sta
 
     let reopened = GraphForge::new(Some(path)).unwrap();
     assert_eq!(reopened.rank("Person", options).unwrap(), first);
+    assert_eq!(reopened.labels().unwrap(), ["Person"]);
+    assert_eq!(reopened.schema().unwrap().num_rows(), 2);
 }

--- a/crates/graphforge-api/tests/fixed_hop_limit.rs
+++ b/crates/graphforge-api/tests/fixed_hop_limit.rs
@@ -1119,6 +1119,14 @@ fn run_ordered_projection_scale(nodes: usize) -> (Vec<Vec<u8>>, DemandSnapshot) 
     );
     assert_eq!(recount_demand.operator_rss.len(), 1);
     assert_eq!(recount_demand.operator_rss[0].operator, "edge_count");
+    if cfg!(target_os = "linux") {
+        let rss = &recount_demand.operator_rss[0];
+        const RECOUNT_RSS_SLACK: u64 = 32 * 1024 * 1024;
+        assert!(
+            rss.peak_bytes <= rss.before_bytes.saturating_add(RECOUNT_RSS_SLACK),
+            "recount peak RSS must stay off the O(E) decode path at nodes={nodes}: {rss:?}"
+        );
+    }
     println!(
         "recount nodes={nodes} rss={:?}",
         recount_demand.operator_rss

--- a/crates/graphforge-exec/src/adjacency.rs
+++ b/crates/graphforge-exec/src/adjacency.rs
@@ -29,7 +29,6 @@ use graphforge_core::{GfError, OntologyMode};
 use graphforge_ir::Direction;
 use graphforge_storage::adjacency::{
     self as csr, ALL_RELATIONS_STEM, AdjacencyManifestRow, CsrIndex, CsrRow, ShardedCsrIndex,
-    build_adjacency_index,
 };
 use graphforge_storage::adjacency_delta::{
     CsrDeltaOverlay, DeltaSegment, overlay_delta_segments, read_delta_chain,
@@ -836,6 +835,10 @@ enum IndexState {
 /// supports it).
 pub struct PersistentAdjacencyProvider {
     dir: PathBuf,
+    /// Owned artifact root; a TempDir owner also removes it on provider drop.
+    rebuild_root: Option<Box<dyn AsRef<std::path::Path> + Send + Sync>>,
+    /// Serialize initial loads/builds; row reads retain their independent views.
+    load_lock: Mutex<()>,
     /// Scan-build fallback, fed the ORIGINAL relation name so per-row relation
     /// filtering still applies (the union read serves the typed `"*"` wildcard).
     scan: ScanBuildAdjacencyProvider,
@@ -852,9 +855,42 @@ impl PersistentAdjacencyProvider {
         Self {
             scan: ScanBuildAdjacencyProvider::new(dir.clone(), mode),
             dir,
+            rebuild_root: None,
+            load_lock: Mutex::new(()),
             state: Mutex::new(None),
             cache: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Keep lazy builds and repairs outside the source graph workspace.
+    /// Passing an owned temporary directory retains it for the provider's lifetime.
+    /// Existing source indexes remain readable until a private rebuild succeeds.
+    #[must_use]
+    pub fn with_rebuild_root(
+        mut self,
+        root: impl AsRef<std::path::Path> + Send + Sync + 'static,
+    ) -> Self {
+        self.rebuild_root = Some(Box::new(root));
+        self
+    }
+
+    fn index_root(&self) -> &std::path::Path {
+        self.rebuild_root
+            .as_deref()
+            .map(AsRef::as_ref)
+            .filter(|root| csr::manifest_path(root).is_file())
+            .unwrap_or(&self.dir)
+    }
+
+    fn rebuild(&self, now: i64) -> Result<Vec<AdjacencyManifestRow>, GfError> {
+        csr::build_adjacency_index_into(
+            &self.dir,
+            self.rebuild_root
+                .as_deref()
+                .map_or(self.dir.as_path(), AsRef::as_ref),
+            now,
+            || Ok(()),
+        )
     }
 
     /// The CSR file stem serving `rel_type_name`: the reserved
@@ -873,18 +909,18 @@ impl PersistentAdjacencyProvider {
     fn state(&self) -> IndexState {
         let mut guard = self.state.lock().expect("adjacency state lock");
         guard
-            .get_or_insert_with(|| Self::read_state(&self.dir))
+            .get_or_insert_with(|| Self::read_state(&self.dir, self.index_root()))
             .clone()
     }
 
-    fn read_state(dir: &std::path::Path) -> IndexState {
-        if !csr::adjacency_dir(dir).exists() {
+    fn read_state(dir: &std::path::Path, index_root: &std::path::Path) -> IndexState {
+        if !csr::adjacency_dir(index_root).exists() {
             return IndexState::Absent;
         }
         let Ok(generation) = read_topology_generation(dir) else {
             return IndexState::Unreadable;
         };
-        let Ok(rows) = csr::read_manifest(dir) else {
+        let Ok(rows) = csr::read_manifest(index_root) else {
             return IndexState::Unreadable;
         };
         // The base generation the CSRs were built at — uniform across rows on a
@@ -897,10 +933,12 @@ impl PersistentAdjacencyProvider {
             Some(b) if uniform && b == generation => (true, Vec::new()),
             // base < counter: serveable iff an intact, bounded delta chain
             // (#765) covers (base, counter]; otherwise stale ⇒ rebuild.
-            Some(b) if uniform && b < generation => match read_delta_chain(dir, b, generation) {
-                Some(chain) => (true, chain),
-                None => (false, Vec::new()),
-            },
+            Some(b) if uniform && b < generation => {
+                match read_delta_chain(index_root, b, generation) {
+                    Some(chain) => (true, chain),
+                    None => (false, Vec::new()),
+                }
+            }
             // Empty / torn manifest, or an index newer than the counter
             // (anomalous, e.g. a counter reset): stale.
             _ => (false, Vec::new()),
@@ -940,7 +978,7 @@ impl PersistentAdjacencyProvider {
         deltas: &[DeltaSegment],
     ) -> Result<Adjacency, GfError> {
         let directed = |d: csr::Direction| -> Result<AdjacencyInner, GfError> {
-            let path = csr::csr_path(&self.dir, stem, d);
+            let path = csr::csr_path(self.index_root(), stem, d);
             if csr::sharded_csr_exists(&path) {
                 let base = Arc::new(ShardedCsrIndex::open(&path)?);
                 if let Some(row) = rows
@@ -1020,7 +1058,7 @@ impl PersistentAdjacencyProvider {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| i64::try_from(d.as_micros()).unwrap_or(i64::MAX));
-        match build_adjacency_index(&self.dir, now) {
+        match self.rebuild(now) {
             Ok(rows) => {
                 let covered = Self::rows_cover(&rows, stem, direction);
                 // Index writes don't bump the topology counter, so re-read it
@@ -1170,6 +1208,10 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
         if !matches!(error, GfError::Storage(_)) {
             return Err(error);
         }
+        let _load = self
+            .load_lock
+            .lock()
+            .map_err(|_| GfError::Storage("adjacency load lock poisoned".into()))?;
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |duration| {
@@ -1177,7 +1219,7 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
             });
         // Unlike initial index admission, failed lazy reads must not hide a
         // failed rebuild behind scan-build. Perform one rebuild and one load.
-        let rows = build_adjacency_index(&self.dir, now)?;
+        let rows = self.rebuild(now)?;
         let stem = Self::stem_for(rel_type_name);
         let view = self.load(&stem, direction, &rows, &[])?;
         self.invalidate();
@@ -1189,6 +1231,10 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
         rel_type_name: &str,
         direction: Direction,
     ) -> Result<Arc<Adjacency>, GfError> {
+        let _load = self
+            .load_lock
+            .lock()
+            .map_err(|_| GfError::Storage("adjacency load lock poisoned".into()))?;
         let stem = Self::stem_for(rel_type_name);
         if let Some(view) = self
             .cache
@@ -1252,7 +1298,7 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
                 fresh: true, rows, ..
             } => {
                 let files_exist = |d: csr::Direction| {
-                    let path = csr::csr_path(&self.dir, &stem, d);
+                    let path = csr::csr_path(self.index_root(), &stem, d);
                     path.exists() || csr::sharded_csr_exists(&path)
                 };
                 let present = Self::rows_cover(&rows, &stem, direction)
@@ -1293,7 +1339,7 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
                         }
                 });
                 for row in relevant {
-                    let path = csr::csr_path(&self.dir, &stem, row.direction);
+                    let path = csr::csr_path(self.index_root(), &stem, row.direction);
                     if !ShardedCsrIndex::open(&path).is_ok_and(|index| {
                         index.node_count() == row.node_count && index.edge_count() == row.edge_count
                     }) {
@@ -1341,6 +1387,7 @@ fn merge_undirected(out: CsrIndex, inbound: CsrIndex) -> Adjacency {
 
 #[cfg(test)]
 mod tests {
+    use graphforge_storage::adjacency::build_adjacency_index;
     use std::path::Path;
 
     use graphforge_core::TypeId;
@@ -1750,6 +1797,93 @@ mod tests {
             if operation < 3 {
                 assert!(Arc::ptr_eq(&reader.view, &repaired));
             }
+        }
+    }
+
+    #[test]
+    fn concurrent_private_loads_share_one_view_and_own_the_cache() {
+        let source = TempDir::new().unwrap();
+        let [src, ..] = write_diamond(source.path());
+        let artifacts = TempDir::new().unwrap();
+        let artifact_path = artifacts.path().to_path_buf();
+        let provider = Arc::new(
+            PersistentAdjacencyProvider::new(source.path().to_path_buf(), OntologyMode::Strict)
+                .with_rebuild_root(artifacts),
+        );
+        let barrier = Arc::new(std::sync::Barrier::new(4));
+        let workers: Vec<_> = (0..4)
+            .map(|_| {
+                let provider = Arc::clone(&provider);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    provider.adjacency("KNOWS", Direction::Out).unwrap()
+                })
+            })
+            .collect();
+        let views: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect();
+        for view in &views {
+            assert!(Arc::ptr_eq(view, &views[0]));
+            assert_eq!(view.neighbors(src).unwrap().len(), 3);
+        }
+        assert!(!csr::adjacency_dir(source.path()).exists());
+        assert!(csr::manifest_path(&artifact_path).is_file());
+        drop(views);
+        drop(provider);
+        assert!(
+            !artifact_path.exists(),
+            "provider owns disposable cache cleanup"
+        );
+    }
+
+    #[test]
+    fn private_rebuild_keeps_source_inventory_unchanged() {
+        for corrupt_index in [false, true] {
+            let source = TempDir::new().unwrap();
+            let artifacts = TempDir::new().unwrap();
+            let [src, ..] = write_diamond(source.path());
+            if corrupt_index {
+                build_adjacency_index(source.path(), TS).unwrap();
+                assert!(overwrite_sharded_csr_payloads(source.path()) > 0);
+            }
+            let before = graphforge_storage::capture_graph_files(source.path())
+                .unwrap()
+                .0;
+            let provider =
+                PersistentAdjacencyProvider::new(source.path().to_path_buf(), OntologyMode::Strict)
+                    .with_rebuild_root(artifacts.path().to_path_buf());
+            let mut reader = AdjacencyReader::new(&provider, "KNOWS", Direction::Out).unwrap();
+            assert_eq!(reader.with_neighbors(src, |row| row.len()).unwrap(), 3);
+            assert_eq!(reader.view.backing(), AdjacencyBacking::CsrNative);
+            assert!(csr::manifest_path(artifacts.path()).is_file());
+            provider.revalidate();
+            assert_eq!(
+                provider.status("KNOWS", Direction::Out),
+                AdjacencyStatus::Hit
+            );
+            assert_eq!(
+                provider.edge_cardinality("KNOWS", Direction::Out).unwrap(),
+                6
+            );
+            assert_eq!(
+                provider
+                    .adjacency("KNOWS", Direction::Out)
+                    .unwrap()
+                    .neighbors(src)
+                    .unwrap()
+                    .len(),
+                3
+            );
+            assert_eq!(
+                graphforge_storage::capture_graph_files(source.path())
+                    .unwrap()
+                    .0,
+                before,
+                "lazy build and corruption repair must not modify the pinned source"
+            );
         }
     }
 

--- a/crates/graphforge-exec/src/adjacency.rs
+++ b/crates/graphforge-exec/src/adjacency.rs
@@ -239,8 +239,7 @@ impl Adjacency {
     /// depends on this ordering.
     ///
     /// Unknown, isolated, or deleted ids yield an empty row — never a panic.
-    #[must_use]
-    pub fn neighbors(&self, node_id: u64) -> NeighborRow<'_> {
+    pub fn neighbors(&self, node_id: u64) -> Result<NeighborRow<'_>, GfError> {
         self.inner.neighbors(node_id)
     }
 
@@ -301,7 +300,7 @@ impl Adjacency {
                 "bounded ordered traversal requires a directed adjacency view".into(),
             )),
             _ => Ok(self
-                .neighbors(node_id)
+                .neighbors(node_id)?
                 .iter()
                 .skip(skip)
                 .take(limit)
@@ -320,8 +319,11 @@ impl Adjacency {
     /// included only when the callback needs them — callers that skip empty
     /// rows should check [`NeighborRow::is_empty`]). Map backings yield only
     /// keys present in the map.
-    pub(crate) fn for_each_row(&self, mut visit: impl FnMut(u64, NeighborRow<'_>)) {
-        self.inner.for_each_row(&mut visit);
+    pub(crate) fn for_each_row(
+        &self,
+        mut visit: impl FnMut(u64, NeighborRow<'_>),
+    ) -> Result<(), GfError> {
+        self.inner.for_each_row(&mut visit)
     }
 }
 
@@ -388,20 +390,17 @@ impl AdjacencyInner {
         }
     }
 
-    fn neighbors(&self, node_id: u64) -> NeighborRow<'_> {
-        match self {
+    fn neighbors(&self, node_id: u64) -> Result<NeighborRow<'_>, GfError> {
+        Ok(match self {
             Self::Empty => NeighborRow::pairs(&[]),
             Self::Map(map) => NeighborRow::pairs(map.get(&node_id).map_or(&[], Vec::as_slice)),
             Self::Csr(csr) => NeighborRow::csr(csr.row(node_id)),
-            Self::Sharded(csr) => NeighborRow::owned(
-                csr.row(node_id)
-                    .expect("authenticated immutable CSR shard changed after open"),
-            ),
+            Self::Sharded(csr) => NeighborRow::owned(csr.row(node_id)?),
             Self::ShardedOverlay { base, replaced, .. } => {
-                NeighborRow::owned(replaced.get(&node_id).cloned().unwrap_or_else(|| {
-                    base.row(node_id)
-                        .expect("authenticated immutable CSR shard changed after open")
-                }))
+                NeighborRow::owned(match replaced.get(&node_id) {
+                    Some(row) => row.clone(),
+                    None => base.row(node_id)?,
+                })
             }
             Self::Overlay(overlay) => match overlay.row(node_id) {
                 graphforge_storage::adjacency_delta::OverlayRow::Base(row) => NeighborRow::csr(row),
@@ -410,9 +409,9 @@ impl AdjacencyInner {
                 }
             },
             Self::Undirected { out, inbound } => {
-                merge_undirected_row(&out.neighbors(node_id), &inbound.neighbors(node_id))
+                merge_undirected_row(&out.neighbors(node_id)?, &inbound.neighbors(node_id)?)
             }
-        }
+        })
     }
 
     fn backing(&self) -> AdjacencyBacking {
@@ -465,7 +464,7 @@ impl AdjacencyInner {
         }
     }
 
-    fn for_each_row(&self, visit: &mut dyn FnMut(u64, NeighborRow<'_>)) {
+    fn for_each_row(&self, visit: &mut dyn FnMut(u64, NeighborRow<'_>)) -> Result<(), GfError> {
         match self {
             Self::Empty => {}
             Self::Map(map) => {
@@ -480,46 +479,51 @@ impl AdjacencyInner {
             }
             Self::Sharded(csr) => {
                 for node_id in 0..csr.node_count() {
-                    visit(node_id, self.neighbors(node_id));
+                    visit(node_id, self.neighbors(node_id)?);
                 }
             }
             Self::Overlay(overlay) => {
                 for node_id in 0..overlay.node_extent {
-                    visit(node_id, self.neighbors(node_id));
+                    visit(node_id, self.neighbors(node_id)?);
                 }
             }
             Self::ShardedOverlay { node_extent, .. } => {
                 for node_id in 0..*node_extent {
-                    visit(node_id, self.neighbors(node_id));
+                    visit(node_id, self.neighbors(node_id)?);
                 }
             }
             Self::Undirected { out, inbound } => {
                 let extent = out.node_extent().max(inbound.node_extent());
                 for node_id in 0..extent {
-                    visit(node_id, self.neighbors(node_id));
+                    visit(node_id, self.neighbors(node_id)?);
                 }
             }
         }
+        Ok(())
     }
 }
 
 impl PartialEq for Adjacency {
     fn eq(&self, other: &Self) -> bool {
-        fn collect(view: &Adjacency) -> Vec<(u64, Vec<(u64, u64)>)> {
+        type Rows = Vec<(u64, Vec<(u64, u64)>)>;
+        fn collect(view: &Adjacency) -> Result<Rows, GfError> {
             let mut rows = Vec::new();
             view.for_each_row(|node_id, row| {
                 if !row.is_empty() {
                     rows.push((node_id, row.to_vec()));
                 }
-            });
+            })?;
             rows.sort_unstable_by_key(|(node_id, _)| *node_id);
-            rows
+            Ok(rows)
         }
-        collect(self) == collect(other)
+        match (collect(self), collect(other)) {
+            (Ok(left), Ok(right)) => left == right,
+            _ => false,
+        }
     }
 }
 
-impl Eq for Adjacency {}
+// Corrupt views are not equal, including to themselves; do not implement Eq.
 
 /// Merge out and in rows with ascending `edge_id` and **out before in on ties**.
 fn merge_undirected_row<'a>(out: &NeighborRow<'a>, inbound: &NeighborRow<'a>) -> NeighborRow<'a> {
@@ -566,8 +570,106 @@ pub trait AdjacencyProvider: Send + Sync {
         direction: Direction,
     ) -> Result<Arc<Adjacency>, GfError>;
 
+    /// Repair a failed index row read. Other providers preserve the original error.
+    fn repair_adjacency(
+        &self,
+        _rel_type_name: &str,
+        _direction: Direction,
+        error: GfError,
+    ) -> Result<Arc<Adjacency>, GfError> {
+        Err(error)
+    }
+
     /// How [`adjacency`](Self::adjacency) for the same key would be served.
     fn status(&self, rel_type_name: &str, direction: Direction) -> AdjacencyStatus;
+
+    /// Cardinality of adjacency entries without opening shard payloads.
+    ///
+    /// The default loads the view. Persistent indexes should read the stamped
+    /// manifest count so unconstrained `count(r)` cannot charge O(E) RSS.
+    fn edge_cardinality(&self, rel_type_name: &str, direction: Direction) -> Result<u64, GfError> {
+        self.adjacency(rel_type_name, direction)?.edge_entry_count()
+    }
+}
+
+/// Query-local row access: only a failed index read can trigger one repair.
+/// The replacement view is retained so later rows do not reopen the bad artifact.
+pub(crate) struct AdjacencyReader<'a> {
+    provider: &'a dyn AdjacencyProvider,
+    relation: &'a str,
+    direction: Direction,
+    view: Arc<Adjacency>,
+    repair_attempted: bool,
+}
+
+impl<'a> AdjacencyReader<'a> {
+    pub(crate) fn new(
+        provider: &'a dyn AdjacencyProvider,
+        relation: &'a str,
+        direction: Direction,
+    ) -> Result<Self, GfError> {
+        Ok(Self {
+            provider,
+            relation,
+            direction,
+            view: provider.adjacency(relation, direction)?,
+            repair_attempted: false,
+        })
+    }
+
+    pub(crate) fn node_extent(&self) -> u64 {
+        self.view.node_extent()
+    }
+
+    fn read<T>(&mut self, read: impl Fn(&Adjacency) -> Result<T, GfError>) -> Result<T, GfError> {
+        match read(&self.view) {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                if self.repair_attempted {
+                    return Err(error);
+                }
+                self.repair_attempted = true;
+                // These closures only perform adjacency row reads. No query
+                // work or emitted output is retried, and repair failure propagates.
+                self.view = self
+                    .provider
+                    .repair_adjacency(self.relation, self.direction, error)?;
+                read(&self.view)
+            }
+        }
+    }
+
+    /// Consume a successfully authenticated row once, preserving borrowed
+    /// map/legacy rows and moving no full-row allocation across this boundary.
+    pub(crate) fn with_neighbors<T>(
+        &mut self,
+        node: u64,
+        visit: impl FnOnce(NeighborRow<'_>) -> T,
+    ) -> Result<T, GfError> {
+        let error = match self.view.neighbors(node) {
+            Ok(row) => return Ok(visit(row)),
+            Err(error) => error,
+        };
+        if self.repair_attempted {
+            return Err(error);
+        }
+        self.repair_attempted = true;
+        self.view = self
+            .provider
+            .repair_adjacency(self.relation, self.direction, error)?;
+        Ok(visit(self.view.neighbors(node)?))
+    }
+    pub(crate) fn degree(&mut self, node: u64) -> Result<u64, GfError> {
+        self.read(|view| view.degree(node))
+    }
+    pub(crate) fn neighbor_chunk(
+        &mut self,
+        node: u64,
+        skip: usize,
+        limit: usize,
+    ) -> Result<Vec<(u64, u64)>, GfError> {
+        self.read(|view| view.neighbor_chunk(node, skip, limit))
+    }
 }
 
 /// Scan-build provider: `graphforge_storage::read_edges` + in-memory build on every
@@ -610,6 +712,25 @@ impl AdjacencyProvider for ScanBuildAdjacencyProvider {
     fn status(&self, _rel_type_name: &str, _direction: Direction) -> AdjacencyStatus {
         AdjacencyStatus::Building
     }
+
+    fn edge_cardinality(&self, rel_type_name: &str, direction: Direction) -> Result<u64, GfError> {
+        footer_edge_cardinality(&self.dir, rel_type_name, self.mode, direction)
+    }
+}
+
+/// Directed `count(r)` is the stored edge-row count. Undirected views expose
+/// each stored edge on both the out and in sides.
+fn footer_edge_cardinality(
+    dir: &std::path::Path,
+    rel_type_name: &str,
+    mode: OntologyMode,
+    direction: Direction,
+) -> Result<u64, GfError> {
+    let rows = graphforge_storage::count_edge_rows(dir, rel_type_name, mode)?;
+    Ok(match direction {
+        Direction::Out | Direction::In => rows,
+        Direction::Undirected => rows.saturating_mul(2),
+    })
 }
 
 /// Build `node_id -> [(edge_id, neighbour_node_id)]` honouring direction and,
@@ -950,9 +1071,11 @@ impl PersistentAdjacencyProvider {
     /// status/adjacency snapshot agreement — is untouched.
     ///
     /// Drops the memoized state and view cache when: the prior read was
-    /// `Unreadable` (always retry — rare and cheap), the index was `Absent`
-    /// (scan-built views are query-scoped), or the observed generation no
-    /// longer matches the counter.
+    /// `Unreadable` (always retry — rare and cheap), the index was still
+    /// `Absent` (no capability dir yet), or the observed generation no
+    /// longer matches the counter. A first-access rebuild promotes Absent
+    /// to Ready, so the published CSR survives revalidate at the same
+    /// generation (#1094).
     pub fn revalidate(&self) {
         let mut state = self.state.lock().expect("adjacency state lock");
         let drop_state = match state.as_ref() {
@@ -1038,6 +1161,29 @@ fn sharded_overlay_rows(
 }
 
 impl AdjacencyProvider for PersistentAdjacencyProvider {
+    fn repair_adjacency(
+        &self,
+        rel_type_name: &str,
+        direction: Direction,
+        error: GfError,
+    ) -> Result<Arc<Adjacency>, GfError> {
+        if !matches!(error, GfError::Storage(_)) {
+            return Err(error);
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |duration| {
+                i64::try_from(duration.as_micros()).unwrap_or(i64::MAX)
+            });
+        // Unlike initial index admission, failed lazy reads must not hide a
+        // failed rebuild behind scan-build. Perform one rebuild and one load.
+        let rows = build_adjacency_index(&self.dir, now)?;
+        let stem = Self::stem_for(rel_type_name);
+        let view = self.load(&stem, direction, &rows, &[])?;
+        self.invalidate();
+        Ok(self.cache_view(&stem, direction, view))
+    }
+
     fn adjacency(
         &self,
         rel_type_name: &str,
@@ -1053,7 +1199,14 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
             return Ok(Arc::clone(view));
         }
         match self.state() {
-            IndexState::Absent | IndexState::Unreadable => {
+            IndexState::Absent => {
+                // Host-scale projects never create `indexes/adjacency/` during
+                // ingest. Scan-building that first request charges O(E) RSS and
+                // fails the S18→S19 plateau gate (#1094). Publish the streamed
+                // CSR once, then serve it; rebuild failure still scan-builds.
+                self.rebuild_and_serve(rel_type_name, &stem, direction)
+            }
+            IndexState::Unreadable => {
                 // A streaming ExpandExec may request the same view once per
                 // input batch. Scan-build exactly once per session/query and
                 // cache it just like a CSR view; writes/revalidation clear the
@@ -1118,6 +1271,57 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
             }
         }
     }
+
+    fn edge_cardinality(&self, rel_type_name: &str, direction: Direction) -> Result<u64, GfError> {
+        let stem = Self::stem_for(rel_type_name);
+        match self.state() {
+            IndexState::Ready {
+                fresh: true,
+                rows,
+                deltas,
+                ..
+            } if deltas.is_empty() && Self::rows_cover(&rows, &stem, direction) => {
+                // Preserve load()'s torn-manifest guard without decoding any
+                // shard payload. A legacy or disagreeing index counts the
+                // authoritative topology instead.
+                let relevant = rows.iter().filter(|row| {
+                    row.relation_type == stem
+                        && match direction {
+                            Direction::Out => row.direction == csr::Direction::Out,
+                            Direction::In => row.direction == csr::Direction::In,
+                            Direction::Undirected => true,
+                        }
+                });
+                for row in relevant {
+                    let path = csr::csr_path(&self.dir, &stem, row.direction);
+                    if !ShardedCsrIndex::open(&path).is_ok_and(|index| {
+                        index.node_count() == row.node_count && index.edge_count() == row.edge_count
+                    }) {
+                        return footer_edge_cardinality(
+                            &self.dir,
+                            rel_type_name,
+                            self.scan.mode,
+                            direction,
+                        );
+                    }
+                }
+                let total = |wanted: csr::Direction| {
+                    rows.iter()
+                        .filter(|row| row.relation_type == stem && row.direction == wanted)
+                        .map(|row| row.edge_count)
+                        .sum::<u64>()
+                };
+                Ok(match direction {
+                    Direction::Out => total(csr::Direction::Out),
+                    Direction::In => total(csr::Direction::In),
+                    Direction::Undirected => {
+                        total(csr::Direction::Out).saturating_add(total(csr::Direction::In))
+                    }
+                })
+            }
+            _ => footer_edge_cardinality(&self.dir, rel_type_name, self.scan.mode, direction),
+        }
+    }
 }
 
 /// Undirected CSR pair without materializing a merged hash map (#340).
@@ -1175,16 +1379,16 @@ mod tests {
             ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
         let out = provider.adjacency("KNOWS", Direction::Out).unwrap();
         // a has three outgoing entries: a→b, a→c, then the parallel a→b.
-        assert_eq!(out.neighbors(a).len(), 3);
+        assert_eq!(out.neighbors(a).unwrap().len(), 3);
         // The self-loop is one Out entry under d...
-        assert_eq!(out.neighbors(d).to_vec(), vec![(6, d)]);
+        assert_eq!(out.neighbors(d).unwrap().to_vec(), vec![(6, d)]);
         // ...and two Undirected entries under d (src-keyed + dst-keyed), after
         // the two incoming diamond edges b→d, c→d.
         let undirected = provider.adjacency("KNOWS", Direction::Undirected).unwrap();
-        assert_eq!(undirected.neighbors(d).len(), 4);
+        assert_eq!(undirected.neighbors(d).unwrap().len(), 4);
         let in_view = provider.adjacency("KNOWS", Direction::In).unwrap();
         // b's incoming: a→b and the parallel a→b.
-        assert_eq!(in_view.neighbors(b).to_vec(), vec![(1, a), (5, a)]);
+        assert_eq!(in_view.neighbors(b).unwrap().to_vec(), vec![(1, a), (5, a)]);
     }
 
     /// `KNOWS` and `OWNS` rows share `_exploratory.parquet`; the rel filter
@@ -1206,7 +1410,7 @@ mod tests {
             ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Exploratory);
         let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
         assert_eq!(
-            view.neighbors(ids[0]).to_vec(),
+            view.neighbors(ids[0]).unwrap().to_vec(),
             vec![(1, ids[1])],
             "OWNS row excluded"
         );
@@ -1229,7 +1433,7 @@ mod tests {
             ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Exploratory);
         let view = provider.adjacency("*", Direction::Out).unwrap();
         assert_eq!(
-            view.neighbors(ids[0]).to_vec(),
+            view.neighbors(ids[0]).unwrap().to_vec(),
             vec![(1, ids[1]), (2, ids[2])],
             "wildcard skips the rel filter"
         );
@@ -1258,7 +1462,7 @@ mod tests {
         let view = provider.adjacency("*", Direction::Out).unwrap();
         // Both relations' edges appear (KNOWS a→b, OWNS a→c), unioned across the
         // two per-relation files — no longer the pre-#823 empty view.
-        let mut got = view.neighbors(ids[0]).to_vec();
+        let mut got = view.neighbors(ids[0]).unwrap().to_vec();
         got.sort_unstable();
         assert_eq!(
             got,
@@ -1295,9 +1499,12 @@ mod tests {
         let provider =
             ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
         let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
-        assert!(view.neighbors(ids[1]).is_empty(), "deleted id yields empty");
+        assert!(
+            view.neighbors(ids[1]).unwrap().is_empty(),
+            "deleted id yields empty"
+        );
         assert_eq!(
-            view.neighbors(ids[2]).to_vec(),
+            view.neighbors(ids[2]).unwrap().to_vec(),
             vec![(3, ids[3])],
             "survivor intact"
         );
@@ -1310,7 +1517,7 @@ mod tests {
             ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
         let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
         assert!(view.is_empty());
-        assert!(view.neighbors(1).is_empty());
+        assert!(view.neighbors(1).unwrap().is_empty());
     }
 
     /// Neighbor order is edge-file row order — BFS emission order depends on
@@ -1335,7 +1542,7 @@ mod tests {
             ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
         let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
         assert_eq!(
-            view.neighbors(hub_id).to_vec(),
+            view.neighbors(hub_id).unwrap().to_vec(),
             vec![(1, spoke_ids[0]), (2, spoke_ids[1]), (3, spoke_ids[2])],
             "entries in edge-file row order"
         );
@@ -1387,7 +1594,7 @@ mod tests {
             neighbor_ids: vec![2],
         };
         let view = merge_undirected(out, inbound);
-        assert_eq!(view.neighbors(0).to_vec(), vec![(7, 1), (7, 2)]);
+        assert_eq!(view.neighbors(0).unwrap().to_vec(), vec![(7, 1), (7, 2)]);
         assert_eq!(view.base_csr_entries_expanded(), 0);
     }
 
@@ -1406,5 +1613,201 @@ mod tests {
         assert_eq!(AdjacencyStatus::Building.as_str(), "building");
         assert_eq!(AdjacencyStatus::Hit.as_str(), "hit");
         assert_eq!(AdjacencyStatus::Miss.as_str(), "miss");
+    }
+
+    fn overwrite_sharded_csr_payloads(project: &Path) -> usize {
+        let mut overwritten = 0;
+        let mut stack = vec![csr::adjacency_dir(project)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|ext| ext.to_str()) != Some("csr") {
+                    continue;
+                }
+                std::fs::write(&path, b"corrupt-payload").unwrap();
+                overwritten += 1;
+            }
+        }
+        overwritten
+    }
+
+    #[test]
+    fn persistent_edge_cardinality_uses_parquet_footers_when_index_is_absent() {
+        let dir = TempDir::new().unwrap();
+        write_diamond(dir.path());
+        assert!(
+            !csr::adjacency_dir(dir.path()).exists(),
+            "diamond fixture must start without an adjacency index"
+        );
+        let provider =
+            PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        assert_eq!(
+            provider.edge_cardinality("KNOWS", Direction::Out).unwrap(),
+            6
+        );
+        assert_eq!(provider.edge_cardinality("*", Direction::Out).unwrap(), 6);
+        assert!(
+            !csr::adjacency_dir(dir.path()).exists(),
+            "count(r) must not publish or decode an adjacency index"
+        );
+    }
+
+    #[test]
+    fn persistent_edge_cardinality_does_not_read_or_decode_shard_payloads() {
+        let dir = TempDir::new().unwrap();
+        let [src, ..] = write_diamond(dir.path());
+        let rows = build_adjacency_index(dir.path(), TS).unwrap();
+        let expected = rows
+            .iter()
+            .filter(|row| row.relation_type == "KNOWS" && row.direction == csr::Direction::Out)
+            .map(|row| row.edge_count)
+            .sum::<u64>();
+        assert!(expected > 0, "diamond fixture must stamp a KNOWS out count");
+        assert!(
+            overwrite_sharded_csr_payloads(dir.path()) > 0,
+            "fixture must publish sharded CSR payloads"
+        );
+
+        let provider =
+            PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        assert_eq!(
+            provider.edge_cardinality("KNOWS", Direction::Out).unwrap(),
+            expected
+        );
+        assert_eq!(
+            provider.edge_cardinality("*", Direction::Out).unwrap(),
+            expected
+        );
+
+        let path = csr::csr_path(dir.path(), "KNOWS", csr::Direction::Out);
+        let reader = ShardedCsrIndex::open(&path).expect("open must not decode shard payloads");
+        assert_eq!(reader.edge_count(), expected);
+        assert!(
+            reader
+                .row(src)
+                .unwrap_err()
+                .to_string()
+                .contains("checksum"),
+            "row() authenticates the payload after open"
+        );
+
+        let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
+        assert_eq!(view.edge_entry_count().unwrap(), expected);
+        assert!(
+            view.degree(src)
+                .unwrap_err()
+                .to_string()
+                .contains("checksum"),
+            "first row touch fails checksum; cardinality must not require it"
+        );
+    }
+    #[test]
+    fn lazy_index_reads_repair_corrupt_shards() {
+        for operation in 0..4 {
+            let dir = TempDir::new().unwrap();
+            let [src, ..] = write_diamond(dir.path());
+            build_adjacency_index(dir.path(), TS).unwrap();
+            assert!(overwrite_sharded_csr_payloads(dir.path()) > 0);
+            let provider =
+                PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+            let corrupt = provider.adjacency("KNOWS", Direction::Out).unwrap();
+            assert!(corrupt.neighbors(src).is_err());
+            assert_ne!(
+                corrupt.as_ref(),
+                corrupt.as_ref(),
+                "corrupt views are never valid equality evidence"
+            );
+            let mut reader = AdjacencyReader::new(&provider, "KNOWS", Direction::Out).unwrap();
+            match operation {
+                0 => assert_eq!(reader.with_neighbors(src, |row| row.len()).unwrap(), 3),
+                1 => assert_eq!(reader.degree(src).unwrap(), 3),
+                2 => assert_eq!(reader.neighbor_chunk(src, 1, 1).unwrap().len(), 1),
+                _ => {
+                    let graph = crate::algorithm_graph::export_adjacency(
+                        &provider,
+                        dir.path(),
+                        OntologyMode::Strict,
+                        crate::algorithm_graph::AdjacencySelection {
+                            label: None,
+                            via: "KNOWS",
+                            direction: Direction::Out,
+                            weight: None,
+                        },
+                    )
+                    .unwrap();
+                    assert_eq!(graph.neighbors(src).len(), 3);
+                }
+            }
+            let repaired = provider.adjacency("KNOWS", Direction::Out).unwrap();
+            assert_eq!(repaired.neighbors(src).unwrap().len(), 3);
+            if operation < 3 {
+                assert!(Arc::ptr_eq(&reader.view, &repaired));
+            }
+        }
+    }
+
+    #[test]
+    fn lazy_index_read_propagates_failed_rebuild() {
+        let dir = TempDir::new().unwrap();
+        let [src, ..] = write_diamond(dir.path());
+        build_adjacency_index(dir.path(), TS).unwrap();
+        assert!(overwrite_sharded_csr_payloads(dir.path()) > 0);
+        let provider =
+            PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let mut reader = AdjacencyReader::new(&provider, "KNOWS", Direction::Out).unwrap();
+        // Topology corruption makes the actual rebuild fail; it cannot be
+        // hidden as a successful empty row or a successful scan fallback.
+        std::fs::write(
+            dir.path().join("topology/edges/KNOWS.parquet"),
+            b"corrupt topology",
+        )
+        .unwrap();
+        let error = reader.with_neighbors(src, |row| row.len()).unwrap_err();
+        assert!(
+            !error.to_string().contains("CSR shard checksum"),
+            "must report the rebuild failure: {error}"
+        );
+        assert!(
+            reader.view.neighbors(src).is_err(),
+            "failed repair must not replace the view with fabricated data"
+        );
+    }
+    #[test]
+    fn row_callback_borrows_high_degree_map_without_copying() {
+        let dir = TempDir::new().unwrap();
+        let provider =
+            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let entries: Vec<_> = (0..65_536).map(|id| (id, id + 1)).collect();
+        let original = entries.as_ptr();
+        let mut reader = AdjacencyReader::new(&provider, "KNOWS", Direction::Out).unwrap();
+        reader.view = Arc::new(Adjacency {
+            inner: AdjacencyInner::Map(HashMap::from([(1, entries)])),
+        });
+        let mut visits = 0;
+        for _ in 0..2 {
+            let first = reader
+                .with_neighbors(1, |row| {
+                    visits += 1;
+                    let NeighborRowKind::Pairs(entries) = row.kind else {
+                        panic!("healthy map rows must remain borrowed");
+                    };
+                    assert_eq!(
+                        entries.as_ptr(),
+                        original,
+                        "a small LIMIT must not clone the entire degree-sized row"
+                    );
+                    entries[0]
+                })
+                .unwrap();
+            assert_eq!(first, (0, 1));
+        }
+        assert_eq!(visits, 2, "each successful row is consumed exactly once");
     }
 }

--- a/crates/graphforge-exec/src/adjacency.rs
+++ b/crates/graphforge-exec/src/adjacency.rs
@@ -22,6 +22,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use arrow::record_batch::RecordBatch;
@@ -839,6 +840,9 @@ pub struct PersistentAdjacencyProvider {
     rebuild_root: Option<Box<dyn AsRef<std::path::Path> + Send + Sync>>,
     /// Serialize initial loads/builds; row reads retain their independent views.
     load_lock: Mutex<()>,
+    /// A graph reset can reuse generation numbers. Reject pre-reset manifests
+    /// until a rebuild succeeds, retaining their shards for outstanding views.
+    reset_pending: AtomicBool,
     /// Scan-build fallback, fed the ORIGINAL relation name so per-row relation
     /// filtering still applies (the union read serves the typed `"*"` wildcard).
     scan: ScanBuildAdjacencyProvider,
@@ -857,6 +861,7 @@ impl PersistentAdjacencyProvider {
             dir,
             rebuild_root: None,
             load_lock: Mutex::new(()),
+            reset_pending: AtomicBool::new(false),
             state: Mutex::new(None),
             cache: Mutex::new(HashMap::new()),
         }
@@ -883,14 +888,38 @@ impl PersistentAdjacencyProvider {
     }
 
     fn rebuild(&self, now: i64) -> Result<Vec<AdjacencyManifestRow>, GfError> {
-        csr::build_adjacency_index_into(
+        let rows = csr::build_adjacency_index_into(
             &self.dir,
             self.rebuild_root
                 .as_deref()
                 .map_or(self.dir.as_path(), AsRef::as_ref),
             now,
             || Ok(()),
-        )
+        )?;
+        self.reset_pending.store(false, Ordering::SeqCst);
+        Ok(rows)
+    }
+
+    /// Reset graph contents without admitting indexes from the old graph when
+    /// its generation numbers are reused. Initial loads and repairs cannot run
+    /// during cleanup. Even failed cleanup leaves old indexes inadmissible.
+    /// Existing views keep their immutable shard files until provider drop.
+    ///
+    /// # Errors
+    /// Returns the cleanup error or a poisoned provider load-lock error.
+    pub fn reset_graph(
+        &self,
+        cleanup: impl FnOnce() -> Result<(), GfError>,
+    ) -> Result<(), GfError> {
+        let _load = self
+            .load_lock
+            .lock()
+            .map_err(|_| GfError::Storage("adjacency load lock poisoned".into()))?;
+        self.reset_pending.store(true, Ordering::SeqCst);
+        self.invalidate();
+        let result = cleanup();
+        self.invalidate();
+        result
     }
 
     /// The CSR file stem serving `rel_type_name`: the reserved
@@ -909,7 +938,13 @@ impl PersistentAdjacencyProvider {
     fn state(&self) -> IndexState {
         let mut guard = self.state.lock().expect("adjacency state lock");
         guard
-            .get_or_insert_with(|| Self::read_state(&self.dir, self.index_root()))
+            .get_or_insert_with(|| {
+                if self.reset_pending.load(Ordering::SeqCst) {
+                    IndexState::Absent
+                } else {
+                    Self::read_state(&self.dir, self.index_root())
+                }
+            })
             .clone()
     }
 
@@ -1885,6 +1920,63 @@ mod tests {
                 "lazy build and corruption repair must not modify the pinned source"
             );
         }
+    }
+
+    #[test]
+    fn failed_reset_and_rebuild_never_read_old_private_index() {
+        let source = TempDir::new().unwrap();
+        let [src, ..] = write_diamond(source.path());
+        let artifacts = TempDir::new().unwrap();
+        let provider =
+            PersistentAdjacencyProvider::new(source.path().to_path_buf(), OntologyMode::Strict)
+                .with_rebuild_root(artifacts);
+        let retained = provider.adjacency("KNOWS", Direction::Out).unwrap();
+        let corrupted_path = source.path().join("topology/edges/KNOWS.parquet");
+        let original = std::fs::read(&corrupted_path).ok();
+        assert!(
+            provider
+                .reset_graph(|| {
+                    std::fs::write(
+                        source.path().join("topology/edges/KNOWS.parquet"),
+                        b"partial cleanup",
+                    )
+                    .unwrap();
+                    Err(GfError::Storage("cleanup failed".into()))
+                })
+                .is_err()
+        );
+        assert_eq!(
+            provider.status("KNOWS", Direction::Out),
+            AdjacencyStatus::Building
+        );
+        assert!(provider.edge_cardinality("KNOWS", Direction::Out).is_err());
+        assert!(provider.adjacency("KNOWS", Direction::Out).is_err());
+        provider.revalidate();
+        assert_eq!(
+            provider.status("KNOWS", Direction::Out),
+            AdjacencyStatus::Building
+        );
+        // No earlier row touch: this still needs the retained shard on disk.
+        assert_eq!(retained.neighbors(src).unwrap().len(), 3);
+        if let Some(bytes) = original {
+            std::fs::write(&corrupted_path, bytes).unwrap();
+        } else {
+            std::fs::remove_file(&corrupted_path).unwrap();
+        }
+        assert_eq!(
+            provider
+                .adjacency("KNOWS", Direction::Out)
+                .unwrap()
+                .neighbors(src)
+                .unwrap()
+                .len(),
+            3
+        );
+        assert_eq!(
+            provider.status("KNOWS", Direction::Out),
+            AdjacencyStatus::Hit
+        );
+        assert_eq!(retained.neighbors(src).unwrap().len(), 3);
     }
 
     #[test]

--- a/crates/graphforge-exec/src/algorithm_graph.rs
+++ b/crates/graphforge-exec/src/algorithm_graph.rs
@@ -682,7 +682,8 @@ pub(crate) fn export_adjacency(
     mode: OntologyMode,
     selection: AdjacencySelection<'_>,
 ) -> Result<AdjacencyGraph, GfError> {
-    let adjacency = provider.adjacency(selection.via, selection.direction)?;
+    let mut adjacency =
+        crate::adjacency::AdjacencyReader::new(provider, selection.via, selection.direction)?;
     let (node_ids, node_uuid_by_id) = selected_nodes(dir, selection.label)?;
     let selected: HashSet<u64> = node_ids.iter().copied().collect();
 
@@ -691,12 +692,14 @@ pub(crate) fn export_adjacency(
     let mut raw = Vec::new();
     let mut edge_ids = HashSet::new();
     for &node_id in &node_ids {
-        for (edge_id, neighbor_id) in adjacency.neighbors(node_id).iter() {
-            if selected.contains(&neighbor_id) {
-                raw.push((node_id, edge_id, neighbor_id));
-                edge_ids.insert(edge_id);
+        adjacency.with_neighbors(node_id, |neighbors| {
+            for (edge_id, neighbor_id) in neighbors.iter() {
+                if selected.contains(&neighbor_id) {
+                    raw.push((node_id, edge_id, neighbor_id));
+                    edge_ids.insert(edge_id);
+                }
             }
-        }
+        })?;
     }
     raw.sort_unstable();
 

--- a/crates/graphforge-exec/src/edge_count.rs
+++ b/crates/graphforge-exec/src/edge_count.rs
@@ -276,12 +276,9 @@ impl ExecutionPlan for EdgeCountExec {
                 "EdgeCountExec only has partition 0, got {partition}"
             )));
         }
-        let adjacency = self
+        let count = self
             .provider
-            .adjacency(&self.rel_type_name, self.direction)
-            .map_err(|error| DataFusionError::External(Box::new(error)))?;
-        let count = adjacency
-            .edge_entry_count()
+            .edge_cardinality(&self.rel_type_name, self.direction)
             .map_err(|error| DataFusionError::External(Box::new(error)))?;
         // No edge candidates are materialized by the cardinality query.
         demand::record_candidates(self.capture_epoch, 0, 0);
@@ -317,5 +314,83 @@ impl Stream for EdgeCountStream {
 impl RecordBatchStream for EdgeCountStream {
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{Array, Int64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::execution::TaskContext;
+    use datafusion::physical_expr::EquivalenceProperties;
+    use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+    use datafusion::physical_plan::{ExecutionPlan, Partitioning, PlanProperties};
+    use futures::StreamExt;
+    use graphforge_core::GfError;
+    use graphforge_ir::Direction;
+
+    use super::*;
+    use crate::adjacency::{Adjacency, AdjacencyProvider, AdjacencyStatus};
+
+    struct CardinalityOnlyProvider {
+        count: u64,
+    }
+
+    impl AdjacencyProvider for CardinalityOnlyProvider {
+        fn adjacency(
+            &self,
+            _rel_type_name: &str,
+            _direction: Direction,
+        ) -> Result<Arc<Adjacency>, GfError> {
+            panic!("EdgeCountExec must not open the adjacency view");
+        }
+
+        fn status(&self, _rel_type_name: &str, _direction: Direction) -> AdjacencyStatus {
+            AdjacencyStatus::Hit
+        }
+
+        fn edge_cardinality(
+            &self,
+            _rel_type_name: &str,
+            _direction: Direction,
+        ) -> Result<u64, GfError> {
+            Ok(self.count)
+        }
+    }
+
+    #[test]
+    fn edge_count_exec_uses_cardinality_without_opening_view() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "total",
+            DataType::Int64,
+            false,
+        )]));
+        let exec = EdgeCountExec::new(EdgeCountSpec {
+            schema: Arc::clone(&schema),
+            props: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(Arc::clone(&schema)),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Final,
+                Boundedness::Bounded,
+            )),
+            rel_type_name: "*".into(),
+            direction: Direction::Out,
+            provider: Arc::new(CardinalityOnlyProvider { count: 42 }),
+        });
+        let mut stream = exec
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("cardinality short-circuit");
+        let batch = futures::executor::block_on(stream.next())
+            .expect("one count batch")
+            .expect("batch ok");
+        let values = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 count");
+        assert_eq!(values.values(), &[42]);
+        assert!(futures::executor::block_on(stream.next()).is_none());
     }
 }

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -2539,14 +2539,15 @@ fn expand_bfs(cfg: &ExpandConfig, input_batches: &[RecordBatch]) -> Result<Recor
     let src_ids = u64_column(&input, cfg.src_col_idx)?;
 
     // --- Obtain the directed adjacency the traversal needs (#762). ---
-    let adjacency = cfg.provider.adjacency(&cfg.rel_type_name, cfg.direction)?;
+    let mut adjacency =
+        adjacency::AdjacencyReader::new(cfg.provider.as_ref(), &cfg.rel_type_name, cfg.direction)?;
 
     // --- BFS per source row, with per-path edge deduplication. ---
     // Run the traversal BEFORE any edge-file read: the BFS needs only the
     // adjacency view, and knowing the traversed edge ids lets the
     // relationship-list read below fetch exactly those rows (#830) instead of
     // scanning the whole file.
-    let emissions = bfs_emit(cfg, &adjacency, src_ids);
+    let emissions = bfs_emit(cfg, &mut adjacency, src_ids)?;
     // No matched paths → empty output under the planned schema. Avoid assembling
     // take-columns from empty input/node batches: under DataFusion 54 an empty
     // seed can still produce wide intermediate schemas that disagree with
@@ -2637,9 +2638,9 @@ fn expand_bfs(cfg: &ExpandConfig, input_batches: &[RecordBatch]) -> Result<Recor
 /// edge list); extension stops once `max_hops` is reached.
 fn bfs_emit(
     cfg: &ExpandConfig,
-    adjacency: &Adjacency,
+    adjacency: &mut adjacency::AdjacencyReader<'_>,
     src_ids: &arrow::array::UInt64Array,
-) -> Vec<(usize, u64, Vec<u64>)> {
+) -> Result<Vec<(usize, u64, Vec<u64>)>, GfError> {
     use std::collections::{HashSet, VecDeque};
 
     let mut emissions: Vec<(usize, u64, Vec<u64>)> = Vec::new();
@@ -2663,24 +2664,26 @@ fn bfs_emit(
         if cfg.max_hops.is_some_and(|m| p.hops >= m) {
             continue;
         }
-        for (edge_id, next) in adjacency.neighbors(p.node).iter() {
-            if p.visited_edges.contains(&edge_id) {
-                continue; // relationship isomorphism: no edge twice per path
+        adjacency.with_neighbors(p.node, |neighbors| {
+            for (edge_id, next) in neighbors.iter() {
+                if p.visited_edges.contains(&edge_id) {
+                    continue; // relationship isomorphism: no edge twice per path
+                }
+                let mut visited = p.visited_edges.clone();
+                visited.insert(edge_id);
+                let mut edge_path = p.edge_path.clone();
+                edge_path.push(edge_id);
+                queue.push_back(PathState {
+                    node: next,
+                    visited_edges: visited,
+                    edge_path,
+                    hops: p.hops + 1,
+                    input_row: p.input_row,
+                });
             }
-            let mut visited = p.visited_edges.clone();
-            visited.insert(edge_id);
-            let mut edge_path = p.edge_path.clone();
-            edge_path.push(edge_id);
-            queue.push_back(PathState {
-                node: next,
-                visited_edges: visited,
-                edge_path,
-                hops: p.hops + 1,
-                input_row: p.input_row,
-            });
-        }
+        })?;
     }
-    emissions
+    Ok(emissions)
 }
 
 /// The public identity of one edge, for the edge-list column (#709). UUIDs +
@@ -3697,7 +3700,8 @@ fn expand_single_hop_chunk(
 
     // The adjacency view: directional for Out/In, merged for Undirected
     // (dedup per input row happens in the emit pass below).
-    let adjacency = cfg.provider.adjacency(&cfg.rel_type_name, cfg.direction)?;
+    let mut adjacency =
+        adjacency::AdjacencyReader::new(cfg.provider.as_ref(), &cfg.rel_type_name, cfg.direction)?;
 
     // Pass 1: walk the frontier collecting (input row, edge_id, neighbor)
     // triples and the distinct traversed edge ids, so the edge read below
@@ -3714,26 +3718,27 @@ fn expand_single_hop_chunk(
             position.seen_edges.clear();
             continue;
         };
-        let neighbors = adjacency.neighbors(src);
-        while position.neighbor_offset < neighbors.len() && triples.len() < max_output {
-            let (edge_id, neighbor) = neighbors
-                .get(position.neighbor_offset)
-                .expect("neighbor_offset < len");
-            position.neighbor_offset += 1;
-            if matches!(cfg.direction, Direction::Undirected)
-                && !position.seen_edges.insert(edge_id)
-            {
-                continue;
+        adjacency.with_neighbors(src, |neighbors| {
+            while position.neighbor_offset < neighbors.len() && triples.len() < max_output {
+                let (edge_id, neighbor) = neighbors
+                    .get(position.neighbor_offset)
+                    .expect("neighbor_offset < len");
+                position.neighbor_offset += 1;
+                if matches!(cfg.direction, Direction::Undirected)
+                    && !position.seen_edges.insert(edge_id)
+                {
+                    continue;
+                }
+                triples.push((row, edge_id, neighbor));
+                traversed.insert(edge_id);
+                reached.insert(neighbor);
             }
-            triples.push((row, edge_id, neighbor));
-            traversed.insert(edge_id);
-            reached.insert(neighbor);
-        }
-        if position.neighbor_offset >= neighbors.len() {
-            position.row += 1;
-            position.neighbor_offset = 0;
-            position.seen_edges.clear();
-        }
+            if position.neighbor_offset >= neighbors.len() {
+                position.row += 1;
+                position.neighbor_offset = 0;
+                position.seen_edges.clear();
+            }
+        })?;
     }
     if triples.is_empty() {
         return Ok(RecordBatch::new_empty(cfg.out_schema.clone()));

--- a/crates/graphforge-exec/src/ordered_one_hop.rs
+++ b/crates/graphforge-exec/src/ordered_one_hop.rs
@@ -248,10 +248,12 @@ impl ExecutionPlan for OrderedOneHopExec {
             )));
         }
         // Inbound view: destinations ordered by node id, multiplicity = in-degree.
-        let inbound = self
-            .provider
-            .adjacency(&self.rel_type_name, Direction::In)
-            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let mut inbound = crate::adjacency::AdjacencyReader::new(
+            self.provider.as_ref(),
+            &self.rel_type_name,
+            Direction::In,
+        )
+        .map_err(|error| DataFusionError::External(Box::new(error)))?;
         let node_extent = inbound.node_extent();
 
         let mut remaining = self.fetch;

--- a/crates/graphforge-exec/src/ordered_two_hop.rs
+++ b/crates/graphforge-exec/src/ordered_two_hop.rs
@@ -262,10 +262,12 @@ impl ExecutionPlan for OrderedTwoHopPathCountExec {
                 "OrderedTwoHopPathCountExec only has partition 0, got {partition}"
             )));
         }
-        let inbound = self
-            .provider
-            .adjacency(&self.rel_type_name, Direction::In)
-            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let mut inbound = crate::adjacency::AdjacencyReader::new(
+            self.provider.as_ref(),
+            &self.rel_type_name,
+            Direction::In,
+        )
+        .map_err(|error| DataFusionError::External(Box::new(error)))?;
         let node_extent = inbound.node_extent();
 
         let mut remaining = self.fetch;
@@ -278,7 +280,7 @@ impl ExecutionPlan for OrderedTwoHopPathCountExec {
             }
             demand::record_adjacency_row(self.capture_epoch, 1);
             let (path_count, examined) = count_two_hop_paths_to(
-                &inbound,
+                &mut inbound,
                 destination,
                 self.require_edge_disjoint,
                 remaining,
@@ -327,7 +329,7 @@ fn usize_from_u64(value: u64) -> usize {
 }
 
 fn count_two_hop_paths_to(
-    inbound: &crate::Adjacency,
+    inbound: &mut crate::adjacency::AdjacencyReader<'_>,
     destination: u64,
     require_edge_disjoint: bool,
     remaining: usize,

--- a/crates/graphforge-exec/tests/adjacency_expand.rs
+++ b/crates/graphforge-exec/tests/adjacency_expand.rs
@@ -121,6 +121,9 @@ use arrow::array::Array;
 async fn explain_shows_stable_expand_exec_across_index_states() {
     let dir = TempDir::new().unwrap();
     let rc = seed(dir.path()).await;
+    // Seeding the parallel edge traverses the first edge and can lazily build
+    // adjacency. Establish the absent-index precondition explicitly.
+    std::fs::remove_dir_all(graphforge_storage::adjacency::adjacency_dir(dir.path())).unwrap();
     let plan = bind(
         "MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN b.name AS bn",
         &rc,
@@ -132,7 +135,7 @@ async fn explain_shows_stable_expand_exec_across_index_states() {
         .unwrap();
     assert!(
         without.contains("ExpandExec") && without.contains("adjacency=building"),
-        "no index: scan-build ExpandExec expected, got:\n{without}"
+        "no index: ExpandExec with pending adjacency build expected, got:\n{without}"
     );
 
     build_adjacency_index(dir.path(), TS).unwrap();

--- a/crates/graphforge-exec/tests/persistent_adjacency.rs
+++ b/crates/graphforge-exec/tests/persistent_adjacency.rs
@@ -131,12 +131,159 @@ fn loaded_view_is_identical_to_scan_build_exploratory_including_wildcard() {
     }
 }
 
+fn write_mixed_relations(dir: &Path) -> Uuid {
+    let mut writer = GraphWriter::open_at(dir, OntologyMode::Exploratory, TS).unwrap();
+    let (a, b) = (new_v7(), new_v7());
+    writer.create_node(a, PERSON).unwrap();
+    writer.create_node(b, PERSON).unwrap();
+    let victim = new_v7();
+    writer.create_edge(victim, "KNOWS", &a, &b).unwrap();
+    writer.create_edge(new_v7(), "KNOWS", &b, &a).unwrap();
+    writer.create_edge(new_v7(), "OWNS", &a, &b).unwrap();
+    writer.flush().unwrap();
+    victim
+}
+
+fn assert_mixed_cardinality(dir: &Path, knows: u64) {
+    let persistent = persistent(dir, OntologyMode::Exploratory);
+    let scanned = scan(dir, OntologyMode::Exploratory);
+    for (relation, expected) in [
+        ("KNOWS", knows),
+        ("OWNS", 1),
+        ("MISSING", 0),
+        ("*", knows + 1),
+    ] {
+        for direction in [Direction::Out, Direction::In, Direction::Undirected] {
+            let expected = if direction == Direction::Undirected {
+                expected * 2
+            } else {
+                expected
+            };
+            assert_eq!(
+                persistent.edge_cardinality(relation, direction).unwrap(),
+                expected,
+                "persistent {relation} {direction:?}"
+            );
+            assert_eq!(
+                scanned.edge_cardinality(relation, direction).unwrap(),
+                expected,
+                "scan {relation} {direction:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn mixed_exploratory_cardinality_preserves_filter_without_index() {
+    let dir = TempDir::new().unwrap();
+    write_mixed_relations(dir.path());
+    assert_mixed_cardinality(dir.path(), 2);
+    assert!(!graphforge_storage::adjacency::adjacency_dir(dir.path()).exists());
+}
+
+#[test]
+fn mixed_exploratory_cardinality_preserves_filter_with_stale_index() {
+    let dir = TempDir::new().unwrap();
+    let victim = write_mixed_relations(dir.path());
+    build_adjacency_index(dir.path(), TS).unwrap();
+    let victims = std::collections::HashSet::from([*victim.as_bytes()]);
+    graphforge_storage::delete_edges(dir.path(), &victims).unwrap();
+    let provider = persistent(dir.path(), OntologyMode::Exploratory);
+    assert_eq!(
+        provider.status("KNOWS", Direction::Out),
+        AdjacencyStatus::Miss
+    );
+    assert_mixed_cardinality(dir.path(), 1);
+    assert_eq!(
+        persistent(dir.path(), OntologyMode::Exploratory).status("KNOWS", Direction::Out),
+        AdjacencyStatus::Miss,
+        "counting must neither rebuild nor serve stale manifest cardinality"
+    );
+}
+
+fn write_advisory_mixed_storage(dir: &Path) -> Uuid {
+    let legacy_victim = write_mixed_relations(dir);
+    let mut writer = GraphWriter::open_at(dir, OntologyMode::Advisory, TS).unwrap();
+    let (a, b) = (new_v7(), new_v7());
+    writer.create_node(a, PERSON).unwrap();
+    writer.create_node(b, PERSON).unwrap();
+    writer.create_edge(new_v7(), "KNOWS", &a, &b).unwrap();
+    writer.create_edge(new_v7(), "KNOWS", &b, &a).unwrap();
+    writer.create_edge(new_v7(), "OWNS", &a, &b).unwrap();
+    writer.flush().unwrap();
+    legacy_victim
+}
+
+fn assert_advisory_mixed_cardinality(dir: &Path, knows: u64) {
+    let persistent = persistent(dir, OntologyMode::Advisory);
+    let scanned = scan(dir, OntologyMode::Advisory);
+    for (relation, expected) in [
+        ("KNOWS", knows),
+        ("OWNS", 2),
+        ("MISSING", 0),
+        ("*", knows + 2),
+    ] {
+        for direction in [Direction::Out, Direction::In, Direction::Undirected] {
+            let expected = if direction == Direction::Undirected {
+                expected * 2
+            } else {
+                expected
+            };
+            assert_eq!(
+                scanned
+                    .adjacency(relation, direction)
+                    .unwrap()
+                    .edge_entry_count()
+                    .unwrap(),
+                expected,
+                "traversal must include typed and legacy {relation} {direction:?}"
+            );
+            assert_eq!(
+                persistent.edge_cardinality(relation, direction).unwrap(),
+                expected,
+                "persistent {relation} {direction:?}"
+            );
+            assert_eq!(
+                scanned.edge_cardinality(relation, direction).unwrap(),
+                expected,
+                "scan {relation} {direction:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn advisory_mixed_storage_cardinality_preserves_filter_without_index() {
+    let dir = TempDir::new().unwrap();
+    write_advisory_mixed_storage(dir.path());
+    assert_advisory_mixed_cardinality(dir.path(), 4);
+    assert!(!graphforge_storage::adjacency::adjacency_dir(dir.path()).exists());
+}
+
+#[test]
+fn advisory_mixed_storage_cardinality_preserves_filter_with_stale_index() {
+    let dir = TempDir::new().unwrap();
+    let victim = write_advisory_mixed_storage(dir.path());
+    build_adjacency_index(dir.path(), TS).unwrap();
+    let victims = std::collections::HashSet::from([*victim.as_bytes()]);
+    graphforge_storage::delete_edges(dir.path(), &victims).unwrap();
+    assert_eq!(
+        persistent(dir.path(), OntologyMode::Advisory).status("KNOWS", Direction::Out),
+        AdjacencyStatus::Miss
+    );
+    assert_advisory_mixed_cardinality(dir.path(), 3);
+    assert_eq!(
+        persistent(dir.path(), OntologyMode::Advisory).status("KNOWS", Direction::Out),
+        AdjacencyStatus::Miss
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Acceptance 2: missing or stale index falls back with identical results
 // ---------------------------------------------------------------------------
 
 #[test]
-fn absent_capability_dir_is_building_and_scan_builds() {
+fn absent_capability_dir_rebuilds_on_first_access() {
     let dir = TempDir::new().unwrap();
     write_diamond(dir.path());
 
@@ -151,10 +298,15 @@ fn absent_capability_dir_is_building_and_scan_builds() {
             .adjacency("KNOWS", Direction::Out)
             .unwrap()
     );
+    assert_eq!(
+        persistent(dir.path(), OntologyMode::Strict).status("KNOWS", Direction::Out),
+        AdjacencyStatus::Hit,
+        "first access must publish the streamed CSR so later queries stay off scan-build"
+    );
 }
 
 #[test]
-fn absent_index_scan_build_is_cached_across_stream_batches() {
+fn absent_index_rebuild_is_cached_across_stream_batches() {
     let dir = TempDir::new().unwrap();
     write_diamond(dir.path());
     let provider = persistent(dir.path(), OntologyMode::Strict);
@@ -163,13 +315,13 @@ fn absent_index_scan_build_is_cached_across_stream_batches() {
     let second = provider.adjacency("KNOWS", Direction::Out).unwrap();
     assert!(
         Arc::ptr_eq(&first, &second),
-        "scan-build must be reused instead of rescanning per input batch"
+        "the published CSR view must be reused instead of rebuilding per input batch"
     );
     provider.revalidate();
     let next_query = provider.adjacency("KNOWS", Direction::Out).unwrap();
     assert!(
-        !Arc::ptr_eq(&first, &next_query),
-        "an absent-index cache must not survive the next query"
+        Arc::ptr_eq(&first, &next_query),
+        "a just-published fresh CSR must survive revalidate at the same generation"
     );
 }
 
@@ -513,6 +665,48 @@ mod session_wiring {
         assert_eq!(rows(&on_stale), rows(&before), "stale fallback identical");
     }
 
+    #[tokio::test]
+    async fn lazy_corrupt_shards_are_repaired_by_fixed_and_variable_traversal() {
+        for query in [
+            "MATCH (a:P {name: 'a'})-[:KNOWS]->(b:P) RETURN 1 AS one",
+            "MATCH (a:P {name: 'a'})-[:KNOWS*1..3]->(b:P) RETURN 1 AS one",
+        ] {
+            let dir = TempDir::new().unwrap();
+            let rc = seeded_chain(dir.path()).await;
+            build_adjacency_index(dir.path(), TS).unwrap();
+            let plan = bind(query, &rc);
+            let expected = session(dir.path(), &rc).execute_plan(&plan).await.unwrap();
+            let mut stack = vec![graphforge_storage::adjacency::adjacency_dir(dir.path())];
+            let mut corrupted = 0;
+            while let Some(path) = stack.pop() {
+                for entry in std::fs::read_dir(path).unwrap() {
+                    let path = entry.unwrap().path();
+                    if path.is_dir() {
+                        stack.push(path);
+                    } else if path.extension().and_then(|ext| ext.to_str()) == Some("csr") {
+                        std::fs::write(path, b"corrupt payload").unwrap();
+                        corrupted += 1;
+                    }
+                }
+            }
+            assert!(corrupted > 0);
+            let result = session(dir.path(), &rc).execute_plan(&plan).await.unwrap();
+            assert_eq!(
+                result.stats.rows_produced, expected.stats.rows_produced,
+                "{query}"
+            );
+            assert!(result.stats.rows_produced > 0);
+            // Recovery must also repair the reusable provider artifact.
+            let repaired = persistent(dir.path(), OntologyMode::Exploratory);
+            assert_eq!(
+                repaired.adjacency("KNOWS", Direction::Out).unwrap(),
+                scan(dir.path(), OntologyMode::Exploratory)
+                    .adjacency("KNOWS", Direction::Out)
+                    .unwrap()
+            );
+        }
+    }
+
     /// CodeRabbit regression (#824): one long-lived session that reads
     /// (caching a loaded view), writes (bumping the generation), and reads
     /// again must observe the post-write adjacency — successful writes
@@ -598,27 +792,34 @@ async fn zero_hop_traversal_on_hit_never_opens_edge_files() {
 // ---------------------------------------------------------------------------
 
 /// A warm shared provider serves repeat queries from its view cache: after
-/// the first load, even deleting every index file does not affect the second
-/// query (nothing is re-read).
+/// the first row read, even deleting every index file does not affect a repeat
+/// read of that authenticated shard.
 #[test]
 fn shared_provider_serves_second_query_from_cache() {
     let dir = TempDir::new().unwrap();
-    write_diamond(dir.path());
+    let [src, ..] = write_diamond(dir.path());
     build_adjacency_index(dir.path(), TS).unwrap();
 
     let provider = persistent(dir.path(), OntologyMode::Strict);
     let first = provider.adjacency("KNOWS", Direction::Out).unwrap();
 
+    let expected = first.neighbors(src).unwrap().to_vec();
+    assert_eq!(expected.len(), 3);
+
     // Remove the whole index AND the edge files; cache must still serve.
     std::fs::remove_dir_all(dir.path().join("indexes")).unwrap();
     std::fs::remove_dir_all(dir.path().join("topology").join("edges")).unwrap();
     let second = provider.adjacency("KNOWS", Direction::Out).unwrap();
+    assert!(Arc::ptr_eq(&first, &second));
+    assert_eq!(second.neighbors(src).unwrap().to_vec(), expected);
     assert_eq!(first, second);
 
     // revalidate() with an unchanged generation keeps the cache too (the
     // session-construction call must not defeat the amortization).
     provider.revalidate();
     let third = provider.adjacency("KNOWS", Direction::Out).unwrap();
+    assert!(Arc::ptr_eq(&first, &third));
+    assert_eq!(third.neighbors(src).unwrap().to_vec(), expected);
     assert_eq!(first, third);
 }
 
@@ -753,4 +954,31 @@ fn revalidate_picks_up_externally_built_index() {
         provider.status("KNOWS", Direction::Out),
         AdjacencyStatus::Hit
     );
+}
+
+#[test]
+fn cardinality_rejects_same_generation_wrong_manifest_counts() {
+    let dir = TempDir::new().unwrap();
+    write_diamond(dir.path());
+    let mut rows = build_adjacency_index(dir.path(), TS).unwrap();
+    let generation = graphforge_storage::read_topology_generation(dir.path()).unwrap();
+    for row in &mut rows {
+        assert_eq!(row.topology_generation, generation);
+        row.edge_count += 100;
+    }
+    graphforge_storage::adjacency::write_manifest(dir.path(), &rows).unwrap();
+    let provider = persistent(dir.path(), OntologyMode::Strict);
+    for relation in ["KNOWS", "*"] {
+        for (direction, expected) in [
+            (Direction::Out, 6),
+            (Direction::In, 6),
+            (Direction::Undirected, 12),
+        ] {
+            assert_eq!(
+                provider.edge_cardinality(relation, direction).unwrap(),
+                expected,
+                "wrong manifest count must not override topology: {relation} {direction:?}"
+            );
+        }
+    }
 }

--- a/crates/graphforge-storage/src/adjacency.rs
+++ b/crates/graphforge-storage/src/adjacency.rs
@@ -152,24 +152,16 @@ impl ShardedCsrIndex {
             if !is_normal_path_component(&shard.file) {
                 return Err(GfError::Storage("invalid CSR shard file name".into()));
             }
-            // Authenticate and structurally validate every bounded shard at
-            // open. Runtime row reads then cannot discover latent corruption
-            // through the infallible traversal interface.
+            // Presence only. Checksum and structural authentication stay on the
+            // first row touch so opening a multi-shard index cannot charge O(E)
+            // process RSS (#1094).
             let shard_path = root.join(&shard.file);
-            let shard_bytes = std::fs::read(&shard_path).map_err(|error| {
+            let metadata = std::fs::metadata(&shard_path).map_err(|error| {
                 GfError::Storage(format!("missing CSR shard {}: {error}", shard.file))
             })?;
-            if sha256_hex(&shard_bytes) != shard.sha256 {
+            if !metadata.is_file() {
                 return Err(GfError::Storage(format!(
-                    "CSR shard checksum mismatch: {}",
-                    shard.file
-                )));
-            }
-            let decoded = read_csr_bytes(&shard_bytes, &shard_path)?;
-            if decoded.node_count() != shard.node_count || decoded.edge_count() != shard.edge_count
-            {
-                return Err(GfError::Storage(format!(
-                    "CSR shard count mismatch: {}",
+                    "missing CSR shard {}",
                     shard.file
                 )));
             }
@@ -2592,6 +2584,28 @@ mod tests {
                 .to_string()
                 .contains("missing CSR shard")
         );
+    }
+
+    #[test]
+    fn opening_sharded_csr_does_not_read_or_decode_shard_payloads() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("KNOWS.out.csr");
+        let expected = sample_csr();
+        write_sharded_csr(&path, &expected, 2).unwrap();
+        let published = ShardedCsrIndex::open(&path).unwrap();
+        assert_eq!(
+            (published.node_count(), published.edge_count()),
+            (expected.node_count(), expected.edge_count())
+        );
+        for record in &published.manifest.shards {
+            std::fs::write(published.root.join(&record.file), b"corrupt-payload").unwrap();
+        }
+        let reader = ShardedCsrIndex::open(&path).expect("open must not decode shard payloads");
+        assert_eq!(
+            (reader.node_count(), reader.edge_count()),
+            (expected.node_count(), expected.edge_count())
+        );
+        assert!(reader.row(0).unwrap_err().to_string().contains("checksum"));
     }
 
     #[test]

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -202,6 +202,113 @@ pub fn read_edges(
     Ok(batches)
 }
 
+/// Count topology edge rows without materializing adjacency or the full graph.
+///
+/// Used by unconstrained `count(r)` so a missing CSR index cannot charge O(E)
+/// RSS (#1094). `"*"` unions every edge file; a Strict name counts its stem.
+/// Advisory named counts include the typed stem and matching legacy exploratory
+/// rows. Shared-file filtering streams only the relation-name column in bounded
+/// batches.
+///
+/// # Errors
+/// Returns [`crate::GfError::Storage`] on an invalid typed stem or footer read
+/// failure, or a malformed relation-name column.
+pub fn count_edge_rows(
+    dir: &Path,
+    rel_name: &str,
+    mode: OntologyMode,
+) -> Result<u64, crate::GfError> {
+    let relation = match mode {
+        OntologyMode::Exploratory => Some("_exploratory"),
+        OntologyMode::Advisory | OntologyMode::Strict if rel_name == "*" => None,
+        OntologyMode::Advisory | OntologyMode::Strict => {
+            let mut comps = Path::new(rel_name).components();
+            let single_normal = matches!(comps.next(), Some(std::path::Component::Normal(_)))
+                && comps.next().is_none();
+            if !single_normal {
+                return Err(crate::GfError::Storage(format!(
+                    "invalid relation name {rel_name:?}: must be a plain file stem"
+                )));
+            }
+            (mode == OntologyMode::Strict).then_some(rel_name)
+        }
+    };
+    let mut total = 0_u64;
+    for (stem, path) in crate::mutator::edge_parquet_files(dir, relation)? {
+        if mode == OntologyMode::Advisory
+            && rel_name != "*"
+            && stem != rel_name
+            && stem != "_exploratory"
+        {
+            continue;
+        }
+        let file = File::open(&path).map_err(|error| {
+            crate::GfError::Storage(format!("open edge footer {}: {error}", path.display()))
+        })?;
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(|error| {
+            crate::GfError::Storage(format!("read edge footer {}: {error}", path.display()))
+        })?;
+        if stem == "_exploratory" && rel_name != "*" {
+            let relation_column = builder
+                .schema()
+                .index_of("rel_type_name")
+                .map_err(|error| {
+                    crate::GfError::Storage(format!(
+                        "edge relation column {}: {error}",
+                        path.display()
+                    ))
+                })?;
+            let projection =
+                parquet::arrow::ProjectionMask::roots(builder.parquet_schema(), [relation_column]);
+            let reader = builder
+                .with_projection(projection)
+                .with_batch_size(8_192)
+                .build()
+                .map_err(|error| {
+                    crate::GfError::Storage(format!(
+                        "read edge relations {}: {error}",
+                        path.display()
+                    ))
+                })?;
+            for batch in reader {
+                let batch = batch.map_err(|error| {
+                    crate::GfError::Storage(format!(
+                        "decode edge relations {}: {error}",
+                        path.display()
+                    ))
+                })?;
+                let names = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                    .ok_or_else(|| {
+                        crate::GfError::Storage(format!(
+                            "edge rel_type_name is not Utf8: {}",
+                            path.display()
+                        ))
+                    })?;
+                let matching =
+                    u64::try_from(names.iter().filter(|name| *name == Some(rel_name)).count())
+                        .map_err(|_| crate::GfError::Storage("edge count exceeds u64".into()))?;
+                total = total
+                    .checked_add(matching)
+                    .ok_or_else(|| crate::GfError::Storage("edge count exceeds u64".into()))?;
+            }
+            continue;
+        }
+        let rows = u64::try_from(builder.metadata().file_metadata().num_rows()).map_err(|_| {
+            crate::GfError::Storage(format!(
+                "edge footer row count overflows u64: {}",
+                path.display()
+            ))
+        })?;
+        total = total
+            .checked_add(rows)
+            .ok_or_else(|| crate::GfError::Storage("edge count exceeds u64".into()))?;
+    }
+    Ok(total)
+}
+
 /// Like [`read_edges`] but returns only rows whose `edge_id` is in
 /// `edge_ids` — the traversal's lazy edge-record read (#830): on an adjacency
 /// Hit, only the traversed edges' records are needed, not the whole file.

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -1973,6 +1973,19 @@ impl GraphConstructionSession {
                     .base_work,
             )
         } else if parent_topology_generation == 0 {
+            // A missing generation counter is not proof that a legacy parent
+            // is empty. Initial construction cannot retain uncertified labels.
+            for path in crate::mutator::node_parquet_files(graph_source_dir)? {
+                let reader = ParquetRecordBatchReaderBuilder::try_new(
+                    File::open(&path).map_err(|error| storage(error.to_string()))?,
+                )
+                .map_err(|error| storage(error.to_string()))?;
+                if reader.metadata().file_metadata().num_rows() != 0 {
+                    return Err(storage(
+                        "generation-zero construction parent contains existing node rows",
+                    ));
+                }
+            }
             (None, UuidConstructionSnapshotWork::default())
         } else {
             let mut snapshot = if let Some(inventory) = &compact_inventory {
@@ -9212,6 +9225,53 @@ mod tests {
         .unwrap()
     }
 
+    #[test]
+    fn generation_zero_accepts_empty_node_parquet() {
+        let root = TempDir::new().unwrap();
+        std::fs::create_dir_all(root.path().join("topology")).unwrap();
+        ArrowWriter::try_new(
+            File::create(root.path().join("topology/nodes.parquet")).unwrap(),
+            crate::schemas::TOPOLOGY_NODES_SCHEMA.clone(),
+            None,
+        )
+        .unwrap()
+        .close()
+        .unwrap();
+        let _session = open(&root, 9876);
+    }
+
+    #[test]
+    fn generation_zero_rejects_unmarked_nonempty_legacy_parent() {
+        let root = TempDir::new().unwrap();
+        let mut writer =
+            crate::GraphWriter::open_at(root.path(), graphforge_core::OntologyMode::Exploratory, 1)
+                .unwrap();
+        writer
+            .create_node(Uuid::now_v7(), graphforge_core::TypeId(0))
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        std::fs::remove_file(root.path().join("topology/generation.json")).unwrap();
+        assert_eq!(crate::read_topology_generation(root.path()).unwrap(), 0);
+        let error = GraphConstructionSession::open(
+            root.path(),
+            Uuid::now_v7(),
+            0,
+            GraphConstructionBudgets::default(),
+        )
+        .err()
+        .expect("nonempty legacy parent cannot be initial construction");
+        assert!(
+            error
+                .to_string()
+                .contains("generation-zero construction parent contains existing node rows"),
+            "{error}"
+        );
+        assert!(!crate::has_runtime_entity_label_encoding_marker(
+            root.path()
+        ));
+    }
+
     fn nonempty_project() -> TempDir {
         nonempty_project_with_nodes(2)
     }
@@ -11366,6 +11426,26 @@ mod tests {
             .join("graph");
         let nodes = crate::read_nodes(&graph).unwrap();
         assert_eq!(nodes.iter().map(RecordBatch::num_rows).sum::<usize>(), 3);
+        assert!(crate::has_runtime_entity_label_encoding_marker(&graph));
+        let person_id = authority
+            .bindings
+            .bindings
+            .iter()
+            .find(|binding| {
+                binding.route_kind == crate::SemanticRouteKind::Entity
+                    && binding.symbol.local_id == "Person"
+            })
+            .unwrap()
+            .storage_id;
+        for batch in &nodes {
+            let ids = batch
+                .column_by_name("type_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow::array::UInt32Array>()
+                .unwrap();
+            assert!(ids.values().iter().all(|id| *id == person_id));
+        }
         let edges = crate::read_edges(
             &graph,
             &relation_route,
@@ -12203,6 +12283,9 @@ mod tests {
     #[test]
     fn generation_two_parent_index_is_structurally_referenced_without_payload_copy() {
         let project = nonempty_project_generation_two();
+        assert!(!crate::has_runtime_entity_label_encoding_marker(
+            project.path()
+        ));
         let operation = Uuid::from_u128(9_340);
         let mut session = GraphConstructionSession::open_with_mode(
             project.path(),
@@ -12218,6 +12301,13 @@ mod tests {
         session.seal().unwrap();
         let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
         let encoded = session.encode_canonical(&shape, 3).unwrap();
+        assert!(
+            encoded
+                .artifacts
+                .iter()
+                .all(|artifact| artifact.path != "topology/runtime_entity_label_encoding.json"),
+            "an append cannot certify the label encoding of an unmarked legacy parent"
+        );
         assert_eq!(encoded.evidence.retained_index_payload_bytes, 0);
         assert_eq!(encoded.evidence.retained_topology_bytes_copied, 0);
         assert_eq!(encoded.evidence.prior_topology_rows_decoded, 0);

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -661,6 +661,21 @@ pub(crate) fn encode(
     let semantic_context = semantic_authority
         .map(ConstructionSemanticAuthority::context)
         .transpose()?;
+    if shape.parent_topology_generation == 0 {
+        // Initial construction owns every node label: encode_nodes uses tagged
+        // runtime IDs or the exact semantic storage authority. Publish that
+        // guarantee with the graph so reopen does not rescan all nodes for a
+        // legacy migration. An append must not certify an unmarked old parent.
+        copy_artifact(
+            std::io::Cursor::new(
+                crate::runtime_entity_labels::runtime_entity_label_encoding_bytes()?,
+            ),
+            &output,
+            "topology/runtime_entity_label_encoding.json",
+            &mut artifacts,
+            &mut evidence,
+        )?;
+    }
 
     let identities_sha256 = shaped_output_sha256(shape_outputs, &shape.identities)?;
     let mut index = crate::uuid_membership::encode_construction_index(

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -407,7 +407,7 @@ pub use property_overlay::{
 pub mod catalog;
 pub use catalog::{
     AdmittedSourceFile, EdgePropertyTable, GraphCatalog, PropertyTable, TopologyNodeTable,
-    TypedEdgeTable, UnionEdgeTable, list_edge_property_stems, list_property_stems,
+    TypedEdgeTable, UnionEdgeTable, count_edge_rows, list_edge_property_stems, list_property_stems,
     node_property_files, node_property_source_files, node_property_source_fragments,
     node_topology_present, read_edge_properties, read_edge_properties_projected, read_edges,
     read_edges_filtered, read_edges_filtered_observed, read_edges_filtered_projected_observed,

--- a/crates/graphforge-storage/src/runtime_entity_labels.rs
+++ b/crates/graphforge-storage/src/runtime_entity_labels.rs
@@ -91,16 +91,21 @@ fn read_encoding_version(dir: &Path) -> Option<u32> {
 pub fn write_runtime_entity_label_encoding_marker(dir: &Path) -> Result<(), GfError> {
     let topology = dir.join("topology");
     std::fs::create_dir_all(&topology).map_err(|e| storage_err(e.to_string()))?;
-    let marker = EncodingMarker {
-        format: "graphforge-runtime-entity-label-encoding".into(),
-        version: RUNTIME_ENTITY_LABEL_ENCODING_VERSION,
-    };
-    let bytes = serde_json::to_vec_pretty(&marker).map_err(|e| storage_err(e.to_string()))?;
+    let bytes = runtime_entity_label_encoding_bytes()?;
     let path = encoding_path(dir);
     let tmp = path.with_extension("json.tmp");
     std::fs::write(&tmp, bytes).map_err(|e| storage_err(e.to_string()))?;
     std::fs::rename(&tmp, &path).map_err(|e| storage_err(e.to_string()))?;
     Ok(())
+}
+
+/// Shared marker bytes for reconciliation and authenticated construction artifacts.
+pub(crate) fn runtime_entity_label_encoding_bytes() -> Result<Vec<u8>, GfError> {
+    let marker = EncodingMarker {
+        format: "graphforge-runtime-entity-label-encoding".into(),
+        version: RUNTIME_ENTITY_LABEL_ENCODING_VERSION,
+    };
+    serde_json::to_vec_pretty(&marker).map_err(|e| storage_err(e.to_string()))
 }
 
 fn ontology_entity_ids(ontology: Option<&OntologyHandle>) -> HashSet<u32> {

--- a/crates/graphforge-storage/src/storage_attribution.rs
+++ b/crates/graphforge-storage/src/storage_attribution.rs
@@ -909,6 +909,9 @@ impl StorageAttributionSnapshot {
 /// Classify one authenticated graph inventory path.
 #[must_use]
 pub fn classify_graph_artifact(relative_path: &str) -> ArtifactCategory {
+    if relative_path == "topology/runtime_entity_label_encoding.json" {
+        return ArtifactCategory::CatalogAndManifests;
+    }
     let path = Path::new(relative_path);
     let mut components = path.components().filter_map(|component| match component {
         std::path::Component::Normal(value) => value.to_str(),
@@ -1427,6 +1430,16 @@ mod tests {
             ArtifactCategory::CatalogAndManifests
         );
         assert_eq!(
+            classify_graph_artifact("topology/runtime_entity_label_encoding.json"),
+            ArtifactCategory::CatalogAndManifests
+        );
+        for unknown in [
+            "topology/runtime_entity_label_encoding.json/unknown",
+            "topology/runtime_entity_label_encoding.json.tmp",
+        ] {
+            assert_eq!(classify_graph_artifact(unknown), ArtifactCategory::Other);
+        }
+        assert_eq!(
             classify_graph_artifact("topology/surrogate_tails.parquet"),
             ArtifactCategory::UuidAndSurrogates
         );
@@ -1577,6 +1590,7 @@ mod tests {
             .unwrap();
         }
         let _ = crate::open_or_initialize_project(project.path()).unwrap();
+        crate::write_runtime_entity_label_encoding_marker(workspace.path()).unwrap();
         let generation = publish_compact_fixture(project.path(), workspace.path());
         let snapshot = capture_storage_attribution(&generation).unwrap();
         snapshot.validate_reconciliation().unwrap();

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -116,10 +116,7 @@ class SurfaceGateTests(unittest.TestCase):
         manifest["method_evidence_groups"]["checkpoint-view"]["test_refs"] = [
             {
                 "path": "crates/graphforge-api/tests/algorithm_public_surface.rs",
-                "symbol": (
-                    "persisted_public_rank_is_exact_after_repeat_and_reopen_"
-                    "and_unavailable_is_stable"
-                ),
+                "symbol": "descriptor_byte_and_embedding_dispatch_are_publicly_covered",
             }
         ]
         errors = self.validate(manifest)


### PR DESCRIPTION
Fresh-index recounts decoded every CSR shard, making RSS grow with graph size and preventing S20 admission. Keep index opening metadata-only, use validated fresh-manifest cardinality, and retain bounded topology fallback for absent or inconsistent counts. Named relations preserve their mode-specific semantics.

Lazy row reads retain one index-repair attempt without copying high-degree rows. Facade providers own private index caches outside authenticated graph inventories. Clearing a graph fences old manifests across reused generation numbers while preserving files needed by outstanding views.

Fresh construction now publishes its runtime-label encoding marker, eliminating unnecessary full-node legacy reconciliation on reopen. Existing append markers are retained; unmarked legacy parents cannot be falsely certified. Storage attribution recognizes only the exact marker path as metadata and continues rejecting unknown artifacts.

Validation:
- Full API BDD: 118 scenarios passed. Full Cypher corpus: 3,897/3,897 passed, zero regressions; all 149 prior CI regressions are resolved.
- Regression tests cover recount/cardinality mismatches, bounded traversal, failed and successful lazy repair, retained-view lifetime, clear/repopulation, source-inventory preservation, fresh/portable zero-scan reopen, semantic labels, legacy-parent admission, and marker retention/classification.
- All 16 storage-attribution tests pass, including the previously failing real compact-generation qualification. Standard storage/executor/API Clippy, formatting, diff checks, and gate-registry checks pass.
- The prior `2d65def2` host run passed S18/S19 correctness but failed the unchanged 10% RSS plateau limit (14.54% growth). This led to the missing-marker fix. The subsequent `eb6eafe6` run passed ingest but exposed the marker-classification omission, fixed at `542e39e3`.

Final-head host validation on OVHC-AGENCY (`542e39e3`): `make -C benchmarks progressive-host-ladder-run` completed with exit 0. S18, S19, and S20 each passed all ten lifecycle phases, with matching source/import query-result hashes. Independent review verified all 12 artifact hashes and the S20 admission projection.

| Rung | Edges | Maximum phase process RSS (bytes) | Wall time (s) |
| --- | ---: | ---: | ---: |
| S18 | 4,194,304 | 185,024,512 | 100 |
| S19 | 8,388,608 | 189,177,856 | 201 |
| S20 | 16,777,216 | 194,035,712 | 403 |

Adjacent peak-RSS growth was 2.245% and 2.568%, within the unchanged 10% gate. Source one-hop retained RSS increased 11.25% from S18 to S19; its maximum across source/reopen increased 4.02%. Individual retained snapshots are not uniformly below 10%. Recount materializes zero child rows; S18/S19 one-hop generates exactly 1,000 candidates and examines 46 adjacency rows. S20 uses 1,000 candidates and 78 adjacency rows.

S20 was admitted from measured capacity and throughput with a 98,885,591,655-byte reserve; actual transient storage was 22,399,303,680 bytes. Evidence is retained at `/home/ubuntu/graphforge-ladder/1094-542e39e3/evidence`. This is GraphForge engineering scale evidence using Graph500-generated data, not official BFS/TEPS or broader release certification. The separate pre-seal public append accounting defect remains tracked under #951.

Exact-head CI Gate must pass before merge.

Closes #1094
