### PR TITLE
refactor(plan,exec): bind read plans through execution resources

### DIFF
--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -61,6 +61,7 @@ pub(crate) mod algorithm_embedding_graphsage;
 pub(crate) mod algorithm_embedding_hashgnn;
 mod algorithm_embedding_invocation;
 pub(crate) mod algorithm_embedding_options;
+pub mod read_resource;
 pub use algorithm_embedding_options::validate_embedding_options;
 pub use algorithm_graph::AlgorithmProjectionFingerprint;
 pub(crate) mod algorithm_arrow_sink;
@@ -2252,6 +2253,8 @@ impl VarLenExpandExec {
         node: &VarLenExpandNode,
         input: Arc<dyn ExecutionPlan>,
         provider: Arc<dyn AdjacencyProvider>,
+        dir: PathBuf,
+        mode: OntologyMode,
     ) -> Self {
         let schema: SchemaRef = Arc::new(node.schema().as_arrow().clone());
         let props = Arc::new(PlanProperties::new(
@@ -2276,8 +2279,8 @@ impl VarLenExpandExec {
             direction: node.direction,
             min_hops: node.min_hops,
             max_hops: node.max_hops,
-            dir: node.dir.clone(),
-            mode: node.mode,
+            dir,
+            mode,
             src_col_idx,
             schema,
             props,
@@ -3212,6 +3215,7 @@ impl ExpandExec {
         provider: Arc<dyn AdjacencyProvider>,
         ordinal_identities: Option<Arc<V4OrdinalIdentitySession>>,
         ordinal_identity_required: bool,
+        resource: &read_resource::GraphReadContext,
     ) -> Self {
         let schema: SchemaRef = Arc::new(node.schema().as_arrow().clone());
         let props = Arc::new(PlanProperties::new(
@@ -3230,8 +3234,8 @@ impl ExpandExec {
             input,
             rel_type_name: node.rel_type_name.clone(),
             direction: node.direction,
-            dir: node.dir.clone(),
-            mode: node.mode,
+            dir: resource.dir.clone(),
+            mode: resource.mode,
             src_col_idx,
             edge_prop_count: node.edge_prop_count,
             input_width: node.input.schema().fields().len(),
@@ -4682,18 +4686,14 @@ fn plan_expand_extension(
         .first()
         .cloned()
         .ok_or_else(|| DataFusionError::Internal("Expand requires one physical input".into()))?;
+    let resource = read_resource::required(session_state)?;
+    resource.validate(expand.read_contract.as_ref())?;
     let provider = session_state
         .config()
         .get_extension::<AdjacencyProviderExt>()
-        .map_or_else(
-            || {
-                Arc::new(ScanBuildAdjacencyProvider::new(
-                    expand.dir.clone(),
-                    expand.mode,
-                )) as Arc<dyn AdjacencyProvider>
-            },
-            |ext| Arc::clone(&ext.0),
-        );
+        .ok_or_else(|| DataFusionError::Plan("GF_READ_RESOURCE_MISSING: adjacency".into()))?
+        .0
+        .clone();
     let identity_extension = session_state
         .config()
         .get_extension::<OrdinalIdentityResolverExt>();
@@ -4707,6 +4707,7 @@ fn plan_expand_extension(
         provider,
         ordinal_identities,
         ordinal_identity_required,
+        &resource,
     )))
 }
 
@@ -4756,23 +4757,20 @@ impl ExtensionPlanner for GraphForgeExtensionPlanner {
             let input = physical_inputs.first().cloned().ok_or_else(|| {
                 DataFusionError::Internal("VarLenExpand requires one physical input".into())
             })?;
-            // The session-scoped provider (#761) travels via SessionConfig
-            // extension; a foreign SessionState without one falls back to a
-            // fresh scan-build provider (today's pre-index behavior).
+            let resource = read_resource::required(session_state)?;
+            resource.validate(var_len.read_contract.as_ref())?;
             let provider = session_state
                 .config()
                 .get_extension::<AdjacencyProviderExt>()
-                .map_or_else(
-                    || {
-                        Arc::new(ScanBuildAdjacencyProvider::new(
-                            var_len.dir.clone(),
-                            var_len.mode,
-                        )) as Arc<dyn AdjacencyProvider>
-                    },
-                    |ext| Arc::clone(&ext.0),
-                );
+                .ok_or_else(|| DataFusionError::Plan("GF_READ_RESOURCE_MISSING: adjacency".into()))?
+                .0
+                .clone();
             return Ok(Some(Arc::new(VarLenExpandExec::new(
-                var_len, input, provider,
+                var_len,
+                input,
+                provider,
+                resource.dir.clone(),
+                resource.mode,
             ))));
         }
         if let Some(opt) = node.as_any().downcast_ref::<OptionalMatchNode>() {
@@ -4820,11 +4818,12 @@ impl QueryPlanner for GraphForgeQueryPlanner {
         logical_plan: &LogicalPlan,
         session_state: &SessionState,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let logical_plan = read_resource::bind(logical_plan, session_state)?;
         let planner = DefaultPhysicalPlanner::with_extension_planners(vec![Arc::new(
             GraphForgeExtensionPlanner,
         )]);
         planner
-            .create_physical_plan(logical_plan, session_state)
+            .create_physical_plan(&logical_plan, session_state)
             .await
     }
 }
@@ -5106,7 +5105,14 @@ impl ExecutionSession {
             },
         );
         let provider: Arc<dyn AdjacencyProvider> = Arc::clone(&adjacency_provider) as _;
+        let catalog = Arc::new(catalog);
         let mut config = datafusion::prelude::SessionConfig::new()
+            .with_extension(Arc::new(read_resource::GraphReadContext {
+                dir: dir.clone(),
+                mode,
+                catalog: catalog.clone(),
+                ontology: ontology.clone(),
+            }))
             .with_extension(Arc::new(AdjacencyProviderExt(provider)))
             .with_extension(Arc::new(graphforge_storage::IoConcurrencyExt::new(
                 resources.io_concurrency,
@@ -5156,7 +5162,6 @@ impl ExecutionSession {
         let semantic_composition_fingerprint = catalog
             .semantic_composition_fingerprint()
             .map(str::to_owned);
-        let catalog = Arc::new(catalog);
         ctx.register_catalog("graph", catalog.clone());
         Self {
             ctx,
@@ -7577,8 +7582,6 @@ mod tests {
             3,
             graphforge_ir::Direction::Out,
             None,
-            dir.path().to_path_buf(),
-            OntologyMode::Exploratory,
             vec![],
             vec![],
             vec![],
@@ -7593,8 +7596,6 @@ mod tests {
             3,
             graphforge_ir::Direction::Out,
             None,
-            dir.path().to_path_buf(),
-            OntologyMode::Exploratory,
             vec![],
             graphforge_plan::var_len_edge_list_field(&[]),
         );
@@ -7677,8 +7678,6 @@ mod tests {
             3,
             graphforge_ir::Direction::Out,
             None,
-            dir.path().to_path_buf(),
-            OntologyMode::Exploratory,
             vec![],
             vec![],
             vec![],
@@ -7693,8 +7692,6 @@ mod tests {
             3,
             graphforge_ir::Direction::Out,
             None,
-            dir.path().to_path_buf(),
-            OntologyMode::Exploratory,
             vec![],
             graphforge_plan::var_len_edge_list_field(&[]),
         );

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -7600,8 +7600,34 @@ mod tests {
             graphforge_plan::var_len_edge_list_field(&[]),
         );
         let optional = OptionalMatchNode::new(input.clone(), input, vec![], vec![]);
-        let state = SessionContext::new().state();
+        let catalog = GraphCatalog::open(dir.path(), None, &RuntimeCatalog::new()).unwrap();
+        let session = ExecutionSession::new_with_target(
+            catalog,
+            None,
+            dir.path().to_path_buf(),
+            OntologyMode::Strict,
+        )
+        .unwrap();
+        let state = session.context().state();
         let planner = DefaultPhysicalPlanner::default();
+
+        let unbound = SessionContext::new().state();
+        for node in [
+            &expand as &dyn UserDefinedLogicalNode,
+            &var_len as &dyn UserDefinedLogicalNode,
+        ] {
+            let error = GraphForgeExtensionPlanner
+                .plan_extension(
+                    &planner,
+                    node,
+                    &[],
+                    std::slice::from_ref(&physical),
+                    &unbound,
+                )
+                .await
+                .unwrap_err();
+            assert!(error.to_string().contains("GF_READ_RESOURCE_MISSING"));
+        }
 
         let physical_expand = GraphForgeExtensionPlanner
             .plan_extension(
@@ -7708,7 +7734,15 @@ mod tests {
             "transitive:KNOWS",
             "conservative_min",
         );
-        let state = SessionContext::new().state();
+        let catalog = GraphCatalog::open(dir.path(), None, &RuntimeCatalog::new()).unwrap();
+        let session = ExecutionSession::new_with_target(
+            catalog,
+            None,
+            dir.path().to_path_buf(),
+            OntologyMode::Strict,
+        )
+        .unwrap();
+        let state = session.context().state();
         let planner = DefaultPhysicalPlanner::default();
         let extension = GraphForgeExtensionPlanner;
 

--- a/crates/graphforge-exec/src/read_resource.rs
+++ b/crates/graphforge-exec/src/read_resource.rs
@@ -1,0 +1,146 @@
+//! Execution-owned binding for the current graph's logical read resources.
+use datafusion::common::{DataFusionError, Result, tree_node::Transformed};
+use datafusion::datasource::{TableProvider, provider_as_source};
+use datafusion::logical_expr::{LogicalPlan, TableSource};
+use graphforge_core::OntologyMode;
+use graphforge_plan::{GraphReadSource, GraphReadTable};
+use graphforge_storage::GraphCatalog;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Session-local authority. Logical plans never own this value.
+pub struct GraphReadContext {
+    pub(crate) dir: PathBuf,
+    pub(crate) mode: OntologyMode,
+    pub(crate) catalog: Arc<GraphCatalog>,
+    pub(crate) ontology: Option<graphforge_ontology::OntologyHandle>,
+}
+
+impl GraphReadContext {
+    pub(crate) fn validate(
+        &self,
+        contract: Option<&graphforge_plan::GraphReadContract>,
+    ) -> Result<()> {
+        if let Some(contract) = contract {
+            let actual =
+                graphforge_rel::GraphPlanLowerer::new(Some(&self.catalog), self.ontology.as_ref())
+                    .map_err(|e| DataFusionError::Plan(e.to_string()))?
+                    .read_contract();
+            if *contract != actual {
+                return Err(DataFusionError::Plan(
+                    "GF_READ_RESOURCE_INCOMPATIBLE: logical identities".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn resolve(&self, source: &GraphReadSource) -> Result<Arc<dyn TableProvider>> {
+        self.validate(source.contract.as_ref())?;
+        if source.composition.as_deref().is_some_and(|expected| {
+            Some(expected) != self.catalog.semantic_composition_fingerprint()
+        }) {
+            return Err(DataFusionError::Plan(
+                "GF_READ_RESOURCE_INCOMPATIBLE: semantic composition".into(),
+            ));
+        }
+        let table: Arc<dyn TableProvider> = match &source.table {
+            GraphReadTable::Nodes => Arc::new(graphforge_storage::TopologyNodeTable::open_project(
+                &self.dir,
+            )?),
+            GraphReadTable::Edges(stem)
+                if stem == "_exploratory" && self.mode != OntologyMode::Exploratory =>
+            {
+                Arc::new(graphforge_storage::UnionEdgeTable::open(&self.dir))
+            }
+            GraphReadTable::Edges(stem) => {
+                Arc::new(graphforge_storage::TypedEdgeTable::open(&self.dir, stem))
+            }
+            GraphReadTable::SemanticEdges(id) => {
+                self.catalog.semantic_edge_table(*id).ok_or_else(|| {
+                    DataFusionError::Plan("GF_READ_RESOURCE_INCOMPATIBLE: semantic relation".into())
+                })?
+            }
+            GraphReadTable::Properties(stem) => {
+                Arc::new(self.catalog.property_table(&self.dir, stem))
+            }
+            GraphReadTable::EdgeProperties(_, Some(id)) => self
+                .catalog
+                .semantic_edge_property_table(*id)
+                .ok_or_else(|| {
+                    DataFusionError::Plan(
+                        "GF_READ_RESOURCE_INCOMPATIBLE: semantic edge properties".into(),
+                    )
+                })?,
+            GraphReadTable::EdgeProperties(stem, None) => {
+                Arc::new(self.catalog.edge_property_table(&self.dir, stem))
+            }
+        };
+        if graphforge_plan::read_resource::semantic_read_schema(&table.schema()) != source.schema()
+        {
+            return Err(DataFusionError::Plan(
+                "GF_READ_RESOURCE_INCOMPATIBLE: read schema".into(),
+            ));
+        }
+        Ok(table)
+    }
+}
+
+pub(crate) fn required(
+    state: &datafusion::execution::SessionState,
+) -> Result<Arc<GraphReadContext>> {
+    state
+        .config()
+        .get_extension::<GraphReadContext>()
+        .filter(|r| !r.dir.as_os_str().is_empty())
+        .ok_or_else(|| {
+            DataFusionError::Plan("GF_READ_RESOURCE_MISSING: current graph is not bound".into())
+        })
+}
+
+pub(crate) fn bind(
+    plan: &LogicalPlan,
+    state: &datafusion::execution::SessionState,
+) -> Result<LogicalPlan> {
+    let resource = state
+        .config()
+        .get_extension::<GraphReadContext>()
+        .filter(|resource| !resource.dir.as_os_str().is_empty());
+    let contract = resource
+        .as_ref()
+        .map(|r| {
+            graphforge_rel::GraphPlanLowerer::new(Some(&r.catalog), r.ontology.as_ref())
+                .map(|l| l.read_contract())
+        })
+        .transpose()
+        .map_err(|e| DataFusionError::Plan(e.to_string()))?;
+    plan.clone()
+        .transform_up_with_subqueries(|mut node| {
+            if let LogicalPlan::TableScan(scan) = &mut node
+                && let Some(source) = scan.source.downcast_ref::<GraphReadSource>()
+            {
+                let provider = required(state)?.resolve(source)?;
+                // Restore the selected provider's public schema only in this
+                // execution clone; logical identity excludes observation counts.
+                *scan = datafusion::logical_expr::TableScan::try_new(
+                    scan.table_name.clone(),
+                    provider_as_source(provider),
+                    scan.projection.clone(),
+                    scan.filters.clone(),
+                    scan.fetch,
+                )?;
+            }
+            node.map_expressions(|expr| {
+                graphforge_rel::expr::bind_graph_read_expression(
+                    expr,
+                    resource.as_ref().map(|r| r.dir.as_path()),
+                    contract.as_ref().map(|c| c.labels.as_slice()),
+                )
+                .map(Transformed::yes)
+            })?
+            .data
+            .recompute_schema()
+            .map(Transformed::yes)
+        })
+        .map(|result| result.data)
+}

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -1356,6 +1356,17 @@ pub(crate) struct PhaseEnv<'a> {
     pub type_map: HashMap<graphforge_value::EntityTypeId, String>,
 }
 
+impl PhaseEnv<'_> {
+    fn bind_read_expression(&self, expr: DfExpr) -> Result<DfExpr, GfError> {
+        graphforge_rel::expr::bind_graph_read_expression(
+            expr,
+            Some(self.dir),
+            Some(&self.lowerer.read_contract().labels),
+        )
+        .map_err(GfError::from_plan_error)
+    }
+}
+
 fn bind_expr_params(
     expr: DfExpr,
     params: &HashMap<String, graphforge_ir::IrLiteral>,
@@ -1779,7 +1790,7 @@ fn resolve_merge_node_properties_by_row(
 ) -> Result<Vec<ResolvedNodeSpec>, GfError> {
     let mut physical = Vec::with_capacity(spec.computed_properties.len());
     for (name, expr) in &spec.computed_properties {
-        let expr = bind_expr_params(expr.clone(), env.params)?;
+        let expr = env.bind_read_expression(bind_expr_params(expr.clone(), env.params)?)?;
         let (expr, eval_schema) = positional_eval_expr(expr, &frontier.df_schema)?;
         let expr = create_physical_expr(&expr, &eval_schema, &ExecutionProps::new())
             .map_err(GfError::from_plan_error)?;
@@ -2123,7 +2134,7 @@ fn resolve_merge_edge_properties_by_row(
 ) -> Result<Vec<ResolvedEdgeSpec>, GfError> {
     let mut physical = Vec::with_capacity(spec.computed_properties.len());
     for (name, expr) in &spec.computed_properties {
-        let expr = bind_expr_params(expr.clone(), env.params)?;
+        let expr = env.bind_read_expression(bind_expr_params(expr.clone(), env.params)?)?;
         let (expr, eval_schema) = positional_eval_expr(expr, &frontier.df_schema)?;
         let expr = create_physical_expr(&expr, &eval_schema, &ExecutionProps::new())
             .map_err(GfError::from_plan_error)?;
@@ -2410,7 +2421,7 @@ fn collect_delete_expr_targets(
             Arc::new(frontier.df_schema.clone()),
         )?;
         let physical = create_physical_expr(
-            &bind_expr_params(df_expr, env.params)?,
+            &env.bind_read_expression(bind_expr_params(df_expr, env.params)?)?,
             &frontier.df_schema,
             &ExecutionProps::new(),
         )
@@ -2800,7 +2811,7 @@ fn run_set_phase_masked(
             env.lowerer
                 .lower_value_expr(env.exprs, var_map, item.value)?
         };
-        let df_expr = bind_expr_params(df_expr, env.params)?;
+        let df_expr = env.bind_read_expression(bind_expr_params(df_expr, env.params)?)?;
         let (df_expr, eval_schema) = positional_eval_expr(df_expr, &frontier.df_schema)?;
         let phys = create_physical_expr(&df_expr, &eval_schema, &ExecutionProps::new())
             .map_err(GfError::from_plan_error)?;
@@ -2987,7 +2998,7 @@ fn run_set_map_phase_with_input(
         } else {
             env.lowerer.lower_value_expr(env.exprs, var_map, item.map)?
         };
-        let df_expr = bind_expr_params(df_expr, env.params)?;
+        let df_expr = env.bind_read_expression(bind_expr_params(df_expr, env.params)?)?;
         let (df_expr, eval_schema) = positional_eval_expr(df_expr, &frontier.df_schema)?;
         let phys = create_physical_expr(&df_expr, &eval_schema, &ExecutionProps::new())
             .map_err(GfError::from_plan_error)?;

--- a/crates/graphforge-exec/tests/bench_traversal_scaling.rs
+++ b/crates/graphforge-exec/tests/bench_traversal_scaling.rs
@@ -141,7 +141,7 @@ fn frontier_schema() -> Arc<Schema> {
     )]))
 }
 
-fn make_node(dir: &Path, min_hops: u16, max_hops: Option<u16>) -> VarLenExpandNode {
+fn make_node(_dir: &Path, min_hops: u16, max_hops: Option<u16>) -> VarLenExpandNode {
     use datafusion::logical_expr::LogicalPlanBuilder;
     use datafusion::logical_expr::logical_plan::LogicalTableSource;
 
@@ -162,8 +162,6 @@ fn make_node(dir: &Path, min_hops: u16, max_hops: Option<u16>) -> VarLenExpandNo
         edge_var,
         Direction::Out,
         Some(graphforge_value::RelationTypeId::decode(0).unwrap()),
-        dir.to_path_buf(),
-        OntologyMode::Strict,
         dst_fields,
         var_len_edge_list_field(&[]),
     )
@@ -174,6 +172,7 @@ fn make_node(dir: &Path, min_hops: u16, max_hops: Option<u16>) -> VarLenExpandNo
 /// caller-held [`GUARD`]) so only the traversal's reads are attributed. Returns
 /// the sorted reached destination `node_id`s and the I/O snapshot.
 async fn run_measured(
+    dir: &Path,
     node: &VarLenExpandNode,
     provider: Arc<dyn AdjacencyProvider>,
     seeds: &[u64],
@@ -190,7 +189,13 @@ async fn run_measured(
         .create_physical_plan()
         .await
         .unwrap();
-    let exec = Arc::new(VarLenExpandExec::new(node, input, provider));
+    let exec = Arc::new(VarLenExpandExec::new(
+        node,
+        input,
+        provider,
+        dir.to_path_buf(),
+        OntologyMode::Strict,
+    ));
 
     io_stats::reset();
     let out = collect(exec, ctx.task_ctx()).await.unwrap();
@@ -252,7 +257,12 @@ fn io_smoke_index_hit_issues_no_full_edge_scan() {
         .unwrap();
 
     // Index Hit: adjacency from CSR, only traversed edge records read.
-    let (hit_reached, hit) = rt.block_on(run_measured(&node, persistent(dir.path()), &seeds));
+    let (hit_reached, hit) = rt.block_on(run_measured(
+        dir.path(),
+        &node,
+        persistent(dir.path()),
+        &seeds,
+    ));
     assert_eq!(
         hit.edge_full_reads, 0,
         "index Hit must not full-scan the edge file: {hit:?}"
@@ -286,7 +296,12 @@ fn io_smoke_index_hit_issues_no_full_edge_scan() {
     );
 
     // Scan-build Miss baseline: full edge-file scan to build adjacency.
-    let (miss_reached, miss) = rt.block_on(run_measured(&node, scan_build(dir.path()), &seeds));
+    let (miss_reached, miss) = rt.block_on(run_measured(
+        dir.path(),
+        &node,
+        scan_build(dir.path()),
+        &seeds,
+    ));
     assert!(
         miss.edge_full_reads >= 1,
         "scan-build must full-scan the edge file: {miss:?}"
@@ -333,7 +348,13 @@ async fn median_expand(
             .create_physical_plan()
             .await
             .unwrap();
-        let exec = Arc::new(VarLenExpandExec::new(&node, input, Arc::clone(provider)));
+        let exec = Arc::new(VarLenExpandExec::new(
+            &node,
+            input,
+            Arc::clone(provider),
+            dir.to_path_buf(),
+            OntologyMode::Strict,
+        ));
         let start = std::time::Instant::now();
         let _ = collect(exec, ctx.task_ctx()).await.unwrap();
         samples.push(start.elapsed());
@@ -369,7 +390,7 @@ async fn bench_scale(n: usize, fan_out: usize, num_seeds: usize, localized: bool
 
     // The edge-count-independent signal: traversed edge records for *1..3.
     let node3 = make_node(dir.path(), 1, Some(3));
-    let (_, io) = run_measured(&node3, Arc::clone(&provider), &seeds).await;
+    let (_, io) = run_measured(dir.path(), &node3, Arc::clone(&provider), &seeds).await;
 
     ScaleResult {
         edges: n * fan_out,

--- a/crates/graphforge-exec/tests/read_execution.rs
+++ b/crates/graphforge-exec/tests/read_execution.rs
@@ -215,3 +215,148 @@ async fn equal_local_property_ids_execute_distinct_domain_columns() {
         assert_eq!(values.values().as_ref(), expected.as_slice());
     }
 }
+
+#[tokio::test]
+async fn logical_read_resources_relocate_and_bind_independently() {
+    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+    use datafusion::logical_expr::LogicalPlan;
+    use std::hash::{Hash, Hasher};
+    let left = TempDir::new().unwrap();
+    let right = TempDir::new().unwrap();
+    let rc = Arc::new(Mutex::new(RuntimeCatalog::new()));
+    for (root, name) in [(left.path(), "left"), (right.path(), "right")] {
+        let create = bind(
+            &format!(
+                "CREATE (a:Person {{name:'seed'}}), (b:Person {{name:'{name}'}}), (a)-[:KNOWS]->(b)"
+            ),
+            rc.clone(),
+        );
+        let writer = session_with(root, &rc.lock().unwrap());
+        writer.execute_create(&create).await.unwrap();
+        if name == "right" {
+            let extra = bind("CREATE (:Person {name:'unconnected'})", rc.clone());
+            writer.execute_create(&extra).await.unwrap();
+        }
+    }
+    let wrong_schema = TempDir::new().unwrap();
+    let create_wrong = bind("CREATE (:Person {name:7})", rc.clone());
+    let writer = session_with(wrong_schema.path(), &rc.lock().unwrap());
+    writer.execute_create(&create_wrong).await.unwrap();
+    for query in [
+        "MATCH (b) WHERE b.name <> 'seed' AND b.name <> 'unconnected' RETURN b.name AS name",
+        "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.name AS name",
+        "MATCH (a:Person)-[:KNOWS*1..2]->(b:Person) RETURN b.name AS name",
+        "MATCH p=(a:Person)-[:KNOWS*1..2]->(b) RETURN nodes(p)[1].name AS name",
+    ] {
+        let ir = bind(query, rc.clone());
+        let left_catalog = GraphCatalog::open(left.path(), None, &rc.lock().unwrap()).unwrap();
+        let right_catalog = GraphCatalog::open(right.path(), None, &rc.lock().unwrap()).unwrap();
+        let left_session = session_with(left.path(), &rc.lock().unwrap());
+        let right_session = session_with(right.path(), &rc.lock().unwrap());
+
+        let lower = |catalog: &GraphCatalog, root: &std::path::Path| {
+            graphforge_rel::GraphPlanLowerer::new_with_dir(
+                Some(catalog),
+                None,
+                root,
+                OntologyMode::Exploratory,
+            )
+            .unwrap()
+            .lower_plan(&ir)
+            .unwrap()
+        };
+        let plan = lower(&left_catalog, left.path());
+        let relocated = lower(&right_catalog, right.path());
+        assert_eq!(plan, relocated, "{query}");
+        let hash = |p: &LogicalPlan| {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            p.hash(&mut h);
+            h.finish()
+        };
+        assert_eq!(hash(&plan), hash(&relocated));
+        let explain = plan.display_indent().to_string();
+        assert_eq!(explain, relocated.display_indent().to_string());
+        assert!(!explain.contains(left.path().to_str().unwrap()));
+        plan.apply(|node| {
+            if let LogicalPlan::TableScan(scan) = node {
+                assert!(
+                    scan.source
+                        .downcast_ref::<graphforge_plan::GraphReadSource>()
+                        .is_some()
+                );
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        let left_state = left_session.context().state();
+        let right_state = right_session.context().state();
+        let (left_physical, right_physical) = tokio::join!(
+            left_state.create_physical_plan(&plan),
+            right_state.create_physical_plan(&plan)
+        );
+        let retained = datafusion::physical_plan::execute_stream(
+            left_physical.unwrap(),
+            left_session.context().task_ctx(),
+        )
+        .unwrap();
+        let right_retained = datafusion::physical_plan::execute_stream(
+            right_physical.unwrap(),
+            right_session.context().task_ctx(),
+        )
+        .unwrap();
+        drop(left_session);
+        drop(right_session);
+        let (left_result, right_result) = tokio::join!(
+            datafusion::physical_plan::common::collect(retained),
+            datafusion::physical_plan::common::collect(right_retained)
+        );
+        let left_result = left_result.unwrap();
+        let right_result = right_result.unwrap();
+        for (batches, expected) in [(&left_result, "left"), (&right_result, "right")] {
+            assert_eq!(
+                batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+                1,
+                "{query}"
+            );
+            assert_eq!(
+                arrow::util::display::array_value_to_string(batches[0].column(0), 0).unwrap(),
+                expected,
+                "{query}; schema={:?}",
+                batches[0].schema()
+            );
+        }
+        let incompatible_schema = session_with(wrong_schema.path(), &rc.lock().unwrap());
+        let error = incompatible_schema
+            .context()
+            .state()
+            .create_physical_plan(&plan)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("GF_READ_RESOURCE_INCOMPATIBLE"),
+            "{query}: {error}"
+        );
+        let mut incompatible_catalog = RuntimeCatalog::new();
+        incompatible_catalog.intern_label("DifferentLabel").unwrap();
+        let incompatible = session_with(right.path(), &incompatible_catalog);
+        let error = incompatible
+            .context()
+            .state()
+            .create_physical_plan(&plan)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("GF_READ_RESOURCE_INCOMPATIBLE"),
+            "{error}"
+        );
+        let foreign = datafusion::execution::SessionStateBuilder::new()
+            .with_default_features()
+            .with_query_planner(Arc::new(graphforge_exec::GraphForgeQueryPlanner))
+            .build();
+        let error = foreign.create_physical_plan(&plan).await.unwrap_err();
+        assert!(
+            error.to_string().contains("GF_READ_RESOURCE_MISSING"),
+            "{error}"
+        );
+    }
+}

--- a/crates/graphforge-exec/tests/read_execution.rs
+++ b/crates/graphforge-exec/tests/read_execution.rs
@@ -227,7 +227,7 @@ async fn logical_read_resources_relocate_and_bind_independently() {
     for (root, name) in [(left.path(), "left"), (right.path(), "right")] {
         let create = bind(
             &format!(
-                "CREATE (a:Person {{name:'seed'}}), (b:Person {{name:'{name}'}}), (a)-[:KNOWS]->(b)"
+                "CREATE (a:Person {{name:'seed'}}), (b:Person {{name:'{name}'}}), (a)-[:KNOWS {{selected:true,name:'{name}'}}]->(b), (a)-[:OTHER {{selected:false,name:'ignored'}}]->(b)"
             ),
             rc.clone(),
         );
@@ -244,6 +244,7 @@ async fn logical_read_resources_relocate_and_bind_independently() {
     writer.execute_create(&create_wrong).await.unwrap();
     for query in [
         "MATCH (b) WHERE b.name <> 'seed' AND b.name <> 'unconnected' RETURN b.name AS name",
+        "MATCH ()-[r]->() WHERE r.selected = true RETURN r.name AS name",
         "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.name AS name",
         "MATCH (a:Person)-[:KNOWS*1..2]->(b:Person) RETURN b.name AS name",
         "MATCH p=(a:Person)-[:KNOWS*1..2]->(b) RETURN nodes(p)[1].name AS name",
@@ -293,6 +294,10 @@ async fn logical_read_resources_relocate_and_bind_independently() {
         let (left_physical, right_physical) = tokio::join!(
             left_state.create_physical_plan(&plan),
             right_state.create_physical_plan(&plan)
+        );
+        assert_eq!(
+            plan, relocated,
+            "binding must leave the logical plan unchanged"
         );
         let retained = datafusion::physical_plan::execute_stream(
             left_physical.unwrap(),

--- a/crates/graphforge-exec/tests/var_len_expand.rs
+++ b/crates/graphforge-exec/tests/var_len_expand.rs
@@ -31,10 +31,21 @@ use graphforge_exec::{AdjacencyProvider, ScanBuildAdjacencyProvider, VarLenExpan
 /// Construct the exec node with a fresh scan-build provider over the node's
 /// project dir — the pre-index behavior these tests pin (the session-injected
 /// persistent provider is exercised by `tests/persistent_adjacency.rs`).
-fn make_exec(node: &VarLenExpandNode, input: Arc<dyn ExecutionPlan>) -> Arc<VarLenExpandExec> {
+fn make_exec(
+    dir: &std::path::Path,
+    mode: OntologyMode,
+    node: &VarLenExpandNode,
+    input: Arc<dyn ExecutionPlan>,
+) -> Arc<VarLenExpandExec> {
     let provider: Arc<dyn AdjacencyProvider> =
-        Arc::new(ScanBuildAdjacencyProvider::new(node.dir.clone(), node.mode));
-    Arc::new(VarLenExpandExec::new(node, input, provider))
+        Arc::new(ScanBuildAdjacencyProvider::new(dir.to_path_buf(), mode));
+    Arc::new(VarLenExpandExec::new(
+        node,
+        input,
+        provider,
+        dir.to_path_buf(),
+        mode,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -116,9 +127,9 @@ fn make_node(
 /// exploratory end-to-end coverage, #762).
 #[allow(clippy::too_many_arguments)]
 fn make_node_with(
-    dir: &Path,
+    _dir: &Path,
     rel_type_name: &str,
-    mode: OntologyMode,
+    _mode: OntologyMode,
     direction: Direction,
     min_hops: u16,
     max_hops: Option<u16>,
@@ -151,9 +162,7 @@ fn make_node_with(
         dst_var,
         edge_var,
         direction,
-        Some(graphforge_value::RelationTypeId::decode(0).unwrap()), // rel_ty (unused by the executor; typed mode reads KNOWS.parquet)
-        dir.to_path_buf(),
-        mode,
+        Some(graphforge_value::RelationTypeId::decode(0).unwrap()),
         dst_fields,
         var_len_edge_list_field(&[]),
     )
@@ -161,7 +170,12 @@ fn make_node_with(
 
 /// Run `VarLenExpandExec` over a frontier of `seed` node_ids and return the
 /// multiset of reached destination `node_id`s.
-async fn run_expand(node: &VarLenExpandNode, seeds: &[u64]) -> Vec<u64> {
+async fn run_expand(
+    dir: &std::path::Path,
+    mode: OntologyMode,
+    node: &VarLenExpandNode,
+    seeds: &[u64],
+) -> Vec<u64> {
     let ctx = SessionContext::new();
 
     // Source frontier as an in-memory physical plan.
@@ -177,7 +191,7 @@ async fn run_expand(node: &VarLenExpandNode, seeds: &[u64]) -> Vec<u64> {
         .await
         .unwrap();
 
-    let exec = make_exec(node, input);
+    let exec = make_exec(dir, mode, node, input);
     let out = collect(exec, ctx.task_ctx()).await.unwrap();
 
     // Destination node_id is the second `node_id` column (after the frontier's).
@@ -206,7 +220,11 @@ fn set(v: &[u64]) -> HashSet<u64> {
 /// (the trailing `var_<edge>.rels` `List<Struct>` column) — i.e. the hop count.
 /// Also asserts the column is a `List<Struct>` whose `edge_uuid` child is
 /// `FixedSizeBinary(16)` (the UUID-only relationship-list contract, #709).
-async fn run_expand_edge_list_lengths(node: &VarLenExpandNode, seeds: &[u64]) -> Vec<usize> {
+async fn run_expand_edge_list_lengths(
+    dir: &std::path::Path,
+    node: &VarLenExpandNode,
+    seeds: &[u64],
+) -> Vec<usize> {
     use arrow::array::{Array, FixedSizeBinaryArray, ListArray, StructArray};
     use arrow::datatypes::DataType;
 
@@ -222,7 +240,7 @@ async fn run_expand_edge_list_lengths(node: &VarLenExpandNode, seeds: &[u64]) ->
         .create_physical_plan()
         .await
         .unwrap();
-    let exec = make_exec(node, input);
+    let exec = make_exec(dir, OntologyMode::Strict, node, input);
     let out = collect(exec, ctx.task_ctx()).await.unwrap();
 
     let mut lengths = Vec::new();
@@ -271,7 +289,7 @@ async fn bounded_1_to_2_on_chain() {
     let ids = write_chain(dir.path(), 5);
     let node = make_node(dir.path(), Direction::Out, 1, Some(2), 0, 1);
 
-    let reached = run_expand(&node, &[ids[0]]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Strict, &node, &[ids[0]]).await;
     // 1 hop → n2 ; 2 hops → n3.
     assert_eq!(set(&reached), set(&[ids[1], ids[2]]));
     assert_eq!(reached.len(), 2, "one path each at hop 1 and hop 2");
@@ -284,7 +302,7 @@ async fn unbounded_on_acyclic_chain_terminates() {
     let ids = write_chain(dir.path(), 5);
     let node = make_node(dir.path(), Direction::Out, 1, None, 0, 1);
 
-    let reached = run_expand(&node, &[ids[0]]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Strict, &node, &[ids[0]]).await;
     assert_eq!(set(&reached), set(&ids[1..]));
 }
 
@@ -296,7 +314,7 @@ async fn unbounded_on_cycle_terminates() {
     let ids = write_cycle(dir.path());
     let node = make_node(dir.path(), Direction::Out, 1, None, 0, 1);
 
-    let reached = run_expand(&node, &[ids[0]]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Strict, &node, &[ids[0]]).await;
     // Reachable from n1: n2 (1 hop), n3 (2 hops), n1 (3 hops, full cycle).
     assert_eq!(set(&reached), set(&ids));
     // Exactly one simple path of each length 1/2/3 from n1.
@@ -310,7 +328,7 @@ async fn min_hops_excludes_one_hop_neighbours() {
     let ids = write_chain(dir.path(), 5);
     let node = make_node(dir.path(), Direction::Out, 2, Some(3), 0, 1);
 
-    let reached = run_expand(&node, &[ids[0]]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Strict, &node, &[ids[0]]).await;
     // 2 hops → n3 ; 3 hops → n4. n2 (1 hop) excluded.
     assert_eq!(set(&reached), set(&[ids[2], ids[3]]));
     assert!(
@@ -326,7 +344,7 @@ async fn direction_in_reaches_predecessors() {
     let ids = write_chain(dir.path(), 5);
     let node = make_node(dir.path(), Direction::In, 1, Some(2), 0, 1);
 
-    let reached = run_expand(&node, &[ids[2]]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Strict, &node, &[ids[2]]).await;
     assert_eq!(set(&reached), set(&[ids[1], ids[0]]));
 }
 
@@ -335,7 +353,7 @@ async fn empty_graph_yields_no_rows() {
     let dir = TempDir::new().unwrap();
     // No nodes/edges written.
     let node = make_node(dir.path(), Direction::Out, 1, None, 0, 1);
-    let reached = run_expand(&node, &[1]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Strict, &node, &[1]).await;
     assert!(reached.is_empty(), "no edges → no expansions");
 }
 
@@ -381,8 +399,6 @@ async fn seeds_from_source_var_not_first_node_id() {
         2, // edge_var → trailing var_2.rels List column
         Direction::Out,
         Some(graphforge_value::RelationTypeId::decode(0).unwrap()),
-        dir.path().to_path_buf(),
-        OntologyMode::Strict,
         dst_fields,
         var_len_edge_list_field(&[]),
     );
@@ -410,7 +426,7 @@ async fn seeds_from_source_var_not_first_node_id() {
         datafusion::catalog::TableProvider::scan(&mem, &ctx.state(), None, &[], None)
             .await
             .unwrap();
-    let exec = make_exec(&node, input);
+    let exec = make_exec(dir.path(), OntologyMode::Strict, &node, input);
     let out = collect(exec, ctx.task_ctx()).await.unwrap();
 
     // Destination node_id column = 2 input node_id cols + node_id position (1) = idx 3.
@@ -436,7 +452,7 @@ async fn min_hops_zero_includes_source_self() {
     let ids = write_chain(dir.path(), 5);
     let node = make_node(dir.path(), Direction::Out, 0, Some(1), 0, 1);
 
-    let reached = run_expand(&node, &[ids[0]]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Strict, &node, &[ids[0]]).await;
     assert_eq!(set(&reached), set(&[ids[0], ids[1]]));
     assert!(
         reached.contains(&ids[0]),
@@ -457,7 +473,7 @@ async fn edge_list_records_hop_counts() {
     let ids = write_chain(dir.path(), 5);
     let node = make_node(dir.path(), Direction::Out, 1, Some(2), 0, 1);
 
-    let mut lengths = run_expand_edge_list_lengths(&node, &[ids[0]]).await;
+    let mut lengths = run_expand_edge_list_lengths(dir.path(), &node, &[ids[0]]).await;
     lengths.sort_unstable();
     assert_eq!(
         lengths,
@@ -474,7 +490,7 @@ async fn edge_list_zero_hop_self_path_is_empty_list() {
     let ids = write_chain(dir.path(), 5);
     let node = make_node(dir.path(), Direction::Out, 0, Some(1), 0, 1);
 
-    let mut lengths = run_expand_edge_list_lengths(&node, &[ids[0]]).await;
+    let mut lengths = run_expand_edge_list_lengths(dir.path(), &node, &[ids[0]]).await;
     lengths.sort_unstable();
     assert_eq!(
         lengths,
@@ -538,8 +554,6 @@ async fn edge_list_carries_edge_properties() {
             2,
             Direction::Out,
             Some(graphforge_value::RelationTypeId::decode(0).unwrap()),
-            dir.path().to_path_buf(),
-            OntologyMode::Strict,
             dst_fields,
             var_len_edge_list_field(&[Field::new("since", DataType::Int64, true)]),
         )
@@ -558,9 +572,12 @@ async fn edge_list_carries_edge_properties() {
         .create_physical_plan()
         .await
         .unwrap();
-    let out = collect(make_exec(&node, input), ctx.task_ctx())
-        .await
-        .unwrap();
+    let out = collect(
+        make_exec(dir.path(), OntologyMode::Strict, &node, input),
+        ctx.task_ctx(),
+    )
+    .await
+    .unwrap();
 
     // One 2-hop path; its edge-list struct's `since` child is [2020, NULL].
     let total: usize = out.iter().map(RecordBatch::num_rows).sum();
@@ -599,7 +616,7 @@ async fn undirected_reaches_both_sides() {
     let dir = TempDir::new().unwrap();
     let ids = write_chain(dir.path(), 3);
     let node = make_node(dir.path(), Direction::Undirected, 1, Some(1), 0, 1);
-    let reached = run_expand(&node, &[ids[1]]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Strict, &node, &[ids[1]]).await;
     assert_eq!(set(&reached), set(&[ids[0], ids[2]]));
 }
 
@@ -628,7 +645,7 @@ async fn exploratory_mode_filters_rel_types_end_to_end() {
         0,
         1,
     );
-    let reached = run_expand(&node, &[ids[0]]).await;
+    let reached = run_expand(dir.path(), OntologyMode::Exploratory, &node, &[ids[0]]).await;
     assert_eq!(set(&reached), set(&[ids[1]]), "OWNS edge not traversed");
 }
 
@@ -653,7 +670,7 @@ async fn explain_display_shows_adjacency_status() {
         .create_physical_plan()
         .await
         .unwrap();
-    let exec = make_exec(&node, input);
+    let exec = make_exec(dir.path(), OntologyMode::Strict, &node, input);
 
     let line = datafusion::physical_plan::displayable(exec.as_ref())
         .one_line()

--- a/crates/graphforge-plan/src/lib.rs
+++ b/crates/graphforge-plan/src/lib.rs
@@ -24,6 +24,9 @@
 // the literal values.
 #![allow(clippy::unnecessary_literal_bound)]
 
+pub mod read_resource;
+pub use read_resource::{GraphReadContract, GraphReadSource, GraphReadTable};
+
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
@@ -126,12 +129,8 @@ pub fn var_len_edge_list_field(prop_fields: &[Field]) -> Arc<Field> {
 /// sequence, so the physical layer ([`VarLenExpandExec`](../graphforge_exec) in physical execution)
 /// performs an iterative BFS over the Parquet edge table.
 ///
-/// # Baked execution context
-///
-/// Like [`GraphCreateNode`], the project `dir` and ontology `mode` are baked in
-/// at lowering time because the physical-planning `ExtensionPlanner` only sees
-/// the DataFusion session state, not the GraphForge project path.  The physical
-/// node reads edges directly from `dir` at execution time.
+/// Execution binds this descriptor to its session's pinned graph resources.
+/// No directory, provider or ontology mode is part of logical identity.
 ///
 /// # Output schema
 ///
@@ -161,14 +160,19 @@ pub struct VarLenExpandNode {
     pub direction: Direction,
     /// Resolved relation type id (`TypeId.0`), or `None` for a wildcard.
     pub rel_ty: Option<RelationTypeId>,
-    /// Project directory the physical node reads edges from.
-    pub dir: PathBuf,
-    /// Ontology mode (drives typed vs exploratory edge-file routing).
-    pub mode: OntologyMode,
+    /// Logical semantic assumptions checked against the execution resource.
+    pub read_contract: Option<GraphReadContract>,
     schema: DFSchemaRef,
 }
 
 impl VarLenExpandNode {
+    /// Attach semantic assumptions without any execution authority.
+    #[must_use]
+    pub fn with_read_contract(mut self, contract: Option<GraphReadContract>) -> Self {
+        self.read_contract = contract;
+        self
+    }
+
     /// Create a variable-length expand node.
     ///
     /// `dst_fields` is the destination node's column list (the storage layer's
@@ -188,8 +192,6 @@ impl VarLenExpandNode {
         edge_var: u32,
         direction: Direction,
         rel_ty: Option<RelationTypeId>,
-        dir: PathBuf,
-        mode: OntologyMode,
         dst_fields: Vec<Arc<Field>>,
         edge_field: Arc<Field>,
     ) -> Self {
@@ -204,8 +206,7 @@ impl VarLenExpandNode {
             edge_var,
             direction,
             rel_ty,
-            dir,
-            mode,
+            read_contract: None,
             schema,
         }
     }
@@ -313,11 +314,10 @@ impl UserDefinedLogicalNodeCore for VarLenExpandNode {
             self.edge_var,
             self.direction,
             self.rel_ty,
-            self.dir.clone(),
-            self.mode,
             dst_fields,
             edge_field,
-        ))
+        )
+        .with_read_contract(self.read_contract.clone()))
     }
 }
 
@@ -362,10 +362,8 @@ pub struct ExpandNode {
     pub direction: Direction,
     /// Resolved relation type id (`TypeId.0`), absent for wildcard expansion.
     pub rel_ty: Option<RelationTypeId>,
-    /// Project directory the physical node reads from.
-    pub dir: PathBuf,
-    /// Ontology mode controlling the persisted edge layout.
-    pub mode: OntologyMode,
+    /// Logical semantic assumptions checked against the execution resource.
+    pub read_contract: Option<GraphReadContract>,
     /// How many of the `var_<edge_var>` fields are edge-property columns
     /// (the trailing ones); the rest are edge topology columns.
     pub edge_prop_count: usize,
@@ -373,6 +371,13 @@ pub struct ExpandNode {
 }
 
 impl ExpandNode {
+    /// Attach semantic assumptions without any execution authority.
+    #[must_use]
+    pub fn with_read_contract(mut self, contract: Option<GraphReadContract>) -> Self {
+        self.read_contract = contract;
+        self
+    }
+
     /// Create an adjacency-backed single-hop expand node.
     ///
     /// `edge_fields` are the typed edge table's topology columns and
@@ -390,8 +395,6 @@ impl ExpandNode {
         edge_var: u32,
         direction: Direction,
         rel_ty: Option<RelationTypeId>,
-        dir: PathBuf,
-        mode: OntologyMode,
         edge_fields: Vec<Arc<Field>>,
         edge_prop_fields: Vec<Arc<Field>>,
         dst_fields: Vec<Arc<Field>>,
@@ -413,8 +416,7 @@ impl ExpandNode {
             edge_var,
             direction,
             rel_ty,
-            dir,
-            mode,
+            read_contract: None,
             edge_prop_count,
             schema,
         }
@@ -528,12 +530,11 @@ impl UserDefinedLogicalNodeCore for ExpandNode {
             self.edge_var,
             self.direction,
             self.rel_ty,
-            self.dir.clone(),
-            self.mode,
             edge_fields,
             edge_prop_fields,
             dst_fields,
-        ))
+        )
+        .with_read_contract(self.read_contract.clone()))
     }
 }
 
@@ -2009,8 +2010,6 @@ mod tests {
             2,
             Direction::Out,
             Some(graphforge_value::RelationTypeId::decode(7).unwrap()),
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Strict,
             dst_node_fields(),
             var_len_edge_list_field(&[]),
         )
@@ -2722,8 +2721,6 @@ mod tests {
             1,
             Direction::Out,
             Some(graphforge_value::RelationTypeId::decode(7).unwrap()),
-            PathBuf::from("/tmp/p"),
-            OntologyMode::Strict,
             edge_fields,
             edge_prop_fields,
             dst_node_fields(),

--- a/crates/graphforge-plan/src/read_resource.rs
+++ b/crates/graphforge-plan/src/read_resource.rs
@@ -1,0 +1,79 @@
+//! Logical descriptors for the current graph's read resources.
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::logical_expr::TableSource;
+use graphforge_value::{EntityTypeId, RelationTypeId};
+use std::sync::Arc;
+
+/// Semantic assumptions used to admit a read binding, independent of location.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GraphReadContract {
+    /// Checked node identities and their logical names/routes.
+    pub labels: Vec<(EntityTypeId, String)>,
+    /// Checked relationship identities and logical names/routes.
+    pub relations: Vec<(RelationTypeId, String)>,
+    /// Semantic composition, never a project or generation identity.
+    pub composition: Option<String>,
+}
+
+/// A deterministic role in the query, independent of its execution location.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum GraphReadTable {
+    /// Node topology, including the selected generation's overlays.
+    Nodes,
+    /// Named edge topology, or `_exploratory` for the all-relations union.
+    Edges(String),
+    /// An authenticated semantic relation.
+    SemanticEdges(RelationTypeId),
+    /// Node property route selected by semantic lowering.
+    Properties(String),
+    /// Edge properties, optionally requiring a semantic relation provider.
+    EdgeProperties(String, Option<RelationTypeId>),
+}
+
+/// Schema-discovered logical source. Contains no executable provider.
+#[derive(Debug, Clone)]
+pub struct GraphReadSource {
+    /// Resource to bind in the execution session.
+    pub table: GraphReadTable,
+    /// Semantic composition required by this source, where applicable.
+    pub composition: Option<String>,
+    /// Complete binding assumptions supplied by semantic lowering.
+    pub contract: Option<GraphReadContract>,
+    schema: SchemaRef,
+}
+
+impl GraphReadSource {
+    /// Construct a source from logical routing and a discovered output schema.
+    #[must_use]
+    pub fn new(
+        table: GraphReadTable,
+        schema: &SchemaRef,
+        composition: Option<String>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            table,
+            schema: semantic_read_schema(schema),
+            composition,
+            contract: None,
+        })
+    }
+}
+
+/// Remove storage-observation metadata from logical schema identity. The bound
+/// physical provider retains its original schema and metadata.
+#[must_use]
+pub fn semantic_read_schema(schema: &SchemaRef) -> SchemaRef {
+    let mut metadata = schema.metadata().clone();
+    metadata.remove("graphforge.property_live_schema");
+    Arc::new(datafusion::arrow::datatypes::Schema::new_with_metadata(
+        schema.fields().clone(),
+        metadata,
+    ))
+}
+
+impl TableSource for GraphReadSource {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}

--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -3231,7 +3231,7 @@ impl<'a> ExprLowerer<'a> {
                 .then_with(|| left_name.cmp(right_name))
         });
         Some(PathNodeHydration {
-            dir: dir.clone(),
+            dir: None,
             labels_by_type,
             prop_stems: stems,
             fields: fields.into(),
@@ -12105,7 +12105,7 @@ fn path_node_struct_fields() -> datafusion::arrow::datatypes::Fields {
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 struct PathNodeHydration {
     /// The project directory the invoke reads node/property files from.
-    dir: std::path::PathBuf,
+    dir: Option<std::path::PathBuf>,
     /// `type_id → label` (ontology + runtime catalog), sorted by id.
     labels_by_type: Vec<(graphforge_value::EntityTypeId, String)>,
     /// The `properties/<stem>.parquet` stems whose fields form the union,
@@ -12119,6 +12119,82 @@ struct PathNodeHydration {
 struct CypherPathNodes {
     signature: Signature,
     hydrate: Option<PathNodeHydration>,
+}
+
+/// Bind graph-reading expressions to an execution-owned resource. Lowering
+/// leaves hydration unbound; only physical planning supplies the directory.
+pub fn bind_graph_read_expression(
+    expr: DfExpr,
+    dir: Option<&std::path::Path>,
+    labels: Option<&[(graphforge_value::EntityTypeId, String)]>,
+) -> datafusion::common::Result<DfExpr> {
+    use datafusion::common::tree_node::{Transformed, TreeNode};
+    expr.transform_up(|mut expr| {
+        if let DfExpr::ScalarFunction(call) = &mut expr {
+            if let Some(nodes) = call.func.inner().downcast_ref::<CypherPathNodes>() {
+                if let Some(hydrate) = &nodes.hydrate {
+                    let dir = dir.ok_or_else(|| {
+                        datafusion::common::DataFusionError::Plan(
+                            "GF_READ_RESOURCE_MISSING: path hydration".into(),
+                        )
+                    })?;
+                    let stems = graphforge_storage::list_property_stems(dir);
+                    let mut fields = vec![
+                        Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
+                        Field::new("labels", DataType::new_list(DataType::Utf8, true), true),
+                    ];
+                    let mut seen: std::collections::HashSet<String> =
+                        fields.iter().map(|f| f.name().clone()).collect();
+                    for stem in &stems {
+                        let table = graphforge_storage::PropertyTable::open_discovered(dir, stem);
+                        for field in table.schema_ref().fields() {
+                            if seen.insert(field.name().clone()) {
+                                fields.push(field.as_ref().clone().with_nullable(true));
+                            }
+                        }
+                    }
+                    if hydrate.prop_stems != stems
+                        || hydrate.fields != fields.into()
+                        || labels != Some(hydrate.labels_by_type.as_slice())
+                    {
+                        return Err(datafusion::common::DataFusionError::Plan(
+                            "GF_READ_RESOURCE_INCOMPATIBLE: path hydration schema or labels".into(),
+                        ));
+                    }
+                    let mut hydrate = hydrate.clone();
+                    hydrate.dir = Some(dir.to_path_buf());
+                    call.func = Arc::new(ScalarUDF::new_from_impl(
+                        CypherPathNodes::with_hydration(hydrate),
+                    ));
+                    return Ok(Transformed::yes(expr));
+                }
+            } else if let Some(quantifier) = call.func.inner().downcast_ref::<CypherQuantifier>() {
+                call.func = Arc::new(ScalarUDF::new_from_impl(CypherQuantifier::new(
+                    quantifier.kind,
+                    bind_graph_read_expression(quantifier.predicate.clone(), dir, labels)?,
+                    quantifier.elem_name.clone(),
+                    quantifier.outer_names.clone(),
+                )));
+                return Ok(Transformed::yes(expr));
+            } else if let Some(comp) = call.func.inner().downcast_ref::<CypherListComp>() {
+                call.func = Arc::new(ScalarUDF::new_from_impl(CypherListComp::new(
+                    comp.filter
+                        .clone()
+                        .map(|e| bind_graph_read_expression(e, dir, labels))
+                        .transpose()?,
+                    comp.projection
+                        .clone()
+                        .map(|e| bind_graph_read_expression(e, dir, labels))
+                        .transpose()?,
+                    comp.elem_name.clone(),
+                    comp.outer_names.clone(),
+                )));
+                return Ok(Transformed::yes(expr));
+            }
+        }
+        Ok(Transformed::no(expr))
+    })
+    .map(|result| result.data)
 }
 
 impl CypherPathNodes {
@@ -12367,56 +12443,62 @@ fn gather_path_node_labels(
     let mut label_ids_of: HashMap<[u8; 16], Vec<graphforge_value::EntityTypeId>> =
         HashMap::with_capacity(unique.len());
 
-    graphforge_storage::visit_nodes_batched(&h.dir, batch_size, |b| {
-        check_path_hydration_cancel()?;
-        path_hydration_stats::record_node_batch(b.num_rows() as u64);
-        if remaining.is_empty() {
-            return Ok(false);
-        }
-        let uuids = hydration_fsb16(b, "node_uuid")?;
-        let type_ids = b
-            .column_by_name("type_ids")
-            .and_then(|c| c.as_any().downcast_ref::<ListArray>())
-            .ok_or_else(|| exec_err("cypher_path_nodes: no List type_ids column".into()))?;
-        for r in 0..b.num_rows() {
-            if uuids.is_null(r) || type_ids.is_null(r) {
-                continue;
+    graphforge_storage::visit_nodes_batched(
+        h.dir.as_deref().ok_or_else(|| {
+            DataFusionError::Plan("GF_READ_RESOURCE_MISSING: path hydration".into())
+        })?,
+        batch_size,
+        |b| {
+            check_path_hydration_cancel()?;
+            path_hydration_stats::record_node_batch(b.num_rows() as u64);
+            if remaining.is_empty() {
+                return Ok(false);
             }
-            let mut u = [0u8; 16];
-            u.copy_from_slice(uuids.value(r));
-            if !remaining.remove(&u) {
-                continue;
-            }
-            let values = type_ids.value(r);
-            let values = values
-                .as_any()
-                .downcast_ref::<UInt32Array>()
-                .ok_or_else(|| {
-                    exec_err("cypher_path_nodes: type_ids values are not UInt32".into())
-                })?;
-            let mut ids = Vec::with_capacity(values.len());
-            for i in 0..values.len() {
-                if !values.is_null(i) {
-                    ids.push(
-                        graphforge_value::EntityTypeId::decode(values.value(i)).map_err(
-                            |error| {
-                                exec_err(format!(
-                                    "cypher_path_nodes: invalid membership identity: {error}"
-                                ))
-                            },
-                        )?,
-                    );
+            let uuids = hydration_fsb16(b, "node_uuid")?;
+            let type_ids = b
+                .column_by_name("type_ids")
+                .and_then(|c| c.as_any().downcast_ref::<ListArray>())
+                .ok_or_else(|| exec_err("cypher_path_nodes: no List type_ids column".into()))?;
+            for r in 0..b.num_rows() {
+                if uuids.is_null(r) || type_ids.is_null(r) {
+                    continue;
+                }
+                let mut u = [0u8; 16];
+                u.copy_from_slice(uuids.value(r));
+                if !remaining.remove(&u) {
+                    continue;
+                }
+                let values = type_ids.value(r);
+                let values = values
+                    .as_any()
+                    .downcast_ref::<UInt32Array>()
+                    .ok_or_else(|| {
+                        exec_err("cypher_path_nodes: type_ids values are not UInt32".into())
+                    })?;
+                let mut ids = Vec::with_capacity(values.len());
+                for i in 0..values.len() {
+                    if !values.is_null(i) {
+                        ids.push(
+                            graphforge_value::EntityTypeId::decode(values.value(i)).map_err(
+                                |error| {
+                                    exec_err(format!(
+                                        "cypher_path_nodes: invalid membership identity: {error}"
+                                    ))
+                                },
+                            )?,
+                        );
+                    }
+                }
+                label_ids_of.insert(u, ids);
+                path_hydration_stats::record_node_gathered(1);
+                path_hydration_stats::record_peak_gathered(label_ids_of.len() as u64);
+                if remaining.is_empty() {
+                    break;
                 }
             }
-            label_ids_of.insert(u, ids);
-            path_hydration_stats::record_node_gathered(1);
-            path_hydration_stats::record_peak_gathered(label_ids_of.len() as u64);
-            if remaining.is_empty() {
-                break;
-            }
-        }
-        Ok(!remaining.is_empty())
-    })?;
+            Ok(!remaining.is_empty())
+        },
+    )?;
     path_hydration_stats::record_resolved(label_ids_of.len() as u64);
     Ok(label_ids_of)
 }
@@ -12490,53 +12572,60 @@ fn gather_path_node_props(
         path_hydration_stats::record_stem_opened();
         let mut remaining: HashSet<[u8; 16]> = unique.iter().copied().collect();
         let mut kept: Vec<datafusion::arrow::array::RecordBatch> = Vec::new();
-        graphforge_storage::visit_properties_batched(&h.dir, stem, batch_size, |b| {
-            check_path_hydration_cancel()?;
-            path_hydration_stats::record_property_batch(b.num_rows() as u64);
-            if remaining.is_empty() {
-                return Ok(false);
-            }
-            let key = hydration_fsb16(b, "node_uuid")?;
-            let mut take_rows: Vec<u32> = Vec::new();
-            let mut take_uuids: Vec<[u8; 16]> = Vec::new();
-            for r in 0..key.len() {
-                if key.is_null(r) {
-                    continue;
+        graphforge_storage::visit_properties_batched(
+            h.dir.as_deref().ok_or_else(|| {
+                DataFusionError::Plan("GF_READ_RESOURCE_MISSING: path hydration".into())
+            })?,
+            stem,
+            batch_size,
+            |b| {
+                check_path_hydration_cancel()?;
+                path_hydration_stats::record_property_batch(b.num_rows() as u64);
+                if remaining.is_empty() {
+                    return Ok(false);
                 }
-                let mut u = [0u8; 16];
-                u.copy_from_slice(key.value(r));
-                if !remaining.contains(&u) {
-                    continue;
+                let key = hydration_fsb16(b, "node_uuid")?;
+                let mut take_rows: Vec<u32> = Vec::new();
+                let mut take_uuids: Vec<[u8; 16]> = Vec::new();
+                for r in 0..key.len() {
+                    if key.is_null(r) {
+                        continue;
+                    }
+                    let mut u = [0u8; 16];
+                    u.copy_from_slice(key.value(r));
+                    if !remaining.contains(&u) {
+                        continue;
+                    }
+                    take_rows.push(
+                        u32::try_from(r)
+                            .map_err(|_| exec_err(format!("property row {r} exceeds u32")))?,
+                    );
+                    take_uuids.push(u);
                 }
-                take_rows.push(
-                    u32::try_from(r)
-                        .map_err(|_| exec_err(format!("property row {r} exceeds u32")))?,
-                );
-                take_uuids.push(u);
-            }
-            if take_rows.is_empty() {
-                return Ok(true);
-            }
-            let indices = UInt32Array::from(take_rows);
-            let filtered = take_record_batch_rows(b, &indices)?;
-            let batch_idx = kept.len();
-            for (local_row, u) in take_uuids.into_iter().enumerate() {
-                if remaining.remove(&u) {
-                    let row = u32::try_from(local_row).map_err(|_| {
-                        exec_err(format!("gathered property row {local_row} exceeds u32"))
-                    })?;
-                    uuid_to_loc.entry(u).or_default().push(PropRowLoc {
-                        stem: si,
-                        batch: batch_idx,
-                        row,
-                    });
-                    path_hydration_stats::record_property_gathered(1);
+                if take_rows.is_empty() {
+                    return Ok(true);
                 }
-            }
-            path_hydration_stats::record_peak_gathered(uuid_to_loc.len() as u64);
-            kept.push(filtered);
-            Ok(!remaining.is_empty())
-        })?;
+                let indices = UInt32Array::from(take_rows);
+                let filtered = take_record_batch_rows(b, &indices)?;
+                let batch_idx = kept.len();
+                for (local_row, u) in take_uuids.into_iter().enumerate() {
+                    if remaining.remove(&u) {
+                        let row = u32::try_from(local_row).map_err(|_| {
+                            exec_err(format!("gathered property row {local_row} exceeds u32"))
+                        })?;
+                        uuid_to_loc.entry(u).or_default().push(PropRowLoc {
+                            stem: si,
+                            batch: batch_idx,
+                            row,
+                        });
+                        path_hydration_stats::record_property_gathered(1);
+                    }
+                }
+                path_hydration_stats::record_peak_gathered(uuid_to_loc.len() as u64);
+                kept.push(filtered);
+                Ok(!remaining.is_empty())
+            },
+        )?;
         kept_by_stem.push(kept);
     }
     Ok((kept_by_stem, uuid_to_loc))
@@ -13905,7 +13994,7 @@ mod tests {
         // With hydration: node_uuid, labels, then the baked property union
         // (#1024) — the shape `render_node_struct` and `x.<prop>` need.
         let hydrated = CypherPathNodes::with_hydration(PathNodeHydration {
-            dir: std::path::PathBuf::from("/nonexistent"),
+            dir: Some(std::path::PathBuf::from("/nonexistent")),
             labels_by_type: vec![(
                 graphforge_value::EntityTypeId::decode(0).unwrap(),
                 "A".to_owned(),
@@ -15564,7 +15653,7 @@ mod tests {
         let missing_bytes = [0xABu8; 16];
 
         let hydrate = PathNodeHydration {
-            dir: dir.path().to_path_buf(),
+            dir: Some(dir.path().to_path_buf()),
             labels_by_type: vec![
                 (
                     graphforge_value::EntityTypeId::decode(1).unwrap(),
@@ -15654,7 +15743,7 @@ mod tests {
         let loop_rels = std::sync::Arc::new(b.finish()) as datafusion::arrow::array::ArrayRef;
 
         let hydrate2 = PathNodeHydration {
-            dir: dir.path().to_path_buf(),
+            dir: Some(dir.path().to_path_buf()),
             labels_by_type: vec![
                 (
                     graphforge_value::EntityTypeId::decode(1).unwrap(),
@@ -15769,7 +15858,7 @@ mod tests {
         let a = to_bytes(&keep_a);
         let b = to_bytes(&keep_b);
         let hydrate = PathNodeHydration {
-            dir: dir.path().to_path_buf(),
+            dir: Some(dir.path().to_path_buf()),
             labels_by_type: vec![(
                 graphforge_value::EntityTypeId::decode(1).unwrap(),
                 "Person".to_owned(),
@@ -15951,7 +16040,7 @@ mod tests {
 
         let bytes = to_bytes(&keep);
         let hydrate = PathNodeHydration {
-            dir: dir.path().to_path_buf(),
+            dir: Some(dir.path().to_path_buf()),
             labels_by_type: vec![
                 (
                     graphforge_value::EntityTypeId::decode(1).unwrap(),
@@ -16084,7 +16173,7 @@ mod tests {
         w.flush().unwrap();
         let bytes = to_bytes(&u);
         let hydrate = PathNodeHydration {
-            dir: dir.path().to_path_buf(),
+            dir: Some(dir.path().to_path_buf()),
             labels_by_type: vec![(
                 graphforge_value::EntityTypeId::decode(1).unwrap(),
                 "Person".to_owned(),

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -3115,7 +3115,6 @@ fn is_source_op(op: &GraphOp) -> bool {
 
 /// Wrap a schema in a [`LogicalTableSource`] suitable for
 /// [`LogicalPlanBuilder::scan`].
-#[cfg(any(test, feature = "differential-testing"))]
 fn table_source(
     schema: datafusion::arrow::datatypes::SchemaRef,
 ) -> Arc<datafusion::logical_expr::logical_plan::LogicalTableSource> {
@@ -3133,7 +3132,9 @@ fn node_scan_source(
         Some(d) => graphforge_storage::TopologyNodeTable::open_project(d)
             .map(|table| datafusion::datasource::TableProvider::schema(&table))
             .map_unsupported_expr()?,
-        None => TOPOLOGY_NODES_SCHEMA.clone(),
+        // Schema-only plans retain their existing non-executable placeholder
+        // and optimizer/explain contract. Admitted reads use descriptors below.
+        None => return Ok(table_source(TOPOLOGY_NODES_SCHEMA.clone())),
     };
     Ok(graphforge_plan::GraphReadSource::new(
         graphforge_plan::GraphReadTable::Nodes,
@@ -3150,7 +3151,10 @@ fn edge_scan_source(
     schema: &datafusion::arrow::datatypes::SchemaRef,
     mode: OntologyMode,
 ) -> Arc<dyn datafusion::logical_expr::TableSource> {
-    let _ = (dir, mode); // Layout selection belongs to the execution resource.
+    if dir.is_none() {
+        return table_source(schema.clone());
+    }
+    let _ = mode; // Layout selection belongs to the execution resource.
     graphforge_plan::GraphReadSource::new(
         graphforge_plan::GraphReadTable::Edges(stem.to_owned()),
         schema,

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -36,7 +36,7 @@ use datafusion::functions_aggregate::expr_fn::{
 };
 use datafusion::logical_expr::{
     Expr as DfExpr, ExprFunctionExt, ExprSchemable, Extension, JoinType, LogicalPlanBuilder,
-    SortExpr, logical_plan::LogicalTableSource,
+    SortExpr,
 };
 
 use graphforge_core::{GfError, OntologyMode};
@@ -461,7 +461,13 @@ impl<'a> GraphPlanLowerer<'a> {
         }
 
         let prop_alias = format!("{node_alias}__props");
-        let prop_src = datafusion::datasource::provider_as_source(Arc::new(prop_table));
+        let prop_src = graphforge_plan::GraphReadSource::new(
+            graphforge_plan::GraphReadTable::Properties(stem.clone()),
+            &prop_schema,
+            self.catalog
+                .and_then(GraphCatalog::semantic_composition_fingerprint)
+                .map(str::to_owned),
+        );
         let prop_scan = LogicalPlanBuilder::scan(prop_alias.clone(), prop_src, None)
             .and_then(LogicalPlanBuilder::build)
             .map_unsupported_expr()?;
@@ -520,7 +526,77 @@ impl<'a> GraphPlanLowerer<'a> {
             self.build_node_shapes(&plan.ops);
         let mut var_map = VarMap::new();
         self.lower_pipeline(&plan.ops, &plan.exprs, &mut var_map)
+            .and_then(|plan| self.attach_read_contract(plan))
             .map_err(|e| GfError::Plan(e.to_string()))
+    }
+
+    /// The semantic assumptions for rebinding this query's current graph.
+    #[must_use]
+    pub fn read_contract(&self) -> graphforge_plan::GraphReadContract {
+        let mut labels = self.type_id_to_entity_name.clone();
+        if let Some(catalog) = self.catalog {
+            labels.extend(catalog.semantic_label_names().clone());
+            labels.extend(
+                catalog
+                    .label_names()
+                    .iter()
+                    .map(|(id, name)| (EntityTypeId::runtime(*id), name.clone())),
+            );
+        }
+        let mut labels: Vec<_> = labels.into_iter().collect();
+        labels.sort_by_key(|(id, _)| id.encode());
+        let mut relations: Vec<_> = self
+            .type_id_to_rel_name
+            .iter()
+            .map(|(id, name)| (*id, name.clone()))
+            .collect();
+        relations.sort_by_key(|(id, _)| id.encode());
+        graphforge_plan::GraphReadContract {
+            labels,
+            relations,
+            composition: self
+                .catalog
+                .and_then(GraphCatalog::semantic_composition_fingerprint)
+                .map(str::to_owned),
+        }
+    }
+
+    fn attach_read_contract(&self, plan: LogicalPlan) -> Result<LogicalPlan, LoweringError> {
+        use datafusion::common::tree_node::Transformed;
+        let contract = self.read_contract();
+        plan.transform_up_with_subqueries(|mut plan| {
+            match &mut plan {
+                LogicalPlan::TableScan(scan) => {
+                    if let Some(source) = scan
+                        .source
+                        .downcast_ref::<graphforge_plan::GraphReadSource>()
+                    {
+                        let mut source = source.clone();
+                        source.contract = Some(contract.clone());
+                        scan.source = Arc::new(source);
+                    }
+                }
+                LogicalPlan::Extension(extension) => {
+                    if let Some(node) = extension
+                        .node
+                        .as_any()
+                        .downcast_ref::<graphforge_plan::ExpandNode>()
+                    {
+                        extension.node =
+                            Arc::new(node.clone().with_read_contract(Some(contract.clone())));
+                    } else if let Some(node) =
+                        extension.node.as_any().downcast_ref::<VarLenExpandNode>()
+                    {
+                        extension.node =
+                            Arc::new(node.clone().with_read_contract(Some(contract.clone())));
+                    }
+                }
+                _ => {}
+            }
+            Ok(Transformed::yes(plan))
+        })
+        .map(|result| result.data)
+        .map_unsupported_expr()
     }
 
     // -----------------------------------------------------------------------
@@ -550,6 +626,7 @@ impl<'a> GraphPlanLowerer<'a> {
     ) -> Result<LogicalPlan, GfError> {
         *self.node_shapes.write().expect("node shapes lock poisoned") = self.build_node_shapes(ops);
         self.lower_pipeline(ops, exprs, var_map)
+            .and_then(|plan| self.attach_read_contract(plan))
             .map_err(|e| GfError::Plan(e.to_string()))
     }
 
@@ -568,6 +645,7 @@ impl<'a> GraphPlanLowerer<'a> {
             schema: input_schema,
         });
         self.lower_pipeline_from(ops, exprs, var_map, input, None)
+            .and_then(|plan| self.attach_read_contract(plan))
             .map_err(|e| GfError::Plan(e.to_string()))
     }
 
@@ -586,6 +664,7 @@ impl<'a> GraphPlanLowerer<'a> {
             schema: input_schema,
         });
         self.lower_pipeline_from(ops, exprs, var_map, input, Some(pending_nodes))
+            .and_then(|plan| self.attach_read_contract(plan))
             .map_err(|e| GfError::Plan(e.to_string()))
     }
 
@@ -3036,55 +3115,47 @@ fn is_source_op(op: &GraphOp) -> bool {
 
 /// Wrap a schema in a [`LogicalTableSource`] suitable for
 /// [`LogicalPlanBuilder::scan`].
-fn table_source(schema: datafusion::arrow::datatypes::SchemaRef) -> Arc<LogicalTableSource> {
-    Arc::new(LogicalTableSource::new(schema))
+#[cfg(any(test, feature = "differential-testing"))]
+fn table_source(
+    schema: datafusion::arrow::datatypes::SchemaRef,
+) -> Arc<datafusion::logical_expr::logical_plan::LogicalTableSource> {
+    Arc::new(datafusion::logical_expr::logical_plan::LogicalTableSource::new(schema))
 }
 
 /// The data source for a node scan.
 ///
-/// With a project `dir`, build a real Parquet-backed [`TopologyNodeTable`]
-/// provider (wrapped via `provider_as_source`) so the scan reads actual rows at
-/// execution time. Without a `dir` (pure logical/explain lowering, e.g. golden
-/// tests), fall back to the schema-only [`LogicalTableSource`].
+/// Discover the admitted project's schema when available, then retain only a
+/// logical descriptor. Execution resolves its provider from the session.
 fn node_scan_source(
     dir: Option<&Path>,
 ) -> Result<Arc<dyn datafusion::logical_expr::TableSource>, LoweringError> {
-    use datafusion::datasource::provider_as_source;
-    match dir {
+    let schema = match dir {
         Some(d) => graphforge_storage::TopologyNodeTable::open_project(d)
-            .map(|table| provider_as_source(Arc::new(table)))
-            .map_unsupported_expr(),
-        None => Ok(table_source(TOPOLOGY_NODES_SCHEMA.clone())),
-    }
+            .map(|table| datafusion::datasource::TableProvider::schema(&table))
+            .map_unsupported_expr()?,
+        None => TOPOLOGY_NODES_SCHEMA.clone(),
+    };
+    Ok(graphforge_plan::GraphReadSource::new(
+        graphforge_plan::GraphReadTable::Nodes,
+        &schema,
+        None,
+    ))
 }
 
-/// The data source for an edge scan over `stem` (a relation name for the typed
-/// table, or `"_exploratory"`). Real provider when `dir` is set; otherwise the
-/// schema-only source (`schema` chooses typed vs exploratory shape).
-///
-/// In a typed project (Strict/Advisory) there is no `_exploratory.parquet`, so
-/// an untyped edge scan over the `"_exploratory"` stem reads the **union** of
-/// every per-relation file via [`graphforge_storage::UnionEdgeTable`] (#823) — the same
-/// `EXPLORATORY_EDGE_SCHEMA`-shaped, `rel_type_name`-tagged rows the shared
-/// exploratory file would have carried, so the untyped single-hop join path is
-/// unchanged otherwise. Exploratory mode keeps reading its shared file.
+/// Logical edge source over a relation stem or the wildcard `_exploratory`.
+/// Execution selects the typed union or shared exploratory file from its mode.
 fn edge_scan_source(
     dir: Option<&Path>,
     stem: &str,
-    schema: datafusion::arrow::datatypes::SchemaRef,
+    schema: &datafusion::arrow::datatypes::SchemaRef,
     mode: OntologyMode,
 ) -> Arc<dyn datafusion::logical_expr::TableSource> {
-    use datafusion::datasource::provider_as_source;
-    match dir {
-        Some(d)
-            if stem == "_exploratory"
-                && matches!(mode, OntologyMode::Strict | OntologyMode::Advisory) =>
-        {
-            provider_as_source(Arc::new(graphforge_storage::UnionEdgeTable::open(d)))
-        }
-        Some(d) => provider_as_source(Arc::new(graphforge_storage::TypedEdgeTable::open(d, stem))),
-        None => table_source(schema),
-    }
+    let _ = (dir, mode); // Layout selection belongs to the execution resource.
+    graphforge_plan::GraphReadSource::new(
+        graphforge_plan::GraphReadTable::Edges(stem.to_owned()),
+        schema,
+        None,
+    )
 }
 
 /// Filter an already-bound node variable by its label type.
@@ -3227,7 +3298,13 @@ fn lower_typed_edge_scan(
             })?;
         return LogicalPlanBuilder::scan(
             alias,
-            datafusion::datasource::provider_as_source(provider),
+            graphforge_plan::GraphReadSource::new(
+                graphforge_plan::GraphReadTable::SemanticEdges(rel_ty),
+                &provider.schema(),
+                catalog
+                    .and_then(GraphCatalog::semantic_composition_fingerprint)
+                    .map(str::to_owned),
+            ),
             None,
         )
         .and_then(LogicalPlanBuilder::build)
@@ -3240,7 +3317,7 @@ fn lower_typed_edge_scan(
         .is_none_or(|s| !s.table_exist(&format!("edges_{rel_name}")));
 
     if use_exploratory {
-        let src = edge_scan_source(dir, "_exploratory", EXPLORATORY_EDGE_SCHEMA.clone(), mode);
+        let src = edge_scan_source(dir, "_exploratory", &EXPLORATORY_EDGE_SCHEMA, mode);
         let filter_expr = col("rel_type_name").eq(lit(rel_name.as_str()));
         // Use alias as the scan qualifier so var_map column refs resolve correctly.
         LogicalPlanBuilder::scan(alias, src, None)
@@ -3248,7 +3325,7 @@ fn lower_typed_edge_scan(
             .and_then(LogicalPlanBuilder::build)
             .map_unsupported_expr()
     } else {
-        let src = edge_scan_source(dir, rel_name, TYPED_EDGE_SCHEMA.clone(), mode);
+        let src = edge_scan_source(dir, rel_name, &TYPED_EDGE_SCHEMA, mode);
         // Use alias as the scan qualifier so downstream join predicates
         // (var_map.get(edge) → "var_N") can resolve edge columns correctly.
         LogicalPlanBuilder::scan(alias, src, None)
@@ -3270,7 +3347,7 @@ fn lower_edge_scan(
     let alias = var_alias(var);
     var_map.insert(var, alias.clone());
 
-    let src = edge_scan_source(dir, "_exploratory", EXPLORATORY_EDGE_SCHEMA.clone(), mode);
+    let src = edge_scan_source(dir, "_exploratory", &EXPLORATORY_EDGE_SCHEMA, mode);
     let mut builder = LogicalPlanBuilder::scan(alias, src, None).map_unsupported_expr()?;
 
     if let Some(type_id) = ty
@@ -3589,10 +3666,9 @@ fn lower_var_len_expand(
         .cloned()
         .unwrap_or_default();
     let rel_for_infer = rel_name.clone();
-    // The physical node reads edges directly from the project directory, so the
-    // dir/mode must be threaded through at lowering time (the ExtensionPlanner
-    // only sees DataFusion session state).
-    let (dir_path, mode) = target.ok_or_else(|| {
+    // Lowering discovers the logical output schema here; execution resolves
+    // the graph resource from its own session context.
+    let (dir_path, _mode) = target.ok_or_else(|| {
         LoweringError::UnsupportedExpr(
             "variable-length expand requires a project directory; \
              lower via new_for_writes or new_with_dir"
@@ -3653,8 +3729,6 @@ fn lower_var_len_expand(
         edge.0,
         dir,
         rel_ty,
-        dir_path.to_path_buf(),
-        mode,
         dst_fields,
         graphforge_plan::var_len_edge_list_field(&prop_fields),
     );
@@ -4028,8 +4102,6 @@ fn try_lower_provider_expand(
         edge.0,
         dir,
         rel_ty,
-        dir_path.to_path_buf(),
-        mode,
         edge_fields,
         edge_prop_fields,
         dst_fields,
@@ -4270,6 +4342,21 @@ fn expand_bound_edge_single_dir(
         .map_unsupported_expr()
 }
 
+fn edge_property_read_source(
+    stem: &str,
+    rel_ty: Option<RelationTypeId>,
+    catalog: Option<&GraphCatalog>,
+    schema: &datafusion::arrow::datatypes::SchemaRef,
+) -> Arc<graphforge_plan::GraphReadSource> {
+    let semantic_id =
+        rel_ty.filter(|id| catalog.is_some_and(|c| c.semantic_edge_property_table(*id).is_some()));
+    let composition = catalog
+        .and_then(GraphCatalog::semantic_composition_fingerprint)
+        .map(str::to_owned);
+    let table = graphforge_plan::GraphReadTable::EdgeProperties(stem.to_owned(), semantic_id);
+    graphforge_plan::GraphReadSource::new(table, schema, composition)
+}
+
 /// LEFT-join an edge scan with its persisted properties (#784), the edge
 /// analogue of [`GraphPlanLowerer::join_node_properties`].
 ///
@@ -4356,7 +4443,7 @@ fn join_edge_properties(
     let mut prop_refs: StdHashMap<String, Vec<DfExpr>> = StdHashMap::new();
     for (idx, (stem, prop_table, prop_cols)) in prop_sources.into_iter().enumerate() {
         let prop_alias = format!("{edge_alias}__eprops_{idx}");
-        let prop_src = datafusion::datasource::provider_as_source(prop_table);
+        let prop_src = edge_property_read_source(&stem, rel_ty, catalog, &prop_table.schema());
         let prop_scan = LogicalPlanBuilder::scan(prop_alias.clone(), prop_src, None)
             .and_then(LogicalPlanBuilder::build)
             .map_unsupported_expr()?;
@@ -5337,14 +5424,14 @@ relation_types:
             .downcast_ref::<VarLenExpandNode>()
             .expect("VarLenExpandNode");
 
-        // Baked execution context + pattern fields.
+        // Logical pattern fields and the semantic binding contract.
         assert_eq!(node.src_var, 0);
         assert_eq!(node.dst_var, 2);
         assert_eq!(node.direction, Direction::Out);
         assert_eq!(node.min_hops, 1);
         assert_eq!(node.max_hops, Some(3));
-        assert_eq!(node.dir, dir.path());
-        assert_eq!(node.mode, OntologyMode::Strict);
+        assert_eq!(node.read_contract.as_ref(), Some(&lowerer.read_contract()));
+        assert!(!format!("{node:?}").contains(&dir.path().display().to_string()));
 
         // Output schema carries the destination node's columns, qualified
         // `var_2`, so a downstream `RETURN b.node_id` can resolve them.
@@ -6323,7 +6410,16 @@ relation_types:
         assert_eq!(node.edge_var, 1);
         assert_eq!(node.dst_var, 2);
         assert_eq!(node.direction, Direction::Out);
-        assert_eq!(node.mode, OntologyMode::Strict);
+        assert_eq!(node.read_contract.as_ref(), Some(&lowerer.read_contract()));
+        assert!(
+            node.read_contract
+                .as_ref()
+                .unwrap()
+                .relations
+                .iter()
+                .any(|(_, name)| name == "KNOWS")
+        );
+        assert!(!format!("{node:?}").contains(&tmp.path().display().to_string()));
         assert_eq!(node.edge_prop_count, 0, "no edge_properties file on disk");
 
         // Schema parity essentials: edge topology under var_1, dst under var_2.

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -299,6 +299,7 @@ export default defineConfig({
                   label: '0025 Storage value contract',
                   slug: 'adr/0025-storage-value-contract',
                 },
+                { label: '0026 Read plan resources', slug: 'adr/0026-read-plan-resources' },
               ],
             },
           ],

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -144,6 +144,7 @@ const PAGES = [
   'adr/0023-composable-multi-ontology.md',
   'adr/0024-storage-format-exceptions.md',
   'adr/0025-storage-value-contract.md',
+  'adr/0026-read-plan-resources.md',
   'releases/roadmap.md',
   'legal/licensing.md',
   'community/security.md',

--- a/docs/adr/0026-read-plan-resources.md
+++ b/docs/adr/0026-read-plan-resources.md
@@ -1,0 +1,48 @@
+# ADR 0026: Read plans bind resources in execution
+
+**Status:** Accepted for implementation
+**Date:** 2026-09-07
+**Related:** #1136, #1008, ADR 0025
+
+## Context
+
+Fixed and variable expansion embed paths and ontology mode. Read scans retain
+storage providers and `nodes(path)` retains a hydration directory. DataFusion
+54.1 TableScan equality excludes its source, so provider ownership is a binding
+problem even when scan equality already ignores location. Expansion and hydrated
+expression equality do include their paths.
+
+## Options
+
+Keeping paths inside opaque handles would preserve the coupling. A global or
+thread-local resolver would make simultaneous and retained queries ambiguous.
+Removing schema discovery from lowering would expand this change into #1006.
+
+## Decision
+
+Read logical nodes and sources describe the query's current graph resource and
+its semantic schema, never a filesystem location or provider address. The
+current-graph role is deterministic across equivalent plans. Existing checked
+IDs, relation names, output schemas and composition assumptions remain semantic
+contracts; they are not substitutes for a pinned execution authority.
+
+An exec-owned SessionConfig extension owns the directory, mode, catalog and
+existing adjacency/ordinal resources. Physical planning resolves logical scan
+descriptors and read expressions against that session before executing them.
+Missing or incompatible bindings fail closed. Physical plans and owned streams
+retain their bound resources; another session cannot retarget them.
+
+Schema discovery remains in lowering for this slice. Mutation nodes retain their
+current seam until their own #1008 family lands. Existing operator names, Arrow
+schemas, checked-ID encodings and durable formats do not change. No durable plan
+serialization codec is introduced by this internal resource boundary.
+
+## Consequences
+
+Read plans can be compared and rebound independently of their original project
+location. The execution boundary must validate semantic assumptions and resolve
+all read sources, including property and semantic relation providers. Tests must
+cover relocated complete plans, simultaneous bindings, retained streams, missing
+authority and incompatible schemas, as well as ordinary query parity and #1094
+bounded traversal. The change does not authorize eager graph scans to construct
+the execution context or a fallback to the working directory.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ are not retained in this tree.
 | 0023 | [Composable ontology modules and semantic bridges](0023-composable-multi-ontology.md) | `0023-composable-multi-ontology.md` |
 | 0024 | [Storage format exceptions for GFDR and compiled ontologies](0024-storage-format-exceptions.md) | `0024-storage-format-exceptions.md` |
 | 0025 | [Storage values have a compiler-independent contract](0025-storage-value-contract.md) | `0025-storage-value-contract.md` |
+| 0026 | [Read plans bind resources in execution](0026-read-plan-resources.md) | `0026-read-plan-resources.md` |
 
 ## Numbering
 

--- a/docs/engineering/adrs/README.md
+++ b/docs/engineering/adrs/README.md
@@ -62,3 +62,4 @@ Keeper set after #2730 (mirrors [`../../adr/README.md`](../../adr/README.md)):
 | 0023 | Composable ontology modules and semantic bridges | Accepted | [`../../adr/0023-composable-multi-ontology.md`](../../adr/0023-composable-multi-ontology.md) |
 | 0024 | Storage format exceptions for GFDR and compiled ontologies | Accepted | [`../../adr/0024-storage-format-exceptions.md`](../../adr/0024-storage-format-exceptions.md) |
 | 0025 | Storage values have a compiler-independent contract | Accepted (extraction pending) | [`../../adr/0025-storage-value-contract.md`](../../adr/0025-storage-value-contract.md) |
+| 0026 | Read plans bind resources in execution | Accepted | [`../../adr/0026-read-plan-resources.md`](../../adr/0026-read-plan-resources.md) |


### PR DESCRIPTION
Read plans currently retain traversal directories, ontology mode, and graph-specific scan providers. This moves fixed/variable traversal, scan sources, and graph-reading expressions to logical descriptors bound through the execution session. The same logical query can bind to relocated, schema-equivalent graphs while preserving checked identities, composition assumptions, and pinned adjacency/ordinal resources. ADR 0026 records the boundary.

Binding rejects missing or incompatible authority before execution. Logical schema comparisons exclude only transient property live-count metadata; the execution clone restores the selected provider’s original schema metadata. Regression tests cover different graph cardinalities, equal plans/hashes/explain output, simultaneous bindings, and both streams surviving their sessions.

Validation:

- Full API BDD: 118/118; whole Cypher corpus: 3,897/3,897, zero baseline regressions.
- API unit tests: 688 passed, including private-cache reset and concurrent-read regressions.
- Targeted read/traversal/cache tests: 46 passed; one existing ignored timing benchmark.
- Plan/rel unit tests: 27 + 234 passed.
- Full rel/exec suites passed after the CI findings were fixed: 879 execution unit tests, all 15 logical-plan goldens, and integration/doc tests. Existing ignored tests remain unchanged.
- Filtered node/edge rebinding tests pass; schema-only explain snapshots remain unchanged, and unbound traversal still returns the typed missing-resource error.
- Clippy with `-D warnings`, formatting, gate registry, Cargo/Bazel drift, and extension-doc checks passed.
- Independent source review found no actionable findings. Exact-head CI remains required before merge. Advisory corpus timing warnings were retained; this PR makes no performance-improvement claim.

M3 read/traversal family of #1008; mutation families remain under the parent. No durable-format or public encoding change.

Closes #1136
