### PR TITLE
fix(bench): preserve native admission interpreter under uv

### DIFF
--- a/benchmarks/harness/graphforge_bench/local_admission_fixture.py
+++ b/benchmarks/harness/graphforge_bench/local_admission_fixture.py
@@ -74,10 +74,14 @@ while True:
         # this explicit mount, the heartbeat would live in BenchExec's overlay
         # and disappear with the container, making descendant cleanup
         # impossible to verify from the supervising process.
+        # Keep BenchExec on the interpreter selected by native admission;
+        # uv's PATH may contain another runexec without host cgroup integration.
         with measure_hybrid_pressure() as hybrid_pressure:
             completed = subprocess.run(
                 [
-                    "runexec",
+                    sys.executable,
+                    "-m",
+                    "benchexec.runexecutor",
                     "--walltimelimit",
                     "1",
                     "--memlimit",

--- a/benchmarks/tests/test_local_admission.py
+++ b/benchmarks/tests/test_local_admission.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
+from contextlib import redirect_stdout
+import io
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 import tempfile
 import unittest
 from unittest.mock import patch
 
 from graphforge_bench.local_admission import CommandResult, exit_code, qualify_local_host
 from graphforge_bench.local_admission_fixture import _parse_runexec_value
+from graphforge_bench.local_admission_fixture import main as fixture_main
 from graphforge_bench.validate_local_admission import validate
 
 
@@ -23,6 +29,44 @@ class LocalAdmissionTests(unittest.TestCase):
         self.assertEqual(_parse_runexec_value("4096B"), 4096)
         self.assertEqual(_parse_runexec_value("0.003s"), 0.003)
         self.assertEqual(_parse_runexec_value("walltime"), "walltime")
+
+    def test_fixture_uses_selected_interpreter_despite_shadow_runexec(self) -> None:
+        # Exercise the fixture's real dispatch and the installed BenchExec CLI.
+        # --help keeps this routing regression independent of native admission;
+        # native accounting and termination are checked by the host probe.
+        run = subprocess.run
+        invoked = []
+        with tempfile.TemporaryDirectory() as directory:
+            shadow = Path(directory) / "runexec"
+            marker = Path(directory) / "shadow-invoked"
+            shadow.write_text(
+                f"#!{sys.executable}\n"
+                "from pathlib import Path\n"
+                f"Path({str(marker)!r}).touch()\n"
+                "raise SystemExit(93)\n",
+                encoding="utf-8",
+            )
+            shadow.chmod(0o755)
+
+            def run_help(command, **kwargs):
+                entrypoint = command[: command.index("--walltimelimit")]
+                completed = run([*entrypoint, "--help"], **kwargs)
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+                self.assertIn("--walltimelimit", completed.stdout)
+                self.assertIn("--overlay-dir", completed.stdout)
+                invoked.append(entrypoint)
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with (
+                patch.dict(os.environ, {"PATH": directory + os.pathsep + os.environ["PATH"]}),
+                patch(
+                    "graphforge_bench.local_admission_fixture.subprocess.run", side_effect=run_help
+                ),
+                redirect_stdout(io.StringIO()),
+            ):
+                fixture_main()
+            self.assertEqual(invoked, [[sys.executable, "-m", "benchexec.runexecutor"]])
+            self.assertFalse(marker.exists(), "PATH-selected runexec must never be invoked")
 
     @staticmethod
     def _linux_roots(directory: str) -> tuple[Path, Path]:


### PR DESCRIPTION
The documented uv-driven host ladder selected system Python for admission, then the fixture launched a different `runexec` from the benchmark virtual environment. On OVHC-AGENCY this failed before S18 with `native_authority_unavailable`, despite direct native admission passing.

Launch BenchExec through the selected interpreter’s supported `benchexec.runexecutor` module. This keeps the existing resource limits, namespace isolation, accounting, descendant termination, and failure handling intact.

Validation: 65 focused admission and host-controller tests passed, including a shadow-PATH regression that exercises the installed CLI. The real uv-driven native authority probe passed on OVHC-AGENCY with cgroups v2 accounting and stopped-descendant evidence. Ruff, diff checks, and gate-registry validation passed. Independent review found no outstanding issues.

Closes #1133

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791365409&installation_model_id=20486&pr_number=1134&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1134&signature=75a7c8461a470a7a67569eb2365f0fe405ab111f94801ed1568a058de745c50f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->