### PR TITLE
refactor(rel): supply lowering with schema and catalog snapshots

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3315,15 +3315,14 @@ impl GraphForge {
             let explained = if needs_writes {
                 graphforge_rel::explain_logical_for_writes(
                     &plan,
-                    Some(&catalog),
+                    &catalog.lowering_snapshot(Some(&self.dir))?,
                     self.ontology.as_ref(),
-                    &self.dir,
                     self.ontology_mode,
                 )
             } else {
                 graphforge_rel::explain_logical_with_catalog(
                     &plan,
-                    Some(&catalog),
+                    Some(&catalog.lowering_snapshot(None)?),
                     self.ontology.as_ref(),
                 )
             };

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5308,9 +5308,8 @@ impl ExecutionSession {
         // catalog). Without it, edges are written with a `_UNKNOWN` relation
         // name and a later `MATCH ()-[:REL]->()` filter never matches.
         let lowerer = GraphPlanLowerer::new_for_writes(
-            Some(&self.catalog),
+            &graphforge_storage::lowering_snapshot(Some(&self.catalog), Some(&resource.dir))?,
             self.ontology.as_ref(),
-            &resource.dir,
             resource.mode,
         )?;
         let logical = bind_query_params(lowerer.lower_plan(plan)?, params)?;
@@ -5461,9 +5460,8 @@ impl ExecutionSession {
             .map_err(GfError::from_plan_error)?;
         let split = write_driver::split_write_plan(&plan.ops)?;
         let lowerer = GraphPlanLowerer::new_for_writes(
-            Some(&self.catalog),
+            &graphforge_storage::lowering_snapshot(Some(&self.catalog), Some(&resource.dir))?,
             self.ontology.as_ref(),
-            &resource.dir,
             resource.mode,
         )?;
 
@@ -5924,9 +5922,8 @@ impl ExecutionSession {
                 ));
             }
             let lowerer = GraphPlanLowerer::new_for_writes(
-                Some(&self.catalog),
+                &graphforge_storage::lowering_snapshot(Some(&self.catalog), Some(&self.dir))?,
                 self.ontology.as_ref(),
-                &self.dir,
                 self.mode,
             )?;
             let logical = lowerer.lower_plan(plan)?;
@@ -5970,12 +5967,17 @@ impl ExecutionSession {
                         .into(),
                 ));
             }
-            GraphPlanLowerer::new(Some(&self.catalog), self.ontology.as_ref())?
-        } else {
-            GraphPlanLowerer::new_with_dir(
-                Some(&self.catalog),
+            GraphPlanLowerer::new(
+                Some(&graphforge_storage::lowering_snapshot(
+                    Some(&self.catalog),
+                    None,
+                )?),
                 self.ontology.as_ref(),
-                &self.dir,
+            )?
+        } else {
+            GraphPlanLowerer::new_for_reads(
+                &graphforge_storage::lowering_snapshot(Some(&self.catalog), Some(&self.dir))?,
+                self.ontology.as_ref(),
                 self.mode,
             )?
         };
@@ -6012,7 +6014,7 @@ impl ExecutionSession {
 }
 
 fn lower_write_terminal_suffix(
-    lowerer: &GraphPlanLowerer<'_>,
+    lowerer: &GraphPlanLowerer,
     plan: &GraphPlan,
     start: Option<usize>,
     frontier: &write_driver::Frontier,
@@ -6037,7 +6039,7 @@ fn lower_write_terminal_suffix(
 #[allow(clippy::too_many_arguments)]
 async fn run_write_relational_segment(
     session: &SessionContext,
-    lowerer: &GraphPlanLowerer<'_>,
+    lowerer: &GraphPlanLowerer,
     plan: &GraphPlan,
     range: std::ops::Range<usize>,
     frontier: &mut write_driver::Frontier,
@@ -6799,9 +6801,12 @@ mod tests {
         let mut runtime = RuntimeCatalog::new();
         runtime.intern_label("DestinationMeaning").unwrap();
         let catalog = GraphCatalog::open(dir.path(), None, &runtime).unwrap();
-        let mut contract = GraphPlanLowerer::new(Some(&catalog), None)
-            .unwrap()
-            .read_contract();
+        let mut contract = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap()
+        .read_contract();
         assert_eq!(contract.labels.len(), 1);
         contract.labels[0].1 = "DifferentMeaning".into();
         let contract = Some(contract);

--- a/crates/graphforge-exec/src/read_resource.rs
+++ b/crates/graphforge-exec/src/read_resource.rs
@@ -22,10 +22,15 @@ impl GraphReadContext {
         contract: Option<&graphforge_plan::GraphReadContract>,
     ) -> Result<()> {
         if let Some(contract) = contract {
-            let actual =
-                graphforge_rel::GraphPlanLowerer::new(Some(&self.catalog), self.ontology.as_ref())
-                    .map_err(|e| DataFusionError::Plan(e.to_string()))?
-                    .read_contract();
+            let actual = graphforge_rel::GraphPlanLowerer::new(
+                Some(
+                    &graphforge_storage::lowering_snapshot(Some(&self.catalog), None)
+                        .map_err(|e| DataFusionError::Plan(e.to_string()))?,
+                ),
+                self.ontology.as_ref(),
+            )
+            .map_err(|e| DataFusionError::Plan(e.to_string()))?
+            .read_contract();
             if *contract != actual {
                 return Err(DataFusionError::Plan(
                     "GF_READ_RESOURCE_INCOMPATIBLE: logical identities".into(),
@@ -109,8 +114,14 @@ pub(crate) fn bind(
     let contract = resource
         .as_ref()
         .map(|r| {
-            graphforge_rel::GraphPlanLowerer::new(Some(&r.catalog), r.ontology.as_ref())
-                .map(|l| l.read_contract())
+            graphforge_rel::GraphPlanLowerer::new(
+                Some(&graphforge_storage::lowering_snapshot(
+                    Some(&r.catalog),
+                    None,
+                )?),
+                r.ontology.as_ref(),
+            )
+            .map(|l| l.read_contract())
         })
         .transpose()
         .map_err(|e| DataFusionError::Plan(e.to_string()))?;

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -1347,7 +1347,7 @@ impl CreateRecorder {
 
 /// Everything the phases borrow from the session.
 pub(crate) struct PhaseEnv<'a> {
-    pub lowerer: &'a GraphPlanLowerer<'a>,
+    pub lowerer: &'a GraphPlanLowerer,
     pub exprs: &'a ExprArena,
     pub dir: &'a Path,
     pub mode: OntologyMode,
@@ -4199,7 +4199,7 @@ mod tests {
     }
 
     fn phase_env<'a>(
-        lowerer: &'a GraphPlanLowerer<'a>,
+        lowerer: &'a GraphPlanLowerer,
         exprs: &'a ExprArena,
         dir: &'a Path,
         params: &'a HashMap<String, IrLiteral>,
@@ -4218,9 +4218,12 @@ mod tests {
     fn set_accumulates_nodes_and_edges_once_across_duplicate_and_null_rows() {
         for is_edge in [false, true] {
             let dir = tempfile::tempdir().unwrap();
-            let lowerer =
-                GraphPlanLowerer::new_for_writes(None, None, dir.path(), OntologyMode::Exploratory)
-                    .unwrap();
+            let lowerer = GraphPlanLowerer::new_for_writes(
+                &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+                None,
+                OntologyMode::Exploratory,
+            )
+            .unwrap();
             let mut exprs = ExprArena::new();
             let value = exprs.push(IrExpr::Literal(IrLiteral::Int(42)));
             let params = HashMap::new();
@@ -4265,9 +4268,12 @@ mod tests {
     fn remove_accumulates_nodes_and_edges_and_ignores_null_optional_rows() {
         for is_edge in [false, true] {
             let dir = tempfile::tempdir().unwrap();
-            let lowerer =
-                GraphPlanLowerer::new_for_writes(None, None, dir.path(), OntologyMode::Exploratory)
-                    .unwrap();
+            let lowerer = GraphPlanLowerer::new_for_writes(
+                &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+                None,
+                OntologyMode::Exploratory,
+            )
+            .unwrap();
             let exprs = ExprArena::new();
             let params = HashMap::new();
             let env = phase_env(&lowerer, &exprs, dir.path(), &params);
@@ -4311,9 +4317,12 @@ mod tests {
     #[test]
     fn set_and_remove_reject_malformed_identity_and_edge_routing_columns() {
         let dir = tempfile::tempdir().unwrap();
-        let lowerer =
-            GraphPlanLowerer::new_for_writes(None, None, dir.path(), OntologyMode::Exploratory)
-                .unwrap();
+        let lowerer = GraphPlanLowerer::new_for_writes(
+            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            None,
+            OntologyMode::Exploratory,
+        )
+        .unwrap();
         let mut exprs = ExprArena::new();
         let value = exprs.push(IrExpr::Literal(IrLiteral::Int(42)));
         let params = HashMap::new();
@@ -4462,9 +4471,12 @@ mod tests {
         assert!(error.to_string().contains("known relation type"));
 
         let dir = tempfile::tempdir().unwrap();
-        let lowerer =
-            GraphPlanLowerer::new_for_writes(None, None, dir.path(), OntologyMode::Exploratory)
-                .unwrap();
+        let lowerer = GraphPlanLowerer::new_for_writes(
+            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            None,
+            OntologyMode::Exploratory,
+        )
+        .unwrap();
         let exprs = ExprArena::new();
         let params = HashMap::new();
         let env = phase_env(&lowerer, &exprs, dir.path(), &params);

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -4219,7 +4219,18 @@ mod tests {
         for is_edge in [false, true] {
             let dir = tempfile::tempdir().unwrap();
             let lowerer = GraphPlanLowerer::new_for_writes(
-                &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+                &graphforge_storage::lowering_snapshot(
+                    Some(
+                        &graphforge_storage::GraphCatalog::open(
+                            dir.path(),
+                            None,
+                            &graphforge_ir::RuntimeCatalog::new(),
+                        )
+                        .unwrap(),
+                    ),
+                    Some(dir.path()),
+                )
+                .unwrap(),
                 None,
                 OntologyMode::Exploratory,
             )
@@ -4269,7 +4280,18 @@ mod tests {
         for is_edge in [false, true] {
             let dir = tempfile::tempdir().unwrap();
             let lowerer = GraphPlanLowerer::new_for_writes(
-                &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+                &graphforge_storage::lowering_snapshot(
+                    Some(
+                        &graphforge_storage::GraphCatalog::open(
+                            dir.path(),
+                            None,
+                            &graphforge_ir::RuntimeCatalog::new(),
+                        )
+                        .unwrap(),
+                    ),
+                    Some(dir.path()),
+                )
+                .unwrap(),
                 None,
                 OntologyMode::Exploratory,
             )
@@ -4318,7 +4340,18 @@ mod tests {
     fn set_and_remove_reject_malformed_identity_and_edge_routing_columns() {
         let dir = tempfile::tempdir().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
-            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            &graphforge_storage::lowering_snapshot(
+                Some(
+                    &graphforge_storage::GraphCatalog::open(
+                        dir.path(),
+                        None,
+                        &graphforge_ir::RuntimeCatalog::new(),
+                    )
+                    .unwrap(),
+                ),
+                Some(dir.path()),
+            )
+            .unwrap(),
             None,
             OntologyMode::Exploratory,
         )
@@ -4472,7 +4505,18 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
-            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            &graphforge_storage::lowering_snapshot(
+                Some(
+                    &graphforge_storage::GraphCatalog::open(
+                        dir.path(),
+                        None,
+                        &graphforge_ir::RuntimeCatalog::new(),
+                    )
+                    .unwrap(),
+                ),
+                Some(dir.path()),
+            )
+            .unwrap(),
             None,
             OntologyMode::Exploratory,
         )

--- a/crates/graphforge-exec/src/write_resource.rs
+++ b/crates/graphforge-exec/src/write_resource.rs
@@ -77,7 +77,10 @@ pub(crate) fn required(
         .validate(contract)
         .map_err(|e| DataFusionError::Plan(format!("GF_WRITE_RESOURCE_INCOMPATIBLE: {e}")))?;
     let lowerer = graphforge_rel::GraphPlanLowerer::new(
-        Some(&binding.resource.catalog),
+        Some(
+            &graphforge_storage::lowering_snapshot(Some(&binding.resource.catalog), None)
+                .map_err(|e| DataFusionError::Plan(e.to_string()))?,
+        ),
         binding.resource.ontology.as_ref(),
     )
     .map_err(|e| DataFusionError::Plan(e.to_string()))?;

--- a/crates/graphforge-exec/tests/read_execution.rs
+++ b/crates/graphforge-exec/tests/read_execution.rs
@@ -248,6 +248,7 @@ async fn logical_read_resources_relocate_and_bind_independently() {
         "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.name AS name",
         "MATCH (a:Person)-[:KNOWS*1..2]->(b:Person) RETURN b.name AS name",
         "MATCH p=(a:Person)-[:KNOWS*1..2]->(b) RETURN nodes(p)[1].name AS name",
+        "MATCH p=(a:Person)-[:KNOWS*1..2]->(b) RETURN [n IN nodes(p) | n.name][1] AS name",
     ] {
         let ir = bind(query, rc.clone());
         let left_catalog = GraphCatalog::open(left.path(), None, &rc.lock().unwrap()).unwrap();
@@ -256,15 +257,21 @@ async fn logical_read_resources_relocate_and_bind_independently() {
         let right_session = session_with(right.path(), &rc.lock().unwrap());
 
         let lower = |catalog: &GraphCatalog, root: &std::path::Path| {
-            graphforge_rel::GraphPlanLowerer::new_with_dir(
-                Some(catalog),
+            let snapshot =
+                graphforge_storage::lowering_snapshot(Some(catalog), Some(root)).unwrap();
+            // Compilation must use the immutable snapshot even when its source
+            // has disappeared. Restore it only for independent execution binding.
+            let unavailable = root.with_extension("unavailable");
+            std::fs::rename(root, &unavailable).unwrap();
+            let lowered = graphforge_rel::GraphPlanLowerer::new_for_reads(
+                &snapshot,
                 None,
-                root,
                 OntologyMode::Exploratory,
             )
             .unwrap()
-            .lower_plan(&ir)
-            .unwrap()
+            .lower_plan(&ir);
+            std::fs::rename(&unavailable, root).unwrap();
+            lowered.unwrap()
         };
         let plan = lower(&left_catalog, left.path());
         let relocated = lower(&right_catalog, right.path());

--- a/crates/graphforge-exec/tests/write_statement.rs
+++ b/crates/graphforge-exec/tests/write_statement.rs
@@ -455,9 +455,8 @@ async fn mutation_plans_relocate_and_bind_only_selected_write_resources() {
         let lower = |root: &Path| {
             let catalog = GraphCatalog::open(root, None, &rt.lock().unwrap()).unwrap();
             graphforge_rel::GraphPlanLowerer::new_for_writes(
-                Some(&catalog),
+                &graphforge_storage::lowering_snapshot(Some(&catalog), Some(root)).unwrap(),
                 None,
-                root,
                 OntologyMode::Exploratory,
             )
             .unwrap()

--- a/crates/graphforge-ir/src/lib.rs
+++ b/crates/graphforge-ir/src/lib.rs
@@ -521,3 +521,6 @@ mod tests {
         assert!(p.nodes.is_empty() && p.edges.is_empty());
     }
 }
+
+pub mod lowering_snapshot;
+pub use lowering_snapshot::LoweringSnapshot;

--- a/crates/graphforge-ir/src/lowering_snapshot.rs
+++ b/crates/graphforge-ir/src/lowering_snapshot.rs
@@ -1,0 +1,92 @@
+//! Immutable schema and catalog facts consumed by relational lowering.
+//!
+//! This value contains no filesystem paths, providers, or graph rows. Storage
+//! constructs it before compilation; execution independently admits resources.
+use arrow::datatypes::SchemaRef;
+use graphforge_value::{
+    EntityTypeId, PropertyId, RelationTypeId, RuntimeEntityId, RuntimeRelationId,
+};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+/// Schema/catalog data for one compilation snapshot.
+#[derive(Debug, Clone, Default)]
+pub struct LoweringSnapshot {
+    /// Checked property identity to display name.
+    pub property_names: HashMap<PropertyId, String>,
+    /// Checked runtime entity identities, separate from ontology IDs.
+    pub runtime_labels: HashMap<RuntimeEntityId, String>,
+    /// Checked runtime relation identities, separate from ontology IDs.
+    pub runtime_relations: HashMap<RuntimeRelationId, String>,
+    /// Semantic relation identities to opaque route stems.
+    pub semantic_relations: HashMap<RelationTypeId, String>,
+    /// Semantic entity identities to opaque property route stems.
+    pub semantic_labels: HashMap<EntityTypeId, String>,
+    /// Semantic entity identities to qualified display names.
+    pub semantic_display_labels: HashMap<EntityTypeId, String>,
+    /// Semantic composition fingerprint, when one is bound.
+    pub composition: Option<String>,
+    /// Dataset topology schema; absent in schema-only snapshots.
+    pub node_schema: Option<SchemaRef>,
+    /// Ordered discovered node routes used by wildcard/path schema unions.
+    pub node_property_stems: Vec<String>,
+    /// Ordered discovered edge routes used by wildcard schema unions.
+    pub edge_property_stems: Vec<String>,
+    /// Node property schemas, including catalog-backed selected routes.
+    pub node_properties: BTreeMap<String, SchemaRef>,
+    /// Edge property schemas, including catalog-backed selected routes.
+    pub edge_properties: BTreeMap<String, SchemaRef>,
+    /// Authenticated semantic edge schemas by checked relation identity.
+    pub semantic_edges: HashMap<RelationTypeId, SchemaRef>,
+    /// Authenticated semantic property schemas by relation identity.
+    pub semantic_edge_properties: HashMap<RelationTypeId, SchemaRef>,
+    /// Names of registered typed edge tables.
+    pub typed_edge_tables: HashSet<String>,
+}
+
+impl LoweringSnapshot {
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn prop_names(&self) -> &HashMap<PropertyId, String> {
+        &self.property_names
+    }
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn label_names(&self) -> &HashMap<RuntimeEntityId, String> {
+        &self.runtime_labels
+    }
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn rel_names(&self) -> &HashMap<RuntimeRelationId, String> {
+        &self.runtime_relations
+    }
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn semantic_rel_routes(&self) -> &HashMap<RelationTypeId, String> {
+        &self.semantic_relations
+    }
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn semantic_label_routes(&self) -> &HashMap<EntityTypeId, String> {
+        &self.semantic_labels
+    }
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn semantic_label_names(&self) -> &HashMap<EntityTypeId, String> {
+        &self.semantic_display_labels
+    }
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn semantic_composition_fingerprint(&self) -> Option<&str> {
+        self.composition.as_deref()
+    }
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn semantic_edge_schema(&self, id: RelationTypeId) -> Option<SchemaRef> {
+        self.semantic_edges.get(&id).cloned()
+    }
+    /// Borrow or clone the corresponding immutable catalog fact.
+    #[must_use]
+    pub fn semantic_edge_property_schema(&self, id: RelationTypeId) -> Option<SchemaRef> {
+        self.semantic_edge_properties.get(&id).cloned()
+    }
+}

--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -597,8 +597,15 @@ impl<'a> ExprLowerer<'a> {
                         CYPHER_REVERSE.call(vec![arg.clone()])
                     });
                 }
-                resolve_builtin(name, lowered, || self.path_node_hydration())
-                    .ok_or_else(|| LoweringError::UnknownFunction(name.clone()))
+                resolve_builtin(name, lowered, {
+                    let hydration = if name.eq_ignore_ascii_case("_path_nodes") {
+                        self.path_node_hydration()?
+                    } else {
+                        None
+                    };
+                    || hydration
+                })
+                .ok_or_else(|| LoweringError::UnknownFunction(name.clone()))
             }
 
             IrExpr::Parameter(name) => Ok(DfExpr::Placeholder(Placeholder {
@@ -1407,8 +1414,15 @@ impl<'a> ExprLowerer<'a> {
             .iter()
             .map(|&a| self.lower(a))
             .collect::<Result<_, _>>()?;
-        resolve_builtin(name, lowered, || self.path_node_hydration())
-            .ok_or_else(|| LoweringError::UnknownFunction(name.to_string()))
+        resolve_builtin(name, lowered, {
+            let hydration = if name.eq_ignore_ascii_case("_path_nodes") {
+                self.path_node_hydration()?
+            } else {
+                None
+            };
+            || hydration
+        })
+        .ok_or_else(|| LoweringError::UnknownFunction(name.to_string()))
     }
 
     /// Resolve a `date(<arg>)` argument to constant i64 epoch-days when the
@@ -3174,9 +3188,11 @@ impl<'a> ExprLowerer<'a> {
     /// occurrence of a name wins, forced nullable — a node without the column
     /// is NULL). `None` without a read target (schema-only lowering), keeping
     /// the UDF's original `node_uuid`-only shape.
-    fn path_node_hydration(&self) -> Option<PathNodeHydration> {
+    fn path_node_hydration(&self) -> Result<Option<PathNodeHydration>, LoweringError> {
         use datafusion::arrow::datatypes::Field;
-        let dir = self.read_target.as_ref()?;
+        let Some(dir) = self.read_target.as_ref() else {
+            return Ok(None);
+        };
         let stems = dir.node_property_stems.clone();
         let mut fields = vec![
             Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
@@ -3185,7 +3201,11 @@ impl<'a> ExprLowerer<'a> {
         let mut seen: std::collections::HashSet<String> =
             fields.iter().map(|f| f.name().clone()).collect();
         for stem in &stems {
-            let table = &dir.node_properties[stem];
+            let table = dir.node_properties.get(stem).ok_or_else(|| {
+                LoweringError::UnsupportedExpr(format!(
+                    "lowering snapshot missing node property schema for stem {stem}"
+                ))
+            })?;
             for f in table.fields() {
                 if f.name() == "node_uuid" || !seen.insert(f.name().clone()) {
                     continue;
@@ -3203,12 +3223,12 @@ impl<'a> ExprLowerer<'a> {
                 .cmp(&right.encode())
                 .then_with(|| left_name.cmp(right_name))
         });
-        Some(PathNodeHydration {
+        Ok(Some(PathNodeHydration {
             dir: None,
             labels_by_type,
             prop_stems: stems,
             fields: fields.into(),
-        })
+        }))
     }
 }
 
@@ -15202,6 +15222,32 @@ mod tests {
             s.contains("var_0.node_uuid"),
             "seed is the uuid column: {s}"
         );
+    }
+
+    #[test]
+    fn path_nodes_rejects_snapshot_missing_discovered_schema() {
+        for name in ["_path_nodes", "_PATH_NODES"] {
+            let mut arena = ExprArena::new();
+            let mut vm = VarMap::new();
+            vm.insert(VarId(0), "var_0");
+            vm.insert(VarId(1), "var_1.rels");
+            let start = arena.push(IrExpr::VarRef(VarId(0)));
+            let rels = arena.push(IrExpr::VarRef(VarId(1)));
+            let id = arena.push(IrExpr::FunctionCall {
+                name: name.into(),
+                args: vec![start, rels],
+            });
+            let snapshot = graphforge_ir::LoweringSnapshot {
+                node_property_stems: vec!["missing".into()],
+                ..Default::default()
+            };
+            let error = make_lowerer(&arena, &vm)
+                .with_read_target(snapshot)
+                .lower(id)
+                .unwrap_err();
+            assert!(matches!(error, LoweringError::UnsupportedExpr(ref message)
+            if message == "lowering snapshot missing node property schema for stem missing"));
+        }
     }
 
     /// A 16-byte uuid stand-in: byte `b` repeated.

--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -138,12 +138,9 @@ pub struct ExprLowerer<'a> {
     /// a single struct column, not a table whose fields are top-level columns.
     /// Empty elsewhere; its length is the current nesting depth.
     elem_struct_cols: Vec<String>,
-    /// The project directory for read-side lowering, when one is attached
-    /// (#1024): lets `nodes(p)` bake a hydrating `cypher_path_nodes` whose
-    /// elements carry labels + the property union discovered from
-    /// `properties/*.parquet`. `None` in schema-only/explain lowering — the
-    /// UDF then keeps its `node_uuid`-only shape.
-    read_target: Option<std::path::PathBuf>,
+    /// Immutable dataset schemas used to describe hydrated `nodes(p)` values.
+    /// Schema-only explanation retains the original UUID-only shape.
+    read_target: Option<graphforge_ir::LoweringSnapshot>,
     /// Wall-clock instant captured ONCE per lowering (lazily, on first use) so all
     /// zero-arg current-time constructors — `date()`/`localtime()`/…/`datetime()`
     /// — in one query fold to the SAME value, making
@@ -262,10 +259,9 @@ impl<'a> ExprLowerer<'a> {
         self
     }
 
-    /// Attach the project directory for read-side lowering, so `nodes(p)` bakes
-    /// a hydrating `cypher_path_nodes` (labels + property union, #1024).
+    /// Attach immutable dataset schemas for the logical `nodes(p)` output.
     #[must_use]
-    pub fn with_read_target(mut self, dir: std::path::PathBuf) -> Self {
+    pub fn with_read_target(mut self, dir: graphforge_ir::LoweringSnapshot) -> Self {
         self.read_target = Some(dir);
         self
     }
@@ -3181,7 +3177,7 @@ impl<'a> ExprLowerer<'a> {
     fn path_node_hydration(&self) -> Option<PathNodeHydration> {
         use datafusion::arrow::datatypes::Field;
         let dir = self.read_target.as_ref()?;
-        let stems = graphforge_storage::list_property_stems(dir);
+        let stems = dir.node_property_stems.clone();
         let mut fields = vec![
             Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
             Field::new("labels", DataType::new_list(DataType::Utf8, true), true),
@@ -3189,8 +3185,8 @@ impl<'a> ExprLowerer<'a> {
         let mut seen: std::collections::HashSet<String> =
             fields.iter().map(|f| f.name().clone()).collect();
         for stem in &stems {
-            let table = graphforge_storage::PropertyTable::open_discovered(dir, stem);
-            for f in table.schema_ref().fields() {
+            let table = &dir.node_properties[stem];
+            for f in table.fields() {
                 if f.name() == "node_uuid" || !seen.insert(f.name().clone()) {
                     continue;
                 }

--- a/crates/graphforge-rel/src/lib.rs
+++ b/crates/graphforge-rel/src/lib.rs
@@ -68,7 +68,7 @@ pub fn explain_logical_with(
 }
 
 /// Like [`explain_logical_with`] but also threads a
-/// [`GraphCatalog`](graphforge_storage::GraphCatalog) so property accesses (e.g.
+/// [`GraphCatalog`](graphforge_ir::LoweringSnapshot) so property accesses (e.g.
 /// `n.name`) resolve to their column names via the catalog's `PropId → name`
 /// map instead of falling back to `prop_<id>` placeholders. Used by the engine
 /// facade's `explain`, which lowers against the instance's runtime catalog.
@@ -78,7 +78,7 @@ pub fn explain_logical_with(
 /// Returns [`GfError`] if the plan cannot be lowered.
 pub fn explain_logical_with_catalog(
     plan: &GraphPlan,
-    catalog: Option<&graphforge_storage::GraphCatalog>,
+    catalog: Option<&graphforge_ir::LoweringSnapshot>,
     ontology: Option<&OntologyHandle>,
 ) -> Result<String, GfError> {
     let lowered = GraphPlanLowerer::new(catalog, ontology)?.lower_plan(plan)?;
@@ -96,13 +96,11 @@ pub fn explain_logical_with_catalog(
 /// Returns [`GfError`] if the plan cannot be lowered.
 pub fn explain_logical_for_writes(
     plan: &GraphPlan,
-    catalog: Option<&graphforge_storage::GraphCatalog>,
+    snapshot: &graphforge_ir::LoweringSnapshot,
     ontology: Option<&OntologyHandle>,
-    dir: &std::path::Path,
     mode: graphforge_core::OntologyMode,
 ) -> Result<String, GfError> {
-    let lowered =
-        GraphPlanLowerer::new_for_writes(catalog, ontology, dir, mode)?.lower_plan(plan)?;
+    let lowered = GraphPlanLowerer::new_for_writes(snapshot, ontology, mode)?.lower_plan(plan)?;
     let ctx = datafusion::prelude::SessionContext::new();
     let final_plan = ctx.state().optimize(&lowered).unwrap_or(lowered);
     Ok(final_plan.display_indent_schema().to_string())

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -25,8 +25,8 @@
 //! Graph-native operators (#578) lower to `graphforge-plan` logical stub nodes wrapped
 //! as [`LogicalPlan::Extension`]; their physical execution is deferred to physical execution.
 
+use graphforge_ir::LoweringSnapshot;
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
 use std::sync::Arc;
 
 use datafusion::arrow::record_batch::RecordBatch;
@@ -51,9 +51,7 @@ use graphforge_plan::{
     OptionalMatchNode, RemoveTarget, ResolvedEdgeSpec, ResolvedNodeSpec, SetTarget, UnwindNode,
     VarLenExpandNode,
 };
-use graphforge_storage::{
-    EXPLORATORY_EDGE_SCHEMA, GraphCatalog, TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA,
-};
+use graphforge_storage::{EXPLORATORY_EDGE_SCHEMA, TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA};
 use graphforge_value::{EntityTypeId, PropertyId, RelationTypeId};
 
 use crate::LogicalPlan;
@@ -85,28 +83,21 @@ impl<T, E: std::fmt::Display> MapUnsupportedExpr<T> for Result<T, E> {
 /// [`lower_plan`](Self::lower_plan) (processes the full pipeline) or
 /// [`lower_op`](Self::lower_op) (processes a single operator given an
 /// existing input plan).
-pub struct GraphPlanLowerer<'a> {
+pub struct GraphPlanLowerer {
     /// The catalog used by scan operators. `None` when called from
     /// `lower()` without a catalog (scan ops return an error). Also the source
     /// of the `PropId → name` map used to resolve property accesses.
-    catalog: Option<&'a GraphCatalog>,
+    catalog: Option<LoweringSnapshot>,
     /// Reverse map: `TypeId.0` → relation type name.
     /// Populated at construction from the ontology; empty in exploratory mode.
     type_id_to_rel_name: HashMap<RelationTypeId, String>,
     /// Reverse map: `TypeId.0` → entity (label) name.
     /// Populated at construction from the ontology; empty in exploratory mode.
     type_id_to_entity_name: HashMap<EntityTypeId, String>,
-    /// Write target for `CREATE`/`MERGE` lowering: the project directory and
-    /// ontology mode.  Set **only** by [`new_for_writes`](Self::new_for_writes)
-    /// — this is the gate that authorizes the write path.  `None` for read
-    /// lowering (`CREATE` then errors).
-    write_target: Option<(&'a Path, OntologyMode)>,
-    /// Read-side project directory + mode, for read operators that must touch
-    /// the on-disk store — variable-length `Expand` bakes this into its
-    /// physical node to read edges.  Set by [`new_with_dir`](Self::new_with_dir)
-    /// **and** implied by a write target.  Crucially this does **not** authorize
-    /// writes, keeping the read/write separation intact.
-    read_dir: Option<(&'a Path, OntologyMode)>,
+    /// Whether compilation permits write operators; execution separately admits authority.
+    write_target: bool,
+    /// Dataset schema facts and compile-time layout policy. No source path is retained.
+    read_snapshot: Option<(LoweringSnapshot, OntologyMode)>,
     /// `VarId.0 → NodeShape`, seeded once per `lower_plan` from the plan's
     /// `NodeScan`s for bare-node-value materialization (#785). Interior
     /// mutability so the `&self` lowering pass can populate it.
@@ -123,10 +114,10 @@ pub struct GraphPlanLowerer<'a> {
     relational_fixed_hop_reference: bool,
 }
 
-impl<'a> GraphPlanLowerer<'a> {
+impl GraphPlanLowerer {
     /// Create a new lowerer for read/query plans.
     ///
-    /// - `catalog`: the [`GraphCatalog`] used by scan operators, or `None`
+    /// - `catalog`: the [`LoweringSnapshot`] used by scan operators, or `None`
     ///   when no catalog is available (scan ops will return an error).
     /// - `ontology`: the compiled ontology, or `None` in exploratory mode.
     ///
@@ -134,49 +125,43 @@ impl<'a> GraphPlanLowerer<'a> {
     /// [`new_for_writes`](Self::new_for_writes) instead.
     /// Returns a validation error if a supplied runtime carries an invalid declared identity.
     pub fn new(
-        catalog: Option<&'a GraphCatalog>,
-        ontology: Option<&'a OntologyHandle>,
+        catalog: Option<&LoweringSnapshot>,
+        ontology: Option<&OntologyHandle>,
     ) -> Result<Self, GfError> {
         Self::build(catalog, ontology, None, None)
     }
 
-    /// Create a lowerer that can lower `CREATE` plans, given the project
-    /// directory and ontology mode the write should target.
-    ///
-    /// This is the **only** constructor that authorizes the write path.  The
-    /// same directory is also exposed read-side, so read operators that need it
-    /// (variable-length `Expand`) work in mixed read/write pipelines.
-    /// Returns a validation error if a supplied runtime carries an invalid declared identity.
+    /// Compile read/write plans from immutable dataset facts.
+    /// This permits write syntax, not execution against a destination.
+    /// Returns a validation error for an invalid declared identity.
     pub fn new_for_writes(
-        catalog: Option<&'a GraphCatalog>,
-        ontology: Option<&'a OntologyHandle>,
-        dir: &'a Path,
+        snapshot: &LoweringSnapshot,
+        ontology: Option<&OntologyHandle>,
         mode: OntologyMode,
     ) -> Result<Self, GfError> {
-        Self::build(catalog, ontology, Some((dir, mode)), Some((dir, mode)))
+        Self::build(
+            Some(snapshot),
+            ontology,
+            Some((snapshot, mode)),
+            Some((snapshot, mode)),
+        )
     }
 
-    /// Create a read/query lowerer that also knows the project directory.
-    ///
-    /// Required for queries containing variable-length `Expand`, whose physical
-    /// node reads edges directly from `dir`.  Equivalent to [`new`](Self::new)
-    /// for all other read operators.  Unlike [`new_for_writes`], this does
-    /// **not** authorize the write path — `CREATE` still errors.
-    /// Returns a validation error if a supplied runtime carries an invalid declared identity.
-    pub fn new_with_dir(
-        catalog: Option<&'a GraphCatalog>,
-        ontology: Option<&'a OntologyHandle>,
-        dir: &'a Path,
+    /// Compile read plans from immutable dataset facts. Write syntax is rejected.
+    /// Returns a validation error for an invalid declared identity.
+    pub fn new_for_reads(
+        snapshot: &LoweringSnapshot,
+        ontology: Option<&OntologyHandle>,
         mode: OntologyMode,
     ) -> Result<Self, GfError> {
-        Self::build(catalog, ontology, None, Some((dir, mode)))
+        Self::build(Some(snapshot), ontology, None, Some((snapshot, mode)))
     }
 
     fn build(
-        catalog: Option<&'a GraphCatalog>,
-        ontology: Option<&'a OntologyHandle>,
-        write_target: Option<(&'a Path, OntologyMode)>,
-        read_dir: Option<(&'a Path, OntologyMode)>,
+        catalog: Option<&LoweringSnapshot>,
+        ontology: Option<&OntologyHandle>,
+        write_target: Option<(&LoweringSnapshot, OntologyMode)>,
+        read_snapshot: Option<(&LoweringSnapshot, OntologyMode)>,
     ) -> Result<Self, GfError> {
         // Relation-name map: ontology IDs and tagged runtime-catalog IDs occupy
         // disjoint plan key spaces. This is essential in advisory mode, where
@@ -191,7 +176,7 @@ impl<'a> GraphPlanLowerer<'a> {
             }
         }
         Ok(Self {
-            catalog,
+            catalog: catalog.cloned(),
             type_id_to_rel_name,
             // Ontology-only: this map drives property-table routing
             // (`node_prop_cols` / `join_node_properties`) and write specs, where
@@ -205,8 +190,8 @@ impl<'a> GraphPlanLowerer<'a> {
                 }
                 names
             },
-            write_target,
-            read_dir,
+            write_target: write_target.is_some(),
+            read_snapshot: read_snapshot.map(|(snapshot, mode)| (snapshot.clone(), mode)),
             node_shapes: std::sync::RwLock::new(HashMap::new()),
             inference_rules: build_inference_rules(ontology)?,
             #[cfg(feature = "differential-testing")]
@@ -224,18 +209,19 @@ impl<'a> GraphPlanLowerer<'a> {
         self
     }
 
-    /// The project directory available to read operators (scans bind their real
-    /// Parquet-backed providers from it). `None` for pure logical/explain
+    /// The dataset facts available to read operators. Execution binds providers. `None` for pure logical/explain
     /// lowering, where scans use a schema-only source.
-    fn read_dir(&self) -> Option<&'a Path> {
-        self.read_dir.map(|(d, _)| d)
+    fn read_snapshot(&self) -> Option<&LoweringSnapshot> {
+        self.read_snapshot.as_ref().map(|(d, _)| d)
     }
 
     /// The ontology mode for read operators. Defaults to `Exploratory` for pure
-    /// logical/explain lowering (`read_dir` is `None`), where scans use a
+    /// logical/explain lowering (`read_snapshot` is `None`), where scans use a
     /// schema-only source and the mode is never consulted.
     fn read_mode(&self) -> OntologyMode {
-        self.read_dir.map_or(OntologyMode::Exploratory, |(_, m)| m)
+        self.read_snapshot
+            .as_ref()
+            .map_or(OntologyMode::Exploratory, |(_, m)| *m)
     }
 
     /// The `PropId.0 → name` map for resolving `PropertyAccess`.
@@ -245,7 +231,7 @@ impl<'a> GraphPlanLowerer<'a> {
     /// property accesses fall back to `"prop_<id>"` — those paths render plans,
     /// not data.
     fn prop_names(&self) -> HashMap<PropertyId, String> {
-        match self.catalog {
+        match self.catalog.as_ref() {
             Some(c) => c.prop_names().clone(),
             None => HashMap::new(),
         }
@@ -261,7 +247,7 @@ impl<'a> GraphPlanLowerer<'a> {
         // `MATCH (n) RETURN n` can resolve a node's stored `type_id` to its
         // label name without colliding with ontology type 0 (#702).
         let mut node_label_names = self.type_id_to_entity_name.clone();
-        if let Some(c) = self.catalog {
+        if let Some(c) = self.catalog.as_ref() {
             node_label_names.extend(c.semantic_label_names().clone());
             for (id, name) in c.label_names() {
                 let plan_id = EntityTypeId::runtime(*id);
@@ -281,14 +267,14 @@ impl<'a> GraphPlanLowerer<'a> {
             node_label_names,
             // Authoritative property lists only when a backing dataset is present:
             // `node_prop_cols` reads each node's columns from the property table
-            // under `read_dir`. With no dir (schema-only/explain lowering) an empty
+            // under `read_snapshot`. With no dir (schema-only/explain lowering) an empty
             // `prop_names` means "unknown", not "absent", so the missing-property→
             // null rewrite (#598) must NOT fire — gate it on having the dataset.
-            self.read_dir().is_some(),
+            self.read_snapshot().is_some(),
         );
         // With a dataset attached, `nodes(p)` hydrates its elements (#1024).
-        if let Some(dir) = self.read_dir() {
-            lowerer = lowerer.with_read_target(dir.to_path_buf());
+        if let Some(dir) = self.read_snapshot() {
+            lowerer = lowerer.with_read_target(dir.clone());
         }
         lowerer
     }
@@ -360,18 +346,14 @@ impl<'a> GraphPlanLowerer<'a> {
     /// schema-only lowering or when no single property table applies (see
     /// [`prop_table_stem`](Self::prop_table_stem)).
     fn node_prop_cols(&self, ty: Option<EntityTypeId>) -> Vec<String> {
-        let Some(dir) = self.read_dir() else {
+        let Some(dir) = self.read_snapshot() else {
             return Vec::new();
         };
         let Some(stem) = self.prop_table_stem(ty) else {
             return Vec::new();
         };
-        let prop_table = self.catalog.map_or_else(
-            || graphforge_storage::PropertyTable::open_discovered(dir, &stem),
-            |catalog| catalog.property_table(dir, &stem),
-        );
+        let prop_table = node_property_schema(dir, &stem);
         prop_table
-            .schema_ref()
             .fields()
             .iter()
             .map(|f| f.name().clone())
@@ -414,18 +396,15 @@ impl<'a> GraphPlanLowerer<'a> {
         use datafusion::common::Column;
         use datafusion::logical_expr::col;
 
-        let Some(dir) = self.read_dir() else {
+        let Some(dir) = self.read_snapshot() else {
             return Ok(scan); // schema-only lowering: no real provider to join
         };
         let Some(stem) = self.prop_table_stem(ty) else {
             return Ok(scan); // no single property table applies (see prop_table_stem)
         };
 
-        let prop_table = self.catalog.map_or_else(
-            || graphforge_storage::PropertyTable::open_discovered(dir, &stem),
-            |catalog| catalog.property_table(dir, &stem),
-        );
-        let prop_schema = prop_table.schema_ref();
+        let prop_table = node_property_schema(dir, &stem);
+        let prop_schema = prop_table;
         let node_alias = var_alias(var);
 
         // Property columns already present under this var's qualifier. A var whose
@@ -465,7 +444,8 @@ impl<'a> GraphPlanLowerer<'a> {
             graphforge_plan::GraphReadTable::Properties(stem.clone()),
             &prop_schema,
             self.catalog
-                .and_then(GraphCatalog::semantic_composition_fingerprint)
+                .as_ref()
+                .and_then(LoweringSnapshot::semantic_composition_fingerprint)
                 .map(str::to_owned),
         );
         let prop_scan = LogicalPlanBuilder::scan(prop_alias.clone(), prop_src, None)
@@ -534,7 +514,7 @@ impl<'a> GraphPlanLowerer<'a> {
     #[must_use]
     pub fn read_contract(&self) -> graphforge_plan::GraphReadContract {
         let mut labels = self.type_id_to_entity_name.clone();
-        if let Some(catalog) = self.catalog {
+        if let Some(catalog) = self.catalog.as_ref() {
             labels.extend(catalog.semantic_label_names().clone());
             labels.extend(
                 catalog
@@ -556,7 +536,8 @@ impl<'a> GraphPlanLowerer<'a> {
             relations,
             composition: self
                 .catalog
-                .and_then(GraphCatalog::semantic_composition_fingerprint)
+                .as_ref()
+                .and_then(LoweringSnapshot::semantic_composition_fingerprint)
                 .map(str::to_owned),
         }
     }
@@ -918,7 +899,7 @@ impl<'a> GraphPlanLowerer<'a> {
                             .index_of_column_by_name(Some(&qualifier), "node_id")
                             .is_none()
                     {
-                        enrich_bound_node_identity(&input, alias, self.read_dir())?
+                        enrich_bound_node_identity(&input, alias, self.read_snapshot())?
                     } else {
                         input
                     };
@@ -935,7 +916,8 @@ impl<'a> GraphPlanLowerer<'a> {
                         None => self.join_node_properties(*var, None, input),
                     };
                 }
-                let scan = lower_node_scan(*var, *ty, var_map, self.read_dir(), pending_nodes)?;
+                let scan =
+                    lower_node_scan(*var, *ty, var_map, self.read_snapshot(), pending_nodes)?;
                 let scan = self.join_node_properties(*var, *ty, scan)?;
                 // Multi-pattern MATCH: comma-separated patterns (`MATCH (a), (b)`)
                 // lower to consecutive *fresh* NodeScans. The first replaces the
@@ -958,9 +940,9 @@ impl<'a> GraphPlanLowerer<'a> {
                     *var,
                     *rel_ty,
                     var_map,
-                    self.catalog,
+                    self.catalog.as_ref(),
                     &self.type_id_to_rel_name,
-                    self.read_dir(),
+                    self.read_snapshot(),
                     self.read_mode(),
                 );
             }
@@ -970,7 +952,7 @@ impl<'a> GraphPlanLowerer<'a> {
                     *ty,
                     var_map,
                     &self.type_id_to_rel_name,
-                    self.read_dir(),
+                    self.read_snapshot(),
                     self.read_mode(),
                 );
             }
@@ -993,10 +975,10 @@ impl<'a> GraphPlanLowerer<'a> {
                     *max_hops,
                     input,
                     var_map,
-                    self.catalog,
+                    self.catalog.as_ref(),
                     &self.type_id_to_rel_name,
                     &self.inference_rules,
-                    self.read_dir,
+                    self.read_snapshot.as_ref().map(|(s, m)| (s, *m)),
                     #[cfg(feature = "differential-testing")]
                     self.relational_fixed_hop_reference,
                 );
@@ -2158,7 +2140,7 @@ impl<'a> GraphPlanLowerer<'a> {
         var_map: &mut VarMap,
         feeds_read: bool,
     ) -> Result<LogicalPlan, LoweringError> {
-        let (_dir, _mode) = self.write_target.ok_or_else(|| {
+        let () = self.write_target.then_some(()).ok_or_else(|| {
             LoweringError::UnsupportedExpr(
                 "CREATE requires a write target; lower via new_for_writes".into(),
             )
@@ -2188,7 +2170,8 @@ impl<'a> GraphPlanLowerer<'a> {
             let node = GraphCreateNode::new_emitting(Arc::new(input), nodes, edges, out_schema)
                 .with_semantic_composition_fingerprint(
                     self.catalog
-                        .and_then(GraphCatalog::semantic_composition_fingerprint),
+                        .as_ref()
+                        .and_then(LoweringSnapshot::semantic_composition_fingerprint),
                 );
             return Ok(LogicalPlan::Extension(Extension {
                 node: Arc::new(node),
@@ -2198,7 +2181,8 @@ impl<'a> GraphPlanLowerer<'a> {
         let node = GraphCreateNode::new(Arc::new(input), nodes, edges)
             .with_semantic_composition_fingerprint(
                 self.catalog
-                    .and_then(GraphCatalog::semantic_composition_fingerprint),
+                    .as_ref()
+                    .and_then(LoweringSnapshot::semantic_composition_fingerprint),
             );
         Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(node),
@@ -2343,7 +2327,7 @@ impl<'a> GraphPlanLowerer<'a> {
     ) -> Result<LogicalPlan, LoweringError> {
         use datafusion::common::TableReference;
 
-        let (_dir, _mode) = self.write_target.ok_or_else(|| {
+        let () = self.write_target.then_some(()).ok_or_else(|| {
             LoweringError::UnsupportedExpr(
                 "DELETE requires a write target; lower via new_for_writes".into(),
             )
@@ -2444,7 +2428,7 @@ impl<'a> GraphPlanLowerer<'a> {
         exprs: &ExprArena,
         var_map: &VarMap,
     ) -> Result<LogicalPlan, LoweringError> {
-        let (_dir, _mode) = self.write_target.ok_or_else(|| {
+        let () = self.write_target.then_some(()).ok_or_else(|| {
             LoweringError::UnsupportedExpr(
                 "SET requires a write target; lower via new_for_writes".into(),
             )
@@ -2481,7 +2465,7 @@ impl<'a> GraphPlanLowerer<'a> {
         items: &[RemovePropItem],
         input: LogicalPlan,
     ) -> Result<LogicalPlan, LoweringError> {
-        let (_dir, _mode) = self.write_target.ok_or_else(|| {
+        let () = self.write_target.then_some(()).ok_or_else(|| {
             LoweringError::UnsupportedExpr(
                 "REMOVE requires a write target; lower via new_for_writes".into(),
             )
@@ -3123,12 +3107,12 @@ fn table_source(
 /// Discover the admitted project's schema when available, then retain only a
 /// logical descriptor. Execution resolves its provider from the session.
 fn node_scan_source(
-    dir: Option<&Path>,
+    dir: Option<&LoweringSnapshot>,
 ) -> Result<Arc<dyn datafusion::logical_expr::TableSource>, LoweringError> {
     let schema = match dir {
-        Some(d) => graphforge_storage::TopologyNodeTable::open_project(d)
-            .map(|table| datafusion::datasource::TableProvider::schema(&table))
-            .map_unsupported_expr()?,
+        Some(d) => d.node_schema.clone().ok_or_else(|| {
+            LoweringError::UnsupportedExpr("dataset snapshot has no node schema".into())
+        })?,
         // Schema-only plans retain their existing non-executable placeholder
         // and optimizer/explain contract. Admitted reads use descriptors below.
         None => return Ok(table_source(TOPOLOGY_NODES_SCHEMA.clone())),
@@ -3143,7 +3127,7 @@ fn node_scan_source(
 /// Logical edge source over a relation stem or the wildcard `_exploratory`.
 /// Execution selects the typed union or shared exploratory file from its mode.
 fn edge_scan_source(
-    dir: Option<&Path>,
+    dir: Option<&LoweringSnapshot>,
     stem: &str,
     schema: &datafusion::arrow::datatypes::SchemaRef,
     mode: OntologyMode,
@@ -3183,7 +3167,7 @@ fn filter_node_by_type(
 fn enrich_bound_node_identity(
     input: &LogicalPlan,
     alias: &str,
-    dir: Option<&Path>,
+    dir: Option<&LoweringSnapshot>,
 ) -> Result<LogicalPlan, LoweringError> {
     use datafusion::common::Column;
     use datafusion::logical_expr::col;
@@ -3224,27 +3208,27 @@ fn lower_node_scan(
     var: VarId,
     ty: Option<EntityTypeId>,
     var_map: &mut VarMap,
-    dir: Option<&Path>,
+    dir: Option<&LoweringSnapshot>,
     pending_nodes: Option<&RecordBatch>,
 ) -> Result<LogicalPlan, LoweringError> {
     let alias = var_alias(var);
     var_map.insert(var, alias.clone());
 
-    let src = if let Some(batch) = pending_nodes.filter(|batch| batch.num_rows() > 0) {
+    let mut builder = LogicalPlanBuilder::scan(alias.clone(), node_scan_source(dir)?, None)
+        .map_unsupported_expr()?;
+    if let Some(batch) = pending_nodes.filter(|batch| batch.num_rows() > 0) {
         use datafusion::datasource::{MemTable, provider_as_source};
-        let mut batches = dir
-            .map(graphforge_storage::read_nodes)
-            .transpose()
-            .map_unsupported_expr()?
-            .unwrap_or_default();
-        batches.push(batch.clone());
-        let table = MemTable::try_new(batch.schema(), vec![batches]).map_unsupported_expr()?;
-        provider_as_source(Arc::new(table))
-    } else {
-        node_scan_source(dir)?
-    };
-    let mut builder = LogicalPlanBuilder::scan(alias.clone(), src, None).map_unsupported_expr()?;
-
+        let table =
+            MemTable::try_new(batch.schema(), vec![vec![batch.clone()]]).map_unsupported_expr()?;
+        let pending =
+            LogicalPlanBuilder::scan(alias.clone(), provider_as_source(Arc::new(table)), None)
+                .and_then(LogicalPlanBuilder::build)
+                .map_unsupported_expr()?;
+        builder = builder
+            .union(pending)
+            .and_then(|builder| builder.alias(alias.clone()))
+            .map_unsupported_expr()?;
+    }
     if let Some(type_id) = ty {
         use datafusion::functions_nested::expr_fn::array_has;
         use datafusion::logical_expr::{col, lit};
@@ -3263,12 +3247,11 @@ fn lower_typed_edge_scan(
     var: VarId,
     rel_ty: RelationTypeId,
     var_map: &mut VarMap,
-    catalog: Option<&GraphCatalog>,
+    catalog: Option<&LoweringSnapshot>,
     type_id_to_rel_name: &HashMap<RelationTypeId, String>,
-    dir: Option<&Path>,
+    dir: Option<&LoweringSnapshot>,
     mode: OntologyMode,
 ) -> Result<LogicalPlan, LoweringError> {
-    use datafusion::catalog::CatalogProvider;
     use datafusion::logical_expr::{col, lit};
 
     let alias = var_alias(var);
@@ -3285,12 +3268,12 @@ fn lower_typed_edge_scan(
     })?;
 
     // Generation-bound semantic relations must consume the exact provider
-    // authenticated and registered by GraphCatalog. Reconstructing a provider
+    // authenticated and registered by LoweringSnapshot. Reconstructing a provider
     // from a string route loses that authority and must never fall back to the
     // exploratory relation-name filter.
     if catalog.is_some_and(|catalog| catalog.semantic_rel_routes().contains_key(&rel_ty)) {
         let provider = catalog
-            .and_then(|catalog| catalog.semantic_edge_table(rel_ty))
+            .and_then(|catalog| catalog.semantic_edge_schema(rel_ty))
             .ok_or_else(|| {
                 LoweringError::UnsupportedExpr(format!(
                     "semantic relation TypeId({}) has no authenticated catalog provider",
@@ -3301,9 +3284,9 @@ fn lower_typed_edge_scan(
             alias,
             graphforge_plan::GraphReadSource::new(
                 graphforge_plan::GraphReadTable::SemanticEdges(rel_ty),
-                &provider.schema(),
+                &provider,
                 catalog
-                    .and_then(GraphCatalog::semantic_composition_fingerprint)
+                    .and_then(LoweringSnapshot::semantic_composition_fingerprint)
                     .map(str::to_owned),
             ),
             None,
@@ -3313,9 +3296,8 @@ fn lower_typed_edge_scan(
     }
 
     // Check if the catalog has a typed edge table for this relation.
-    let use_exploratory = catalog
-        .and_then(|c| c.schema("graph"))
-        .is_none_or(|s| !s.table_exist(&format!("edges_{rel_name}")));
+    let use_exploratory =
+        catalog.is_none_or(|c| !c.typed_edge_tables.contains(&format!("edges_{rel_name}")));
 
     if use_exploratory {
         let src = edge_scan_source(dir, "_exploratory", &EXPLORATORY_EDGE_SCHEMA, mode);
@@ -3340,7 +3322,7 @@ fn lower_edge_scan(
     ty: Option<RelationTypeId>,
     var_map: &mut VarMap,
     type_id_to_rel_name: &HashMap<RelationTypeId, String>,
-    dir: Option<&Path>,
+    dir: Option<&LoweringSnapshot>,
     mode: OntologyMode,
 ) -> Result<LogicalPlan, LoweringError> {
     use datafusion::logical_expr::{col, lit};
@@ -3639,7 +3621,7 @@ fn lower_var_len_expand(
     var_map: &mut VarMap,
     type_id_to_rel_name: &HashMap<RelationTypeId, String>,
     inference_rules: &HashMap<RelationTypeId, Vec<(String, String)>>,
-    target: Option<(&Path, OntologyMode)>,
+    target: Option<(&LoweringSnapshot, OntologyMode)>,
 ) -> Result<LogicalPlan, LoweringError> {
     use datafusion::logical_expr::col;
 
@@ -3671,8 +3653,8 @@ fn lower_var_len_expand(
     // the graph resource from its own session context.
     let (dir_path, _mode) = target.ok_or_else(|| {
         LoweringError::UnsupportedExpr(
-            "variable-length expand requires a project directory; \
-             lower via new_for_writes or new_with_dir"
+            "variable-length expand requires a dataset snapshot; \
+             lower via new_for_writes or new_for_reads"
                 .into(),
         )
     })?;
@@ -3689,10 +3671,9 @@ fn lower_var_len_expand(
     let prop_fields: Vec<datafusion::arrow::datatypes::Field> = if rel_name == "*" {
         let mut seen = std::collections::HashSet::new();
         let mut fields = Vec::new();
-        for stem in graphforge_storage::list_edge_property_stems(dir_path) {
-            let prop_table =
-                graphforge_storage::EdgePropertyTable::open_discovered(dir_path, &stem);
-            for f in prop_table.schema_ref().fields() {
+        for stem in dir_path.edge_property_stems.clone() {
+            let prop_table = edge_property_schema(dir_path, &stem);
+            for f in prop_table.fields() {
                 if topology_names.contains(&f.name().as_str()) {
                     continue;
                 }
@@ -3703,10 +3684,8 @@ fn lower_var_len_expand(
         }
         fields
     } else {
-        let prop_table =
-            graphforge_storage::EdgePropertyTable::open_discovered(dir_path, &rel_name);
+        let prop_table = edge_property_schema(dir_path, &rel_name);
         prop_table
-            .schema_ref()
             .fields()
             .iter()
             .filter(|f| !topology_names.contains(&f.name().as_str()))
@@ -3826,10 +3805,10 @@ fn lower_expand(
     max_hops: Option<u16>,
     input: LogicalPlan,
     var_map: &mut VarMap,
-    catalog: Option<&GraphCatalog>,
+    catalog: Option<&LoweringSnapshot>,
     type_id_to_rel_name: &HashMap<RelationTypeId, String>,
     inference_rules: &HashMap<RelationTypeId, Vec<(String, String)>>,
-    target: Option<(&Path, OntologyMode)>,
+    target: Option<(&LoweringSnapshot, OntologyMode)>,
     #[cfg(feature = "differential-testing")] relational_reference: bool,
 ) -> Result<LogicalPlan, LoweringError> {
     // Variable-length expand cannot be expressed in relational algebra; emit
@@ -4040,7 +4019,7 @@ fn try_lower_provider_expand(
     input: &LogicalPlan,
     var_map: &mut VarMap,
     type_id_to_rel_name: &HashMap<RelationTypeId, String>,
-    target: Option<(&Path, OntologyMode)>,
+    target: Option<(&LoweringSnapshot, OntologyMode)>,
 ) -> Result<Option<LogicalPlan>, LoweringError> {
     let Some((dir_path, mode)) = target else {
         return Ok(None); // schema-only lowering has no execution provider
@@ -4074,7 +4053,7 @@ fn try_lower_provider_expand(
         edge_schema.fields().iter().cloned().collect();
     let base_names: HashSet<&str> = edge_fields.iter().map(|f| f.name().as_str()).collect();
     let mut stems = if rel_name == "*" {
-        graphforge_storage::list_edge_property_stems(dir_path)
+        dir_path.edge_property_stems.clone()
     } else {
         vec![rel_name.clone()]
     };
@@ -4082,8 +4061,8 @@ fn try_lower_provider_expand(
     let mut seen = HashSet::new();
     let mut edge_prop_fields = Vec::new();
     for stem in stems {
-        let prop_table = graphforge_storage::EdgePropertyTable::open_discovered(dir_path, &stem);
-        for field in prop_table.schema_ref().fields() {
+        let prop_table = edge_property_schema(dir_path, &stem);
+        for field in prop_table.fields() {
             if field.name() != "edge_uuid"
                 && !base_names.contains(field.name().as_str())
                 && seen.insert(field.name().clone())
@@ -4166,9 +4145,9 @@ fn expand_single_dir(
     out_direction: bool,
     input: LogicalPlan,
     var_map: &mut VarMap,
-    catalog: Option<&GraphCatalog>,
+    catalog: Option<&LoweringSnapshot>,
     type_id_to_rel_name: &HashMap<RelationTypeId, String>,
-    target: Option<(&Path, OntologyMode)>,
+    target: Option<(&LoweringSnapshot, OntologyMode)>,
 ) -> Result<LogicalPlan, LoweringError> {
     use datafusion::logical_expr::col;
 
@@ -4286,7 +4265,7 @@ fn expand_bound_edge_single_dir(
     input: LogicalPlan,
     var_map: &mut VarMap,
     type_id_to_rel_name: &HashMap<RelationTypeId, String>,
-    target: Option<(&Path, OntologyMode)>,
+    target: Option<(&LoweringSnapshot, OntologyMode)>,
 ) -> Result<LogicalPlan, LoweringError> {
     use datafusion::common::TableReference;
     use datafusion::logical_expr::{col, lit};
@@ -4346,13 +4325,13 @@ fn expand_bound_edge_single_dir(
 fn edge_property_read_source(
     stem: &str,
     rel_ty: Option<RelationTypeId>,
-    catalog: Option<&GraphCatalog>,
+    catalog: Option<&LoweringSnapshot>,
     schema: &datafusion::arrow::datatypes::SchemaRef,
 ) -> Arc<graphforge_plan::GraphReadSource> {
     let semantic_id =
-        rel_ty.filter(|id| catalog.is_some_and(|c| c.semantic_edge_property_table(*id).is_some()));
+        rel_ty.filter(|id| catalog.is_some_and(|c| c.semantic_edge_property_schema(*id).is_some()));
     let composition = catalog
-        .and_then(GraphCatalog::semantic_composition_fingerprint)
+        .and_then(LoweringSnapshot::semantic_composition_fingerprint)
         .map(str::to_owned);
     let table = graphforge_plan::GraphReadTable::EdgeProperties(stem.to_owned(), semantic_id);
     graphforge_plan::GraphReadSource::new(table, schema, composition)
@@ -4376,8 +4355,8 @@ fn join_edge_properties(
     edge_alias: &str,
     rel_ty: Option<RelationTypeId>,
     type_id_to_rel_name: &HashMap<RelationTypeId, String>,
-    catalog: Option<&GraphCatalog>,
-    dir: Option<&Path>,
+    catalog: Option<&LoweringSnapshot>,
+    dir: Option<&LoweringSnapshot>,
     scan: LogicalPlan,
 ) -> Result<LogicalPlan, LoweringError> {
     use datafusion::logical_expr::{col, lit};
@@ -4400,15 +4379,9 @@ fn join_edge_properties(
     let mut prop_order = Vec::new();
     let mut seen_props = HashSet::new();
     let mut push_source =
-        |stem: String, registered: Option<Arc<dyn datafusion::datasource::TableProvider>>| {
-            let table = registered.unwrap_or_else(|| {
-                Arc::new(catalog.map_or_else(
-                    || graphforge_storage::EdgePropertyTable::open_discovered(dir, &stem),
-                    |catalog| catalog.edge_property_table(dir, &stem),
-                ))
-            });
+        |stem: String, registered: Option<datafusion::arrow::datatypes::SchemaRef>| {
+            let table = registered.unwrap_or_else(|| edge_property_schema(dir, &stem));
             let prop_cols: Vec<String> = table
-                .schema()
                 .fields()
                 .iter()
                 .map(|f| f.name().clone())
@@ -4428,10 +4401,10 @@ fn join_edge_properties(
         let Some(rel_name) = type_id_to_rel_name.get(&rel_ty) else {
             return Ok(scan); // unknown relation name: nothing to resolve
         };
-        let registered = catalog.and_then(|catalog| catalog.semantic_edge_property_table(rel_ty));
+        let registered = catalog.and_then(|catalog| catalog.semantic_edge_property_schema(rel_ty));
         push_source(rel_name.clone(), registered);
     } else {
-        for stem in graphforge_storage::list_edge_property_stems(dir) {
+        for stem in dir.edge_property_stems.clone() {
             push_source(stem, None);
         }
     }
@@ -4444,7 +4417,7 @@ fn join_edge_properties(
     let mut prop_refs: StdHashMap<String, Vec<DfExpr>> = StdHashMap::new();
     for (idx, (stem, prop_table, prop_cols)) in prop_sources.into_iter().enumerate() {
         let prop_alias = format!("{edge_alias}__eprops_{idx}");
-        let prop_src = edge_property_read_source(&stem, rel_ty, catalog, &prop_table.schema());
+        let prop_src = edge_property_read_source(&stem, rel_ty, catalog, &prop_table);
         let prop_scan = LogicalPlanBuilder::scan(prop_alias.clone(), prop_src, None)
             .and_then(LogicalPlanBuilder::build)
             .map_unsupported_expr()?;
@@ -4495,6 +4468,27 @@ fn join_edge_properties(
 // Tests
 // ---------------------------------------------------------------------------
 
+fn node_property_schema(
+    snapshot: &LoweringSnapshot,
+    stem: &str,
+) -> datafusion::arrow::datatypes::SchemaRef {
+    snapshot
+        .node_properties
+        .get(stem)
+        .cloned()
+        .unwrap_or_else(|| graphforge_storage::schemas::PROPERTY_BASE_SCHEMA.clone())
+}
+fn edge_property_schema(
+    snapshot: &LoweringSnapshot,
+    stem: &str,
+) -> datafusion::arrow::datatypes::SchemaRef {
+    snapshot
+        .edge_properties
+        .get(stem)
+        .cloned()
+        .unwrap_or_else(|| graphforge_storage::schemas::EDGE_PROPERTY_BASE_SCHEMA.clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4535,16 +4529,14 @@ relation_types:
                 let handle = OntologyHandle::new(runtime);
                 for result in [
                     GraphPlanLowerer::new(None, Some(&handle)),
-                    GraphPlanLowerer::new_with_dir(
-                        None,
+                    GraphPlanLowerer::new_for_reads(
+                        &LoweringSnapshot::default(),
                         Some(&handle),
-                        Path::new("."),
                         OntologyMode::Strict,
                     ),
                     GraphPlanLowerer::new_for_writes(
-                        None,
+                        &LoweringSnapshot::default(),
                         Some(&handle),
-                        Path::new("."),
                         OntologyMode::Strict,
                     ),
                 ] {
@@ -4637,7 +4629,11 @@ relation_types:
     #[test]
     fn filter_lowers_predicate() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let mut arena = ExprArena::new();
         let lit = arena.push(IrExpr::Literal(IrLiteral::Bool(true)));
@@ -4663,7 +4659,11 @@ relation_types:
     #[test]
     fn project_lowers_columns() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let mut arena = ExprArena::new();
         let lit = arena.push(IrExpr::Literal(IrLiteral::Int(1)));
@@ -4697,7 +4697,11 @@ relation_types:
     #[test]
     fn project_with_distinct_wraps_in_distinct() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let mut arena = ExprArena::new();
         let lit = arena.push(IrExpr::Literal(IrLiteral::Int(1)));
@@ -4731,7 +4735,11 @@ relation_types:
     #[test]
     fn with_where_scalar_alias_uses_projected_scope_then_drops_inputs() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
         let mut builder = GraphPlan::builder("openCypher");
         let value = builder.push_expr(IrExpr::Literal(IrLiteral::Bool(true)));
         let predicate = builder.push_expr(IrExpr::VarRef(VarId(9)));
@@ -4762,7 +4770,11 @@ relation_types:
     #[test]
     fn with_where_forwards_complete_node_shape_through_new_scope() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
         let mut builder = GraphPlan::builder("openCypher");
         let node = builder.push_expr(IrExpr::VarRef(VarId(0)));
         let predicate = builder.push_expr(IrExpr::Literal(IrLiteral::Bool(true)));
@@ -4799,7 +4811,11 @@ relation_types:
     #[test]
     fn aggregate_count_star() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let arena = ExprArena::new();
         let agg = AggExpr {
@@ -4934,7 +4950,11 @@ relation_types:
     #[test]
     fn sort_lowers_keys() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         // Use a literal rather than a VarRef to avoid schema validation on
         // the empty base relation (DataFusion rejects unknown column names).
@@ -4967,7 +4987,11 @@ relation_types:
     #[test]
     fn limit_lowers_correctly() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let arena = ExprArena::new();
         let var_map = VarMap::new();
@@ -4992,7 +5016,11 @@ relation_types:
     #[test]
     fn skip_lowers_correctly() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let arena = ExprArena::new();
         let var_map = VarMap::new();
@@ -5018,7 +5046,11 @@ relation_types:
     #[test]
     fn unsupported_op_returns_error() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let arena = ExprArena::new();
         let var_map = VarMap::new();
@@ -5046,9 +5078,8 @@ relation_types:
 
         let dir = tempfile::tempdir().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
+            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
             None,
-            None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
@@ -5260,7 +5291,11 @@ relation_types:
     #[test]
     fn lower_plan_empty_ops_succeeds() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let plan = GraphPlan::builder("openCypher").build();
         let result = lowerer.lower_plan(&plan);
@@ -5270,7 +5305,11 @@ relation_types:
     #[test]
     fn union_requires_two_branch_plans() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
         let plan = GraphPlan::builder("openCypher")
             .push_op(GraphOp::Union {
                 all: true,
@@ -5287,7 +5326,11 @@ relation_types:
     #[test]
     fn integration_filter_project_limit_pipeline() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         // Build the plan using GraphPlanBuilder so expressions live in plan.exprs.
         let mut builder = GraphPlan::builder("openCypher");
@@ -5322,7 +5365,11 @@ relation_types:
     #[test]
     fn node_scan_no_type_produces_table_scan() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let plan = GraphPlan::builder("openCypher")
             .push_op(GraphOp::NodeScan {
@@ -5340,7 +5387,11 @@ relation_types:
     #[test]
     fn node_scan_with_type_produces_filter_over_scan() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let plan = GraphPlan::builder("openCypher")
             .push_op(GraphOp::NodeScan {
@@ -5415,9 +5466,12 @@ relation_types:
         use graphforge_plan::VarLenExpandNode;
 
         let (dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer =
-            GraphPlanLowerer::new_with_dir(Some(&catalog), None, dir.path(), OntologyMode::Strict)
-                .unwrap();
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(dir.path())).unwrap(),
+            None,
+            OntologyMode::Strict,
+        )
+        .unwrap();
 
         let lp = lowerer.lower_plan(&var_len_plan()).unwrap();
         let DfLogicalPlan::Extension(ext) = &lp else {
@@ -5446,15 +5500,19 @@ relation_types:
     }
 
     #[test]
-    fn expand_var_len_without_dir_errors() {
-        // The read-only constructor has no project directory, so a
-        // variable-length expand cannot bake its edge-read path.
+    fn expand_var_len_without_dataset_snapshot_errors() {
+        // Schema-only lowering has no dataset snapshot for edge reads.
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
         let err = lowerer.lower_plan(&var_len_plan()).unwrap_err();
         assert!(
-            err.to_string().contains("project directory"),
-            "expected a project-directory error, got: {err}"
+            err.to_string()
+                .contains("variable-length expand requires a dataset snapshot"),
+            "expected a missing dataset snapshot error, got: {err}"
         );
     }
 
@@ -5480,7 +5538,11 @@ relation_types:
     #[test]
     fn optional_produces_extension_node() {
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         let child = GraphPlan::builder("openCypher")
             .push_op(GraphOp::NodeScan {
@@ -5510,7 +5572,11 @@ relation_types:
         use graphforge_plan::OptionalMatchNode;
 
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
 
         // Outer binds var_0; the optional child binds a fresh, unshared var_1,
         // so `join_keys` is empty and all 5 inner columns are kept. This test
@@ -5631,7 +5697,11 @@ relation_types:
         // NOT be appended again (they live on the outer side) — otherwise the
         // node's schema would carry duplicate `var_0` fields (#718).
         let (_dir, catalog, _rc) = make_catalog_and_lowerer();
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
         let child = GraphPlan::builder("openCypher")
             .push_op(GraphOp::NodeScan {
                 var: VarId(0),
@@ -5706,9 +5776,8 @@ relation_types:
     fn create_lowers_to_extension_with_write_target() {
         let dir = tempfile::TempDir::new().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
+            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
             None,
-            None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
@@ -5727,9 +5796,8 @@ relation_types:
 
         let dir = tempfile::TempDir::new().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
+            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
             None,
-            None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
@@ -5789,22 +5857,21 @@ relation_types:
     }
 
     #[test]
-    fn new_with_dir_does_not_authorize_writes() {
-        // `new_with_dir` grants read-side directory access (for var-length
+    fn new_for_reads_does_not_authorize_writes() {
+        // `new_for_reads` grants read-side directory access (for var-length
         // Expand) but must NOT open the write path — only `new_for_writes`
         // authorizes CREATE.
         let dir = tempfile::TempDir::new().unwrap();
-        let lowerer = GraphPlanLowerer::new_with_dir(
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
             None,
-            None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
         let result = lowerer.lower_plan(&create_plan_with_props());
         assert!(
             result.is_err(),
-            "new_with_dir must not authorize CREATE; only new_for_writes does"
+            "new_for_reads must not authorize CREATE; only new_for_writes does"
         );
     }
 
@@ -5813,9 +5880,8 @@ relation_types:
         use graphforge_ir::{CreateNodeSpec, CreatePattern};
         let dir = tempfile::TempDir::new().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
+            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
             None,
-            None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
@@ -6044,9 +6110,8 @@ relation_types:
         let rc = graphforge_ir::RuntimeCatalog::new();
         let catalog = graphforge_storage::GraphCatalog::open(dir.path(), None, &rc).unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
-            Some(&catalog),
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(dir.path())).unwrap(),
             None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
@@ -6062,11 +6127,10 @@ relation_types:
         let dir = tempfile::TempDir::new().unwrap();
         let rc = graphforge_ir::RuntimeCatalog::new();
         let catalog = graphforge_storage::GraphCatalog::open(dir.path(), None, &rc).unwrap();
-        // `new_with_dir` grants read access but not the write path.
-        let lowerer = GraphPlanLowerer::new_with_dir(
-            Some(&catalog),
+        // `new_for_reads` grants read access but not the write path.
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(dir.path())).unwrap(),
             None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
@@ -6087,9 +6151,8 @@ relation_types:
         let rc = graphforge_ir::RuntimeCatalog::new();
         let catalog = graphforge_storage::GraphCatalog::open(dir.path(), None, &rc).unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
-            Some(&catalog),
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(dir.path())).unwrap(),
             None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
@@ -6197,11 +6260,10 @@ relation_types:
     fn writes_lowerer<'a>(
         catalog: &'a graphforge_storage::GraphCatalog,
         dir: &'a std::path::Path,
-    ) -> GraphPlanLowerer<'a> {
+    ) -> GraphPlanLowerer {
         GraphPlanLowerer::new_for_writes(
-            Some(catalog),
+            &graphforge_storage::lowering_snapshot(Some(catalog), Some(dir)).unwrap(),
             None,
-            dir,
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap()
@@ -6326,10 +6388,9 @@ relation_types:
         let rc = graphforge_ir::RuntimeCatalog::new();
         let catalog = graphforge_storage::GraphCatalog::open(dir.path(), None, &rc).unwrap();
         // Read-side dir access only — no write authorization.
-        let lowerer = GraphPlanLowerer::new_with_dir(
-            Some(&catalog),
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(dir.path())).unwrap(),
             None,
-            dir.path(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();
@@ -6397,9 +6458,12 @@ relation_types:
         use datafusion::logical_expr::UserDefinedLogicalNodeCore;
 
         let (tmp, catalog, plan) = typed_single_hop_fixture(Direction::Out);
-        let lowerer =
-            GraphPlanLowerer::new_with_dir(Some(&catalog), None, tmp.path(), OntologyMode::Strict)
-                .unwrap();
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(tmp.path())).unwrap(),
+            None,
+            OntologyMode::Strict,
+        )
+        .unwrap();
 
         let lp = lowerer.lower_plan(&plan).unwrap();
         let DfLogicalPlan::Extension(ext) = &lp else {
@@ -6443,9 +6507,12 @@ relation_types:
     #[test]
     fn project_backed_undirected_single_hop_emits_plain_extension() {
         let (tmp, catalog, plan) = typed_single_hop_fixture(Direction::Undirected);
-        let lowerer =
-            GraphPlanLowerer::new_with_dir(Some(&catalog), None, tmp.path(), OntologyMode::Strict)
-                .unwrap();
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(tmp.path())).unwrap(),
+            None,
+            OntologyMode::Strict,
+        )
+        .unwrap();
 
         let lp = lowerer.lower_plan(&plan).unwrap();
         // No DISTINCT wrapper: the self-loop dedup happens inside ExpandExec
@@ -6465,7 +6532,11 @@ relation_types:
     #[test]
     fn schema_only_single_hop_keeps_join_path() {
         let (_tmp, catalog, plan) = typed_single_hop_fixture(Direction::Out);
-        let lowerer = GraphPlanLowerer::new(Some(&catalog), None).unwrap();
+        let lowerer = GraphPlanLowerer::new(
+            Some(&graphforge_storage::lowering_snapshot(Some(&catalog), None).unwrap()),
+            None,
+        )
+        .unwrap();
         let lp = lowerer.lower_plan(&plan).unwrap();
         assert!(
             matches!(lp, DfLogicalPlan::Join(_)),
@@ -6478,10 +6549,9 @@ relation_types:
         use datafusion::logical_expr::UserDefinedLogicalNodeCore;
 
         let (tmp, catalog, plan) = typed_single_hop_fixture(Direction::Out);
-        let lowerer = GraphPlanLowerer::new_with_dir(
-            Some(&catalog),
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(tmp.path())).unwrap(),
             None,
-            tmp.path(),
             OntologyMode::Exploratory,
         )
         .unwrap();
@@ -6522,9 +6592,12 @@ relation_types:
                 max_hops: Some(1),
             })
             .build();
-        let lowerer =
-            GraphPlanLowerer::new_with_dir(Some(&catalog), None, tmp.path(), OntologyMode::Strict)
-                .unwrap();
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(tmp.path())).unwrap(),
+            None,
+            OntologyMode::Strict,
+        )
+        .unwrap();
         let lp = lowerer.lower_plan(&plan).unwrap();
         let DfLogicalPlan::Extension(ext) = &lp else {
             panic!("expected wildcard ExpandNode, got {lp:?}");
@@ -6559,9 +6632,12 @@ relation_types:
                 max_hops: Some(1),
             })
             .build();
-        let lowerer =
-            GraphPlanLowerer::new_with_dir(Some(&catalog), None, tmp.path(), OntologyMode::Strict)
-                .unwrap();
+        let lowerer = GraphPlanLowerer::new_for_reads(
+            &graphforge_storage::lowering_snapshot(Some(&catalog), Some(tmp.path())).unwrap(),
+            None,
+            OntologyMode::Strict,
+        )
+        .unwrap();
         let err = lowerer.lower_plan(&plan).unwrap_err();
         assert!(
             err.to_string().contains("unbound") || err.to_string().contains("Unbound"),

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -5078,7 +5078,18 @@ relation_types:
 
         let dir = tempfile::tempdir().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
-            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            &graphforge_storage::lowering_snapshot(
+                Some(
+                    &graphforge_storage::GraphCatalog::open(
+                        dir.path(),
+                        None,
+                        &graphforge_ir::RuntimeCatalog::new(),
+                    )
+                    .unwrap(),
+                ),
+                Some(dir.path()),
+            )
+            .unwrap(),
             None,
             graphforge_core::OntologyMode::Exploratory,
         )
@@ -5776,7 +5787,18 @@ relation_types:
     fn create_lowers_to_extension_with_write_target() {
         let dir = tempfile::TempDir::new().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
-            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            &graphforge_storage::lowering_snapshot(
+                Some(
+                    &graphforge_storage::GraphCatalog::open(
+                        dir.path(),
+                        None,
+                        &graphforge_ir::RuntimeCatalog::new(),
+                    )
+                    .unwrap(),
+                ),
+                Some(dir.path()),
+            )
+            .unwrap(),
             None,
             graphforge_core::OntologyMode::Exploratory,
         )
@@ -5796,7 +5818,18 @@ relation_types:
 
         let dir = tempfile::TempDir::new().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
-            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            &graphforge_storage::lowering_snapshot(
+                Some(
+                    &graphforge_storage::GraphCatalog::open(
+                        dir.path(),
+                        None,
+                        &graphforge_ir::RuntimeCatalog::new(),
+                    )
+                    .unwrap(),
+                ),
+                Some(dir.path()),
+            )
+            .unwrap(),
             None,
             graphforge_core::OntologyMode::Exploratory,
         )
@@ -5863,7 +5896,18 @@ relation_types:
         // authorizes CREATE.
         let dir = tempfile::TempDir::new().unwrap();
         let lowerer = GraphPlanLowerer::new_for_reads(
-            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            &graphforge_storage::lowering_snapshot(
+                Some(
+                    &graphforge_storage::GraphCatalog::open(
+                        dir.path(),
+                        None,
+                        &graphforge_ir::RuntimeCatalog::new(),
+                    )
+                    .unwrap(),
+                ),
+                Some(dir.path()),
+            )
+            .unwrap(),
             None,
             graphforge_core::OntologyMode::Exploratory,
         )
@@ -5880,7 +5924,18 @@ relation_types:
         use graphforge_ir::{CreateNodeSpec, CreatePattern};
         let dir = tempfile::TempDir::new().unwrap();
         let lowerer = GraphPlanLowerer::new_for_writes(
-            &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+            &graphforge_storage::lowering_snapshot(
+                Some(
+                    &graphforge_storage::GraphCatalog::open(
+                        dir.path(),
+                        None,
+                        &graphforge_ir::RuntimeCatalog::new(),
+                    )
+                    .unwrap(),
+                ),
+                Some(dir.path()),
+            )
+            .unwrap(),
             None,
             graphforge_core::OntologyMode::Exploratory,
         )

--- a/crates/graphforge-rel/tests/logical_plan_golden.rs
+++ b/crates/graphforge-rel/tests/logical_plan_golden.rs
@@ -110,10 +110,9 @@ fn render_lowered(query: &str) -> String {
     // `Expand` can bake its edge-read path; the directory is not rendered in
     // the explain output, so a throwaway temp dir keeps snapshots deterministic.
     let dir = tempfile::tempdir().expect("tempdir");
-    let lowered = graphforge_rel::GraphPlanLowerer::new_with_dir(
-        None,
+    let lowered = graphforge_rel::GraphPlanLowerer::new_for_reads(
+        &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
         Some(&handle),
-        dir.path(),
         OntologyMode::Advisory,
     )
     .expect("valid ontology identities")
@@ -160,10 +159,9 @@ fn render_property_read(query: &str) -> String {
     writer.flush().expect("flush");
 
     let catalog = GraphCatalog::open(dir.path(), None, &rc.lock().unwrap()).expect("catalog");
-    let lowered = graphforge_rel::GraphPlanLowerer::new_with_dir(
-        Some(&catalog),
+    let lowered = graphforge_rel::GraphPlanLowerer::new_for_reads(
+        &graphforge_storage::lowering_snapshot(Some(&catalog), Some(dir.path())).unwrap(),
         None,
-        dir.path(),
         OntologyMode::Exploratory,
     )
     .expect("valid ontology identities")

--- a/crates/graphforge-rel/tests/logical_plan_golden.rs
+++ b/crates/graphforge-rel/tests/logical_plan_golden.rs
@@ -111,7 +111,18 @@ fn render_lowered(query: &str) -> String {
     // the explain output, so a throwaway temp dir keeps snapshots deterministic.
     let dir = tempfile::tempdir().expect("tempdir");
     let lowered = graphforge_rel::GraphPlanLowerer::new_for_reads(
-        &graphforge_storage::lowering_snapshot(None, Some(dir.path())).unwrap(),
+        &graphforge_storage::lowering_snapshot(
+            Some(
+                &graphforge_storage::GraphCatalog::open(
+                    dir.path(),
+                    None,
+                    &graphforge_ir::RuntimeCatalog::new(),
+                )
+                .unwrap(),
+            ),
+            Some(dir.path()),
+        )
+        .unwrap(),
         Some(&handle),
         OntologyMode::Advisory,
     )

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -3192,6 +3192,18 @@ impl GraphCatalog {
             )
     }
 
+    /// Retain one inventory while collecting a compilation's schema facts.
+    pub(crate) fn lowering_property_inventory(
+        &self,
+    ) -> Option<Arc<crate::AuthenticatedPropertyInventory>> {
+        self.schema
+            .authority
+            .read()
+            .expect("property inventory lock poisoned")
+            .property_inventory
+            .clone()
+    }
+
     /// Canonical routes in this catalog's authenticated inventory.
     #[must_use]
     pub fn property_routes(&self, kind: crate::PropertyRouteKind) -> Vec<String> {

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -489,3 +489,6 @@ impl StorageProvider for ParquetProvider {
         Err(GfError::NotImplemented("scan_nodes"))
     }
 }
+
+mod lowering_snapshot;
+pub use lowering_snapshot::lowering_snapshot;

--- a/crates/graphforge-storage/src/lowering_snapshot.rs
+++ b/crates/graphforge-storage/src/lowering_snapshot.rs
@@ -33,6 +33,22 @@ impl GraphCatalog {
         }
         if let Some(dir) = dir {
             let inventory = self.lowering_property_inventory();
+            if inventory.is_none() && !dir.exists() {
+                // A standalone writer may target a directory that it will create
+                // only at execution. Capture the empty schema without creating it.
+                snapshot.node_schema = Some(
+                    crate::TopologyNodeTable::open_project(dir)
+                        .map_err(GfError::from_plan_error)?
+                        .schema(),
+                );
+                return Ok(snapshot);
+            }
+            let inventory = inventory.ok_or_else(|| {
+                GfError::Validation(
+                    "dataset lowering snapshot requires a retained authenticated catalog inventory"
+                        .into(),
+                )
+            })?;
             snapshot.node_schema = Some(
                 crate::TopologyNodeTable::open_project(dir)
                     .map_err(GfError::from_plan_error)?
@@ -45,7 +61,7 @@ impl GraphCatalog {
             nodes.extend(snapshot.semantic_labels.values().cloned());
             let mut edges: std::collections::BTreeSet<String> =
                 snapshot.edge_property_stems.iter().cloned().collect();
-            if let Some(inventory) = &inventory {
+            {
                 nodes.extend(
                     inventory
                         .routes(crate::PropertyRouteKind::Node)
@@ -60,37 +76,23 @@ impl GraphCatalog {
             for stem in nodes {
                 snapshot.node_properties.insert(
                     stem.clone(),
-                    inventory
-                        .as_ref()
-                        .map_or_else(
-                            || crate::PropertyTable::open_discovered(dir, &stem),
-                            |inventory| {
-                                crate::PropertyTable::open_authenticated(
-                                    dir,
-                                    &stem,
-                                    std::sync::Arc::clone(inventory),
-                                )
-                            },
-                        )
-                        .schema(),
+                    crate::PropertyTable::open_authenticated(
+                        dir,
+                        &stem,
+                        std::sync::Arc::clone(&inventory),
+                    )
+                    .schema(),
                 );
             }
             for stem in edges {
                 snapshot.edge_properties.insert(
                     stem.clone(),
-                    inventory
-                        .as_ref()
-                        .map_or_else(
-                            || crate::EdgePropertyTable::open_discovered(dir, &stem),
-                            |inventory| {
-                                crate::EdgePropertyTable::open_authenticated(
-                                    dir,
-                                    &stem,
-                                    std::sync::Arc::clone(inventory),
-                                )
-                            },
-                        )
-                        .schema(),
+                    crate::EdgePropertyTable::open_authenticated(
+                        dir,
+                        &stem,
+                        std::sync::Arc::clone(&inventory),
+                    )
+                    .schema(),
                 );
             }
         }
@@ -106,29 +108,12 @@ pub fn lowering_snapshot(
     if let Some(catalog) = catalog {
         return catalog.lowering_snapshot(dir);
     }
-    let mut snapshot = LoweringSnapshot::default();
-    if let Some(dir) = dir {
-        snapshot.node_schema = Some(
-            crate::TopologyNodeTable::open_project(dir)
-                .map_err(GfError::from_plan_error)?
-                .schema(),
-        );
-        snapshot.node_property_stems = crate::list_property_stems(dir);
-        snapshot.edge_property_stems = crate::list_edge_property_stems(dir);
-        for stem in &snapshot.node_property_stems {
-            snapshot.node_properties.insert(
-                stem.clone(),
-                crate::PropertyTable::open_discovered(dir, &stem).schema(),
-            );
-        }
-        for stem in &snapshot.edge_property_stems {
-            snapshot.edge_properties.insert(
-                stem.clone(),
-                crate::EdgePropertyTable::open_discovered(dir, &stem).schema(),
-            );
-        }
+    if dir.is_some() {
+        return Err(GfError::Validation(
+            "dataset lowering snapshot requires an admitted catalog".into(),
+        ));
     }
-    Ok(snapshot)
+    Ok(LoweringSnapshot::default())
 }
 
 #[cfg(test)]
@@ -139,6 +124,29 @@ mod tests {
     use graphforge_ontology::{OntologyModuleId, QualifiedSymbol, SymbolKind};
     use graphforge_value::EntityTypeId;
     use std::collections::HashMap;
+
+    #[test]
+    fn dataset_snapshot_requires_admission_but_preserves_absent_write_target() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("not-created");
+        let catalog = GraphCatalog::open(&target, None, &RuntimeCatalog::new()).unwrap();
+        let empty = catalog.lowering_snapshot(Some(&target)).unwrap();
+        assert!(empty.node_schema.is_some());
+        assert!(empty.node_properties.is_empty());
+        assert!(!target.exists());
+        assert!(
+            matches!(lowering_snapshot(None, Some(&target)), Err(GfError::Validation(message))
+            if message == "dataset lowering snapshot requires an admitted catalog")
+        );
+        // Malformed data must not be opened or authenticated by a fallback.
+        // The retained catalog has no inventory; rejection precedes discovery.
+        std::fs::create_dir_all(target.join("properties")).unwrap();
+        std::fs::write(target.join("properties/Person.parquet"), b"not parquet").unwrap();
+        assert!(
+            matches!(catalog.lowering_snapshot(Some(&target)), Err(GfError::Validation(message))
+            if message == "dataset lowering snapshot requires a retained authenticated catalog inventory")
+        );
+    }
 
     #[test]
     fn selected_semantic_schema_survives_absent_discovery_without_expanding_unions() {

--- a/crates/graphforge-storage/src/lowering_snapshot.rs
+++ b/crates/graphforge-storage/src/lowering_snapshot.rs
@@ -1,0 +1,210 @@
+//! Capture schema facts before entering the relational compiler.
+use crate::{GfError, GraphCatalog};
+use datafusion::catalog::CatalogProvider;
+use datafusion::datasource::TableProvider;
+use graphforge_ir::LoweringSnapshot;
+use std::path::Path;
+
+impl GraphCatalog {
+    /// Capture catalog names and, when requested, dataset schemas without graph rows.
+    pub fn lowering_snapshot(&self, dir: Option<&Path>) -> Result<LoweringSnapshot, GfError> {
+        let mut snapshot = LoweringSnapshot {
+            property_names: self.prop_names().clone(),
+            runtime_labels: self.label_names().clone(),
+            runtime_relations: self.rel_names().clone(),
+            semantic_relations: self.semantic_rel_routes().clone(),
+            semantic_labels: self.semantic_label_routes().clone(),
+            semantic_display_labels: self.semantic_label_names().clone(),
+            composition: self.semantic_composition_fingerprint().map(str::to_owned),
+            ..Default::default()
+        };
+        if let Some(schema) = self.schema("graph") {
+            snapshot.typed_edge_tables = schema.table_names().into_iter().collect();
+        }
+        for id in self.semantic_rel_routes().keys() {
+            if let Some(table) = self.semantic_edge_table(*id) {
+                snapshot.semantic_edges.insert(*id, table.schema());
+            }
+            if let Some(table) = self.semantic_edge_property_table(*id) {
+                snapshot
+                    .semantic_edge_properties
+                    .insert(*id, table.schema());
+            }
+        }
+        if let Some(dir) = dir {
+            let inventory = self.lowering_property_inventory();
+            snapshot.node_schema = Some(
+                crate::TopologyNodeTable::open_project(dir)
+                    .map_err(GfError::from_plan_error)?
+                    .schema(),
+            );
+            snapshot.node_property_stems = crate::list_property_stems(dir);
+            snapshot.edge_property_stems = crate::list_edge_property_stems(dir);
+            let mut nodes: std::collections::BTreeSet<String> =
+                snapshot.node_property_stems.iter().cloned().collect();
+            nodes.extend(snapshot.semantic_labels.values().cloned());
+            let mut edges: std::collections::BTreeSet<String> =
+                snapshot.edge_property_stems.iter().cloned().collect();
+            if let Some(inventory) = &inventory {
+                nodes.extend(
+                    inventory
+                        .routes(crate::PropertyRouteKind::Node)
+                        .map(str::to_owned),
+                );
+                edges.extend(
+                    inventory
+                        .routes(crate::PropertyRouteKind::Edge)
+                        .map(str::to_owned),
+                );
+            }
+            for stem in nodes {
+                snapshot.node_properties.insert(
+                    stem.clone(),
+                    inventory
+                        .as_ref()
+                        .map_or_else(
+                            || crate::PropertyTable::open_discovered(dir, &stem),
+                            |inventory| {
+                                crate::PropertyTable::open_authenticated(
+                                    dir,
+                                    &stem,
+                                    std::sync::Arc::clone(inventory),
+                                )
+                            },
+                        )
+                        .schema(),
+                );
+            }
+            for stem in edges {
+                snapshot.edge_properties.insert(
+                    stem.clone(),
+                    inventory
+                        .as_ref()
+                        .map_or_else(
+                            || crate::EdgePropertyTable::open_discovered(dir, &stem),
+                            |inventory| {
+                                crate::EdgePropertyTable::open_authenticated(
+                                    dir,
+                                    &stem,
+                                    std::sync::Arc::clone(inventory),
+                                )
+                            },
+                        )
+                        .schema(),
+                );
+            }
+        }
+        Ok(snapshot)
+    }
+}
+
+/// Capture a lowering snapshot for schema-only or dataset compilation.
+pub fn lowering_snapshot(
+    catalog: Option<&GraphCatalog>,
+    dir: Option<&Path>,
+) -> Result<LoweringSnapshot, GfError> {
+    if let Some(catalog) = catalog {
+        return catalog.lowering_snapshot(dir);
+    }
+    let mut snapshot = LoweringSnapshot::default();
+    if let Some(dir) = dir {
+        snapshot.node_schema = Some(
+            crate::TopologyNodeTable::open_project(dir)
+                .map_err(GfError::from_plan_error)?
+                .schema(),
+        );
+        snapshot.node_property_stems = crate::list_property_stems(dir);
+        snapshot.edge_property_stems = crate::list_edge_property_stems(dir);
+        for stem in &snapshot.node_property_stems {
+            snapshot.node_properties.insert(
+                stem.clone(),
+                crate::PropertyTable::open_discovered(dir, &stem).schema(),
+            );
+        }
+        for stem in &snapshot.edge_property_stems {
+            snapshot.edge_properties.insert(
+                stem.clone(),
+                crate::EdgePropertyTable::open_discovered(dir, &stem).schema(),
+            );
+        }
+    }
+    Ok(snapshot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use graphforge_core::{OntologyMode, TypeId};
+    use graphforge_ir::{IrLiteral, RuntimeCatalog};
+    use graphforge_ontology::{OntologyModuleId, QualifiedSymbol, SymbolKind};
+    use graphforge_value::EntityTypeId;
+    use std::collections::HashMap;
+
+    #[test]
+    fn selected_semantic_schema_survives_absent_discovery_without_expanding_unions() {
+        let dir = tempfile::tempdir().unwrap();
+        let symbol = QualifiedSymbol {
+            module: OntologyModuleId {
+                ontology_id: "https://example.test/schema".into(),
+                authored_version: "1".into(),
+                canonical_digest: "a".repeat(64),
+            },
+            kind: SymbolKind::Entity,
+            local_id: "Person".into(),
+        };
+        let route = crate::SemanticStorageBindings::opaque_route(
+            crate::SemanticRouteKind::Entity,
+            &symbol,
+            None,
+        );
+        let id = EntityTypeId::ontology(TypeId(1)).unwrap();
+        let uuid = graphforge_core::uuid::new_v7();
+        let mut writer = crate::GraphWriter::open_at(dir.path(), OntologyMode::Strict, 1).unwrap();
+        writer.create_node(uuid, id).unwrap();
+        writer
+            .set_properties(
+                &uuid,
+                Some(&route),
+                HashMap::from([("name".into(), IrLiteral::Str("retained".into()))]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        let bindings = crate::SemanticStorageBindings {
+            contract_version: 1,
+            composition_fingerprint: "b".repeat(64),
+            bindings: vec![crate::SemanticStorageBinding {
+                route_kind: crate::SemanticRouteKind::Entity,
+                storage_id: id.encode(),
+                route: route.clone(),
+                symbol,
+                owner: None,
+            }],
+        };
+        let catalog = GraphCatalog::open_with_semantic_bindings(
+            dir.path(),
+            None,
+            &RuntimeCatalog::new(),
+            Some(&bindings),
+        )
+        .unwrap();
+        let before = catalog.lowering_snapshot(Some(dir.path())).unwrap();
+        assert_eq!(before.node_property_stems, vec![route.clone()]);
+        let expected = before.node_properties[&route].clone();
+        assert!(expected.field_with_name("name").is_ok());
+        std::fs::rename(
+            dir.path().join("properties"),
+            dir.path().join("retained-properties"),
+        )
+        .unwrap();
+        assert!(crate::list_property_stems(dir.path()).is_empty());
+        let after = catalog.lowering_snapshot(Some(dir.path())).unwrap();
+        assert_eq!(after.semantic_labels[&id], route);
+        assert_eq!(after.node_properties[&route], expected);
+        assert!(
+            after.node_property_stems.is_empty(),
+            "cached selected schemas must not expand the discovered path union"
+        );
+        assert_eq!(after.edge_property_stems, before.edge_property_stems);
+    }
+}

--- a/docs/adr/0029-lowering-schema-snapshot.md
+++ b/docs/adr/0029-lowering-schema-snapshot.md
@@ -1,0 +1,46 @@
+# ADR 0029: Compile against immutable schema and catalog data
+
+## Status
+
+Accepted for #1148, the first slice of #1006.
+
+## Decision
+
+`graphforge-ir::LoweringSnapshot` contains checked identity/name maps, semantic
+composition and route assumptions, and Arrow schemas. It contains no source
+paths, executable providers, or graph rows. Storage constructs the snapshot
+before relational compilation using the existing catalog and schema discovery.
+This uses existing dependencies: storage already consumes IR, and IR already
+owns Arrow and checked semantic identities.
+
+Relational lowering owns a copy of these facts. Schema-only explanation retains
+its historical logical table sources; dataset lowering emits the existing read
+descriptors and semantic contracts. Explicit write lowering enables compiling
+write operations, but execution alone admits write authority. Compile mode does
+not become machine authority embedded in the logical plan.
+
+Buffered node scans combine an ordinary logical node scan with the statement's
+pending rows. They no longer load stored topology during lowering. Execution
+binds and reads the stored side under its existing resource context.
+
+Schema metadata follows the existing read-source contract: only transient
+property live-count metadata is omitted from logical identity. Other metadata
+and physical/public schemas retain their existing semantics.
+
+## Remaining parent work
+
+Runtime path hydration remains in rel for this slice. Its execution binding may
+validate stored schema facts and its visitors still perform runtime reads. The
+next #1006 slice moves that implementation behind ordinary execution demand,
+cancellation and accounting. Shared schema definitions and the unused
+StorageProvider abstraction also remain pending the parent's final dependency
+cleanup. This decision does not claim that rel's production storage dependency
+has been removed.
+
+## Evidence
+
+Read-resource integration tests capture a snapshot, make the source directory
+unavailable during lowering, and then independently bind complete plans to two
+schema-equivalent graphs with different cardinalities. Existing fixed/variable
+traversal, wildcard properties, path hydration, write visibility, read-only
+explanation and incompatible-resource tests remain parity gates.

--- a/docs/adr/0029-lowering-schema-snapshot.md
+++ b/docs/adr/0029-lowering-schema-snapshot.md
@@ -29,7 +29,12 @@ and physical/public schemas retain their existing semantics.
 
 ## Remaining parent work
 
-Runtime path hydration remains in rel for this slice. Its execution binding may
+Runtime path hydration remains in rel for this slice. Specifically,
+`expr::bind_graph_read_expression` revalidates property schemas at physical
+binding; `gather_path_node_labels` and `gather_path_node_props` still invoke
+storage visitors at execution. Rel also imports shared storage schema constants.
+The unused `StorageProvider` stubs live in `graphforge-storage/src/lib.rs`, not
+in rel. Its execution binding may
 validate stored schema facts and its visitors still perform runtime reads. The
 next #1006 slice moves that implementation behind ordinary execution demand,
 cancellation and accounting. Shared schema definitions and the unused
@@ -44,3 +49,9 @@ unavailable during lowering, and then independently bind complete plans to two
 schema-equivalent graphs with different cardinalities. Existing fixed/variable
 traversal, wildcard properties, path hydration, write visibility, read-only
 explanation and incompatible-resource tests remain parity gates.
+
+Dataset snapshot construction requires a catalog's retained authenticated
+property inventory. It does not re-admit routes through discovery helpers that
+hash graph data. A catalog admitted for an absent standalone write target can
+supply its empty schema without creating that target; a missing inventory for
+an existing target is rejected. No-catalog callers are schema-only.


### PR DESCRIPTION
Lowering currently discovers storage schemas while constructing logical plans. This change supplies a schema/catalog snapshot from outside the relational compiler, so an already captured snapshot can lower queries after its source workspace becomes unavailable. Nested expressions, path descriptions, and mutation phases use the same input; execution retains resource validation and write authority.

The producer reuses authenticated catalog inventory and schema caches. It rejects missing admission rather than falling back to graph-file authentication, and preserves empty standalone write targets. Malformed path schema descriptions return a structured lowering error. Regression coverage also preserves pending-node visibility through CREATE, SET, and MERGE.

This is the lowering-input slice of #1006. Runtime path hydration, its accounting, and the remaining storage dependency stay tracked by that parent; ADR 0029 inventories those call sites.

Validation:
- Final relational unit tests: 236 passed; logical-plan goldens: 15 passed.
- Final execution integration tests: 7 read and 16 write passed.
- Storage snapshot boundary regressions: 2 passed.
- Full API unit suite before the final bounded review fixes: 689 passed.
- Final BDD: 118 scenarios passed; TCK: 3,897/3,897 passed, with no baseline regressions. Required workspace Clippy passed.
- Formatting, pre-push-fast, gate-registry, and diff checks passed.
- Optional all-target Clippy stopped on two pre-existing float-comparison assertions in unchanged core embedding-options tests; no suppressions or unrelated changes were added.

Closes #1148

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791393184&installation_model_id=20486&pr_number=1150&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1150&signature=c054f971f9ff127c99510ba619347014d43a39065fe82c3b608e71583787039d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->