### PR TITLE
refactor(plan): bind mutation resources at execution

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -1403,6 +1403,11 @@ impl GraphForge {
             Some(Arc::clone(&self.ordinal_identities)),
             &self.session_resource_config(),
         )?;
+        let session = if self.read_only {
+            session.restrict_to_reads()
+        } else {
+            session
+        };
 
         let result = self.block_on(async {
             if is_write {
@@ -1823,6 +1828,11 @@ impl GraphForge {
             Some(Arc::clone(&self.ordinal_identities)),
             &self.session_resource_config(),
         )?;
+        let session = if self.read_only {
+            session.restrict_to_reads()
+        } else {
+            session
+        };
 
         // Build the stream on the instance's long-lived runtime so the tasks it
         // spawns (repartition/coalesce) outlive this call — they are dropped
@@ -3342,6 +3352,8 @@ impl GraphForge {
                 Some(Arc::clone(&self.ordinal_identities)),
                 &self.session_resource_config(),
             )?;
+        // This private session only renders a plan into text. No executable plan or
+        // write capability escapes this side-effect-free explanation boundary.
         let physical = self.block_on(async move { session.explain_physical(&plan).await })?;
 
         Ok(format!(
@@ -4832,6 +4844,94 @@ mod tests {
         uuid::Uuid::parse_str(generation).unwrap_or_else(|error| {
             panic!("absent-target child={child_id} invalid generation={generation:?}: {error}")
         })
+    }
+
+    #[test]
+    fn read_only_write_explanations_preserve_catalog_and_generation() {
+        fn files(root: &std::path::Path) -> std::collections::BTreeMap<PathBuf, Vec<u8>> {
+            fn visit(
+                root: &std::path::Path,
+                dir: &std::path::Path,
+                out: &mut std::collections::BTreeMap<PathBuf, Vec<u8>>,
+            ) {
+                for entry in std::fs::read_dir(dir).unwrap() {
+                    let path = entry.unwrap().path();
+                    if path.is_dir() {
+                        visit(root, &path, out);
+                    } else {
+                        out.insert(
+                            path.strip_prefix(root).unwrap().to_path_buf(),
+                            std::fs::read(path).unwrap(),
+                        );
+                    }
+                }
+            }
+            let mut out = std::collections::BTreeMap::new();
+            visit(root, root, &mut out);
+            out
+        }
+        let project = tempfile::TempDir::new().unwrap();
+        let graph = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
+        graph.execute("CREATE (:Person {name:'original'})").unwrap();
+        let resolved = graph.generation_for_read().unwrap();
+        let view = GraphForge::open_resolved_with_lifecycle_mode(
+            resolved.container_root().to_path_buf(),
+            resolved,
+            true,
+            graphforge_storage::filesystem_admission::ProjectLifecycleMode::Ephemeral,
+        )
+        .unwrap();
+        let before_catalog = view.runtime_catalog.lock().unwrap().to_record_batch();
+        let before_generation = view.generation_for_read().unwrap().generation_uuid();
+        let before_files = files(&view.dir);
+        assert!(
+            view.explain("CREATE (:NewLabel {fresh:1})")
+                .unwrap()
+                .contains("GraphCreateExec")
+        );
+        assert_eq!(
+            view.runtime_catalog.lock().unwrap().to_record_batch(),
+            before_catalog
+        );
+        for (query, operator) in [
+            ("CREATE (:Person {name:'new'})", "GraphCreateExec"),
+            ("MATCH (n:Person) SET n.name = 'changed'", "GraphSetExec"),
+            ("MATCH (n:Person) REMOVE n.name", "GraphRemoveExec"),
+            ("MATCH (n:Person) DELETE n", "GraphDeleteExec"),
+        ] {
+            assert!(view.explain(query).unwrap().contains(operator));
+        }
+        assert_eq!(
+            view.runtime_catalog.lock().unwrap().to_record_batch(),
+            before_catalog
+        );
+        assert_eq!(
+            view.generation_for_read().unwrap().generation_uuid(),
+            before_generation
+        );
+        assert_eq!(files(&view.dir), before_files);
+        // Execution binding observes runtime names, unlike snapshot-only EXPLAIN.
+        // Rejection must nevertheless preserve canonical data and authority.
+        for query in [
+            "CREATE (:Person {name:'new'})",
+            "MATCH (n:Person) SET n.name='changed'",
+            "MATCH (n:Person) REMOVE n.name",
+            "MATCH (n:Person) DELETE n",
+        ] {
+            assert!(view.execute(query).is_err());
+        }
+        assert_eq!(files(&view.dir), before_files);
+        assert_eq!(
+            view.generation_for_read().unwrap().generation_uuid(),
+            before_generation
+        );
+        assert_eq!(
+            view.execute_read_only("MATCH (n:Person) RETURN n.name")
+                .unwrap()
+                .batches[0]
+                .num_rows(),
+            1
+        );
     }
 
     #[test]

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -62,6 +62,7 @@ pub(crate) mod algorithm_embedding_hashgnn;
 mod algorithm_embedding_invocation;
 pub(crate) mod algorithm_embedding_options;
 pub mod read_resource;
+pub mod write_resource;
 pub use algorithm_embedding_options::validate_embedding_options;
 pub use algorithm_graph::AlgorithmProjectionFingerprint;
 pub(crate) mod algorithm_arrow_sink;
@@ -549,8 +550,16 @@ fn dynamic_struct_contains_node(fields: &arrow::datatypes::Fields) -> bool {
 impl GraphCreateExec {
     /// Build a physical CREATE node from its logical counterpart and planned
     /// input.
-    #[must_use]
-    pub fn new(node: &GraphCreateNode, input: Arc<dyn ExecutionPlan>) -> Self {
+    ///
+    /// # Errors
+    /// Rejects a write resource incompatible with the logical binding contract.
+    pub fn new(
+        node: &GraphCreateNode,
+        input: Arc<dyn ExecutionPlan>,
+        resource: &write_resource::BoundWriteResource,
+    ) -> Result<Self, DataFusionError> {
+        resource.validate(node.write_contract.as_ref())?;
+        resource.validate_composition(node.semantic_composition_fingerprint.as_deref())?;
         let emit_rows = node.emits_rows();
         // Summary mode → the fixed write-summary schema; emit-rows mode → the
         // created-entity row schema the logical node declares.
@@ -586,20 +595,20 @@ impl GraphCreateExec {
                 })
             })
             .collect();
-        Self {
+        Ok(Self {
             input,
             nodes: node.nodes.clone(),
             edges: node.edges.clone(),
             ref_cols,
             in_df_schema: in_schema.clone(),
-            dir: node.dir.clone(),
-            mode: node.mode,
+            dir: resource.dir.clone(),
+            mode: resource.mode,
             semantic_composition_fingerprint: node.semantic_composition_fingerprint.clone(),
             schema,
             emit_rows,
             effects: Arc::new(std::sync::Mutex::new(CreateTally::default())),
             props,
-        }
+        })
     }
 
     /// Read back the accumulated side-effect tally (emit-rows mode), for
@@ -1385,8 +1394,15 @@ pub struct GraphDeleteExec {
 
 impl GraphDeleteExec {
     /// Build the physical DELETE node from its logical counterpart and input.
-    #[must_use]
-    pub fn new(node: &GraphDeleteNode, input: Arc<dyn ExecutionPlan>) -> Self {
+    ///
+    /// # Errors
+    /// Rejects a write resource incompatible with the logical binding contract.
+    pub fn new(
+        node: &GraphDeleteNode,
+        input: Arc<dyn ExecutionPlan>,
+        resource: &write_resource::BoundWriteResource,
+    ) -> Result<Self, DataFusionError> {
+        resource.validate(node.write_contract.as_ref())?;
         let schema = GraphDeleteNode::summary_schema();
         let props = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
@@ -1410,14 +1426,14 @@ impl GraphDeleteExec {
                 })
             })
             .collect();
-        Self {
+        Ok(Self {
             input,
             cols,
             detach: node.detach,
-            dir: node.dir.clone(),
+            dir: resource.dir.clone(),
             schema,
             props,
-        }
+        })
     }
 }
 
@@ -1958,8 +1974,15 @@ pub struct GraphSetExec {
 
 impl GraphSetExec {
     /// Build the physical SET node from its logical counterpart and input.
-    #[must_use]
-    pub fn new(node: &GraphSetNode, input: Arc<dyn ExecutionPlan>) -> Self {
+    ///
+    /// # Errors
+    /// Rejects a write resource incompatible with the logical binding contract.
+    pub fn new(
+        node: &GraphSetNode,
+        input: Arc<dyn ExecutionPlan>,
+        resource: &write_resource::BoundWriteResource,
+    ) -> Result<Self, DataFusionError> {
+        resource.validate(node.write_contract.as_ref())?;
         let schema = GraphSetNode::summary_schema();
         let props = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
@@ -1976,16 +1999,16 @@ impl GraphSetExec {
                 Some((col, t.value.clone()))
             })
             .collect();
-        Self {
+        Ok(Self {
             input,
             targets,
-            type_id_to_entity_name: node.type_id_to_entity_name.clone(),
-            mode: node.mode,
-            dir: node.dir.clone(),
+            type_id_to_entity_name: resource.type_map.clone(),
+            mode: resource.mode,
+            dir: resource.dir.clone(),
             in_df_schema,
             schema,
             props,
-        }
+        })
     }
 }
 
@@ -2099,8 +2122,15 @@ pub struct GraphRemoveExec {
 
 impl GraphRemoveExec {
     /// Build the physical REMOVE node from its logical counterpart and input.
-    #[must_use]
-    pub fn new(node: &GraphRemoveNode, input: Arc<dyn ExecutionPlan>) -> Self {
+    ///
+    /// # Errors
+    /// Rejects a write resource incompatible with the logical binding contract.
+    pub fn new(
+        node: &GraphRemoveNode,
+        input: Arc<dyn ExecutionPlan>,
+        resource: &write_resource::BoundWriteResource,
+    ) -> Result<Self, DataFusionError> {
+        resource.validate(node.write_contract.as_ref())?;
         let schema = GraphRemoveNode::summary_schema();
         let props = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
@@ -2116,15 +2146,15 @@ impl GraphRemoveExec {
                 WriteCol::resolve(in_df_schema, t.var, t.is_edge, &t.prop_name)
             })
             .collect();
-        Self {
+        Ok(Self {
             input,
             targets,
-            type_id_to_entity_name: node.type_id_to_entity_name.clone(),
-            mode: node.mode,
-            dir: node.dir.clone(),
+            type_id_to_entity_name: resource.type_map.clone(),
+            mode: resource.mode,
+            dir: resource.dir.clone(),
             schema,
             props,
-        }
+        })
     }
 }
 
@@ -4735,25 +4765,36 @@ impl ExtensionPlanner for GraphForgeExtensionPlanner {
             let input = physical_inputs.first().cloned().ok_or_else(|| {
                 DataFusionError::Internal("GraphCreate requires one physical input".into())
             })?;
-            return Ok(Some(Arc::new(GraphCreateExec::new(create, input))));
+            let resource = write_resource::required(session_state, create.write_contract.as_ref())?;
+            resource.validate_composition(create.semantic_composition_fingerprint.as_deref())?;
+            return Ok(Some(Arc::new(GraphCreateExec::new(
+                create, input, &resource,
+            )?)));
         }
         if let Some(delete) = node.as_any().downcast_ref::<GraphDeleteNode>() {
             let input = physical_inputs.first().cloned().ok_or_else(|| {
                 DataFusionError::Internal("GraphDelete requires one physical input".into())
             })?;
-            return Ok(Some(Arc::new(GraphDeleteExec::new(delete, input))));
+            let resource = write_resource::required(session_state, delete.write_contract.as_ref())?;
+            return Ok(Some(Arc::new(GraphDeleteExec::new(
+                delete, input, &resource,
+            )?)));
         }
         if let Some(set) = node.as_any().downcast_ref::<GraphSetNode>() {
             let input = physical_inputs.first().cloned().ok_or_else(|| {
                 DataFusionError::Internal("GraphSet requires one physical input".into())
             })?;
-            return Ok(Some(Arc::new(GraphSetExec::new(set, input))));
+            let resource = write_resource::required(session_state, set.write_contract.as_ref())?;
+            return Ok(Some(Arc::new(GraphSetExec::new(set, input, &resource)?)));
         }
         if let Some(remove) = node.as_any().downcast_ref::<GraphRemoveNode>() {
             let input = physical_inputs.first().cloned().ok_or_else(|| {
                 DataFusionError::Internal("GraphRemove requires one physical input".into())
             })?;
-            return Ok(Some(Arc::new(GraphRemoveExec::new(remove, input))));
+            let resource = write_resource::required(session_state, remove.write_contract.as_ref())?;
+            return Ok(Some(Arc::new(GraphRemoveExec::new(
+                remove, input, &resource,
+            )?)));
         }
         if let Some(expand) = node.as_any().downcast_ref::<graphforge_plan::ExpandNode>() {
             return plan_expand_extension(expand, physical_inputs, session_state).map(Some);
@@ -4967,6 +5008,33 @@ struct OrdinalIdentityConfig {
 }
 
 impl ExecutionSession {
+    /// Remove mutation permission while retaining this session's read authority.
+    #[must_use]
+    pub fn restrict_to_reads(mut self) -> Self {
+        let mut state = self.ctx.state();
+        if let Some(resource) = state
+            .config()
+            .get_extension::<read_resource::GraphReadContext>()
+        {
+            state
+                .config_mut()
+                .set_extension(Arc::new(write_resource::GraphWriteContext {
+                    resource,
+                    writable: false,
+                }));
+        }
+        self.ctx = SessionContext::new_with_state(state);
+        self
+    }
+
+    /// Obtain the explicit admitted write target for physical operator construction.
+    ///
+    /// # Errors
+    /// Returns a typed error for missing or read-only mutation authority.
+    pub fn write_resource(&self) -> Result<write_resource::BoundWriteResource, GfError> {
+        write_resource::required(&self.ctx.state(), None).map_err(GfError::from_plan_error)
+    }
+
     /// Create a read/query session.
     ///
     /// Write execution (`CREATE`) requires a project directory — use
@@ -5111,19 +5179,26 @@ impl ExecutionSession {
         );
         let provider: Arc<dyn AdjacencyProvider> = Arc::clone(&adjacency_provider) as _;
         let catalog = Arc::new(catalog);
+        let read_resource = Arc::new(read_resource::GraphReadContext {
+            dir: dir.clone(),
+            mode,
+            catalog: catalog.clone(),
+            ontology: ontology.clone(),
+        });
         let mut config = datafusion::prelude::SessionConfig::new()
-            .with_extension(Arc::new(read_resource::GraphReadContext {
-                dir: dir.clone(),
-                mode,
-                catalog: catalog.clone(),
-                ontology: ontology.clone(),
-            }))
+            .with_extension(read_resource.clone())
             .with_extension(Arc::new(AdjacencyProviderExt(provider)))
             .with_extension(Arc::new(graphforge_storage::IoConcurrencyExt::new(
                 resources.io_concurrency,
             )))
             .with_target_partitions(resources.target_partitions)
             .with_batch_size(resources.batch_size);
+        if !dir.as_os_str().is_empty() {
+            config.set_extension(Arc::new(write_resource::GraphWriteContext {
+                resource: read_resource,
+                writable: true,
+            }));
+        }
         if identity.session.is_some() || identity.required {
             config = config.with_extension(Arc::new(OrdinalIdentityResolverExt(identity.session)));
         }
@@ -5222,12 +5297,10 @@ impl ExecutionSession {
         {
             return self.execute_write_statement_with_params(plan, params).await;
         }
-        if self.dir.as_os_str().is_empty() {
-            return Err(GfError::Execution(
-                "execute_create requires a write target; build the session with new_with_target"
-                    .into(),
-            ));
-        }
+        let resource = self.write_resource()?;
+        resource
+            .validate_composition(plan.composition_fingerprint.as_deref())
+            .map_err(GfError::from_plan_error)?;
 
         // Pass the catalog: although CREATE has no scans, the lowerer resolves
         // each edge's relation-type name from it (the ontology map alone is
@@ -5237,8 +5310,8 @@ impl ExecutionSession {
         let lowerer = GraphPlanLowerer::new_for_writes(
             Some(&self.catalog),
             self.ontology.as_ref(),
-            &self.dir,
-            self.mode,
+            &resource.dir,
+            resource.mode,
         )?;
         let logical = bind_query_params(lowerer.lower_plan(plan)?, params)?;
 
@@ -5382,18 +5455,16 @@ impl ExecutionSession {
         plan: &GraphPlan,
         params: &HashMap<String, graphforge_ir::IrLiteral>,
     ) -> Result<ExecutionResult, GfError> {
-        if self.dir.as_os_str().is_empty() {
-            return Err(GfError::Execution(
-                "write statements require a write target; build the session with new_with_target"
-                    .into(),
-            ));
-        }
+        let resource = self.write_resource()?;
+        resource
+            .validate_composition(plan.composition_fingerprint.as_deref())
+            .map_err(GfError::from_plan_error)?;
         let split = write_driver::split_write_plan(&plan.ops)?;
         let lowerer = GraphPlanLowerer::new_for_writes(
             Some(&self.catalog),
             self.ontology.as_ref(),
-            &self.dir,
-            self.mode,
+            &resource.dir,
+            resource.mode,
         )?;
 
         // Run the read prefix once, keeping the variable registrations the
@@ -5418,12 +5489,12 @@ impl ExecutionSession {
         let env = write_driver::PhaseEnv {
             lowerer: &lowerer,
             exprs: &plan.exprs,
-            dir: &self.dir,
-            mode: self.mode,
+            dir: &resource.dir,
+            mode: resource.mode,
             params,
             type_map: lowerer.entity_name_map(),
         };
-        let mut wctx = write_driver::StatementWriteContext::new(&self.dir, self.mode)?
+        let mut wctx = write_driver::StatementWriteContext::new(&resource.dir, resource.mode)?
             .with_semantic_composition_fingerprint(self.semantic_composition_fingerprint.clone());
         let create_retention =
             write_driver::create_retention_by_write(&plan.ops, &plan.exprs, &split);
@@ -5477,9 +5548,9 @@ impl ExecutionSession {
             }
             None => None,
         };
-        write_driver::commit_statement(&mut wctx, &self.dir)?;
+        write_driver::commit_statement(&mut wctx, &resource.dir)?;
         self.catalog
-            .refresh_property_inventory(&self.dir)
+            .refresh_property_inventory(&resource.dir)
             .map_err(GfError::from_execution_error)?;
         self.adjacency_provider.invalidate();
 
@@ -6666,11 +6737,11 @@ mod tests {
                     is_reference: false,
                 }],
                 vec![],
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
                 Arc::new(DFSchema::try_from(output_schema.as_ref().clone()).unwrap()),
             );
-            let exec = Arc::new(GraphCreateExec::new(&node, physical));
+            let exec = Arc::new(
+                GraphCreateExec::new(&node, physical, &test_write_resource(dir.path())).unwrap(),
+            );
             assert!(exec.emits_rows());
             let batches = collect(exec.clone(), SessionContext::new().task_ctx())
                 .await
@@ -6701,12 +6772,84 @@ mod tests {
         );
     }
 
+    fn test_write_resource(dir: &std::path::Path) -> write_resource::BoundWriteResource {
+        let catalog = GraphCatalog::open(dir, None, &RuntimeCatalog::new()).unwrap();
+        ExecutionSession::new_with_target(
+            catalog,
+            None,
+            dir.to_path_buf(),
+            OntologyMode::Exploratory,
+        )
+        .unwrap()
+        .write_resource()
+        .unwrap()
+    }
+
     fn empty_write_input() -> (Arc<LogicalPlan>, Arc<dyn ExecutionPlan>) {
         let logical = Arc::new(LogicalPlanBuilder::empty(false).build().unwrap());
         let physical: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::new(
             logical.schema().as_arrow().clone(),
         )));
         (logical, physical)
+    }
+
+    #[test]
+    fn direct_write_constructors_reject_incompatible_logical_contracts() {
+        let dir = TempDir::new().unwrap();
+        let mut runtime = RuntimeCatalog::new();
+        runtime.intern_label("DestinationMeaning").unwrap();
+        let catalog = GraphCatalog::open(dir.path(), None, &runtime).unwrap();
+        let mut contract = GraphPlanLowerer::new(Some(&catalog), None)
+            .unwrap()
+            .read_contract();
+        assert_eq!(contract.labels.len(), 1);
+        contract.labels[0].1 = "DifferentMeaning".into();
+        let contract = Some(contract);
+        let session = ExecutionSession::new_with_target(
+            catalog,
+            None,
+            dir.path().to_path_buf(),
+            OntologyMode::Exploratory,
+        )
+        .unwrap();
+        let resource = session.write_resource().unwrap();
+        let before = std::fs::read_dir(dir.path()).unwrap().count();
+        let (input, physical) = empty_write_input();
+        let errors = [
+            GraphCreateExec::new(
+                &GraphCreateNode::new(input.clone(), vec![], vec![])
+                    .with_write_contract(contract.clone()),
+                physical.clone(),
+                &resource,
+            )
+            .unwrap_err(),
+            GraphDeleteExec::new(
+                &GraphDeleteNode::new(input.clone(), vec![], false)
+                    .with_write_contract(contract.clone()),
+                physical.clone(),
+                &resource,
+            )
+            .unwrap_err(),
+            GraphSetExec::new(
+                &GraphSetNode::new(input.clone(), vec![]).with_write_contract(contract.clone()),
+                physical.clone(),
+                &resource,
+            )
+            .unwrap_err(),
+            GraphRemoveExec::new(
+                &GraphRemoveNode::new(input, vec![]).with_write_contract(contract),
+                physical,
+                &resource,
+            )
+            .unwrap_err(),
+        ];
+        for error in errors {
+            assert!(
+                error.to_string().contains("GF_WRITE_RESOURCE_INCOMPATIBLE"),
+                "{error}"
+            );
+        }
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), before);
     }
 
     #[test]
@@ -7209,58 +7352,60 @@ mod tests {
     fn write_execs_expose_stable_plan_contracts_and_reject_invalid_shape() {
         let dir = TempDir::new().unwrap();
         let (logical, physical) = empty_write_input();
-        let create: Arc<dyn ExecutionPlan> = Arc::new(GraphCreateExec::new(
-            &GraphCreateNode::new(
-                logical.clone(),
-                vec![],
-                vec![],
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
-            ),
-            physical.clone(),
-        ));
-        let delete: Arc<dyn ExecutionPlan> = Arc::new(GraphDeleteExec::new(
-            &GraphDeleteNode::new(
-                logical.clone(),
-                vec![DeleteTarget {
-                    var: 0,
-                    is_edge: false,
-                }],
-                true,
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
-            ),
-            physical.clone(),
-        ));
-        let set: Arc<dyn ExecutionPlan> = Arc::new(GraphSetExec::new(
-            &GraphSetNode::new(
-                logical.clone(),
-                vec![SetTarget {
-                    var: 0,
-                    is_edge: false,
-                    prop_name: "score".into(),
-                    value: lit(1_i64),
-                }],
-                HashMap::new(),
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
-            ),
-            physical.clone(),
-        ));
-        let remove: Arc<dyn ExecutionPlan> = Arc::new(GraphRemoveExec::new(
-            &GraphRemoveNode::new(
-                logical,
-                vec![RemoveTarget {
-                    var: 0,
-                    is_edge: false,
-                    prop_name: "score".into(),
-                }],
-                HashMap::new(),
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
-            ),
-            physical,
-        ));
+        let create: Arc<dyn ExecutionPlan> = Arc::new(
+            GraphCreateExec::new(
+                &GraphCreateNode::new(logical.clone(), vec![], vec![]),
+                physical.clone(),
+                &test_write_resource(dir.path()),
+            )
+            .unwrap(),
+        );
+        let delete: Arc<dyn ExecutionPlan> = Arc::new(
+            GraphDeleteExec::new(
+                &GraphDeleteNode::new(
+                    logical.clone(),
+                    vec![DeleteTarget {
+                        var: 0,
+                        is_edge: false,
+                    }],
+                    true,
+                ),
+                physical.clone(),
+                &test_write_resource(dir.path()),
+            )
+            .unwrap(),
+        );
+        let set: Arc<dyn ExecutionPlan> = Arc::new(
+            GraphSetExec::new(
+                &GraphSetNode::new(
+                    logical.clone(),
+                    vec![SetTarget {
+                        var: 0,
+                        is_edge: false,
+                        prop_name: "score".into(),
+                        value: lit(1_i64),
+                    }],
+                ),
+                physical.clone(),
+                &test_write_resource(dir.path()),
+            )
+            .unwrap(),
+        );
+        let remove: Arc<dyn ExecutionPlan> = Arc::new(
+            GraphRemoveExec::new(
+                &GraphRemoveNode::new(
+                    logical,
+                    vec![RemoveTarget {
+                        var: 0,
+                        is_edge: false,
+                        prop_name: "score".into(),
+                    }],
+                ),
+                physical,
+                &test_write_resource(dir.path()),
+            )
+            .unwrap(),
+        );
 
         for (plan, expected_name) in [
             (create, "GraphCreateExec"),
@@ -7303,46 +7448,38 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let (logical, physical) = empty_write_input();
         let plans: Vec<Arc<dyn ExecutionPlan>> = vec![
-            Arc::new(GraphCreateExec::new(
-                &GraphCreateNode::new(
-                    logical.clone(),
-                    vec![],
-                    vec![],
-                    dir.path().to_path_buf(),
-                    OntologyMode::Exploratory,
-                ),
-                physical.clone(),
-            )),
-            Arc::new(GraphDeleteExec::new(
-                &GraphDeleteNode::new(
-                    logical.clone(),
-                    vec![],
-                    false,
-                    dir.path().to_path_buf(),
-                    OntologyMode::Exploratory,
-                ),
-                physical.clone(),
-            )),
-            Arc::new(GraphSetExec::new(
-                &GraphSetNode::new(
-                    logical.clone(),
-                    vec![],
-                    HashMap::new(),
-                    dir.path().to_path_buf(),
-                    OntologyMode::Exploratory,
-                ),
-                physical.clone(),
-            )),
-            Arc::new(GraphRemoveExec::new(
-                &GraphRemoveNode::new(
-                    logical,
-                    vec![],
-                    HashMap::new(),
-                    dir.path().to_path_buf(),
-                    OntologyMode::Exploratory,
-                ),
-                physical,
-            )),
+            Arc::new(
+                GraphCreateExec::new(
+                    &GraphCreateNode::new(logical.clone(), vec![], vec![]),
+                    physical.clone(),
+                    &test_write_resource(dir.path()),
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                GraphDeleteExec::new(
+                    &GraphDeleteNode::new(logical.clone(), vec![], false),
+                    physical.clone(),
+                    &test_write_resource(dir.path()),
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                GraphSetExec::new(
+                    &GraphSetNode::new(logical.clone(), vec![]),
+                    physical.clone(),
+                    &test_write_resource(dir.path()),
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                GraphRemoveExec::new(
+                    &GraphRemoveNode::new(logical, vec![]),
+                    physical,
+                    &test_write_resource(dir.path()),
+                )
+                .unwrap(),
+            ),
         ];
 
         for plan in plans {
@@ -7466,48 +7603,33 @@ mod tests {
         let (input, _) = empty_write_input();
         let logical_nodes: Vec<(Arc<dyn UserDefinedLogicalNode>, &str)> = vec![
             (
-                Arc::new(GraphCreateNode::new(
-                    input.clone(),
-                    vec![],
-                    vec![],
-                    dir.path().to_path_buf(),
-                    OntologyMode::Exploratory,
-                )),
+                Arc::new(GraphCreateNode::new(input.clone(), vec![], vec![])),
                 "GraphCreateExec",
             ),
             (
-                Arc::new(GraphDeleteNode::new(
-                    input.clone(),
-                    vec![],
-                    false,
-                    dir.path().to_path_buf(),
-                    OntologyMode::Exploratory,
-                )),
+                Arc::new(GraphDeleteNode::new(input.clone(), vec![], false)),
                 "GraphDeleteExec",
             ),
             (
-                Arc::new(GraphSetNode::new(
-                    input.clone(),
-                    vec![],
-                    HashMap::new(),
-                    dir.path().to_path_buf(),
-                    OntologyMode::Exploratory,
-                )),
+                Arc::new(GraphSetNode::new(input.clone(), vec![])),
                 "GraphSetExec",
             ),
             (
-                Arc::new(GraphRemoveNode::new(
-                    input,
-                    vec![],
-                    HashMap::new(),
-                    dir.path().to_path_buf(),
-                    OntologyMode::Exploratory,
-                )),
+                Arc::new(GraphRemoveNode::new(input, vec![])),
                 "GraphRemoveExec",
             ),
         ];
-        let context = SessionContext::new();
-        let state = context.state();
+        let catalog = GraphCatalog::open(dir.path(), None, &RuntimeCatalog::new()).unwrap();
+        let session = ExecutionSession::new_with_target(
+            catalog,
+            None,
+            dir.path().to_path_buf(),
+            OntologyMode::Exploratory,
+        )
+        .unwrap();
+        let state = session.context().state();
+        let missing = SessionContext::new().state();
+        let readonly = session.restrict_to_reads().context().state();
         let planner = GraphForgeQueryPlanner;
 
         for (node, expected_name) in logical_nodes {
@@ -7517,42 +7639,27 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(physical.name(), expected_name);
+            for (state, code) in [
+                (&missing, "GF_WRITE_RESOURCE_MISSING"),
+                (&readonly, "GF_WRITE_RESOURCE_READ_ONLY"),
+            ] {
+                let error = planner
+                    .create_physical_plan(&logical, state)
+                    .await
+                    .unwrap_err();
+                assert!(error.to_string().contains(code), "{error}");
+            }
         }
     }
 
     #[tokio::test]
     async fn extension_planner_rejects_missing_write_inputs_and_declines_unknown_nodes() {
-        let dir = TempDir::new().unwrap();
         let (input, _) = empty_write_input();
         let nodes: Vec<Arc<dyn UserDefinedLogicalNode>> = vec![
-            Arc::new(GraphCreateNode::new(
-                input.clone(),
-                vec![],
-                vec![],
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
-            )),
-            Arc::new(GraphDeleteNode::new(
-                input.clone(),
-                vec![],
-                false,
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
-            )),
-            Arc::new(GraphSetNode::new(
-                input.clone(),
-                vec![],
-                HashMap::new(),
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
-            )),
-            Arc::new(GraphRemoveNode::new(
-                input,
-                vec![],
-                HashMap::new(),
-                dir.path().to_path_buf(),
-                OntologyMode::Exploratory,
-            )),
+            Arc::new(GraphCreateNode::new(input.clone(), vec![], vec![])),
+            Arc::new(GraphDeleteNode::new(input.clone(), vec![], false)),
+            Arc::new(GraphSetNode::new(input.clone(), vec![])),
+            Arc::new(GraphRemoveNode::new(input, vec![])),
         ];
         let state = SessionContext::new().state();
         let physical_planner = DefaultPhysicalPlanner::default();

--- a/crates/graphforge-exec/src/write_resource.rs
+++ b/crates/graphforge-exec/src/write_resource.rs
@@ -1,0 +1,95 @@
+//! Explicit session-owned mutation authority, separate from read access.
+use crate::read_resource::GraphReadContext;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::SessionState;
+use graphforge_core::OntologyMode;
+use graphforge_plan::GraphReadContract;
+use graphforge_value::EntityTypeId;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub(crate) struct GraphWriteContext {
+    pub resource: Arc<GraphReadContext>,
+    pub writable: bool,
+}
+
+/// An admitted target retained by physical write operators.
+#[derive(Debug, Clone)]
+pub struct BoundWriteResource {
+    pub(crate) dir: PathBuf,
+    pub(crate) mode: OntologyMode,
+    contract: GraphReadContract,
+    pub(crate) composition: Option<String>,
+    pub(crate) type_map: HashMap<EntityTypeId, String>,
+}
+
+impl BoundWriteResource {
+    pub(crate) fn validate(&self, expected: Option<&GraphReadContract>) -> Result<()> {
+        if expected.is_some_and(|expected| *expected != self.contract) {
+            return Err(DataFusionError::Plan(
+                "GF_WRITE_RESOURCE_INCOMPATIBLE: logical identities".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_composition(&self, expected: Option<&str>) -> Result<()> {
+        if expected.is_some() && expected != self.composition.as_deref() {
+            return Err(DataFusionError::Plan(
+                "GF_WRITE_RESOURCE_INCOMPATIBLE: semantic composition".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// The explicit admitted destination, never recovered from a logical node.
+    #[must_use]
+    pub fn directory(&self) -> &Path {
+        &self.dir
+    }
+}
+
+pub(crate) fn required(
+    state: &SessionState,
+    contract: Option<&GraphReadContract>,
+) -> Result<BoundWriteResource> {
+    let binding = state
+        .config()
+        .get_extension::<GraphWriteContext>()
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "GF_WRITE_RESOURCE_MISSING: mutation requires a write target".into(),
+            )
+        })?;
+    if !binding.writable {
+        return Err(DataFusionError::Plan(
+            "GF_WRITE_RESOURCE_READ_ONLY: session does not authorize writes".into(),
+        ));
+    }
+    if binding.resource.dir.as_os_str().is_empty() {
+        return Err(DataFusionError::Plan(
+            "GF_WRITE_RESOURCE_MISSING: mutation requires a write target".into(),
+        ));
+    }
+    binding
+        .resource
+        .validate(contract)
+        .map_err(|e| DataFusionError::Plan(format!("GF_WRITE_RESOURCE_INCOMPATIBLE: {e}")))?;
+    let lowerer = graphforge_rel::GraphPlanLowerer::new(
+        Some(&binding.resource.catalog),
+        binding.resource.ontology.as_ref(),
+    )
+    .map_err(|e| DataFusionError::Plan(e.to_string()))?;
+    Ok(BoundWriteResource {
+        dir: binding.resource.dir.clone(),
+        mode: binding.resource.mode,
+        contract: lowerer.read_contract(),
+        composition: binding
+            .resource
+            .catalog
+            .semantic_composition_fingerprint()
+            .map(str::to_owned),
+        type_map: lowerer.entity_name_map(),
+    })
+}

--- a/crates/graphforge-exec/tests/create_input_driven.rs
+++ b/crates/graphforge-exec/tests/create_input_driven.rs
@@ -70,7 +70,22 @@ fn ref_input_batch(persons: &[(Uuid, u64)]) -> RecordBatch {
     RecordBatch::try_new(ref_input_schema(), vec![Arc::new(uuid_arr), Arc::new(ids)]).unwrap()
 }
 
-async fn run(node: GraphCreateNode, input_batch: RecordBatch) -> (u64, u64) {
+fn test_write_resource(dir: &Path) -> graphforge_exec::write_resource::BoundWriteResource {
+    let catalog =
+        graphforge_storage::GraphCatalog::open(dir, None, &graphforge_ir::RuntimeCatalog::new())
+            .unwrap();
+    graphforge_exec::ExecutionSession::new_with_target(
+        catalog,
+        None,
+        dir.to_path_buf(),
+        OntologyMode::Exploratory,
+    )
+    .unwrap()
+    .write_resource()
+    .unwrap()
+}
+
+async fn run(dir: &Path, node: GraphCreateNode, input_batch: RecordBatch) -> (u64, u64) {
     let ctx = SessionContext::new();
     let input: Arc<dyn ExecutionPlan> = ctx
         .read_batch(input_batch)
@@ -78,7 +93,9 @@ async fn run(node: GraphCreateNode, input_batch: RecordBatch) -> (u64, u64) {
         .create_physical_plan()
         .await
         .unwrap();
-    let exec = Arc::new(graphforge_exec::GraphCreateExec::new(&node, input));
+    let exec = Arc::new(
+        graphforge_exec::GraphCreateExec::new(&node, input, &test_write_resource(dir)).unwrap(),
+    );
     let out = collect(exec, ctx.task_ctx()).await.unwrap();
     let b = &out[0];
     let nodes = b
@@ -135,11 +152,9 @@ async fn create_per_matched_row_references_and_mints() {
             properties: vec![],
             computed_properties: vec![],
         }],
-        dir.path().to_path_buf(),
-        OntologyMode::Strict,
     );
 
-    let (nodes, edges) = run(node, ref_input_batch(&persons)).await;
+    let (nodes, edges) = run(dir.path(), node, ref_input_batch(&persons)).await;
     // Per row: 1 mint (`b`) + 1 edge; the reference `a` is not counted.
     assert_eq!((nodes, edges), (3, 3), "one new b + one edge per matched a");
 
@@ -166,13 +181,11 @@ async fn create_over_empty_match_creates_nothing() {
             is_reference: false,
         }],
         vec![],
-        dir.path().to_path_buf(),
-        OntologyMode::Strict,
     );
 
     // Empty input batch (no matched rows).
     let empty = RecordBatch::new_empty(ref_input_schema());
-    let (nodes, edges) = run(node, empty).await;
+    let (nodes, edges) = run(dir.path(), node, empty).await;
     assert_eq!((nodes, edges), (0, 0), "empty match creates nothing");
 }
 
@@ -194,8 +207,6 @@ async fn standalone_create_over_unit_row_creates_once() {
             is_reference: false,
         }],
         vec![],
-        dir.path().to_path_buf(),
-        OntologyMode::Strict,
     );
 
     // A single unit row (no columns).
@@ -206,7 +217,7 @@ async fn standalone_create_over_unit_row_creates_once() {
         &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(1)),
     )
     .unwrap();
-    let (nodes, edges) = run(node, unit_batch).await;
+    let (nodes, edges) = run(dir.path(), node, unit_batch).await;
     assert_eq!((nodes, edges), (1, 0), "standalone CREATE mints once");
 }
 
@@ -227,8 +238,6 @@ async fn null_referenced_node_uuid_errors() {
             is_reference: true,
         }],
         vec![],
-        dir.path().to_path_buf(),
-        OntologyMode::Strict,
     );
 
     // One input row whose node_uuid is null (e.g. an unmatched OPTIONAL MATCH).
@@ -251,7 +260,10 @@ async fn null_referenced_node_uuid_errors() {
         .create_physical_plan()
         .await
         .unwrap();
-    let exec = Arc::new(graphforge_exec::GraphCreateExec::new(&node, input));
+    let exec = Arc::new(
+        graphforge_exec::GraphCreateExec::new(&node, input, &test_write_resource(dir.path()))
+            .unwrap(),
+    );
     let err = collect(exec, ctx.task_ctx()).await;
     assert!(
         err.is_err(),
@@ -280,8 +292,6 @@ async fn create_accumulates_across_multiple_input_batches() {
             is_reference: false,
         }],
         vec![],
-        dir.path().to_path_buf(),
-        OntologyMode::Strict,
     );
 
     // Two batches: 2 rows + 1 row, same schema as ref_input_plan (var_0).
@@ -295,7 +305,10 @@ async fn create_accumulates_across_multiple_input_batches() {
         .create_physical_plan()
         .await
         .unwrap();
-    let exec = Arc::new(graphforge_exec::GraphCreateExec::new(&node, input));
+    let exec = Arc::new(
+        graphforge_exec::GraphCreateExec::new(&node, input, &test_write_resource(dir.path()))
+            .unwrap(),
+    );
     let out = collect(exec, ctx.task_ctx()).await.unwrap();
     let nodes = out[0]
         .column(0)

--- a/crates/graphforge-exec/tests/write_statement.rs
+++ b/crates/graphforge-exec/tests/write_statement.rs
@@ -427,3 +427,178 @@ async fn statement_commit_bumps_topology_generation_only_for_topology() {
         3
     );
 }
+
+#[tokio::test]
+async fn mutation_plans_relocate_and_bind_only_selected_write_resources() {
+    use datafusion::logical_expr::LogicalPlan;
+    use std::hash::{Hash, Hasher};
+    for (query, expected_left, expected_right) in [
+        (
+            "CREATE (:Person {name:'new'})",
+            vec!["left", "new"],
+            vec!["new", "right"],
+        ),
+        (
+            "MATCH (n:Person) SET n.name = n.name + '-set'",
+            vec!["left-set"],
+            vec!["right-set"],
+        ),
+        ("MATCH (n:Person) REMOVE n.name", vec![], vec![]),
+        ("MATCH (n:Person) DELETE n", vec![], vec![]),
+    ] {
+        let left = TempDir::new().unwrap();
+        let right = TempDir::new().unwrap();
+        let rt = Arc::new(Mutex::new(RuntimeCatalog::new()));
+        seed(left.path(), &rt, &["CREATE (:Person {name:'left'})"]).await;
+        seed(right.path(), &rt, &["CREATE (:Person {name:'right'})"]).await;
+        let ir = bind(query, &rt);
+        let lower = |root: &Path| {
+            let catalog = GraphCatalog::open(root, None, &rt.lock().unwrap()).unwrap();
+            graphforge_rel::GraphPlanLowerer::new_for_writes(
+                Some(&catalog),
+                None,
+                root,
+                OntologyMode::Exploratory,
+            )
+            .unwrap()
+            .lower_plan(&ir)
+            .unwrap()
+        };
+        let plan = lower(left.path());
+        let relocated = lower(right.path());
+        assert_eq!(plan, relocated, "{query}");
+        let hash = |plan: &LogicalPlan| {
+            let mut hash = std::collections::hash_map::DefaultHasher::new();
+            plan.hash(&mut hash);
+            hash.finish()
+        };
+        assert_eq!(hash(&plan), hash(&relocated));
+        let explain = plan.display_indent().to_string();
+        assert_eq!(explain, relocated.display_indent().to_string());
+        assert!(!explain.contains(left.path().to_str().unwrap()));
+        assert!(!explain.contains(right.path().to_str().unwrap()));
+        let left_session = session(left.path(), &rt);
+        let right_session = session(right.path(), &rt);
+        let left_state = left_session.context().state();
+        let right_state = right_session.context().state();
+        let (left_physical, right_physical) = tokio::join!(
+            left_state.create_physical_plan(&plan),
+            right_state.create_physical_plan(&plan),
+        );
+        let left_stream = datafusion::physical_plan::execute_stream(
+            left_physical.unwrap(),
+            left_session.context().task_ctx(),
+        )
+        .unwrap();
+        let right_stream = datafusion::physical_plan::execute_stream(
+            right_physical.unwrap(),
+            right_session.context().task_ctx(),
+        )
+        .unwrap();
+        drop(left_session);
+        drop(right_session);
+        let left_result = datafusion::physical_plan::common::collect(left_stream)
+            .await
+            .unwrap();
+        assert_eq!(left_result.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+        let names = |root: &Path| {
+            let mut names: Vec<_> = logical_property_rows(root, "_untyped")
+                .into_iter()
+                .filter_map(|row| match row.values.get("name") {
+                    Some(graphforge_ir::IrLiteral::Str(name)) => Some(name.clone()),
+                    _ => None,
+                })
+                .collect();
+            names.sort();
+            names
+        };
+        assert_eq!(
+            names(right.path()),
+            ["right"],
+            "the other retained stream has not been polled"
+        );
+        let right_result = datafusion::physical_plan::common::collect(right_stream)
+            .await
+            .unwrap();
+        assert_eq!(right_result.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+        assert_eq!(names(left.path()), expected_left, "{query}");
+        assert_eq!(names(right.path()), expected_right, "{query}");
+        assert_eq!(
+            plan, relocated,
+            "binding leaves logical descriptors untouched"
+        );
+    }
+}
+
+#[tokio::test]
+async fn statement_and_literal_writes_require_explicit_writable_context() {
+    let dir = TempDir::new().unwrap();
+    let rt = Arc::new(Mutex::new(RuntimeCatalog::new()));
+    seed(dir.path(), &rt, &["CREATE (:Person {name:'original'})"]).await;
+    for query in [
+        "CREATE (:Person {name:'new'})",
+        "MATCH (n:Person) SET n.name = 'changed'",
+        "MATCH (n:Person) REMOVE n.name",
+        "MATCH (n:Person) DELETE n",
+        "MERGE (:Person {name:'original'})",
+    ] {
+        let plan = bind(query, &rt);
+        let readonly = session(dir.path(), &rt).restrict_to_reads();
+        let catalog = GraphCatalog::open(dir.path(), None, &rt.lock().unwrap()).unwrap();
+        let missing = ExecutionSession::new(catalog, None).unwrap();
+        for (session, code) in [
+            (readonly, "GF_WRITE_RESOURCE_READ_ONLY"),
+            (missing, "GF_WRITE_RESOURCE_MISSING"),
+        ] {
+            let error = session.execute_write_statement(&plan).await.unwrap_err();
+            assert!(error.to_string().contains(code), "{query}: {error}");
+            let error = session.execute_create(&plan).await.unwrap_err();
+            assert!(error.to_string().contains(code), "{query}: {error}");
+        }
+    }
+    let properties = logical_property_rows(dir.path(), "_untyped");
+    assert_eq!(properties.len(), 1);
+    assert_eq!(
+        properties[0].values.get("name"),
+        Some(&graphforge_ir::IrLiteral::Str("original".into()))
+    );
+}
+
+#[tokio::test]
+async fn mixed_create_set_merge_preserves_buffered_visibility_and_atomic_rollback() {
+    for fail in [false, true] {
+        let dir = TempDir::new().unwrap();
+        let rt = Arc::new(Mutex::new(RuntimeCatalog::new()));
+        let query = if fail {
+            "CREATE (n:P {x:1}) SET n.x=2 MERGE (m:P {x:2}) DELETE m SET m.x=3"
+        } else {
+            "CREATE (n:P {x:1}) SET n.x=2 MERGE (m:P {x:2}) RETURN m"
+        };
+        let result = run(dir.path(), &rt, query).await;
+        if fail {
+            assert!(result.unwrap_err().to_string().contains("deleted"));
+            assert_eq!(rows(&dir.path().join("topology/nodes.parquet")), 0);
+            assert!(logical_property_rows(dir.path(), "_untyped").is_empty());
+        } else {
+            let result = result.unwrap();
+            assert_eq!(result.stats.rows_produced, 1);
+            assert_eq!(result.side_effects.as_ref().unwrap().nodes_created, 1);
+            let receipt = result.mutation_receipt.unwrap();
+            assert_eq!(
+                receipt
+                    .effects
+                    .iter()
+                    .filter(|effect| effect.kind == MutationKind::CreateNode)
+                    .count(),
+                1
+            );
+            assert_eq!(rows(&dir.path().join("topology/nodes.parquet")), 1);
+            let properties = logical_property_rows(dir.path(), "_untyped");
+            assert_eq!(properties.len(), 1);
+            assert_eq!(
+                properties[0].values.get("x"),
+                Some(&graphforge_ir::IrLiteral::Int(2))
+            );
+        }
+    }
+}

--- a/crates/graphforge-plan/src/lib.rs
+++ b/crates/graphforge-plan/src/lib.rs
@@ -24,21 +24,19 @@
 // the literal values.
 #![allow(clippy::unnecessary_literal_bound)]
 
+mod literal_key;
 pub mod read_resource;
 pub use read_resource::{GraphReadContract, GraphReadSource, GraphReadTable};
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema};
 use datafusion::common::{DFSchema, DFSchemaRef, Result as DfResult, TableReference};
 use datafusion::logical_expr::{Expr, ExprSchemable, LogicalPlan, UserDefinedLogicalNodeCore};
 
-use graphforge_core::OntologyMode;
 use graphforge_ir::{Direction, IrLiteral};
 use graphforge_value::{EntityTypeId, RelationTypeId};
 
@@ -879,7 +877,7 @@ impl UserDefinedLogicalNodeCore for GraphMergeNode {
 /// label IDs are paired with their resolved names and property maps are
 /// evaluated to literal key/value pairs, so the execution layer needs no
 /// access to the IR arena or ontology.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ResolvedNodeSpec {
     /// Pattern variable id (`VarId.0`).
     pub var: u32,
@@ -902,7 +900,7 @@ pub struct ResolvedNodeSpec {
 }
 
 /// An edge to create, fully resolved.  See [`ResolvedNodeSpec`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ResolvedEdgeSpec {
     /// Pattern variable id of the edge.
     pub var: u32,
@@ -929,12 +927,48 @@ pub struct ResolvedEdgeSpec {
     pub computed_properties: Vec<(String, Expr)>,
 }
 
+// Both mutation specification keys use the same literal policy; extension
+// nodes derive their equality and hashing from these semantic components.
+macro_rules! impl_spec_key {
+    ($name:ident, $($field:ident),+ $(,)?) => {
+        impl $name {
+            fn semantic_key(&self) -> impl Eq + Hash + '_ {
+                ($(&self.$field,)+ literal_key::Properties(&self.properties))
+            }
+        }
+        impl PartialEq for $name {
+            fn eq(&self, other: &Self) -> bool { self.semantic_key() == other.semantic_key() }
+        }
+        impl Eq for $name {}
+        impl Hash for $name {
+            fn hash<H: Hasher>(&self, state: &mut H) { self.semantic_key().hash(state); }
+        }
+    };
+}
+impl_spec_key!(
+    ResolvedNodeSpec,
+    var,
+    label_ids,
+    label_names,
+    computed_properties,
+    is_reference
+);
+impl_spec_key!(
+    ResolvedEdgeSpec,
+    var,
+    src,
+    dst,
+    rel_type_id,
+    rel_type_name,
+    direction,
+    computed_properties
+);
+
 /// Logical node for `CREATE`: a write specification driven by an input plan.
 ///
-/// Carries the resolved node/edge specs plus the project directory and ontology
-/// mode needed to drive a writer.  The directory is baked in at lowering time
-/// because the physical-planning layer (an `ExtensionPlanner`) only sees the
-/// DataFusion session state, not the GraphForge project path.
+/// Carries resolved node/edge specifications and semantic binding assumptions.
+/// The physical planner obtains the destination and write policy from its
+/// explicit execution context.
 ///
 /// # Input
 ///
@@ -947,7 +981,7 @@ pub struct ResolvedEdgeSpec {
 ///
 /// Output schema is a one-row write summary: `nodes_created` / `edges_created`
 /// (`UInt64`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GraphCreateNode {
     /// Input plan whose rows drive the writes (the implicit unit row for a
     /// standalone CREATE; the MATCH results for a mixed pipeline).
@@ -956,14 +990,11 @@ pub struct GraphCreateNode {
     pub nodes: Vec<ResolvedNodeSpec>,
     /// Edges to create, in pattern order.
     pub edges: Vec<ResolvedEdgeSpec>,
-    /// Target project directory.
-    pub dir: PathBuf,
-    /// Ontology mode (drives writer edge / property routing).
-    pub mode: OntologyMode,
     /// Exact composition fingerprint authenticating opaque storage routes.
     pub semantic_composition_fingerprint: Option<String>,
-    /// Output schema: the one-row write summary in summary mode, or the
-    /// created-entity row schema in emit-rows mode (#814).
+    /// Semantic identities required by the write binding.
+    pub write_contract: Option<GraphReadContract>,
+    /// One-row summary or created-entity rows in emit-rows mode (#814).
     schema: DFSchemaRef,
     /// `true` when the node emits created-entity rows (write-result RETURN);
     /// `false` for the terminal one-row summary.
@@ -971,6 +1002,13 @@ pub struct GraphCreateNode {
 }
 
 impl GraphCreateNode {
+    /// Attach logical binding assumptions, never executable authority.
+    #[must_use]
+    pub fn with_write_contract(mut self, contract: Option<GraphReadContract>) -> Self {
+        self.write_contract = contract;
+        self
+    }
+
     /// Build the write-summary Arrow schema
     /// (`nodes_created`, `edges_created`, `properties_set`, `labels_added`).
     #[must_use]
@@ -990,19 +1028,16 @@ impl GraphCreateNode {
         input: Arc<LogicalPlan>,
         nodes: Vec<ResolvedNodeSpec>,
         edges: Vec<ResolvedEdgeSpec>,
-        dir: PathBuf,
-        mode: OntologyMode,
     ) -> Self {
         let schema = Arc::new(
             DFSchema::try_from(Self::summary_schema())
                 .expect("write-summary schema is always valid"),
         );
         Self {
+            write_contract: None,
             input,
             nodes,
             edges,
-            dir,
-            mode,
             semantic_composition_fingerprint: None,
             schema,
             emit_rows: false,
@@ -1020,16 +1055,13 @@ impl GraphCreateNode {
         input: Arc<LogicalPlan>,
         nodes: Vec<ResolvedNodeSpec>,
         edges: Vec<ResolvedEdgeSpec>,
-        dir: PathBuf,
-        mode: OntologyMode,
         output_schema: DFSchemaRef,
     ) -> Self {
         Self {
+            write_contract: None,
             input,
             nodes,
             edges,
-            dir,
-            mode,
             semantic_composition_fingerprint: None,
             schema: output_schema,
             emit_rows: true,
@@ -1052,231 +1084,6 @@ impl GraphCreateNode {
 }
 
 impl_partial_ord!(GraphCreateNode);
-
-// `IrLiteral` is `PartialEq` (so we derive `PartialEq`) but not `Eq`/`Hash`
-// (it carries `f64`).  `UserDefinedLogicalNodeCore` requires `Eq + Hash`, so we
-// provide them by hand: `Eq` is the empty marker (literal property values are
-// never NaN-reflexivity-sensitive in practice — matching DataFusion's own
-// float-bearing nodes), and `Hash` normalises each literal (floats via
-// `to_bits`).  `schema` is excluded from both (it is derived from the rest).
-impl PartialEq for GraphCreateNode {
-    fn eq(&self, other: &Self) -> bool {
-        self.input == other.input
-            && self.nodes == other.nodes
-            && self.edges == other.edges
-            && self.dir == other.dir
-            && self.mode == other.mode
-            && self.semantic_composition_fingerprint == other.semantic_composition_fingerprint
-            && self.emit_rows == other.emit_rows
-    }
-}
-
-impl Eq for GraphCreateNode {}
-
-fn hash_literal<H: Hasher>(lit: &IrLiteral, state: &mut H) {
-    match lit {
-        IrLiteral::Null => 0u8.hash(state),
-        IrLiteral::Bool(b) => {
-            1u8.hash(state);
-            b.hash(state);
-        }
-        IrLiteral::Int(i) => {
-            2u8.hash(state);
-            i.hash(state);
-        }
-        IrLiteral::Float(f) => {
-            3u8.hash(state);
-            f.to_bits().hash(state);
-        }
-        IrLiteral::Str(s) => {
-            4u8.hash(state);
-            s.hash(state);
-        }
-        IrLiteral::Uuid(uuid) => {
-            14u8.hash(state);
-            uuid.hash(state);
-        }
-        IrLiteral::Duration {
-            months,
-            days,
-            seconds,
-            nanos,
-        } => {
-            5u8.hash(state);
-            months.hash(state);
-            days.hash(state);
-            seconds.hash(state);
-            nanos.hash(state);
-        }
-        IrLiteral::DateTime(t) => {
-            6u8.hash(state);
-            t.hash(state);
-        }
-        IrLiteral::Date(d) => {
-            7u8.hash(state);
-            d.hash(state);
-        }
-        IrLiteral::LocalDateTime { days, nanos } => {
-            8u8.hash(state);
-            days.hash(state);
-            nanos.hash(state);
-        }
-        IrLiteral::Time(n) => {
-            9u8.hash(state);
-            n.hash(state);
-        }
-        IrLiteral::ZonedTime { nanos, offset } => {
-            10u8.hash(state);
-            nanos.hash(state);
-            offset.hash(state);
-        }
-        IrLiteral::ZonedDateTime {
-            days,
-            nanos,
-            offset,
-            zone,
-        } => {
-            11u8.hash(state);
-            days.hash(state);
-            nanos.hash(state);
-            offset.hash(state);
-            zone.hash(state);
-        }
-        IrLiteral::Spatial(value) => {
-            15u8.hash(state);
-            value.spatial_type.hash(state);
-            value.extension_name.hash(state);
-            value.extension_metadata.hash(state);
-            hash_spatial_coordinates(&value.coordinates, state);
-        }
-        IrLiteral::List(items) => {
-            12u8.hash(state);
-            items.len().hash(state);
-            for it in items {
-                hash_literal(it, state);
-            }
-        }
-        IrLiteral::Map(entries) => {
-            13u8.hash(state);
-            entries.len().hash(state);
-            for (key, value) in entries {
-                key.hash(state);
-                hash_literal(value, state);
-            }
-        }
-    }
-}
-
-fn hash_spatial_coordinates<H: Hasher>(
-    coordinates: &graphforge_core::SpatialCoordinates,
-    state: &mut H,
-) {
-    use graphforge_core::SpatialCoordinates;
-    fn point<H: Hasher>(value: &[f64; 2], state: &mut H) {
-        value[0].to_bits().hash(state);
-        value[1].to_bits().hash(state);
-    }
-    match coordinates {
-        SpatialCoordinates::Point(value) => {
-            0u8.hash(state);
-            point(value, state);
-        }
-        SpatialCoordinates::LineString(values) => {
-            1u8.hash(state);
-            values.len().hash(state);
-            for value in values {
-                point(value, state);
-            }
-        }
-        SpatialCoordinates::Polygon(rings) => {
-            2u8.hash(state);
-            rings.len().hash(state);
-            for ring in rings {
-                ring.len().hash(state);
-                for value in ring {
-                    point(value, state);
-                }
-            }
-        }
-        SpatialCoordinates::MultiPoint(values) => {
-            3u8.hash(state);
-            values.len().hash(state);
-            for value in values {
-                point(value, state);
-            }
-        }
-        SpatialCoordinates::MultiLineString(lines) => {
-            4u8.hash(state);
-            lines.len().hash(state);
-            for line in lines {
-                line.len().hash(state);
-                for value in line {
-                    point(value, state);
-                }
-            }
-        }
-        SpatialCoordinates::MultiPolygon(polygons) => {
-            5u8.hash(state);
-            polygons.len().hash(state);
-            for polygon in polygons {
-                polygon.len().hash(state);
-                for ring in polygon {
-                    ring.len().hash(state);
-                    for value in ring {
-                        point(value, state);
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn hash_props<H: Hasher>(props: &[(String, IrLiteral)], state: &mut H) {
-    props.len().hash(state);
-    for (k, v) in props {
-        k.hash(state);
-        hash_literal(v, state);
-    }
-}
-
-// Computed-property values are `Expr` (not `Hash`); hash the count and keys and
-// let `PartialEq` disambiguate the exprs (matching `GraphSetNode::hash`).
-fn hash_computed<H: Hasher>(props: &[(String, Expr)], state: &mut H) {
-    props.len().hash(state);
-    for (k, _) in props {
-        k.hash(state);
-    }
-}
-
-impl Hash for GraphCreateNode {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.input.hash(state);
-        self.nodes.len().hash(state);
-        for n in &self.nodes {
-            n.var.hash(state);
-            n.label_ids.hash(state);
-            n.label_names.hash(state);
-            n.is_reference.hash(state);
-            hash_props(&n.properties, state);
-            hash_computed(&n.computed_properties, state);
-        }
-        self.edges.len().hash(state);
-        for e in &self.edges {
-            e.var.hash(state);
-            e.src.hash(state);
-            e.dst.hash(state);
-            e.rel_type_id.hash(state);
-            e.rel_type_name.hash(state);
-            e.direction.hash(state);
-            hash_props(&e.properties, state);
-            hash_computed(&e.computed_properties, state);
-        }
-        self.dir.hash(state);
-        self.mode.hash(state);
-        self.semantic_composition_fingerprint.hash(state);
-        self.emit_rows.hash(state);
-    }
-}
 
 impl UserDefinedLogicalNodeCore for GraphCreateNode {
     fn name(&self) -> &str {
@@ -1345,20 +1152,11 @@ impl UserDefinedLogicalNodeCore for GraphCreateNode {
                 }
             }
         }
-        // Preserve emit-rows mode + its output schema (a plain `new` would reset
-        // to summary mode and drop the created-rows schema).
-        if self.emit_rows {
-            Ok(Self::new_emitting(
-                input,
-                nodes,
-                edges,
-                self.dir.clone(),
-                self.mode,
-                self.schema.clone(),
-            ))
-        } else {
-            Ok(Self::new(input, nodes, edges, self.dir.clone(), self.mode))
-        }
+        let mut node = self.clone();
+        node.input = input;
+        node.nodes = nodes;
+        node.edges = edges;
+        Ok(node)
     }
 }
 
@@ -1384,11 +1182,10 @@ pub struct DeleteTarget {
 /// Logical node for `DELETE` / `DETACH DELETE` (#740): a delete specification
 /// driven by an input plan (the preceding `MATCH`).
 ///
-/// Like [`GraphCreateNode`], the project directory and ontology mode are baked
-/// in at lowering time (the `ExtensionPlanner` sees only the DataFusion session
-/// state). The input rows supply the identities of the entities to delete; the
+/// Like [`GraphCreateNode`], execution requires an explicit write binding.
+/// The input rows supply the identities of the entities to delete; the
 /// node emits a one-row write summary `nodes_deleted` / `edges_deleted`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GraphDeleteNode {
     /// Input plan whose rows carry the matched entities' identities.
     pub input: Arc<LogicalPlan>,
@@ -1396,14 +1193,19 @@ pub struct GraphDeleteNode {
     pub targets: Vec<DeleteTarget>,
     /// `true` for `DETACH DELETE` (also remove a node's incident edges).
     pub detach: bool,
-    /// Target project directory.
-    pub dir: PathBuf,
-    /// Ontology mode (drives writer edge / property routing).
-    pub mode: OntologyMode,
+    /// Semantic identities required by the write binding.
+    pub write_contract: Option<GraphReadContract>,
     schema: DFSchemaRef,
 }
 
 impl GraphDeleteNode {
+    /// Attach logical binding assumptions, never executable authority.
+    #[must_use]
+    pub fn with_write_contract(mut self, contract: Option<GraphReadContract>) -> Self {
+        self.write_contract = contract;
+        self
+    }
+
     /// Build the write-summary Arrow schema (`nodes_deleted`, `edges_deleted`).
     #[must_use]
     pub fn summary_schema() -> Arc<Schema> {
@@ -1415,53 +1217,22 @@ impl GraphDeleteNode {
 
     /// Create a new graph-delete node over `input`.
     #[must_use]
-    pub fn new(
-        input: Arc<LogicalPlan>,
-        targets: Vec<DeleteTarget>,
-        detach: bool,
-        dir: PathBuf,
-        mode: OntologyMode,
-    ) -> Self {
+    pub fn new(input: Arc<LogicalPlan>, targets: Vec<DeleteTarget>, detach: bool) -> Self {
         let schema = Arc::new(
             DFSchema::try_from(Self::summary_schema())
                 .expect("write-summary schema is always valid"),
         );
         Self {
+            write_contract: None,
             input,
             targets,
             detach,
-            dir,
-            mode,
             schema,
         }
     }
 }
 
 impl_partial_ord!(GraphDeleteNode);
-
-// `schema` is derived from the rest, so it is excluded from `PartialEq`/`Hash`
-// (it is not part of the node's logical identity).
-impl PartialEq for GraphDeleteNode {
-    fn eq(&self, other: &Self) -> bool {
-        self.input == other.input
-            && self.targets == other.targets
-            && self.detach == other.detach
-            && self.dir == other.dir
-            && self.mode == other.mode
-    }
-}
-
-impl Eq for GraphDeleteNode {}
-
-impl Hash for GraphDeleteNode {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.input.hash(state);
-        self.targets.hash(state);
-        self.detach.hash(state);
-        self.dir.hash(state);
-        self.mode.hash(state);
-    }
-}
 
 impl UserDefinedLogicalNodeCore for GraphDeleteNode {
     fn name(&self) -> &str {
@@ -1496,13 +1267,9 @@ impl UserDefinedLogicalNodeCore for GraphDeleteNode {
                 .next()
                 .unwrap_or_else(|| (*self.input).clone()),
         );
-        Ok(Self::new(
-            input,
-            self.targets.clone(),
-            self.detach,
-            self.dir.clone(),
-            self.mode,
-        ))
+        let mut node = self.clone();
+        node.input = input;
+        Ok(node)
     }
 }
 
@@ -1519,10 +1286,10 @@ impl UserDefinedLogicalNodeCore for GraphDeleteNode {
 ///
 /// The property-file **stem** is resolved per row in the exec layer, not baked
 /// here: a node uses its `type_id` (→ `_untyped` in Exploratory mode, else the
-/// entity name from [`GraphSetNode::type_id_to_entity_name`]); an edge uses its
+/// entity name from the admitted execution context); an edge uses its
 /// `rel_type_name` column (edge property files are keyed by relation name in
 /// every mode).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SetTarget {
     /// Pattern variable id (`VarId.0`).
     pub var: u32,
@@ -1550,30 +1317,30 @@ pub struct RemoveTarget {
 /// Logical node for `SET <prop> = <expr>` (#791): a property-write driven by an
 /// input plan (the preceding `MATCH`).
 ///
-/// Mirrors [`GraphDeleteNode`] — project directory and ontology mode are baked
-/// in at lowering time. Each target's value expression is evaluated per matched
-/// row by the physical layer, the resulting per-row literal written to the
-/// entity's property file. Node-target file stems are resolved per row from the
-/// row's `type_id` via [`type_id_to_entity_name`](Self::type_id_to_entity_name)
-/// (handles an untyped `MATCH (n)` whose rows span several entity types). The
+/// Each target's value expression is evaluated per matched row by the physical
+/// layer. Property routes are resolved from the admitted execution context and
+/// each row's checked identity, including an untyped `MATCH (n)` whose rows span
+/// several entity types. The
 /// node emits a one-row summary `properties_set`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GraphSetNode {
     /// Input plan whose rows carry the matched entities' identities + columns.
     pub input: Arc<LogicalPlan>,
     /// The property assignments, with resolved node/edge kind + value expr.
     pub targets: Vec<SetTarget>,
-    /// Maps a node `type_id` to its property-file entity stem, for per-row node
-    /// stem resolution (an empty map / missing id falls back to `_untyped`).
-    pub type_id_to_entity_name: HashMap<graphforge_value::EntityTypeId, String>,
-    /// Target project directory.
-    pub dir: PathBuf,
-    /// Ontology mode (drives node property-file routing).
-    pub mode: OntologyMode,
+    /// Semantic identities required by the write binding.
+    pub write_contract: Option<GraphReadContract>,
     schema: DFSchemaRef,
 }
 
 impl GraphSetNode {
+    /// Attach logical binding assumptions, never executable authority.
+    #[must_use]
+    pub fn with_write_contract(mut self, contract: Option<GraphReadContract>) -> Self {
+        self.write_contract = contract;
+        self
+    }
+
     /// Build the write-summary Arrow schema (`properties_set`).
     #[must_use]
     pub fn summary_schema() -> Arc<Schema> {
@@ -1586,60 +1353,21 @@ impl GraphSetNode {
 
     /// Create a new graph-set node over `input`.
     #[must_use]
-    pub fn new(
-        input: Arc<LogicalPlan>,
-        targets: Vec<SetTarget>,
-        type_id_to_entity_name: HashMap<graphforge_value::EntityTypeId, String>,
-        dir: PathBuf,
-        mode: OntologyMode,
-    ) -> Self {
+    pub fn new(input: Arc<LogicalPlan>, targets: Vec<SetTarget>) -> Self {
         let schema = Arc::new(
             DFSchema::try_from(Self::summary_schema())
                 .expect("write-summary schema is always valid"),
         );
         Self {
+            write_contract: None,
             input,
             targets,
-            type_id_to_entity_name,
-            dir,
-            mode,
             schema,
         }
     }
 }
 
 impl_partial_ord!(GraphSetNode);
-
-// `schema` is derived; excluded from `PartialEq`/`Hash` (not part of logical
-// identity). The value exprs ARE part of identity, so they are included.
-impl PartialEq for GraphSetNode {
-    fn eq(&self, other: &Self) -> bool {
-        self.input == other.input
-            && self.targets == other.targets
-            && self.dir == other.dir
-            && self.mode == other.mode
-            && self.type_id_to_entity_name == other.type_id_to_entity_name
-    }
-}
-
-impl Eq for GraphSetNode {}
-
-impl Hash for GraphSetNode {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.input.hash(state);
-        // `SetTarget` is not `Hash` (it holds an `Expr`, which is not `Hash`);
-        // hash the stable scalar fields and let `PartialEq` disambiguate the
-        // value exprs. Plan-node hashing only needs to be consistent with `Eq`
-        // for buckets, not collision-free.
-        for t in &self.targets {
-            t.var.hash(state);
-            t.is_edge.hash(state);
-            t.prop_name.hash(state);
-        }
-        self.dir.hash(state);
-        self.mode.hash(state);
-    }
-}
 
 impl UserDefinedLogicalNodeCore for GraphSetNode {
     fn name(&self) -> &str {
@@ -1679,35 +1407,34 @@ impl UserDefinedLogicalNodeCore for GraphSetNode {
                 t.value = e;
             }
         }
-        Ok(Self::new(
-            input,
-            targets,
-            self.type_id_to_entity_name.clone(),
-            self.dir.clone(),
-            self.mode,
-        ))
+        let mut node = self.clone();
+        node.input = input;
+        node.targets = targets;
+        Ok(node)
     }
 }
 
 /// Logical node for `REMOVE <prop>` (#791): the value-less dual of
 /// [`GraphSetNode`]. Emits a one-row summary `properties_removed`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GraphRemoveNode {
     /// Input plan whose rows carry the matched entities' identities + columns.
     pub input: Arc<LogicalPlan>,
     /// The properties to remove, with resolved node/edge kind.
     pub targets: Vec<RemoveTarget>,
-    /// Maps a node `type_id` to its property-file entity stem (see
-    /// [`GraphSetNode::type_id_to_entity_name`]).
-    pub type_id_to_entity_name: HashMap<graphforge_value::EntityTypeId, String>,
-    /// Target project directory.
-    pub dir: PathBuf,
-    /// Ontology mode (drives node property-file routing).
-    pub mode: OntologyMode,
+    /// Semantic identities required by the write binding.
+    pub write_contract: Option<GraphReadContract>,
     schema: DFSchemaRef,
 }
 
 impl GraphRemoveNode {
+    /// Attach logical binding assumptions, never executable authority.
+    #[must_use]
+    pub fn with_write_contract(mut self, contract: Option<GraphReadContract>) -> Self {
+        self.write_contract = contract;
+        self
+    }
+
     /// Build the write-summary Arrow schema (`properties_removed`).
     #[must_use]
     pub fn summary_schema() -> Arc<Schema> {
@@ -1720,50 +1447,21 @@ impl GraphRemoveNode {
 
     /// Create a new graph-remove node over `input`.
     #[must_use]
-    pub fn new(
-        input: Arc<LogicalPlan>,
-        targets: Vec<RemoveTarget>,
-        type_id_to_entity_name: HashMap<graphforge_value::EntityTypeId, String>,
-        dir: PathBuf,
-        mode: OntologyMode,
-    ) -> Self {
+    pub fn new(input: Arc<LogicalPlan>, targets: Vec<RemoveTarget>) -> Self {
         let schema = Arc::new(
             DFSchema::try_from(Self::summary_schema())
                 .expect("write-summary schema is always valid"),
         );
         Self {
+            write_contract: None,
             input,
             targets,
-            type_id_to_entity_name,
-            dir,
-            mode,
             schema,
         }
     }
 }
 
 impl_partial_ord!(GraphRemoveNode);
-
-impl PartialEq for GraphRemoveNode {
-    fn eq(&self, other: &Self) -> bool {
-        self.input == other.input
-            && self.targets == other.targets
-            && self.dir == other.dir
-            && self.mode == other.mode
-            && self.type_id_to_entity_name == other.type_id_to_entity_name
-    }
-}
-
-impl Eq for GraphRemoveNode {}
-
-impl Hash for GraphRemoveNode {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.input.hash(state);
-        self.targets.hash(state);
-        self.dir.hash(state);
-        self.mode.hash(state);
-    }
-}
 
 impl UserDefinedLogicalNodeCore for GraphRemoveNode {
     fn name(&self) -> &str {
@@ -1793,13 +1491,9 @@ impl UserDefinedLogicalNodeCore for GraphRemoveNode {
                 .next()
                 .unwrap_or_else(|| (*self.input).clone()),
         );
-        Ok(Self::new(
-            input,
-            self.targets.clone(),
-            self.type_id_to_entity_name.clone(),
-            self.dir.clone(),
-            self.mode,
-        ))
+        let mut node = self.clone();
+        node.input = input;
+        Ok(node)
     }
 }
 
@@ -2189,8 +1883,6 @@ mod tests {
                 is_reference: false,
             }],
             vec![],
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Strict,
         );
         assert_eq!(UserDefinedLogicalNodeCore::name(&node), "GraphCreate");
         // Input-driven now (one CREATE per input row).
@@ -2217,8 +1909,6 @@ mod tests {
                     is_reference: false,
                 }],
                 vec![],
-                PathBuf::from("/tmp/gf"),
-                OntologyMode::Exploratory,
             )
         };
         let (a, b) = (mk(), mk());
@@ -2228,6 +1918,111 @@ mod tests {
         a.hash(&mut ha);
         b.hash(&mut hb);
         assert_eq!(ha.finish(), hb.finish());
+    }
+
+    #[test]
+    fn mutation_literal_keys_are_reflexive_and_hash_consistent() {
+        use graphforge_core::{
+            SpatialCoordinates, SpatialCrs, SpatialGeometryType, SpatialType, SpatialValue,
+        };
+        use std::collections::hash_map::DefaultHasher;
+        fn make(value: IrLiteral) -> GraphCreateNode {
+            GraphCreateNode::new(
+                empty_plan(),
+                vec![ResolvedNodeSpec {
+                    var: 0,
+                    label_ids: vec![],
+                    label_names: vec!["Place".into()],
+                    properties: vec![("value".into(), value)],
+                    computed_properties: vec![],
+                    is_reference: false,
+                }],
+                vec![],
+            )
+        }
+        fn hash(node: &GraphCreateNode) -> u64 {
+            let mut hash = DefaultHasher::new();
+            node.hash(&mut hash);
+            hash.finish()
+        }
+        let spatial = |value| {
+            IrLiteral::Spatial(SpatialValue {
+                spatial_type: SpatialType {
+                    geometry: SpatialGeometryType::Point,
+                    crs: SpatialCrs::Preserved("OGC:CRS84".into()),
+                },
+                coordinates: SpatialCoordinates::Point([value, 0.0]),
+                extension_name: Some("geoarrow.point".into()),
+                extension_metadata: None,
+            })
+        };
+        for wrap in [
+            |value| IrLiteral::Float(value),
+            |value| {
+                IrLiteral::List(vec![IrLiteral::Map(vec![(
+                    "x".into(),
+                    IrLiteral::Float(value),
+                )])])
+            },
+        ] {
+            let positive = make(wrap(0.0));
+            let negative = make(wrap(-0.0));
+            assert_eq!(positive, negative);
+            assert_eq!(hash(&positive), hash(&negative));
+            let nan = make(wrap(f64::from_bits(0x7ff8_0000_0000_0001)));
+            assert_eq!(nan, nan.clone());
+            assert_eq!(hash(&nan), hash(&nan.clone()));
+            assert_ne!(nan, make(wrap(f64::from_bits(0x7ff8_0000_0000_0002))));
+        }
+        assert_eq!(make(spatial(0.0)), make(spatial(-0.0)));
+        assert_eq!(hash(&make(spatial(0.0))), hash(&make(spatial(-0.0))));
+        let nan = make(spatial(f64::NAN));
+        assert_eq!(nan, nan.clone());
+        assert_eq!(hash(&nan), hash(&nan.clone()));
+        assert_ne!(
+            make(IrLiteral::Map(vec![
+                ("a".into(), IrLiteral::Int(1)),
+                ("b".into(), IrLiteral::Int(2))
+            ])),
+            make(IrLiteral::Map(vec![
+                ("b".into(), IrLiteral::Int(2)),
+                ("a".into(), IrLiteral::Int(1))
+            ]))
+        );
+        let original = make(IrLiteral::Int(1));
+        let mut computed = original.clone();
+        computed.nodes[0]
+            .computed_properties
+            .push(("extra".into(), datafusion::logical_expr::lit(1)));
+        assert_ne!(original, computed);
+        for value in [0.0, -0.0, f64::NAN] {
+            let mut node = original.clone();
+            node.nodes[0]
+                .computed_properties
+                .push(("computed".into(), datafusion::logical_expr::lit(value)));
+            assert_eq!(node, node.clone());
+            assert_eq!(hash(&node), hash(&node.clone()));
+        }
+        let emitting = GraphCreateNode::new_emitting(
+            original.input.clone(),
+            original.nodes.clone(),
+            original.edges.clone(),
+            original.schema.clone(),
+        );
+        assert_ne!(
+            original, emitting,
+            "output mode remains semantic even with the same schema"
+        );
+        let mut composition = original.clone();
+        composition.semantic_composition_fingerprint = Some("semantic-contract".into());
+        assert_ne!(original, composition);
+        let rebuilt = composition
+            .with_exprs_and_inputs(
+                composition.expressions(),
+                vec![(*composition.input).clone()],
+            )
+            .unwrap();
+        assert_eq!(composition, rebuilt);
     }
 
     #[test]
@@ -2260,8 +2055,6 @@ mod tests {
                     is_reference: false,
                 }],
                 vec![],
-                PathBuf::from("/tmp/gf"),
-                OntologyMode::Exploratory,
             );
             let mut hasher = DefaultHasher::new();
             node.hash(&mut hasher);
@@ -2325,8 +2118,6 @@ mod tests {
                     is_reference: false,
                 }],
                 vec![],
-                PathBuf::from("/tmp/gf"),
-                OntologyMode::Strict,
             )
         };
         let (first, second) = (make(), make());
@@ -2347,9 +2138,6 @@ mod tests {
                 prop_name: "age".to_owned(),
                 value,
             }],
-            HashMap::new(),
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Exploratory,
         )
     }
 
@@ -2361,9 +2149,6 @@ mod tests {
                 is_edge: false,
                 prop_name: "age".to_owned(),
             }],
-            HashMap::new(),
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Exploratory,
         )
     }
 
@@ -2450,8 +2235,6 @@ mod tests {
                 properties: vec![],
                 computed_properties: vec![("weight".into(), lit(2_i64))],
             }],
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Strict,
             output_schema.clone(),
         );
         assert!(node.emits_rows());
@@ -2486,8 +2269,6 @@ mod tests {
                 is_edge: false,
             }],
             true,
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Exploratory,
         );
         assert_eq!(UserDefinedLogicalNodeCore::name(&node), "GraphDelete");
         assert_eq!(UserDefinedLogicalNodeCore::inputs(&node).len(), 1);
@@ -2503,13 +2284,7 @@ mod tests {
         assert_eq!(node, rebuilt);
         assert_ne!(
             node,
-            GraphDeleteNode::new(
-                empty_plan(),
-                node.targets.clone(),
-                false,
-                node.dir.clone(),
-                node.mode,
-            )
+            GraphDeleteNode::new(empty_plan(), node.targets.clone(), false)
         );
         let mut first = DefaultHasher::new();
         let mut second = DefaultHasher::new();
@@ -2524,20 +2299,8 @@ mod tests {
 
         let set = set_node(lit(1_i64));
         let remove = remove_node();
-        let create = GraphCreateNode::new(
-            empty_plan(),
-            vec![],
-            vec![],
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Strict,
-        );
-        let delete = GraphDeleteNode::new(
-            empty_plan(),
-            vec![],
-            false,
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Strict,
-        );
+        let create = GraphCreateNode::new(empty_plan(), vec![], vec![]);
+        let delete = GraphDeleteNode::new(empty_plan(), vec![], false);
 
         assert_eq!(create.partial_cmp(&create), None);
         assert_eq!(delete.partial_cmp(&delete), None);
@@ -2658,20 +2421,8 @@ mod tests {
             "GraphMerge"
         );
 
-        let create = GraphCreateNode::new(
-            empty_plan(),
-            vec![],
-            vec![],
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Strict,
-        );
-        let delete = GraphDeleteNode::new(
-            empty_plan(),
-            vec![],
-            true,
-            PathBuf::from("/tmp/gf"),
-            OntologyMode::Strict,
-        );
+        let create = GraphCreateNode::new(empty_plan(), vec![], vec![]);
+        let delete = GraphDeleteNode::new(empty_plan(), vec![], true);
         let set = set_node(lit(1_i64));
         let remove = remove_node();
         for rendered in [

--- a/crates/graphforge-plan/src/literal_key.rs
+++ b/crates/graphforge-plan/src/literal_key.rs
@@ -1,0 +1,234 @@
+//! Plan-local literal equality. Public IR equality and serialization are unchanged.
+use graphforge_ir::IrLiteral;
+use std::hash::{Hash, Hasher};
+
+/// Signed zeros compare equally; NaNs are reflexive and retain their payload.
+fn float_key(value: f64) -> u64 {
+    if value == 0.0 { 0 } else { value.to_bits() }
+}
+
+fn sequence_eq<T>(left: &[T], right: &[T], eq: impl Fn(&T, &T) -> bool) -> bool {
+    left.len() == right.len() && left.iter().zip(right).all(|(a, b)| eq(a, b))
+}
+
+fn literal_eq(left: &IrLiteral, right: &IrLiteral) -> bool {
+    match (left, right) {
+        (IrLiteral::Float(a), IrLiteral::Float(b)) => float_key(*a) == float_key(*b),
+        (IrLiteral::List(a), IrLiteral::List(b)) => sequence_eq(a, b, literal_eq),
+        (IrLiteral::Map(a), IrLiteral::Map(b)) => properties_eq(a, b),
+        (IrLiteral::Spatial(a), IrLiteral::Spatial(b)) => {
+            a.spatial_type == b.spatial_type
+                && a.extension_name == b.extension_name
+                && a.extension_metadata == b.extension_metadata
+                && spatial_eq(&a.coordinates, &b.coordinates)
+        }
+        _ => left == right,
+    }
+}
+
+fn spatial_eq(
+    left: &graphforge_core::SpatialCoordinates,
+    right: &graphforge_core::SpatialCoordinates,
+) -> bool {
+    use graphforge_core::SpatialCoordinates::{
+        LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    };
+    let point = |a: &[f64; 2], b: &[f64; 2]| {
+        float_key(a[0]) == float_key(b[0]) && float_key(a[1]) == float_key(b[1])
+    };
+    let line = |a: &Vec<[f64; 2]>, b: &Vec<[f64; 2]>| sequence_eq(a, b, point);
+    let polygon = |a: &Vec<Vec<[f64; 2]>>, b: &Vec<Vec<[f64; 2]>>| sequence_eq(a, b, line);
+    match (left, right) {
+        (Point(a), Point(b)) => point(a, b),
+        (LineString(a), LineString(b)) | (MultiPoint(a), MultiPoint(b)) => line(a, b),
+        (Polygon(a), Polygon(b)) | (MultiLineString(a), MultiLineString(b)) => polygon(a, b),
+        (MultiPolygon(a), MultiPolygon(b)) => sequence_eq(a, b, polygon),
+        _ => false,
+    }
+}
+
+fn properties_eq(left: &[(String, IrLiteral)], right: &[(String, IrLiteral)]) -> bool {
+    sequence_eq(left, right, |(ak, av), (bk, bv)| {
+        ak == bk && literal_eq(av, bv)
+    })
+}
+
+/// Borrowed key avoids copying literal payloads during plan comparison/hashing.
+pub(crate) struct Properties<'a>(pub &'a [(String, IrLiteral)]);
+impl Eq for Properties<'_> {}
+impl PartialEq for Properties<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        properties_eq(self.0, other.0)
+    }
+}
+impl Hash for Properties<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        hash_props(self.0, state);
+    }
+}
+
+fn hash_literal<H: Hasher>(lit: &IrLiteral, state: &mut H) {
+    match lit {
+        IrLiteral::Null => 0u8.hash(state),
+        IrLiteral::Bool(b) => {
+            1u8.hash(state);
+            b.hash(state);
+        }
+        IrLiteral::Int(i) => {
+            2u8.hash(state);
+            i.hash(state);
+        }
+        IrLiteral::Float(f) => {
+            3u8.hash(state);
+            float_key(*f).hash(state);
+        }
+        IrLiteral::Str(s) => {
+            4u8.hash(state);
+            s.hash(state);
+        }
+        IrLiteral::Uuid(uuid) => {
+            14u8.hash(state);
+            uuid.hash(state);
+        }
+        IrLiteral::Duration {
+            months,
+            days,
+            seconds,
+            nanos,
+        } => {
+            5u8.hash(state);
+            months.hash(state);
+            days.hash(state);
+            seconds.hash(state);
+            nanos.hash(state);
+        }
+        IrLiteral::DateTime(t) => {
+            6u8.hash(state);
+            t.hash(state);
+        }
+        IrLiteral::Date(d) => {
+            7u8.hash(state);
+            d.hash(state);
+        }
+        IrLiteral::LocalDateTime { days, nanos } => {
+            8u8.hash(state);
+            days.hash(state);
+            nanos.hash(state);
+        }
+        IrLiteral::Time(n) => {
+            9u8.hash(state);
+            n.hash(state);
+        }
+        IrLiteral::ZonedTime { nanos, offset } => {
+            10u8.hash(state);
+            nanos.hash(state);
+            offset.hash(state);
+        }
+        IrLiteral::ZonedDateTime {
+            days,
+            nanos,
+            offset,
+            zone,
+        } => {
+            11u8.hash(state);
+            days.hash(state);
+            nanos.hash(state);
+            offset.hash(state);
+            zone.hash(state);
+        }
+        IrLiteral::Spatial(value) => {
+            15u8.hash(state);
+            value.spatial_type.hash(state);
+            value.extension_name.hash(state);
+            value.extension_metadata.hash(state);
+            hash_spatial_coordinates(&value.coordinates, state);
+        }
+        IrLiteral::List(items) => {
+            12u8.hash(state);
+            items.len().hash(state);
+            for it in items {
+                hash_literal(it, state);
+            }
+        }
+        IrLiteral::Map(entries) => {
+            13u8.hash(state);
+            entries.len().hash(state);
+            for (key, value) in entries {
+                key.hash(state);
+                hash_literal(value, state);
+            }
+        }
+    }
+}
+
+fn hash_spatial_coordinates<H: Hasher>(
+    coordinates: &graphforge_core::SpatialCoordinates,
+    state: &mut H,
+) {
+    use graphforge_core::SpatialCoordinates;
+    fn point<H: Hasher>(value: &[f64; 2], state: &mut H) {
+        float_key(value[0]).hash(state);
+        float_key(value[1]).hash(state);
+    }
+    match coordinates {
+        SpatialCoordinates::Point(value) => {
+            0u8.hash(state);
+            point(value, state);
+        }
+        SpatialCoordinates::LineString(values) => {
+            1u8.hash(state);
+            values.len().hash(state);
+            for value in values {
+                point(value, state);
+            }
+        }
+        SpatialCoordinates::Polygon(rings) => {
+            2u8.hash(state);
+            rings.len().hash(state);
+            for ring in rings {
+                ring.len().hash(state);
+                for value in ring {
+                    point(value, state);
+                }
+            }
+        }
+        SpatialCoordinates::MultiPoint(values) => {
+            3u8.hash(state);
+            values.len().hash(state);
+            for value in values {
+                point(value, state);
+            }
+        }
+        SpatialCoordinates::MultiLineString(lines) => {
+            4u8.hash(state);
+            lines.len().hash(state);
+            for line in lines {
+                line.len().hash(state);
+                for value in line {
+                    point(value, state);
+                }
+            }
+        }
+        SpatialCoordinates::MultiPolygon(polygons) => {
+            5u8.hash(state);
+            polygons.len().hash(state);
+            for polygon in polygons {
+                polygon.len().hash(state);
+                for ring in polygon {
+                    ring.len().hash(state);
+                    for value in ring {
+                        point(value, state);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn hash_props<H: Hasher>(props: &[(String, IrLiteral)], state: &mut H) {
+    props.len().hash(state);
+    for (k, v) in props {
+        k.hash(state);
+        hash_literal(v, state);
+    }
+}

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -526,7 +526,7 @@ impl<'a> GraphPlanLowerer<'a> {
             self.build_node_shapes(&plan.ops);
         let mut var_map = VarMap::new();
         self.lower_pipeline(&plan.ops, &plan.exprs, &mut var_map)
-            .and_then(|plan| self.attach_read_contract(plan))
+            .and_then(|plan| self.attach_graph_contract(plan))
             .map_err(|e| GfError::Plan(e.to_string()))
     }
 
@@ -561,7 +561,7 @@ impl<'a> GraphPlanLowerer<'a> {
         }
     }
 
-    fn attach_read_contract(&self, plan: LogicalPlan) -> Result<LogicalPlan, LoweringError> {
+    fn attach_graph_contract(&self, plan: LogicalPlan) -> Result<LogicalPlan, LoweringError> {
         use datafusion::common::tree_node::Transformed;
         let contract = self.read_contract();
         plan.transform_up_with_subqueries(|mut plan| {
@@ -577,6 +577,22 @@ impl<'a> GraphPlanLowerer<'a> {
                     }
                 }
                 LogicalPlan::Extension(extension) => {
+                    if let Some(node) = extension.node.as_any().downcast_ref::<GraphCreateNode>() {
+                        extension.node =
+                            Arc::new(node.clone().with_write_contract(Some(contract.clone())));
+                    }
+                    if let Some(node) = extension.node.as_any().downcast_ref::<GraphDeleteNode>() {
+                        extension.node =
+                            Arc::new(node.clone().with_write_contract(Some(contract.clone())));
+                    }
+                    if let Some(node) = extension.node.as_any().downcast_ref::<GraphSetNode>() {
+                        extension.node =
+                            Arc::new(node.clone().with_write_contract(Some(contract.clone())));
+                    }
+                    if let Some(node) = extension.node.as_any().downcast_ref::<GraphRemoveNode>() {
+                        extension.node =
+                            Arc::new(node.clone().with_write_contract(Some(contract.clone())));
+                    }
                     if let Some(node) = extension
                         .node
                         .as_any()
@@ -626,7 +642,7 @@ impl<'a> GraphPlanLowerer<'a> {
     ) -> Result<LogicalPlan, GfError> {
         *self.node_shapes.write().expect("node shapes lock poisoned") = self.build_node_shapes(ops);
         self.lower_pipeline(ops, exprs, var_map)
-            .and_then(|plan| self.attach_read_contract(plan))
+            .and_then(|plan| self.attach_graph_contract(plan))
             .map_err(|e| GfError::Plan(e.to_string()))
     }
 
@@ -645,7 +661,7 @@ impl<'a> GraphPlanLowerer<'a> {
             schema: input_schema,
         });
         self.lower_pipeline_from(ops, exprs, var_map, input, None)
-            .and_then(|plan| self.attach_read_contract(plan))
+            .and_then(|plan| self.attach_graph_contract(plan))
             .map_err(|e| GfError::Plan(e.to_string()))
     }
 
@@ -664,7 +680,7 @@ impl<'a> GraphPlanLowerer<'a> {
             schema: input_schema,
         });
         self.lower_pipeline_from(ops, exprs, var_map, input, Some(pending_nodes))
-            .and_then(|plan| self.attach_read_contract(plan))
+            .and_then(|plan| self.attach_graph_contract(plan))
             .map_err(|e| GfError::Plan(e.to_string()))
     }
 
@@ -2142,7 +2158,7 @@ impl<'a> GraphPlanLowerer<'a> {
         var_map: &mut VarMap,
         feeds_read: bool,
     ) -> Result<LogicalPlan, LoweringError> {
-        let (dir, mode) = self.write_target.ok_or_else(|| {
+        let (_dir, _mode) = self.write_target.ok_or_else(|| {
             LoweringError::UnsupportedExpr(
                 "CREATE requires a write target; lower via new_for_writes".into(),
             )
@@ -2169,24 +2185,17 @@ impl<'a> GraphPlanLowerer<'a> {
                 let v = VarId(spec.var);
                 var_map.insert(v, var_alias(v));
             }
-            let node = GraphCreateNode::new_emitting(
-                Arc::new(input),
-                nodes,
-                edges,
-                dir.to_path_buf(),
-                mode,
-                out_schema,
-            )
-            .with_semantic_composition_fingerprint(
-                self.catalog
-                    .and_then(GraphCatalog::semantic_composition_fingerprint),
-            );
+            let node = GraphCreateNode::new_emitting(Arc::new(input), nodes, edges, out_schema)
+                .with_semantic_composition_fingerprint(
+                    self.catalog
+                        .and_then(GraphCatalog::semantic_composition_fingerprint),
+                );
             return Ok(LogicalPlan::Extension(Extension {
                 node: Arc::new(node),
             }));
         }
 
-        let node = GraphCreateNode::new(Arc::new(input), nodes, edges, dir.to_path_buf(), mode)
+        let node = GraphCreateNode::new(Arc::new(input), nodes, edges)
             .with_semantic_composition_fingerprint(
                 self.catalog
                     .and_then(GraphCatalog::semantic_composition_fingerprint),
@@ -2334,7 +2343,7 @@ impl<'a> GraphPlanLowerer<'a> {
     ) -> Result<LogicalPlan, LoweringError> {
         use datafusion::common::TableReference;
 
-        let (dir, mode) = self.write_target.ok_or_else(|| {
+        let (_dir, _mode) = self.write_target.ok_or_else(|| {
             LoweringError::UnsupportedExpr(
                 "DELETE requires a write target; lower via new_for_writes".into(),
             )
@@ -2369,7 +2378,7 @@ impl<'a> GraphPlanLowerer<'a> {
             })
             .collect::<Result<_, LoweringError>>()?;
 
-        let node = GraphDeleteNode::new(Arc::new(input), targets, detach, dir.to_path_buf(), mode);
+        let node = GraphDeleteNode::new(Arc::new(input), targets, detach);
         Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(node),
         }))
@@ -2435,7 +2444,7 @@ impl<'a> GraphPlanLowerer<'a> {
         exprs: &ExprArena,
         var_map: &VarMap,
     ) -> Result<LogicalPlan, LoweringError> {
-        let (dir, mode) = self.write_target.ok_or_else(|| {
+        let (_dir, _mode) = self.write_target.ok_or_else(|| {
             LoweringError::UnsupportedExpr(
                 "SET requires a write target; lower via new_for_writes".into(),
             )
@@ -2459,13 +2468,7 @@ impl<'a> GraphPlanLowerer<'a> {
             })
             .collect::<Result<_, LoweringError>>()?;
 
-        let node = GraphSetNode::new(
-            Arc::new(input),
-            targets,
-            self.type_id_to_entity_name.clone(),
-            dir.to_path_buf(),
-            mode,
-        );
+        let node = GraphSetNode::new(Arc::new(input), targets);
         Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(node),
         }))
@@ -2478,7 +2481,7 @@ impl<'a> GraphPlanLowerer<'a> {
         items: &[RemovePropItem],
         input: LogicalPlan,
     ) -> Result<LogicalPlan, LoweringError> {
-        let (dir, mode) = self.write_target.ok_or_else(|| {
+        let (_dir, _mode) = self.write_target.ok_or_else(|| {
             LoweringError::UnsupportedExpr(
                 "REMOVE requires a write target; lower via new_for_writes".into(),
             )
@@ -2497,13 +2500,7 @@ impl<'a> GraphPlanLowerer<'a> {
             })
             .collect::<Result<_, LoweringError>>()?;
 
-        let node = GraphRemoveNode::new(
-            Arc::new(input),
-            targets,
-            self.type_id_to_entity_name.clone(),
-            dir.to_path_buf(),
-            mode,
-        );
+        let node = GraphRemoveNode::new(Arc::new(input), targets);
         Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(node),
         }))

--- a/docs/adr/0026-read-plan-resources.md
+++ b/docs/adr/0026-read-plan-resources.md
@@ -32,10 +32,10 @@ descriptors and read expressions against that session before executing them.
 Missing or incompatible bindings fail closed. Physical plans and owned streams
 retain their bound resources; another session cannot retarget them.
 
-Schema discovery remains in lowering for this slice. Mutation nodes retain their
-current seam until their own #1008 family lands. Existing operator names, Arrow
-schemas, checked-ID encodings and durable formats do not change. No durable plan
-serialization codec is introduced by this internal resource boundary.
+Schema discovery remains in lowering. The mutation family uses the same resource
+boundary with distinct write admission, as described below. Existing operator
+names, Arrow schemas, checked-ID encodings and durable formats do not change.
+No durable plan serialization codec is introduced by this internal resource boundary.
 
 ## Consequences
 
@@ -46,3 +46,30 @@ cover relocated complete plans, simultaneous bindings, retained streams, missing
 authority and incompatible schemas, as well as ordinary query parity and #1094
 bounded traversal. The change does not authorize eager graph scans to construct
 the execution context or a fallback to the working directory.
+
+## Mutation family completion (#1008)
+
+CREATE, DELETE, SET and REMOVE use the same deterministic current-graph role.
+Their logical nodes retain checked identities, expressions, output shape and
+semantic binding requirements. Paths, ontology mode and executable routing maps
+belong to an explicit execution-owned write context. Read authority alone does
+not grant write authority. Missing, read-only or incompatible write bindings fail
+before any mutation, including literal-only statements.
+
+The existing statement driver remains the owner of ordering, buffered visibility,
+commit/rollback and write receipts, including MERGE. Physical extension planning
+and the driver share the admitted session authority; neither recovers a target
+from a logical node. Runtime ID/name mappings used during lowering are semantic
+assumptions to validate, rather than an executable provider registry.
+
+All logical extension equality and hashing use their semantic content. Literal
+and computed property distinctions, composition fingerprints, and output modes
+remain significant; filesystem placement and execution policy do not. This does
+not introduce a persisted plan codec or change public Arrow/IR encodings.
+
+Mutation literal keys normalize signed zero and make NaNs reflexive while
+preserving their payload bits, recursively through lists, maps and spatial
+coordinates. Computed expressions retain DataFusion's own equality/hash contract.
+This policy is local to logical plans; public literal equality and serialization
+are unchanged. All eleven extension nodes derive equality and hashing, with the
+shared literal adapter confined to resolved mutation specifications.


### PR DESCRIPTION
CREATE, DELETE, SET and REMOVE plans now carry semantic write specifications and binding contracts while an explicit execution-owned context supplies the selected destination, policy and routing maps. All four physical constructors and the literal/mixed statement driver reject missing, read-only or incompatible authority. Read-only EXPLAIN remains a private, side-effect-free text-rendering operation.

This completes the mutation family following the merged read family. All eleven logical extension nodes derive equality and hashing; a shared borrowed literal adapter fixes signed-zero hash consistency and reflexive NaN equality without changing public IR equality or serialization. Existing operator/explain names and durable formats are preserved. ADR 0026 records the completed context boundary.

Validation on the combined codec + mutation head:

- Full plan/rel/exec unit and integration batch passed, including 15 unchanged logical goldens, actual four-op full-plan relocation/selected writes, retained streams, direct-constructor mismatches, missing/read-only entry points, cache/reset and traversal tests.
- All 16 write tests and 28 plan tests passed, including mixed CREATE→SET→MERGE visibility, receipt and late-failure rollback.
- The read-only facade write-EXPLAIN/actual-write-rejection regression passed. The pre-rebase full API unit cohort of 688 tests also passed, with the corrected new test verified independently.
- Full API BDD 118/118 and openCypher TCK 3897/3897 passed. Advisory TCK timing warnings remain under concurrent host validation; no performance claim.
- Changed-crate clippy with warnings denied, formatting, `make pre-push-fast`, Cargo/Bazel drift and gate registry checks passed. Exact-head integration CI remains required.

Closes #1008
