### PR TITLE
refactor(exec,api): share mutation transactions and recovery

### DIFF
--- a/crates/graphforge-api/src/algorithm_writeback.rs
+++ b/crates/graphforge-api/src/algorithm_writeback.rs
@@ -317,6 +317,24 @@ mod tests {
     }
 
     #[test]
+    fn existing_cypher_property_counter_semantics() {
+        let graph = GraphForge::new(None).unwrap();
+        graph.execute("CREATE (:Person {name:'seed'})").unwrap();
+        let repeated = graph
+            .execute("MATCH (n:Person) SET n.metric=1 SET n.metric=2")
+            .unwrap();
+        assert_eq!(repeated.side_effects.unwrap().properties_set, 1);
+        let same_value = graph.execute("MATCH (n:Person) SET n.metric=2").unwrap();
+        assert_eq!(same_value.side_effects.unwrap().properties_set, 1);
+        let created = graph
+            .execute("CREATE (n:NewPerson {metric:1}) SET n.metric=2")
+            .unwrap();
+        assert_eq!(created.side_effects.unwrap().properties_set, 1);
+        let empty = graph.execute("MATCH (n:Absent) SET n.metric=3").unwrap();
+        assert_eq!(empty.side_effects.unwrap().properties_set, 0);
+    }
+
+    #[test]
     fn rank_and_cluster_writes_persist_without_topology_changes() {
         let (dir, graph, uuid) = graph();
         let generation = graphforge_storage::read_topology_generation(&graph.dir).unwrap();

--- a/crates/graphforge-api/src/algorithm_writeback.rs
+++ b/crates/graphforge-api/src/algorithm_writeback.rs
@@ -62,68 +62,57 @@ impl GraphForge {
             &known,
         )?;
 
-        let mut catalog = self
+        let prior_catalog = self
             .runtime_catalog
             .lock()
-            .expect("runtime catalog poisoned");
-        let prior_catalog = catalog.clone();
-        let mut next_catalog = catalog.clone();
-        next_catalog.intern_property(property, Some(label))?;
-        let prior_snapshot = crate::graph_snapshot::capture(&self.dir)?;
-        let expected_generation = *self
-            .current_generation_uuid
-            .lock()
-            .expect("generation UUID lock poisoned");
-        let mut staged = graphforge_storage::RewriteBatch::new();
-        if self.path.is_some() {
-            let catalog_batch = next_catalog.to_record_batch();
-            staged.stage(
-                &self.dir.join("topology/runtime_catalog.parquet"),
-                catalog_batch.schema(),
-                &catalog_batch,
-            )?;
-        }
-        let inventory = self.property_inventory_for_session();
-        let touched = graphforge_storage::stage_set_node_properties_authenticated(
-            &mut staged,
+            .expect("runtime catalog poisoned")
+            .clone();
+        let mut transaction = graphforge_exec::mutation::MutationTransaction::new(&prior_catalog);
+        transaction.intern_property(property, Some(label))?;
+        let working = transaction.catalog();
+        let catalog = graphforge_storage::GraphCatalog::open_authenticated_with_semantic_bindings(
             &self.dir,
-            &inventory,
+            self.ontology.as_ref(),
+            &working.lock().expect("mutation catalog poisoned"),
+            self.semantic_storage_bindings
+                .lock()
+                .expect("semantic storage binding lock poisoned")
+                .as_ref(),
+            self.property_inventory_for_session(),
+        )
+        .map_err(GfError::from_execution_error)?;
+        let session =
+            graphforge_exec::ExecutionSession::new_with_target_provider_resources_and_identity(
+                catalog,
+                self.ontology.clone(),
+                self.dir.clone(),
+                self.ontology_mode,
+                std::sync::Arc::clone(&self.adjacency_provider),
+                Some(std::sync::Arc::clone(&self.ordinal_identities)),
+                &self.session_resource_config(),
+            )?;
+        let session = if self.read_only {
+            session.restrict_to_reads()
+        } else {
+            session
+        };
+        let resource = session.write_resource()?;
+        let mut lifecycle = crate::mutation_transaction::FacadeMutationLifecycle::new(
+            self,
+            prior_catalog,
+            true,
+            None,
+        )?;
+        let touched = match transaction.stage_node_properties(
+            &resource,
+            &self.property_inventory_for_session(),
             stem,
             &updates,
-        )?;
-        staged.commit_at(&self.dir)?;
-        *catalog = next_catalog;
-        drop(catalog);
-        let mut outputs = updates
-            .keys()
-            .map(|uuid| graphforge_exec::MutationSubject {
-                uuid: *uuid,
-                kind: graphforge_exec::MutationSubjectKind::Node,
-            })
-            .collect::<Vec<_>>();
-        outputs.sort_unstable();
-        let receipt = graphforge_exec::MutationReceipt {
-            effects: vec![graphforge_exec::MutationEffect {
-                kind: graphforge_exec::MutationKind::SetProperty,
-                inputs: Vec::new(),
-                outputs,
-            }],
+        ) {
+            Ok(touched) => touched,
+            Err(error) => return transaction.abort(&mut lifecycle, error),
         };
-        if let Err(error) = self.publish_graph_mutation(&receipt) {
-            let still_prior = *self
-                .current_generation_uuid
-                .lock()
-                .expect("generation UUID lock poisoned")
-                == expected_generation;
-            if still_prior {
-                crate::graph_snapshot::restore(&prior_snapshot.bytes, &self.dir)?;
-                *self
-                    .runtime_catalog
-                    .lock()
-                    .expect("runtime catalog poisoned") = prior_catalog;
-            }
-            return Err(error);
-        }
+        transaction.commit(&resource, true, &mut lifecycle)?;
         Ok(touched)
     }
 }

--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -813,3 +813,87 @@ fn facade_reopens_relation_edge_property_through_default_context() {
         "1999"
     );
 }
+
+#[test]
+fn semantic_post_current_fault_helper() {
+    let Ok(root) = std::env::var("GF_SEMANTIC_MUTATION_FAULT_ROOT") else {
+        return;
+    };
+    let forge = GraphForge::new(Some(&root)).unwrap();
+    assert!(forge.semantic_storage_bindings.lock().unwrap().is_none());
+    let before = graphforge_storage::resolve_project_generation(std::path::Path::new(&root))
+        .unwrap()
+        .generation_uuid();
+    let error = forge
+        .execute_with_composition(
+            "CREATE (n:`research:Person` {name:'Ada'})",
+            single_module_fixture(),
+        )
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("cause=injected_failpoint"),
+        "{error}"
+    );
+    let selected =
+        graphforge_storage::resolve_project_generation(std::path::Path::new(&root)).unwrap();
+    assert_ne!(selected.generation_uuid(), before);
+    let durable = graphforge_storage::semantic_storage_bindings(&selected).unwrap();
+    assert!(durable.is_some());
+    // Check the recovered owner before a query can install a context or project
+    // bindings. This distinguishes recovery from merely successful reopen.
+    assert_eq!(*forge.semantic_storage_bindings.lock().unwrap(), durable);
+    assert_eq!(
+        *forge.current_generation_uuid.lock().unwrap(),
+        selected.generation_uuid()
+    );
+    let reopened = GraphForge::new(Some(&root)).unwrap();
+    assert_eq!(*reopened.semantic_storage_bindings.lock().unwrap(), durable);
+    for owner in [&forge, &reopened] {
+        let result = owner
+            .execute("MATCH (n:`research:Person`) RETURN n.name")
+            .unwrap();
+        assert_eq!(
+            result
+                .batches
+                .iter()
+                .map(arrow::record_batch::RecordBatch::num_rows)
+                .sum::<usize>(),
+            1
+        );
+        let batch = result
+            .batches
+            .iter()
+            .find(|batch| batch.num_rows() > 0)
+            .unwrap();
+        assert_eq!(
+            arrow::util::display::array_value_to_string(batch.column(0), 0).unwrap(),
+            "Ada"
+        );
+    }
+}
+
+#[test]
+fn semantic_post_current_failure_reconciles_new_bindings_on_existing_owner() {
+    let root = tempfile::TempDir::new().unwrap();
+    let forge = GraphForge::new(root.path().to_str()).unwrap();
+    install_composition_authority(&forge, &single_module_fixture());
+    drop(forge);
+    let status = std::process::Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "composition_binding_tests::semantic_post_current_fault_helper",
+            "--nocapture",
+        ])
+        .env("GF_SEMANTIC_MUTATION_FAULT_ROOT", root.path())
+        .env(
+            "GRAPHFORGE_PROJECT_FAILPOINTS",
+            "graphforge-internal-subprocess-v1",
+        )
+        .env(
+            "GRAPHFORGE_PROJECT_FAILPOINT",
+            "project.after_current_replace.error",
+        )
+        .status()
+        .unwrap();
+    assert!(status.success(), "semantic post-CURRENT helper: {status}");
+}

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -250,6 +250,8 @@ impl GraphForge {
 
     fn refresh_worker_handle(&self) -> Self {
         Self {
+            #[cfg(test)]
+            last_mutation_outcome: std::sync::Mutex::new(None),
             identity: self.identity.clone(),
             path: self.path.clone(),
             lifecycle_mode: self.lifecycle_mode,

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -99,6 +99,9 @@ mod invocation_descriptor;
 mod knowledge;
 mod maintenance;
 mod multi_ontology;
+mod mutation_transaction;
+#[cfg(test)]
+mod mutation_transaction_fault_tests;
 pub use multi_ontology::{
     ActivationProfileChangeRequest, BridgeAdoptionRequest, BridgeCandidate, BridgeDeleteRequest,
     BridgeUpdateRequest, CompositionValidationReceipt, ModuleAdoptionRequest, ModuleCandidate,
@@ -474,6 +477,8 @@ pub struct GraphForge {
     /// closes the remaining window for mutation APIs that still operate through
     /// this exact facade instance.
     /// Same-instance write admission and visibility coordinator.
+    #[cfg(test)]
+    last_mutation_outcome: Mutex<Option<graphforge_exec::mutation::MutationOutcome>>,
     pub(crate) graph_visibility: Arc<write_modes::WriteCoordinator>,
     /// Validated embedded write behavior for this facade.
     write_options: GraphForgeOptions,
@@ -637,6 +642,8 @@ impl GraphForge {
             )),
             embedding_refresh_epoch: Instant::now(),
             embedding_refresh_visibility: Arc::new(Mutex::new(())),
+            #[cfg(test)]
+            last_mutation_outcome: Mutex::new(None),
             graph_visibility: Arc::new(write_modes::WriteCoordinator::new(&options)),
             write_options: options,
             heavy_query_admission: Arc::new(resource_policy::HeavyQueryAdmission::new(
@@ -844,6 +851,8 @@ impl GraphForge {
             )),
             embedding_refresh_epoch: Instant::now(),
             embedding_refresh_visibility: Arc::new(Mutex::new(())),
+            #[cfg(test)]
+            last_mutation_outcome: Mutex::new(None),
             graph_visibility: Arc::new(write_modes::WriteCoordinator::new(&write_options)),
             write_options,
             resource_policy,
@@ -909,14 +918,17 @@ impl GraphForge {
     }
 
     fn admit_heavy_query(&self) -> Result<tokio::sync::SemaphorePermit<'_>, GfError> {
+        self.graph_visibility.health.check()?;
         self.heavy_query_admission.try_acquire()
     }
 
     fn admit_heavy_query_owned(&self) -> Result<tokio::sync::OwnedSemaphorePermit, GfError> {
+        self.graph_visibility.health.check()?;
         self.heavy_query_admission.try_acquire_owned()
     }
 
     fn generation_for_read(&self) -> Result<ResolvedProjectGeneration, GfError> {
+        self.graph_visibility.health.check()?;
         if self.read_only {
             Ok(self.resolved_generation.clone())
         } else {
@@ -1180,11 +1192,32 @@ impl GraphForge {
         if ast.clauses.is_empty() {
             return Err(GfError::Validation("empty query".into()));
         }
+        let is_mutation = ast.has_mutation_clauses();
+        if is_mutation && self.read_only {
+            return Err(GfError::Execution(
+                "GF_WRITE_RESOURCE_READ_ONLY: session does not authorize writes".into(),
+            ));
+        }
+        let _mutation_admission = (is_mutation && publish)
+            .then(|| self.graph_visibility.lock())
+            .transpose()?;
+        let transaction = is_mutation.then(|| {
+            graphforge_exec::mutation::MutationTransaction::new(
+                &self
+                    .runtime_catalog
+                    .lock()
+                    .expect("runtime catalog poisoned"),
+            )
+        });
+        let binding_catalog = transaction.as_ref().map_or_else(
+            || Arc::clone(&self.runtime_catalog),
+            |transaction| transaction.catalog(),
+        );
         validate_typed_parameter_binding(
             &ast,
             params,
             self.ontology.clone(),
-            &self.runtime_catalog,
+            &binding_catalog,
             self.ontology_mode,
             self.procedure_snapshot(),
         )?;
@@ -1194,7 +1227,7 @@ impl GraphForge {
         let plan = {
             let mut binder = Binder::new(
                 self.ontology.clone(),
-                self.runtime_catalog.clone(),
+                binding_catalog.clone(),
                 self.ontology_mode,
             )
             .with_procedures(self.procedure_snapshot());
@@ -1229,6 +1262,8 @@ impl GraphForge {
             candidate,
             composition_mode,
             legacy_route_moves,
+            transaction,
+            is_mutation && publish,
         );
         let result = result.map_err(publicize_query_error)?;
         shape_result(result, self.ontology_mode, self.ontology.as_ref())
@@ -1291,7 +1326,9 @@ impl GraphForge {
         params: &HashMap<String, IrLiteral>,
         publish: bool,
     ) -> Result<ExecutionResult, GfError> {
-        self.run_plan_with_publish_and_bindings(plan, params, publish, None, None, None)
+        self.run_plan_with_publish_and_bindings(
+            plan, params, publish, None, None, None, None, false,
+        )
     }
 
     #[allow(clippy::too_many_lines)] // one visibility lock spans execution and publication
@@ -1303,6 +1340,8 @@ impl GraphForge {
         candidate_bindings: Option<&graphforge_storage::SemanticStorageBindings>,
         composition_mode: Option<OntologyMode>,
         legacy_route_moves: Option<&[(std::path::PathBuf, std::path::PathBuf)]>,
+        transaction: Option<graphforge_exec::mutation::MutationTransaction>,
+        write_admission_held: bool,
     ) -> Result<ExecutionResult, GfError> {
         use graphforge_exec::ExecutionSession;
 
@@ -1324,27 +1363,44 @@ impl GraphForge {
             })
             .count();
         let is_write = write_ops > 0;
+        if is_write && self.read_only {
+            return Err(GfError::Execution(
+                "GF_WRITE_RESOURCE_READ_ONLY: session does not authorize writes".into(),
+            ));
+        }
         // Transaction commit already holds write admission when publish is false.
-        let _write_visibility = (is_write && publish)
+        let _write_visibility = (is_write && publish && !write_admission_held)
             .then(|| self.graph_visibility.lock())
             .transpose()?;
         let _read_visibility = (!is_write)
             .then(|| self.graph_visibility.read())
             .transpose()?;
-        let expected_generation_before_write = *self
-            .current_generation_uuid
+        let prior_catalog = self
+            .runtime_catalog
             .lock()
-            .expect("generation UUID lock poisoned");
-        // File-backed generations restore from the still-authoritative parent
-        // generation on publish failure instead of capturing a whole-workspace
-        // Arrow snapshot envelope.
-        let rollback_generation = (is_write && publish)
-            .then(|| {
-                graphforge_storage::resolve_project_generation(
-                    self.resolved_generation.container_root(),
-                )
-            })
-            .transpose()?;
+            .expect("runtime catalog poisoned")
+            .clone();
+        let mut transaction = if is_write {
+            Some(transaction.unwrap_or_else(|| {
+                graphforge_exec::mutation::MutationTransaction::new(&prior_catalog)
+            }))
+        } else {
+            None
+        };
+        let working_catalog = transaction.as_ref().map_or_else(
+            || Arc::clone(&self.runtime_catalog),
+            |transaction| transaction.catalog(),
+        );
+        let mut lifecycle = if is_write {
+            Some(mutation_transaction::FacadeMutationLifecycle::new(
+                self,
+                prior_catalog,
+                publish,
+                candidate_bindings,
+            )?)
+        } else {
+            None
+        };
         let mut legacy_migration = None;
         if legacy_route_moves.is_some_and(|moves| !moves.is_empty()) {
             if !is_write || !publish {
@@ -1362,10 +1418,7 @@ impl GraphForge {
         // Open a catalog snapshot reflecting the freshly-bound runtime catalog so
         // read scans resolve property names interned during bind.
         let catalog = {
-            let rc = self
-                .runtime_catalog
-                .lock()
-                .expect("runtime catalog poisoned");
+            let rc = working_catalog.lock().expect("runtime catalog poisoned");
             let installed = self
                 .semantic_storage_bindings
                 .lock()
@@ -1403,50 +1456,42 @@ impl GraphForge {
             session
         };
 
-        let result = self.block_on(async {
+        let execution = self.block_on(async {
             if is_write {
                 session
-                    .execute_write_statement_with_params(&plan, params)
+                    .prepare_write_statement_with_params(
+                        &plan,
+                        params,
+                        transaction.as_mut().expect("write transaction"),
+                    )
                     .await
             } else {
                 session.execute_plan_with_params(&plan, params).await
             }
-        })?;
-
-        // Persist the runtime catalog after a write so a later `GraphForge::new`
-        // on this directory reloads the types/properties the binder observed
-        // (the read side already loads it on open). In-memory instances skip
-        // this — their temp dir is discarded on drop. (#725)
-        if is_write && self.path.is_some() {
-            let rc = self
-                .runtime_catalog
-                .lock()
-                .expect("runtime catalog poisoned");
-            persist_runtime_catalog(&self.dir, &rc)?;
+        });
+        let result = match execution {
+            Ok(result) => result,
+            Err(error) => {
+                if let Some(transaction) = transaction.take() {
+                    return transaction.abort(lifecycle.as_mut().expect("write lifecycle"), error);
+                }
+                return Err(error);
+            }
+        };
+        if let Some(transaction) = transaction.take() {
+            let resource = session.write_resource()?;
+            transaction.commit(
+                &resource,
+                true,
+                lifecycle.as_mut().expect("write lifecycle"),
+            )?;
         }
         if publish
-            && let Some(receipt) = result
+            && let Some(_receipt) = result
                 .mutation_receipt
                 .as_ref()
                 .filter(|receipt| !receipt.is_empty())
         {
-            let rollback_generation = rollback_generation
-                .as_ref()
-                .expect("write path resolved a rollback generation");
-            if let Err(error) =
-                self.publish_graph_mutation_with_bindings(receipt, candidate_bindings)
-            {
-                let still_prior = *self
-                    .current_generation_uuid
-                    .lock()
-                    .expect("generation UUID lock poisoned")
-                    == expected_generation_before_write;
-                if still_prior {
-                    rematerialize_graph_workspace(rollback_generation, &self.dir)?;
-                    self.adjacency_provider.invalidate();
-                }
-                return Err(error);
-            }
             if let Some(candidate) = candidate_bindings {
                 // The write visibility lock still covers this swap, so an
                 // older request can never overwrite a newer publication.
@@ -1834,11 +1879,11 @@ impl GraphForge {
         // stream is demand-driven and may outlive this call; holding the slot
         // for the full consumer lifetime would serialize all streaming clients.
         drop(admission);
-        Ok(shape_stream(
+        Ok(self.graph_visibility.health.guard_stream(shape_stream(
             stream,
             self.ontology_mode,
             self.ontology.as_ref(),
-        ))
+        )))
     }
 
     /// Streaming query plus a [`RuntimeGuard`] that keeps the instance's
@@ -1990,6 +2035,7 @@ impl GraphForge {
         label: &str,
         verb: &str,
     ) -> Result<(graphforge_value::EntityTypeSelection, String), GfError> {
+        self.graph_visibility.health.check()?;
         if label.is_empty() || label.trim() != label || label.chars().any(char::is_control) {
             return Err(GfError::Validation(format!(
                 "invalid {verb} label {label:?}"
@@ -2080,6 +2126,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
+        self.graph_visibility.health.check()?;
         let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Rank(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
@@ -2171,6 +2218,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
+        self.graph_visibility.health.check()?;
         let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Cluster(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
@@ -2260,6 +2308,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
+        self.graph_visibility.health.check()?;
         let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Similar(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
@@ -2455,6 +2504,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
+        self.graph_visibility.health.check()?;
         let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Analyze(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
@@ -2670,6 +2720,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
+        self.graph_visibility.health.check()?;
         let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Analyze(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(
@@ -2819,6 +2870,7 @@ impl GraphForge {
         &self,
         descriptor: &InvocationDescriptor,
     ) -> Result<arrow::record_batch::RecordBatch, InvocationError> {
+        self.graph_visibility.health.check()?;
         let _graph_visibility = self.graph_visibility.lock()?;
         let Algorithm::Paths(by) = descriptor.algorithm() else {
             return Err(InvocationDescriptorError::Invalid(

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -1211,7 +1211,7 @@ impl GraphForge {
         });
         let binding_catalog = transaction.as_ref().map_or_else(
             || Arc::clone(&self.runtime_catalog),
-            |transaction| transaction.catalog(),
+            graphforge_exec::mutation::MutationTransaction::catalog,
         );
         validate_typed_parameter_binding(
             &ast,
@@ -1332,6 +1332,7 @@ impl GraphForge {
     }
 
     #[allow(clippy::too_many_lines)] // one visibility lock spans execution and publication
+    #[allow(clippy::too_many_arguments)] // keep publication, binding and pre-admitted write context explicit
     fn run_plan_with_publish_and_bindings(
         &self,
         plan: &GraphPlan,
@@ -1389,7 +1390,7 @@ impl GraphForge {
         };
         let working_catalog = transaction.as_ref().map_or_else(
             || Arc::clone(&self.runtime_catalog),
-            |transaction| transaction.catalog(),
+            graphforge_exec::mutation::MutationTransaction::catalog,
         );
         let mut lifecycle = if is_write {
             Some(mutation_transaction::FacadeMutationLifecycle::new(

--- a/crates/graphforge-api/src/mutation_transaction.rs
+++ b/crates/graphforge-api/src/mutation_transaction.rs
@@ -1,0 +1,716 @@
+//! Facade generation adapter for the execution-owned mutation transaction.
+use std::sync::Arc;
+
+use graphforge_core::GfError;
+use graphforge_exec::mutation::MutationLifecycle;
+use graphforge_ir::RuntimeCatalog;
+use graphforge_storage::{ResolvedProjectGeneration, SemanticStorageBindings};
+
+use crate::GraphForge;
+
+pub(crate) struct FacadeMutationLifecycle<'a> {
+    graph: &'a GraphForge,
+    parent: ResolvedProjectGeneration,
+    prior_catalog: RuntimeCatalog,
+    publish: bool,
+    bindings: Option<&'a SemanticStorageBindings>,
+    unpublished: Option<graphforge_storage::GraphWorkspaceCheckpoint>,
+}
+
+impl<'a> FacadeMutationLifecycle<'a> {
+    pub(crate) fn new(
+        graph: &'a GraphForge,
+        prior_catalog: RuntimeCatalog,
+        publish: bool,
+        bindings: Option<&'a SemanticStorageBindings>,
+    ) -> Result<Self, GfError> {
+        if graph.read_only {
+            return Err(GfError::Execution(
+                "GF_WRITE_RESOURCE_READ_ONLY: session does not authorize writes".into(),
+            ));
+        }
+        let parent = graphforge_storage::resolve_project_generation(
+            graph.resolved_generation.container_root(),
+        )?;
+        let unpublished = if publish {
+            None
+        } else {
+            Some(graphforge_storage::GraphWorkspaceCheckpoint::capture(
+                &graph.dir,
+            )?)
+        };
+        Ok(Self {
+            graph,
+            parent,
+            prior_catalog,
+            publish,
+            bindings,
+            unpublished,
+        })
+    }
+
+    fn refresh_unpublished(&self) -> Result<(), GfError> {
+        let (inventory, _) = graphforge_storage::capture_graph_files(&self.graph.dir)?;
+        let inventory = Arc::new(
+            graphforge_storage::AuthenticatedPropertyInventory::from_materialized_generation(
+                &self.parent,
+                &self.graph.dir,
+                inventory.files,
+            )?,
+        );
+        *self
+            .graph
+            .property_authority
+            .lock()
+            .expect("property authority lock poisoned") = crate::GenerationPropertyAuthority {
+            generation_uuid: self.parent.generation_uuid(),
+            inventory,
+        };
+        Ok(())
+    }
+}
+
+impl MutationLifecycle for FacadeMutationLifecycle<'_> {
+    fn publish(
+        &mut self,
+        outcome: &graphforge_exec::mutation::MutationOutcome,
+        catalog: &RuntimeCatalog,
+    ) -> Result<(), GfError> {
+        *self
+            .graph
+            .runtime_catalog
+            .lock()
+            .expect("runtime catalog poisoned") = catalog.clone();
+        #[cfg(test)]
+        {
+            *self
+                .graph
+                .last_mutation_outcome
+                .lock()
+                .expect("mutation test outcome poisoned") = Some(outcome.clone());
+        }
+        if self.publish && !outcome.receipt.is_empty() {
+            self.graph
+                .publish_graph_mutation_with_bindings(&outcome.receipt, self.bindings)?;
+        }
+        Ok(())
+    }
+
+    fn complete(&mut self) -> Result<(), GfError> {
+        if !self.publish {
+            self.refresh_unpublished()?;
+        }
+        self.graph.adjacency_provider.invalidate();
+        Ok(())
+    }
+
+    fn abort(&mut self) -> Result<(), GfError> {
+        let health = self.graph.graph_visibility.health.clone();
+        health.recover(|| self.restore())
+    }
+}
+
+impl FacadeMutationLifecycle<'_> {
+    fn restore(&mut self) -> Result<(), GfError> {
+        // Resolve actual durable authority, not a possibly stale in-memory UUID.
+        // An unknown CURRENT fails before any parent restoration.
+        let current = graphforge_storage::resolve_project_generation(
+            self.graph.resolved_generation.container_root(),
+        )?;
+        if current.generation_uuid() == self.parent.generation_uuid() {
+            if let Some(checkpoint) = &mut self.unpublished {
+                checkpoint.restore(&self.graph.dir)?;
+                self.refresh_unpublished()?;
+            } else {
+                crate::rematerialize_graph_workspace(&self.parent, &self.graph.dir)?;
+                self.graph.install_property_generation(&self.parent)?;
+            }
+            *self
+                .graph
+                .runtime_catalog
+                .lock()
+                .expect("runtime catalog poisoned") = self.prior_catalog.clone();
+        } else {
+            // Publication may have succeeded before a later operation failed.
+            // Reconcile from the selected generation; never reinstall old files.
+            crate::rematerialize_graph_workspace(&current, &self.graph.dir)?;
+            let catalog = crate::load_runtime_catalog(&self.graph.dir)?;
+            self.graph.install_property_generation(&current)?;
+            *self
+                .graph
+                .semantic_storage_bindings
+                .lock()
+                .expect("semantic storage binding lock poisoned") =
+                graphforge_storage::semantic_storage_bindings(&current)?;
+            *self
+                .graph
+                .runtime_catalog
+                .lock()
+                .expect("runtime catalog poisoned") = catalog;
+        }
+        *self
+            .graph
+            .uuid_membership_index
+            .lock()
+            .expect("UUID membership index lock poisoned") = None;
+        self.graph.adjacency_provider.invalidate();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{FixedSizeBinaryArray, Float64Array, Int64Array};
+    use graphforge_core::algorithms::{ClusterAlgorithm, RankAlgorithm};
+    use graphforge_core::{ClusterOptions, RankOptions};
+    use std::collections::HashMap;
+
+    fn algorithm(
+        graph: &GraphForge,
+        cluster: bool,
+        property: Option<&str>,
+    ) -> arrow::record_batch::RecordBatch {
+        if cluster {
+            graph
+                .cluster(
+                    "Person",
+                    ClusterOptions {
+                        by: ClusterAlgorithm::Components,
+                        via: Some("KNOWS".into()),
+                        directed: true,
+                        write_property: property.map(str::to_owned),
+                        ..Default::default()
+                    },
+                )
+                .unwrap()
+        } else {
+            graph
+                .rank(
+                    "Person",
+                    RankOptions {
+                        by: RankAlgorithm::Degree,
+                        via: Some("KNOWS".into()),
+                        directed: true,
+                        write_property: property.map(str::to_owned),
+                    },
+                )
+                .unwrap()
+        }
+    }
+
+    #[test]
+    fn mixed_property_and_statement_preparation_rejects_second_without_losing_first() {
+        use graphforge_exec::mutation::MutationTransaction;
+        use graphforge_ir::{Binder, IrLiteral};
+        for property_first in [false, true] {
+            let graph = GraphForge::new(None).unwrap();
+            let node = graph
+                .add_node(
+                    "Person",
+                    &HashMap::from([("name".into(), crate::PropValue::Str("retained".into()))]),
+                )
+                .unwrap();
+            let prior = graph.runtime_catalog.lock().unwrap().clone();
+            let mut transaction = MutationTransaction::new(&prior);
+            transaction.intern_property("metric", None).unwrap();
+            let working = transaction.catalog();
+            let plan = Binder::new(None, working.clone(), graph.ontology_mode)
+                .bind(&graphforge_cypher::parse("MATCH (n:Person) SET n.metric=2").unwrap())
+                .unwrap();
+            let inventory = graph.property_inventory_for_session();
+            let catalog =
+                graphforge_storage::GraphCatalog::open_authenticated_with_semantic_bindings(
+                    &graph.dir,
+                    None,
+                    &working.lock().unwrap(),
+                    None,
+                    inventory.clone(),
+                )
+                .unwrap();
+            let session = graphforge_exec::ExecutionSession::new_with_target(
+                catalog,
+                None,
+                graph.dir.clone(),
+                graph.ontology_mode,
+            )
+            .unwrap();
+            let resource = session.write_resource().unwrap();
+            let (_, stem) = graph.algorithm_label("Person", "rank").unwrap();
+            let updates = HashMap::from([(
+                *node.uuid.as_bytes(),
+                HashMap::from([("metric".into(), IrLiteral::Int(1))]),
+            )]);
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            if property_first {
+                transaction
+                    .stage_node_properties(&resource, &inventory, &stem, &updates)
+                    .unwrap();
+            } else {
+                runtime
+                    .block_on(session.prepare_write_statement_with_params(
+                        &plan,
+                        &Default::default(),
+                        &mut transaction,
+                    ))
+                    .unwrap();
+            }
+            let outcome = transaction.outcome();
+            let error = if property_first {
+                runtime
+                    .block_on(session.prepare_write_statement_with_params(
+                        &plan,
+                        &Default::default(),
+                        &mut transaction,
+                    ))
+                    .unwrap_err()
+            } else {
+                transaction
+                    .stage_node_properties(&resource, &inventory, &stem, &updates)
+                    .unwrap_err()
+            };
+            assert!(error.to_string().contains("already prepared"), "{error}");
+            assert_eq!(transaction.outcome(), outcome);
+            let mut lifecycle = FacadeMutationLifecycle::new(&graph, prior, true, None).unwrap();
+            transaction.commit(&resource, true, &mut lifecycle).unwrap();
+            assert_eq!(
+                graph.last_mutation_outcome.lock().unwrap().as_ref(),
+                Some(&outcome)
+            );
+            let result = graph.execute("MATCH (n:Person) RETURN n.metric").unwrap();
+            let values = result.batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            assert_eq!(values.values(), &[if property_first { 1 } else { 2 }]);
+        }
+    }
+
+    #[test]
+    fn fresh_and_populated_ephemeral_abort_restore_catalog_data_and_allow_new_writes() {
+        for populated in [false, true] {
+            let graph = GraphForge::new(None).unwrap();
+            if populated {
+                graph.execute("CREATE (:Person {name:'retained'})").unwrap();
+            }
+            let prior_catalog = graph.runtime_catalog.lock().unwrap().to_record_batch();
+            let prior_files = graphforge_storage::capture_graph_files(&graph.dir)
+                .unwrap()
+                .0;
+            let prior_generation = *graph.current_generation_uuid.lock().unwrap();
+            let error = graph
+                .execute(
+                    "CREATE (a:Temporary {ephemeral_metric:1}) DELETE a SET a.ephemeral_metric=2",
+                )
+                .unwrap_err();
+            assert!(!error.to_string().is_empty());
+            assert_eq!(
+                graph.runtime_catalog.lock().unwrap().to_record_batch(),
+                prior_catalog
+            );
+            assert_eq!(
+                graphforge_storage::capture_graph_files(&graph.dir)
+                    .unwrap()
+                    .0,
+                prior_files
+            );
+            assert_eq!(
+                *graph.current_generation_uuid.lock().unwrap(),
+                prior_generation
+            );
+            let result = graph.execute("MATCH (n) RETURN n").unwrap();
+            assert_eq!(
+                result
+                    .batches
+                    .iter()
+                    .map(|batch| batch.num_rows())
+                    .sum::<usize>(),
+                usize::from(populated)
+            );
+            graph
+                .execute("CREATE (:Person {name:'after_abort'})")
+                .unwrap();
+            assert_eq!(
+                graph.node_count("Person").unwrap(),
+                if populated { 2 } else { 1 }
+            );
+        }
+    }
+
+    #[test]
+    fn real_analyst_and_cypher_share_receipts_counters_values_and_reopen() {
+        for cluster in [false, true] {
+            for analyst_first in [false, true] {
+                let root = tempfile::TempDir::new().unwrap();
+                let graph = GraphForge::new(root.path().to_str()).unwrap();
+                let mut names = HashMap::new();
+                let mut nodes = Vec::new();
+                for name in ["a", "b", "c"] {
+                    let node = graph
+                        .add_node(
+                            "Person",
+                            &HashMap::from([("name".into(), crate::PropValue::Str(name.into()))]),
+                        )
+                        .unwrap();
+                    names.insert(*node.uuid.as_bytes(), name);
+                    nodes.push(node);
+                }
+                graph
+                    .execute(if cluster {
+                        "MATCH (n:Person) SET n.metric = 0"
+                    } else {
+                        "MATCH (n:Person) SET n.metric = 0.0"
+                    })
+                    .unwrap();
+                graph
+                    .add_edge(&nodes[0], "KNOWS", &nodes[1], &HashMap::new())
+                    .unwrap();
+                // Warm actual property and adjacency resources before either write.
+                graph
+                    .execute("MATCH (n:Person) RETURN n.name ORDER BY n.name")
+                    .unwrap();
+                let dry = algorithm(&graph, cluster, None);
+                let uuids = dry
+                    .column_by_name("node_uuid")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
+                let mut cases = Vec::new();
+                for row in 0..dry.num_rows() {
+                    let uuid: [u8; 16] = uuids.value(row).try_into().unwrap();
+                    let value = if cluster {
+                        dry.column_by_name("community_id")
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<Int64Array>()
+                            .unwrap()
+                            .value(row)
+                            .to_string()
+                    } else {
+                        format!(
+                            "{:?}",
+                            dry.column_by_name("score")
+                                .unwrap()
+                                .as_any()
+                                .downcast_ref::<Float64Array>()
+                                .unwrap()
+                                .value(row)
+                        )
+                    };
+                    cases.push(format!("WHEN '{}' THEN {value}", names[&uuid]));
+                }
+                let query = format!(
+                    "MATCH (n:Person) SET n.metric = CASE n.name {} END",
+                    cases.join(" ")
+                );
+                let topology = graphforge_storage::read_topology_generation(&graph.dir).unwrap();
+                let before = *graph.current_generation_uuid.lock().unwrap();
+                let mut outcomes = Vec::new();
+                for analyst in [analyst_first, !analyst_first] {
+                    if analyst {
+                        algorithm(&graph, cluster, Some("metric"));
+                    } else {
+                        graph.execute(&query).unwrap();
+                    }
+                    outcomes.push(graph.last_mutation_outcome.lock().unwrap().clone().unwrap());
+                    assert_eq!(
+                        graphforge_storage::read_topology_generation(&graph.dir).unwrap(),
+                        topology
+                    );
+                    assert_ne!(*graph.current_generation_uuid.lock().unwrap(), before);
+                    assert!(
+                        graph.runtime_catalog.lock().unwrap().contains_property(
+                            "metric",
+                            if analyst { Some("Person") } else { None }
+                        )
+                    );
+                }
+                // Same identities are deliberately reused, so every receipt field
+                // and its deterministic subject ordering can be compared directly.
+                assert_eq!(outcomes[0], outcomes[1]);
+                assert_eq!(outcomes[0].side_effects.properties_set, 3);
+                assert_eq!(outcomes[0].side_effects.properties_removed, 3);
+                graph
+                    .execute(&query.replace("n.metric", "n.fresh_cypher"))
+                    .unwrap();
+                let fresh_cypher = graph.last_mutation_outcome.lock().unwrap().clone().unwrap();
+                algorithm(&graph, cluster, Some("fresh_analyst"));
+                let fresh_analyst = graph.last_mutation_outcome.lock().unwrap().clone().unwrap();
+                assert_eq!(fresh_cypher, fresh_analyst);
+                assert_eq!(fresh_analyst.side_effects.properties_set, 3);
+                assert_eq!(fresh_analyst.side_effects.properties_removed, 0);
+                let catalog = graph.runtime_catalog.lock().unwrap();
+                assert!(catalog.contains_property("fresh_cypher", None));
+                assert!(catalog.contains_property("fresh_analyst", Some("Person")));
+                drop(catalog);
+                let values = graph.execute("MATCH (n:Person) RETURN n.fresh_cypher AS expected, n.fresh_analyst AS actual ORDER BY n.name").unwrap();
+                for batch in &values.batches {
+                    assert_eq!(batch.column(0), batch.column(1));
+                }
+
+                assert_eq!(outcomes[0].receipt.effects.len(), 1);
+                assert_eq!(outcomes[0].receipt.effects[0].outputs.len(), 3);
+                let values = graph
+                    .execute("MATCH (n:Person) RETURN n.name, n.metric ORDER BY n.name")
+                    .unwrap()
+                    .batches;
+                drop(graph);
+                let reopened = GraphForge::new(root.path().to_str()).unwrap();
+                let actual = reopened
+                    .execute("MATCH (n:Person) RETURN n.name, n.metric ORDER BY n.name")
+                    .unwrap()
+                    .batches;
+                assert_eq!(actual.len(), values.len());
+                for (actual, expected) in actual.iter().zip(&values) {
+                    assert_eq!(actual.schema().fields(), expected.schema().fields());
+                    let mut actual_metadata = actual.schema().metadata().clone();
+                    let mut expected_metadata = expected.schema().metadata().clone();
+                    let actual_query = actual_metadata.remove("graphforge.query_id").unwrap();
+                    let expected_query = expected_metadata.remove("graphforge.query_id").unwrap();
+                    assert!(uuid::Uuid::parse_str(&actual_query).is_ok());
+                    assert!(uuid::Uuid::parse_str(&expected_query).is_ok());
+                    assert_ne!(actual_query, expected_query);
+                    assert_eq!(actual_metadata, expected_metadata);
+                    assert_eq!(actual.columns(), expected.columns());
+                }
+                assert!(
+                    reopened
+                        .runtime_catalog
+                        .lock()
+                        .unwrap()
+                        .contains_property("metric", Some("Person"))
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod recovery_tests {
+    use super::*;
+    use futures::StreamExt;
+    use std::collections::HashMap;
+    use std::process::Command;
+
+    #[test]
+    fn failed_restore_helper() {
+        let Ok(root) = std::env::var("GF_MUTATION_RESTORE_ROOT") else {
+            return;
+        };
+        if std::env::var("GF_MUTATION_STANDALONE").as_deref() == Ok("1") {
+            failed_standalone_restore(&root);
+            return;
+        }
+        let graph = GraphForge::new(Some(&root)).unwrap();
+        let (mut stream, _, _retained) = graph
+            .execute_stream_owned("MATCH (n:Person) RETURN n.name", &HashMap::new())
+            .unwrap();
+        let permit = graph.graph_visibility.lock().unwrap();
+        let error = graph
+            .execute_write_without_publish(
+                "MATCH (n:Person) DELETE n SET n.metric = 1",
+                &HashMap::new(),
+            )
+            .unwrap_err();
+        drop(permit);
+        let message = error.to_string();
+        assert!(message.contains("mutation restore failed"), "{message}");
+        let backup = message
+            .split("rollback backup retained at ")
+            .nth(1)
+            .unwrap()
+            .split(": ")
+            .next()
+            .unwrap();
+        assert!(
+            std::path::Path::new(backup)
+                .join("topology/nodes.parquet")
+                .exists(),
+            "{message}"
+        );
+        for query in ["MATCH (n:Person) RETURN n", "CREATE (:Person)"] {
+            assert!(
+                graph
+                    .execute(query)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("unavailable after failed recovery")
+            );
+        }
+        assert!(graph.labels().is_err());
+        assert!(graph.node_count("Person").is_err());
+        assert!(graph.rank("Person", Default::default()).is_err());
+        assert!(graph.cluster("Person", Default::default()).is_err());
+        let output = std::path::Path::new(&root).join("must-not-export.gf");
+        assert!(
+            graph
+                .export_portable(crate::PortableExportRequest {
+                    selection: crate::PortableSelection::Current,
+                    output: output.clone()
+                })
+                .is_err()
+        );
+        assert!(!output.exists());
+        graph
+            .block_on(async {
+                let error = stream
+                    .next()
+                    .await
+                    .expect("retained stream must report failure")
+                    .unwrap_err();
+                assert!(
+                    error
+                        .to_string()
+                        .contains("unavailable after failed recovery")
+                );
+                assert!(stream.next().await.is_none());
+                Ok(())
+            })
+            .unwrap();
+        // The durable parent is still authoritative and usable by a fresh owner.
+        let reopened = GraphForge::new(Some(&root)).unwrap();
+        assert_eq!(reopened.node_count("Person").unwrap(), 2);
+        std::fs::remove_dir_all(backup).unwrap();
+    }
+
+    #[test]
+    fn failed_restore_retains_backup_and_denies_later_reads_writes_and_lazy_stream() {
+        let root = tempfile::TempDir::new().unwrap();
+        let graph = GraphForge::new(root.path().to_str()).unwrap();
+        graph
+            .execute("CREATE (:Person {name:'a'}), (:Person {name:'b'})")
+            .unwrap();
+        drop(graph);
+        let status = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("mutation_transaction::recovery_tests::failed_restore_helper")
+            .arg("--nocapture")
+            .env("GF_MUTATION_RESTORE_ROOT", root.path())
+            .env(
+                "GRAPHFORGE_PROJECT_FAILPOINTS",
+                "graphforge-internal-subprocess-v1",
+            )
+            .env(
+                "GRAPHFORGE_PROJECT_FAILPOINT",
+                "mutation.restore.after_copy.error",
+            )
+            .status()
+            .unwrap();
+        assert!(status.success(), "restore failure helper: {status}");
+    }
+    fn failed_standalone_restore(root: &str) {
+        let graph = GraphForge::new(Some(root)).unwrap();
+        let catalog = graph.runtime_catalog();
+        let bind = |query: &str| {
+            graphforge_ir::Binder::new(
+                None,
+                Arc::clone(&catalog),
+                graphforge_core::OntologyMode::Exploratory,
+            )
+            .bind(&graphforge_cypher::parse(query).unwrap())
+            .unwrap()
+        };
+        let read = bind("MATCH (n:Person) RETURN n.name");
+        let write = bind("MATCH (n:Person) DELETE n SET n.metric = 1");
+        let physical_catalog =
+            graphforge_storage::GraphCatalog::open(&graph.dir, None, &catalog.lock().unwrap())
+                .unwrap();
+        let session = graphforge_exec::ExecutionSession::new_with_target(
+            physical_catalog,
+            None,
+            graph.dir.clone(),
+            graphforge_core::OntologyMode::Exploratory,
+        )
+        .unwrap();
+        let mut stream = graph
+            .block_on(session.execute_plan_stream(&read, &HashMap::new()))
+            .unwrap();
+        let error = graph
+            .block_on(session.execute_write_statement(&write))
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("mutation restore failed"), "{message}");
+        let backup = message
+            .split("rollback backup retained at ")
+            .nth(1)
+            .unwrap()
+            .split(": ")
+            .next()
+            .unwrap();
+        assert!(
+            std::path::Path::new(backup)
+                .join("topology/nodes.parquet")
+                .exists()
+        );
+        assert!(
+            graph
+                .block_on(session.execute_plan(&read))
+                .unwrap_err()
+                .to_string()
+                .contains("unavailable after failed recovery")
+        );
+        assert!(
+            graph
+                .block_on(session.execute_write_statement(&write))
+                .unwrap_err()
+                .to_string()
+                .contains("unavailable after failed recovery")
+        );
+        assert!(session.write_resource().is_err());
+        graph
+            .block_on(async {
+                assert!(
+                    stream
+                        .next()
+                        .await
+                        .unwrap()
+                        .unwrap_err()
+                        .to_string()
+                        .contains("unavailable after failed recovery")
+                );
+                assert!(stream.next().await.is_none());
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(
+            GraphForge::new(Some(root))
+                .unwrap()
+                .node_count("Person")
+                .unwrap(),
+            2
+        );
+        std::fs::remove_dir_all(backup).unwrap();
+    }
+
+    #[test]
+    fn standalone_failed_restore_denies_retained_stream_and_same_session_writes() {
+        let root = tempfile::TempDir::new().unwrap();
+        let graph = GraphForge::new(root.path().to_str()).unwrap();
+        graph
+            .execute("CREATE (:Person {name:'a'}), (:Person {name:'b'})")
+            .unwrap();
+        drop(graph);
+        let status = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("mutation_transaction::recovery_tests::failed_restore_helper")
+            .arg("--nocapture")
+            .env("GF_MUTATION_RESTORE_ROOT", root.path())
+            .env("GF_MUTATION_STANDALONE", "1")
+            .env(
+                "GRAPHFORGE_PROJECT_FAILPOINTS",
+                "graphforge-internal-subprocess-v1",
+            )
+            .env(
+                "GRAPHFORGE_PROJECT_FAILPOINT",
+                "mutation.restore.after_copy.error",
+            )
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "standalone restore failure helper: {status}"
+        );
+    }
+}

--- a/crates/graphforge-api/src/mutation_transaction_fault_tests.rs
+++ b/crates/graphforge-api/src/mutation_transaction_fault_tests.rs
@@ -1,0 +1,165 @@
+//! Publication authority parity for real Cypher and analyst mutations.
+use crate::GraphForge;
+use arrow::array::{Array, Float64Array};
+use graphforge_core::RankOptions;
+use graphforge_core::algorithms::RankAlgorithm;
+use std::process::Command;
+
+fn rank_options(write: bool) -> RankOptions {
+    RankOptions {
+        by: RankAlgorithm::Degree,
+        via: Some("KNOWS".into()),
+        directed: true,
+        write_property: write.then(|| "fault_metric".into()),
+    }
+}
+
+fn values(graph: &GraphForge, published: bool, score: f64) {
+    let result = graph
+        .execute("MATCH (n:Person) RETURN n.fault_metric ORDER BY n.name")
+        .unwrap();
+    assert_eq!(
+        result.batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        3
+    );
+    for batch in result.batches {
+        let column = batch.column(0);
+        if published {
+            let column = column.as_any().downcast_ref::<Float64Array>().unwrap();
+            assert_eq!(column.null_count(), 0);
+            for row in 0..column.len() {
+                assert_eq!(column.value(row), score);
+            }
+        } else {
+            assert_eq!(column.logical_null_count(), column.len());
+        }
+    }
+}
+
+#[test]
+fn mutation_authority_fault_helper() {
+    let Ok(root) = std::env::var("GF_MUTATION_AUTHORITY_ROOT") else {
+        return;
+    };
+    let analyst = std::env::var("GF_MUTATION_AUTHORITY_ANALYST").unwrap() == "1";
+    let hook = std::env::var("GRAPHFORGE_PROJECT_FAILPOINT").unwrap();
+    let published = hook == "project.after_current_replace.error";
+    let graph = GraphForge::new(Some(&root)).unwrap();
+    let before = graphforge_storage::resolve_project_generation(std::path::Path::new(&root))
+        .unwrap()
+        .generation_uuid();
+    let topology = graphforge_storage::read_topology_generation(&graph.dir).unwrap();
+    let edges = graph
+        .execute("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name ORDER BY a.name")
+        .unwrap()
+        .batches;
+    // A directed cycle gives every node the same real Degree output. Derive
+    // the SET value from that output rather than assuming degree conventions.
+    let dry = graph.rank("Person", rank_options(false)).unwrap();
+    let scores = dry
+        .column_by_name("score")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    assert_eq!(scores.len(), 3);
+    assert_eq!(scores.null_count(), 0);
+    let score = scores.value(0);
+    assert!(score > 0.0);
+    assert!((0..scores.len()).all(|row| scores.value(row) == score));
+    {
+        let catalog = graph.runtime_catalog.lock().unwrap();
+        assert!(!catalog.contains_property("fault_metric", None));
+        assert!(!catalog.contains_property("fault_metric", Some("Person")));
+    }
+    let error = if analyst {
+        graph.rank("Person", rank_options(true)).unwrap_err()
+    } else {
+        graph
+            .execute(&format!("MATCH (n:Person) SET n.fault_metric = {score:?}"))
+            .unwrap_err()
+    };
+    if hook == "project.before_current_replace.error" {
+        // Native replacement wraps and bounds the nested I/O cause. Its public
+        // error retains the publication phase and authoritative commit state.
+        assert_eq!(error.code(), "GF_PUBLICATION_FAILED");
+        assert!(
+            error.to_string().contains("phase=CURRENT committed=false"),
+            "{error}"
+        );
+    } else {
+        assert!(
+            error.to_string().contains("cause=injected_failpoint"),
+            "{hook}: {error}"
+        );
+    }
+    let selected = graphforge_storage::resolve_project_generation(std::path::Path::new(&root))
+        .unwrap()
+        .generation_uuid();
+    assert_eq!(selected != before, published, "{hook}");
+    let reopened = GraphForge::new(Some(&root)).unwrap();
+    for owner in [&graph, &reopened] {
+        assert_eq!(*owner.current_generation_uuid.lock().unwrap(), selected);
+        let catalog = owner.runtime_catalog.lock().unwrap();
+        // These ownership scopes intentionally differ between the two APIs.
+        assert_eq!(
+            catalog.contains_property("fault_metric", if analyst { Some("Person") } else { None }),
+            published
+        );
+        drop(catalog);
+        values(owner, published, score);
+        assert_eq!(
+            graphforge_storage::read_topology_generation(&owner.dir).unwrap(),
+            topology
+        );
+        let actual = owner
+            .execute("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name ORDER BY a.name")
+            .unwrap()
+            .batches;
+        assert_eq!(actual.len(), edges.len());
+        for (actual, expected) in actual.iter().zip(&edges) {
+            assert_eq!(actual.columns(), expected.columns());
+        }
+        assert_eq!(owner.node_count("Person").unwrap(), 3);
+    }
+}
+
+#[test]
+fn cypher_and_rank_failpoints_preserve_selected_generation_authority() {
+    let mut failures = Vec::new();
+    for hook in [
+        "rewrite.before_intent.error",
+        "rewrite.after_durable_intent.error",
+        "project.before_current_replace.error",
+        "project.after_current_replace.error",
+    ] {
+        for analyst in [false, true] {
+            let root = tempfile::TempDir::new().unwrap();
+            let graph = GraphForge::new(root.path().to_str()).unwrap();
+            graph.execute("CREATE (a:Person {name:'a'}), (b:Person {name:'b'}), (c:Person {name:'c'}), (a)-[:KNOWS]->(b), (b)-[:KNOWS]->(c), (c)-[:KNOWS]->(a)").unwrap();
+            drop(graph);
+            let status = Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "mutation_transaction_fault_tests::mutation_authority_fault_helper",
+                    "--nocapture",
+                ])
+                .env("GF_MUTATION_AUTHORITY_ROOT", root.path())
+                .env(
+                    "GF_MUTATION_AUTHORITY_ANALYST",
+                    if analyst { "1" } else { "0" },
+                )
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINTS",
+                    "graphforge-internal-subprocess-v1",
+                )
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", hook)
+                .status()
+                .unwrap();
+            if !status.success() {
+                failures.push(format!("{hook}, analyst={analyst}: {status}"));
+            }
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}

--- a/crates/graphforge-api/src/node_selector.rs
+++ b/crates/graphforge-api/src/node_selector.rs
@@ -18,6 +18,7 @@ const MAX_SELECTOR_ROWS: usize = 1_000_000;
 impl GraphForge {
     /// Resolve one typed selector to a UUID without invoking Cypher or an algorithm.
     pub(crate) fn resolve_node_selector(&self, selector: &NodeSelector) -> Result<Uuid, GfError> {
+        self.graph_visibility.health.check()?;
         match selector {
             NodeSelector::Uuid(uuid) => self.require_node(*uuid),
             NodeSelector::Handle(handle) => {

--- a/crates/graphforge-api/src/portable.rs
+++ b/crates/graphforge-api/src/portable.rs
@@ -341,6 +341,7 @@ impl GraphForge {
         ),
         GfError,
     > {
+        self.graph_visibility.health.check()?;
         let root = self.resolved_generation.container_root();
         match selection {
             PortableSelection::Current => Ok((

--- a/crates/graphforge-api/src/transaction.rs
+++ b/crates/graphforge-api/src/transaction.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 use arrow::array::{Array, FixedSizeBinaryArray};
 use arrow::record_batch::RecordBatch;
 use graphforge_core::{GfError, ProjectErrorCode, PropValue};
+use graphforge_exec::mutation::MutationLifecycle;
 use graphforge_ir::IrLiteral;
 use uuid::Uuid;
 
@@ -500,43 +501,55 @@ impl GraphTransaction {
             });
         }
 
-        for (query, params) in &cypher {
-            graph
-                .execute_write_without_publish(query, params)
-                .inspect_err(|_| {
-                    let _ = crate::rematerialize_graph_workspace(&prior, &graph.dir);
-                })?;
-        }
+        let prior_catalog = graph
+            .runtime_catalog
+            .lock()
+            .expect("runtime catalog poisoned")
+            .clone();
+        // Inner statements stage against the current private workspace. The outer
+        // owner restores the transaction's original authority on every later
+        // failure, including clock and publication failures.
+        let mut lifecycle = crate::mutation_transaction::FacadeMutationLifecycle::new(
+            graph,
+            prior_catalog,
+            true,
+            None,
+        )?;
+        let result = (|| {
+            for (query, params) in &cypher {
+                graph.execute_write_without_publish(query, params)?;
+            }
 
-        if request.graph_mutations.is_empty() && knowledge_row_count(&request.knowledge) == 0 {
-            let recorded_at = (graph.clock.lock().expect("clock lock poisoned"))()?;
-            let receipt = graphforge_exec::MutationReceipt::default();
-            graph.publish_graph_mutation_with_context(
-                &receipt,
-                self.context.operation_uuid.0,
-                self.context.actor_uuid,
-                recorded_at,
-            )?;
-            let generation = *graph
-                .current_generation_uuid
-                .lock()
-                .expect("generation UUID lock poisoned");
-            return Ok(TransactionCommitReceipt {
-                generation_uuid: generation,
-                composite_receipt: None,
-            });
-        }
+            if request.graph_mutations.is_empty() && knowledge_row_count(&request.knowledge) == 0 {
+                let recorded_at = (graph.clock.lock().expect("clock lock poisoned"))()?;
+                let receipt = graphforge_exec::MutationReceipt::default();
+                graph.publish_graph_mutation_with_context(
+                    &receipt,
+                    self.context.operation_uuid.0,
+                    self.context.actor_uuid,
+                    recorded_at,
+                )?;
+                let generation = *graph
+                    .current_generation_uuid
+                    .lock()
+                    .expect("generation UUID lock poisoned");
+                return Ok(TransactionCommitReceipt {
+                    generation_uuid: generation,
+                    composite_receipt: None,
+                });
+            }
 
-        let receipt = graph
-            .publish_composite_transaction_admitted(request)
-            .inspect_err(|_| {
-                let _ = crate::rematerialize_graph_workspace(&prior, &graph.dir);
-            })?;
-        let generation_uuid = generation_from_receipt(&receipt)?;
-        Ok(TransactionCommitReceipt {
-            generation_uuid,
-            composite_receipt: Some(receipt),
-        })
+            let receipt = graph.publish_composite_transaction_admitted(request)?;
+            let generation_uuid = generation_from_receipt(&receipt)?;
+            Ok(TransactionCommitReceipt {
+                generation_uuid,
+                composite_receipt: Some(receipt),
+            })
+        })();
+        if result.is_err() {
+            lifecycle.abort()?;
+        }
+        result
     }
 
     /// Abandon staged work without publishing.
@@ -725,6 +738,143 @@ mod tests {
             operation_uuid: OperationId(uuid7(seed)),
             actor_uuid: None,
         }
+    }
+
+    #[test]
+    fn later_cypher_failure_restores_outer_catalog_data_and_reopen() {
+        let directory = TempDir::new().unwrap();
+        let graph = GraphForge::new(directory.path().to_str()).unwrap();
+        graph.execute("CREATE (:Person {name:'retained'})").unwrap();
+        let catalog = graph.runtime_catalog.lock().unwrap().to_record_batch();
+        let files = graphforge_storage::capture_graph_files(&graph.dir)
+            .unwrap()
+            .0;
+        let generation = *graph.current_generation_uuid.lock().unwrap();
+        let tx = graph.begin_transaction(context(71)).unwrap();
+        tx.stage_cypher("CREATE (:Temporary {transaction_metric:1})", HashMap::new())
+            .unwrap();
+        tx.stage_cypher(
+            "MATCH (n:Temporary) DELETE n SET n.transaction_metric=2",
+            HashMap::new(),
+        )
+        .unwrap();
+        assert!(tx.commit(&graph).is_err());
+        assert_eq!(
+            graph.runtime_catalog.lock().unwrap().to_record_batch(),
+            catalog
+        );
+        assert_eq!(
+            graphforge_storage::capture_graph_files(&graph.dir)
+                .unwrap()
+                .0,
+            files
+        );
+        assert_eq!(*graph.current_generation_uuid.lock().unwrap(), generation);
+        let reopened = GraphForge::new(directory.path().to_str()).unwrap();
+        for owner in [&graph, &reopened] {
+            assert!(
+                !owner
+                    .runtime_catalog
+                    .lock()
+                    .unwrap()
+                    .contains_property("transaction_metric", None)
+            );
+            assert_eq!(owner.node_count("Person").unwrap(), 1);
+            let result = owner.execute("MATCH (n) RETURN n").unwrap();
+            assert_eq!(
+                result
+                    .batches
+                    .iter()
+                    .map(|batch| batch.num_rows())
+                    .sum::<usize>(),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn outer_transaction_post_current_helper() {
+        let Ok(root) = std::env::var("GF_OUTER_MUTATION_ROOT") else {
+            return;
+        };
+        let graph = GraphForge::new(Some(&root)).unwrap();
+        assert!(
+            !graph
+                .runtime_catalog
+                .lock()
+                .unwrap()
+                .contains_property("outer_metric", None)
+        );
+        let before = *graph.current_generation_uuid.lock().unwrap();
+        let tx = graph.begin_transaction(context(72)).unwrap();
+        tx.stage_cypher(
+            "CREATE (a:Person {name:'committed'}) SET a.outer_metric=1",
+            HashMap::new(),
+        )
+        .unwrap();
+        let error = tx.commit(&graph).unwrap_err();
+        assert!(
+            error.to_string().contains("cause=injected_failpoint"),
+            "{error}"
+        );
+        let selected = graphforge_storage::resolve_project_generation(std::path::Path::new(&root))
+            .unwrap()
+            .generation_uuid();
+        assert_ne!(selected, before);
+        let reopened = GraphForge::new(Some(&root)).unwrap();
+        let committed_catalog = graph.runtime_catalog.lock().unwrap().to_record_batch();
+        assert_eq!(
+            reopened.runtime_catalog.lock().unwrap().to_record_batch(),
+            committed_catalog
+        );
+        for owner in [&graph, &reopened] {
+            assert_eq!(*owner.current_generation_uuid.lock().unwrap(), selected);
+            assert!(
+                owner
+                    .runtime_catalog
+                    .lock()
+                    .unwrap()
+                    .contains_property("outer_metric", None)
+            );
+            assert_eq!(owner.node_count("Person").unwrap(), 2);
+            let result = owner
+                .execute("MATCH (n:Person) WHERE n.name='committed' AND n.outer_metric=1 RETURN n")
+                .unwrap();
+            assert_eq!(
+                result
+                    .batches
+                    .iter()
+                    .map(|batch| batch.num_rows())
+                    .sum::<usize>(),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn outer_transaction_post_current_failure_preserves_selected_authority() {
+        let directory = TempDir::new().unwrap();
+        let graph = GraphForge::new(directory.path().to_str()).unwrap();
+        graph.execute("CREATE (:Person {name:'retained'})").unwrap();
+        drop(graph);
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "transaction::tests::outer_transaction_post_current_helper",
+                "--nocapture",
+            ])
+            .env("GF_OUTER_MUTATION_ROOT", directory.path())
+            .env(
+                "GRAPHFORGE_PROJECT_FAILPOINTS",
+                "graphforge-internal-subprocess-v1",
+            )
+            .env(
+                "GRAPHFORGE_PROJECT_FAILPOINT",
+                "project.after_current_replace.error",
+            )
+            .status()
+            .unwrap();
+        assert!(status.success(), "{status}");
     }
 
     #[test]

--- a/crates/graphforge-api/src/write_modes.rs
+++ b/crates/graphforge-api/src/write_modes.rs
@@ -60,6 +60,7 @@ impl GraphForgeOptions {
 }
 
 pub(crate) struct WriteCoordinator {
+    pub(crate) health: graphforge_exec::mutation::MutationHealth,
     mode: ProjectWriteMode,
     visibility: RwLock<()>,
     queued: Mutex<QueuedState>,
@@ -87,6 +88,7 @@ pub(crate) enum WritePermit<'a> {
 impl WriteCoordinator {
     pub(crate) fn new(options: &GraphForgeOptions) -> Self {
         Self {
+            health: graphforge_exec::mutation::MutationHealth::default(),
             mode: options.write_mode,
             visibility: RwLock::new(()),
             queued: Mutex::new(QueuedState::default()),
@@ -99,12 +101,16 @@ impl WriteCoordinator {
         &self,
         cancellation: Option<&CancellationToken>,
     ) -> Result<WritePermit<'_>, GfError> {
+        self.health.check()?;
         if self.mode != ProjectWriteMode::QueuedWriter {
             return self
                 .visibility
                 .write()
-                .map(|guard| WritePermit::Direct { _guard: guard })
-                .map_err(|_| validation("write coordinator lock poisoned"));
+                .map_err(|_| validation("write coordinator lock poisoned"))
+                .and_then(|guard| {
+                    self.health.check()?;
+                    Ok(WritePermit::Direct { _guard: guard })
+                });
         }
         if cancellation.is_some_and(CancellationToken::is_cancelled) {
             return Err(cancelled());
@@ -151,10 +157,12 @@ impl WriteCoordinator {
                     self.changed.notify_all();
                     return Err(cancelled());
                 }
-                return Ok(WritePermit::Queued {
+                let permit = WritePermit::Queued {
                     coordinator: self,
                     _guard: guard,
-                });
+                };
+                self.health.check()?;
+                return Ok(permit);
             }
             state = self
                 .changed
@@ -169,6 +177,7 @@ impl WriteCoordinator {
     }
 
     pub(crate) fn read(&self) -> Result<RwLockReadGuard<'_, ()>, GfError> {
+        self.health.check()?;
         if self.mode == ProjectWriteMode::QueuedWriter {
             let mut state = self
                 .queued
@@ -181,9 +190,12 @@ impl WriteCoordinator {
                     .map_err(|_| validation("write queue lock poisoned"))?;
             }
         }
-        self.visibility
+        let guard = self
+            .visibility
             .read()
-            .map_err(|_| validation("write coordinator lock poisoned"))
+            .map_err(|_| validation("write coordinator lock poisoned"))?;
+        self.health.check()?;
+        Ok(guard)
     }
 
     #[cfg(test)]

--- a/crates/graphforge-ast/src/ast.rs
+++ b/crates/graphforge-ast/src/ast.rs
@@ -40,6 +40,23 @@ pub struct AstQuery {
     pub span: Span,
 }
 
+impl AstQuery {
+    /// Whether this query contains an explicit graph mutation clause.
+    #[must_use]
+    pub fn has_mutation_clauses(&self) -> bool {
+        self.clauses.iter().any(|clause| {
+            matches!(
+                clause,
+                AstClause::Create(_)
+                    | AstClause::Merge(_)
+                    | AstClause::Set(_)
+                    | AstClause::Remove(_)
+                    | AstClause::Delete(_)
+            )
+        })
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Clause variants
 // ---------------------------------------------------------------------------

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -709,10 +709,11 @@ impl ExecutionPlan for GraphCreateExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        use futures::StreamExt;
+
         self.mutation_health
             .check()
             .map_err(|error| DataFusionError::External(Box::new(error)))?;
-        use futures::StreamExt;
 
         if partition != 0 {
             return Err(DataFusionError::Internal(format!(
@@ -1507,10 +1508,11 @@ impl ExecutionPlan for GraphDeleteExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        use futures::StreamExt;
+
         self.mutation_health
             .check()
             .map_err(|error| DataFusionError::External(Box::new(error)))?;
-        use futures::StreamExt;
 
         if partition != 0 {
             return Err(DataFusionError::Internal(format!(
@@ -2082,10 +2084,11 @@ impl ExecutionPlan for GraphSetExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        use futures::StreamExt;
+
         self.mutation_health
             .check()
             .map_err(|error| DataFusionError::External(Box::new(error)))?;
-        use futures::StreamExt;
 
         if partition != 0 {
             return Err(DataFusionError::Internal(format!(
@@ -2235,10 +2238,11 @@ impl ExecutionPlan for GraphRemoveExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        use futures::StreamExt;
+
         self.mutation_health
             .check()
             .map_err(|error| DataFusionError::External(Box::new(error)))?;
-        use futures::StreamExt;
 
         if partition != 0 {
             return Err(DataFusionError::Internal(format!(

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -61,7 +61,7 @@ pub(crate) mod algorithm_embedding_graphsage;
 pub(crate) mod algorithm_embedding_hashgnn;
 mod algorithm_embedding_invocation;
 pub(crate) mod algorithm_embedding_options;
-mod mutation;
+pub mod mutation;
 pub mod read_resource;
 pub mod write_resource;
 pub use algorithm_embedding_options::validate_embedding_options;
@@ -446,6 +446,7 @@ pub struct GraphCreateExec {
     /// row-dependent computed property values (#814).
     in_df_schema: DFSchemaRef,
     dir: PathBuf,
+    mutation_health: mutation::MutationHealth,
     mode: OntologyMode,
     semantic_composition_fingerprint: Option<String>,
     schema: SchemaRef,
@@ -603,6 +604,7 @@ impl GraphCreateExec {
             ref_cols,
             in_df_schema: in_schema.clone(),
             dir: resource.dir.clone(),
+            mutation_health: resource.health.clone(),
             mode: resource.mode,
             semantic_composition_fingerprint: node.semantic_composition_fingerprint.clone(),
             schema,
@@ -690,6 +692,7 @@ impl ExecutionPlan for GraphCreateExec {
             ref_cols: self.ref_cols.clone(),
             in_df_schema: self.in_df_schema.clone(),
             dir: self.dir.clone(),
+            mutation_health: self.mutation_health.clone(),
             mode: self.mode,
             semantic_composition_fingerprint: self.semantic_composition_fingerprint.clone(),
             schema: self.schema.clone(),
@@ -706,6 +709,9 @@ impl ExecutionPlan for GraphCreateExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        self.mutation_health
+            .check()
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         use futures::StreamExt;
 
         if partition != 0 {
@@ -802,10 +808,12 @@ impl ExecutionPlan for GraphCreateExec {
                 summary_batch(&cfg.out_schema, &tally).map_err(to_df_err)
             }
         };
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            schema,
-            futures::stream::once(fut),
-        )))
+        Ok(self
+            .mutation_health
+            .guard_stream(Box::pin(RecordBatchStreamAdapter::new(
+                schema,
+                futures::stream::once(fut),
+            ))))
     }
 }
 
@@ -1389,6 +1397,7 @@ pub struct GraphDeleteExec {
     cols: Vec<DeleteCol>,
     detach: bool,
     dir: PathBuf,
+    mutation_health: mutation::MutationHealth,
     schema: SchemaRef,
     props: Arc<PlanProperties>,
 }
@@ -1432,6 +1441,7 @@ impl GraphDeleteExec {
             cols,
             detach: node.detach,
             dir: resource.dir.clone(),
+            mutation_health: resource.health.clone(),
             schema,
             props,
         })
@@ -1486,6 +1496,7 @@ impl ExecutionPlan for GraphDeleteExec {
             cols: self.cols.clone(),
             detach: self.detach,
             dir: self.dir.clone(),
+            mutation_health: self.mutation_health.clone(),
             schema: self.schema.clone(),
             props: self.props.clone(),
         }))
@@ -1496,6 +1507,9 @@ impl ExecutionPlan for GraphDeleteExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        self.mutation_health
+            .check()
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         use futures::StreamExt;
 
         if partition != 0 {
@@ -1551,10 +1565,12 @@ impl ExecutionPlan for GraphDeleteExec {
                     .map_err(to_df_err)?;
             delete_summary_batch(&out_schema, nodes_deleted, edges_deleted).map_err(to_df_err)
         };
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            stream_schema,
-            futures::stream::once(fut),
-        )))
+        Ok(self
+            .mutation_health
+            .guard_stream(Box::pin(RecordBatchStreamAdapter::new(
+                stream_schema,
+                futures::stream::once(fut),
+            ))))
     }
 }
 
@@ -1966,6 +1982,7 @@ pub struct GraphSetExec {
     type_id_to_entity_name: HashMap<graphforge_value::EntityTypeId, String>,
     mode: OntologyMode,
     dir: PathBuf,
+    mutation_health: mutation::MutationHealth,
     /// Logical input schema (with `var_<n>` qualifiers) — used to build the
     /// per-target physical value exprs.
     in_df_schema: DFSchemaRef,
@@ -2006,6 +2023,7 @@ impl GraphSetExec {
             type_id_to_entity_name: resource.type_map.clone(),
             mode: resource.mode,
             dir: resource.dir.clone(),
+            mutation_health: resource.health.clone(),
             in_df_schema,
             schema,
             props,
@@ -2052,6 +2070,7 @@ impl ExecutionPlan for GraphSetExec {
             type_id_to_entity_name: self.type_id_to_entity_name.clone(),
             mode: self.mode,
             dir: self.dir.clone(),
+            mutation_health: self.mutation_health.clone(),
             in_df_schema: self.in_df_schema.clone(),
             schema: self.schema.clone(),
             props: self.props.clone(),
@@ -2063,6 +2082,9 @@ impl ExecutionPlan for GraphSetExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        self.mutation_health
+            .check()
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         use futures::StreamExt;
 
         if partition != 0 {
@@ -2097,10 +2119,12 @@ impl ExecutionPlan for GraphSetExec {
             let total = acc.apply(&dir).map_err(to_df_err)?;
             count_summary_batch(&out_schema, total).map_err(to_df_err)
         };
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            stream_schema,
-            futures::stream::once(fut),
-        )))
+        Ok(self
+            .mutation_health
+            .guard_stream(Box::pin(RecordBatchStreamAdapter::new(
+                stream_schema,
+                futures::stream::once(fut),
+            ))))
     }
 }
 
@@ -2117,6 +2141,7 @@ pub struct GraphRemoveExec {
     type_id_to_entity_name: HashMap<graphforge_value::EntityTypeId, String>,
     mode: OntologyMode,
     dir: PathBuf,
+    mutation_health: mutation::MutationHealth,
     schema: SchemaRef,
     props: Arc<PlanProperties>,
 }
@@ -2153,6 +2178,7 @@ impl GraphRemoveExec {
             type_id_to_entity_name: resource.type_map.clone(),
             mode: resource.mode,
             dir: resource.dir.clone(),
+            mutation_health: resource.health.clone(),
             schema,
             props,
         })
@@ -2198,6 +2224,7 @@ impl ExecutionPlan for GraphRemoveExec {
             type_id_to_entity_name: self.type_id_to_entity_name.clone(),
             mode: self.mode,
             dir: self.dir.clone(),
+            mutation_health: self.mutation_health.clone(),
             schema: self.schema.clone(),
             props: self.props.clone(),
         }))
@@ -2208,6 +2235,9 @@ impl ExecutionPlan for GraphRemoveExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        self.mutation_health
+            .check()
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         use futures::StreamExt;
 
         if partition != 0 {
@@ -2235,10 +2265,12 @@ impl ExecutionPlan for GraphRemoveExec {
             let total = acc.apply(&dir).map_err(to_df_err)?;
             count_summary_batch(&out_schema, total).map_err(to_df_err)
         };
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            stream_schema,
-            futures::stream::once(fut),
-        )))
+        Ok(self
+            .mutation_health
+            .guard_stream(Box::pin(RecordBatchStreamAdapter::new(
+                stream_schema,
+                futures::stream::once(fut),
+            ))))
     }
 }
 
@@ -4981,6 +5013,7 @@ impl Drop for QueryEvidenceStream {
 ///
 /// `ExecutionSession` is `Send + Sync`.
 pub struct ExecutionSession {
+    mutation_health: mutation::MutationHealth,
     ctx: SessionContext,
     /// The graph catalog, retained so read lowering can decide typed-vs-
     /// exploratory edge tables. The same `Arc` is also registered on `ctx`.
@@ -5180,7 +5213,9 @@ impl ExecutionSession {
         );
         let provider: Arc<dyn AdjacencyProvider> = Arc::clone(&adjacency_provider) as _;
         let catalog = Arc::new(catalog);
+        let mutation_health = mutation::MutationHealth::default();
         let read_resource = Arc::new(read_resource::GraphReadContext {
+            health: mutation_health.clone(),
             dir: dir.clone(),
             mode,
             catalog: catalog.clone(),
@@ -5245,6 +5280,7 @@ impl ExecutionSession {
             .map(str::to_owned);
         ctx.register_catalog("graph", catalog.clone());
         Self {
+            mutation_health,
             ctx,
             catalog,
             ontology,
@@ -5456,6 +5492,34 @@ impl ExecutionSession {
         params: &HashMap<String, graphforge_ir::IrLiteral>,
     ) -> Result<ExecutionResult, GfError> {
         let resource = self.write_resource()?;
+        let mut lifecycle = mutation::LocalMutationLifecycle::new(self, resource.clone())?;
+        let mut transaction = mutation::MutationTransaction::local();
+        let result = match self
+            .prepare_write_statement_with_params(plan, params, &mut transaction)
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => return transaction.abort(&mut lifecycle, error),
+        };
+        transaction.commit(&resource, false, &mut lifecycle)?;
+        Ok(result)
+    }
+
+    /// Evaluate and stage a statement without installing files or publishing.
+    /// The caller's transaction owns the catalog used to build this session.
+    ///
+    /// # Errors
+    /// Returns an error for missing write authority, evaluation or staging failure.
+    #[allow(clippy::too_many_lines)]
+    pub async fn prepare_write_statement_with_params(
+        &self,
+        plan: &GraphPlan,
+        params: &HashMap<String, graphforge_ir::IrLiteral>,
+        transaction: &mut mutation::MutationTransaction,
+    ) -> Result<ExecutionResult, GfError> {
+        let resource = self.write_resource()?;
+        transaction.admit(&resource)?;
+        transaction.ensure_unprepared()?;
         resource
             .validate_composition(plan.composition_fingerprint.as_deref())
             .map_err(GfError::from_plan_error)?;
@@ -5547,14 +5611,9 @@ impl ExecutionSession {
             }
             None => None,
         };
-        write_driver::commit_statement(&mut wctx, &resource.dir)?;
-        self.catalog
-            .refresh_property_inventory(&resource.dir)
-            .map_err(GfError::from_execution_error)?;
-        self.adjacency_provider.invalidate();
-
         let c = wctx.mutation.counters;
         let mutation_receipt = Some(wctx.mutation_receipt());
+        transaction.prepare_statement(wctx, &resource)?;
         let side_effects = Some(SideEffects {
             nodes_created: c.nodes_created,
             nodes_deleted: c.nodes_deleted,
@@ -5578,7 +5637,7 @@ impl ExecutionSession {
             });
         }
 
-        let batch = write_driver::statement_summary_batch(&wctx.mutation.counters)?;
+        let batch = write_driver::statement_summary_batch(&transaction.state.counters)?;
         Ok(ExecutionResult {
             schema: batch.schema(),
             batches: vec![batch],
@@ -5886,17 +5945,19 @@ impl ExecutionSession {
             datafusion::physical_plan::execute_stream(Arc::clone(&physical), Arc::clone(&task_ctx))
                 .map_err(GfError::from_execution_error)?;
         let schema = stream.schema();
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            schema,
-            QueryEvidenceStream {
-                inner: Some(stream),
-                physical,
-                task_ctx,
-                memory_reserved_before,
-                returned_batch_bytes: 0,
-                finalized: false,
-            },
-        )))
+        Ok(self
+            .mutation_health
+            .guard_stream(Box::pin(RecordBatchStreamAdapter::new(
+                schema,
+                QueryEvidenceStream {
+                    inner: Some(stream),
+                    physical,
+                    task_ctx,
+                    memory_reserved_before,
+                    returned_batch_bytes: 0,
+                    finalized: false,
+                },
+            ))))
     }
 
     /// Render the physical plan for a [`GraphPlan`] (indented, one line per
@@ -5952,6 +6013,7 @@ impl ExecutionSession {
         plan: &GraphPlan,
         params: &HashMap<String, graphforge_ir::IrLiteral>,
     ) -> Result<(Arc<dyn ExecutionPlan>, SchemaRef), GfError> {
+        self.mutation_health.check()?;
         // Read lowering always needs the catalog (typed-vs-exploratory edge
         // routing). Scans additionally bind their real Parquet-backed providers
         // from the project directory. A read-only session built via `new` has an
@@ -7547,6 +7609,7 @@ mod tests {
             let input = MemorySourceConfig::try_new_from_batches(schema, vec![batch]).unwrap();
             let summary = GraphDeleteNode::summary_schema();
             let exec: Arc<dyn ExecutionPlan> = Arc::new(GraphDeleteExec {
+                mutation_health: mutation::MutationHealth::default(),
                 input,
                 cols: if include_edge {
                     vec![

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -61,6 +61,7 @@ pub(crate) mod algorithm_embedding_graphsage;
 pub(crate) mod algorithm_embedding_hashgnn;
 mod algorithm_embedding_invocation;
 pub(crate) mod algorithm_embedding_options;
+mod mutation;
 pub mod read_resource;
 pub mod write_resource;
 pub use algorithm_embedding_options::validate_embedding_options;
@@ -5552,7 +5553,7 @@ impl ExecutionSession {
             .map_err(GfError::from_execution_error)?;
         self.adjacency_provider.invalidate();
 
-        let c = wctx.counters;
+        let c = wctx.mutation.counters;
         let mutation_receipt = Some(wctx.mutation_receipt());
         let side_effects = Some(SideEffects {
             nodes_created: c.nodes_created,
@@ -5577,7 +5578,7 @@ impl ExecutionSession {
             });
         }
 
-        let batch = write_driver::statement_summary_batch(&wctx.counters)?;
+        let batch = write_driver::statement_summary_batch(&wctx.mutation.counters)?;
         Ok(ExecutionResult {
             schema: batch.schema(),
             batches: vec![batch],

--- a/crates/graphforge-exec/src/mutation.rs
+++ b/crates/graphforge-exec/src/mutation.rs
@@ -86,7 +86,6 @@ impl MutationState {
     /// Commit a statement's staged files with the existing topology index and
     /// adjacency-delta participant. Property-only commits do not open a writer.
     pub(crate) fn commit_topology(
-        &mut self,
         staged: graphforge_storage::RewriteBatch,
         writer: &mut graphforge_storage::GraphWriter,
         dir: &std::path::Path,
@@ -148,11 +147,13 @@ pub struct MutationTransaction {
     )>,
     validate_catalog: bool,
     prepared: bool,
-    topology: Option<(
-        graphforge_storage::GraphWriter,
-        HashSet<[u8; 16]>,
-        HashSet<[u8; 16]>,
-    )>,
+    topology: Option<PreparedTopology>,
+}
+
+struct PreparedTopology {
+    writer: graphforge_storage::GraphWriter,
+    deleted_nodes: HashSet<[u8; 16]>,
+    deleted_edges: HashSet<[u8; 16]>,
 }
 
 impl MutationTransaction {
@@ -237,6 +238,7 @@ impl MutationTransaction {
     ///
     /// # Errors
     /// Returns an error if the authenticated property rewrite cannot be staged.
+    #[allow(clippy::implicit_hasher)] // matches the storage SET accumulator contract
     pub fn stage_node_properties(
         &mut self,
         resource: &crate::write_resource::BoundWriteResource,
@@ -310,11 +312,11 @@ impl MutationTransaction {
         self.staged = crate::write_driver::stage_statement(&mut context, resource.directory())?;
         self.prepared = true;
         self.state = context.mutation;
-        self.topology = Some((
-            context.writer,
-            context.pending_node_deletes,
-            context.pending_edge_deletes,
-        ));
+        self.topology = Some(PreparedTopology {
+            writer: context.writer,
+            deleted_nodes: context.pending_node_deletes,
+            deleted_edges: context.pending_edge_deletes,
+        });
         Ok(())
     }
 
@@ -349,10 +351,13 @@ impl MutationTransaction {
         self.admit(resource)?;
         let staged = std::mem::replace(&mut self.staged, graphforge_storage::RewriteBatch::new());
         match &mut self.topology {
-            Some((writer, nodes, edges)) => {
-                self.state
-                    .commit_topology(staged, writer, resource.directory(), nodes, edges)
-            }
+            Some(topology) => MutationState::commit_topology(
+                staged,
+                &mut topology.writer,
+                resource.directory(),
+                &topology.deleted_nodes,
+                &topology.deleted_edges,
+            ),
             None => staged.commit_at(resource.directory()),
         }
     }

--- a/crates/graphforge-exec/src/mutation.rs
+++ b/crates/graphforge-exec/src/mutation.rs
@@ -442,10 +442,6 @@ impl<'a> LocalMutationLifecycle<'a> {
         session: &'a crate::ExecutionSession,
         resource: crate::write_resource::BoundWriteResource,
     ) -> Result<Self, graphforge_core::GfError> {
-        // Preserve GraphWriter::open_at's fresh-target behavior after explicit
-        // resource admission, before capturing the empty rollback baseline.
-        std::fs::create_dir_all(resource.directory())
-            .map_err(|error| graphforge_core::GfError::Storage(error.to_string()))?;
         Ok(Self {
             checkpoint: graphforge_storage::GraphWorkspaceCheckpoint::capture(
                 resource.directory(),
@@ -474,10 +470,16 @@ impl MutationLifecycle for LocalMutationLifecycle<'_> {
     }
     fn abort(&mut self) -> Result<(), graphforge_core::GfError> {
         let health = self.session.mutation_health.clone();
-        health.recover(|| {
-            self.checkpoint.restore(self.resource.directory())?;
-            self.complete()
-        })
+        health.recover(
+            || match self.checkpoint.restore(self.resource.directory())? {
+                graphforge_storage::GraphWorkspaceRestoration::Absent => {
+                    // Preserve the original inventory-less catalog: no writer ran.
+                    self.session.adjacency_provider.invalidate();
+                    Ok(())
+                }
+                graphforge_storage::GraphWorkspaceRestoration::Materialized => self.complete(),
+            },
+        )
     }
 }
 

--- a/crates/graphforge-exec/src/mutation.rs
+++ b/crates/graphforge-exec/src/mutation.rs
@@ -1,0 +1,125 @@
+//! Shared mutation accounting. Storage staging and publication consume the same
+//! state for statement and analyst mutations.
+
+use std::collections::{BTreeMap, HashSet};
+
+/// The openCypher write counters a statement reports.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WriteCounters {
+    pub nodes_created: u64,
+    pub edges_created: u64,
+    pub nodes_deleted: u64,
+    pub edges_deleted: u64,
+    pub properties_set: u64,
+    pub properties_removed: u64,
+    pub labels_added: u64,
+    pub labels_removed: u64,
+}
+
+/// Deduplicated effects and property counters for one mutation boundary.
+#[derive(Default)]
+pub(crate) struct MutationState {
+    pub counters: WriteCounters,
+    pub property_sets: HashSet<(bool, [u8; 16], String)>,
+    pub effects: BTreeMap<
+        crate::MutationKind,
+        (
+            HashSet<crate::MutationSubject>,
+            HashSet<crate::MutationSubject>,
+        ),
+    >,
+}
+
+impl MutationState {
+    pub(crate) fn record_mutation_input(
+        &mut self,
+        kind: crate::MutationKind,
+        subject_kind: crate::MutationSubjectKind,
+        uuid: [u8; 16],
+    ) {
+        self.effects
+            .entry(kind)
+            .or_default()
+            .0
+            .insert(crate::MutationSubject {
+                uuid,
+                kind: subject_kind,
+            });
+    }
+
+    pub(crate) fn record_mutation_output(
+        &mut self,
+        kind: crate::MutationKind,
+        subject_kind: crate::MutationSubjectKind,
+        uuid: [u8; 16],
+    ) {
+        self.effects
+            .entry(kind)
+            .or_default()
+            .1
+            .insert(crate::MutationSubject {
+                uuid,
+                kind: subject_kind,
+            });
+    }
+
+    pub(crate) fn mutation_receipt(&self) -> crate::MutationReceipt {
+        crate::MutationReceipt::from_accumulators(self.effects.clone())
+    }
+
+    pub(crate) fn record_property_set(
+        &mut self,
+        is_edge: bool,
+        uuid: [u8; 16],
+        name: &str,
+    ) -> bool {
+        if self.property_sets.insert((is_edge, uuid, name.to_owned())) {
+            self.counters.properties_set += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl MutationState {
+    /// Commit a statement's staged files with the existing topology index and
+    /// adjacency-delta participant. Property-only commits do not open a writer.
+    pub(crate) fn commit_topology(
+        &mut self,
+        staged: graphforge_storage::RewriteBatch,
+        writer: &mut graphforge_storage::GraphWriter,
+        dir: &std::path::Path,
+        deleted_node_ids: &HashSet<[u8; 16]>,
+        deleted_edge_ids: &HashSet<[u8; 16]>,
+    ) -> Result<(), graphforge_core::GfError> {
+        use graphforge_core::uuid::Uuid;
+        // Adjacency delta segment (#765): a statement is pure-append iff it stages
+        // no deletes (SET/REMOVE never touch topology). Pure-append → record the
+        // created edges so the index serves them without a rebuild; otherwise the
+        // statement breaks the chain at this generation (a DELETE invalidates the
+        // incremental path), so write no segment and clear any stale file there.
+        let pure_append = deleted_node_ids.is_empty() && deleted_edge_ids.is_empty();
+        let pending = writer.take_pending_delta();
+        let deleted_nodes = deleted_node_ids
+            .iter()
+            .copied()
+            .map(Uuid::from_bytes)
+            .collect::<Vec<_>>();
+        let deleted_edges = deleted_edge_ids
+            .iter()
+            .copied()
+            .map(Uuid::from_bytes)
+            .collect::<Vec<_>>();
+        if let Some(generation) =
+            writer.commit_topology_aware_with_uuid_index(staged, deleted_nodes, deleted_edges)?
+        {
+            if pure_append {
+                writer.write_segment_best_effort(generation, &pending);
+            } else {
+                graphforge_storage::adjacency_delta::discard_segment(dir, generation);
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/graphforge-exec/src/mutation.rs
+++ b/crates/graphforge-exec/src/mutation.rs
@@ -123,3 +123,545 @@ impl MutationState {
         Ok(())
     }
 }
+
+/// Neutral, deterministic effects and counters from one mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MutationOutcome {
+    /// Deduplicated subjects grouped by mutation kind.
+    pub receipt: crate::MutationReceipt,
+    /// Existing statement counter semantics, shared with analyst writes.
+    pub side_effects: crate::SideEffects,
+}
+
+/// A mutation's private catalog, accounting and staged files.
+///
+/// Binding uses `catalog()` before constructing the execution session, so the
+/// session's admitted identity contract and the staged catalog share one view.
+/// Preparing a mutation does not publish or install its catalog in the facade.
+pub struct MutationTransaction {
+    catalog: std::sync::Arc<std::sync::Mutex<graphforge_ir::RuntimeCatalog>>,
+    pub(crate) state: MutationState,
+    pub(crate) staged: graphforge_storage::RewriteBatch,
+    admitted: Option<(
+        crate::write_resource::BoundWriteResource,
+        arrow::record_batch::RecordBatch,
+    )>,
+    validate_catalog: bool,
+    prepared: bool,
+    topology: Option<(
+        graphforge_storage::GraphWriter,
+        HashSet<[u8; 16]>,
+        HashSet<[u8; 16]>,
+    )>,
+}
+
+impl MutationTransaction {
+    /// Begin with an isolated copy of the currently visible catalog.
+    #[must_use]
+    pub fn new(catalog: &graphforge_ir::RuntimeCatalog) -> Self {
+        Self {
+            catalog: std::sync::Arc::new(std::sync::Mutex::new(catalog.clone())),
+            state: MutationState::default(),
+            staged: graphforge_storage::RewriteBatch::new(),
+            topology: None,
+            admitted: None,
+            validate_catalog: true,
+            prepared: false,
+        }
+    }
+
+    pub(crate) fn local() -> Self {
+        let mut transaction = Self::new(&graphforge_ir::RuntimeCatalog::new());
+        transaction.validate_catalog = false;
+        transaction
+    }
+
+    pub(crate) fn ensure_unprepared(&self) -> Result<(), graphforge_core::GfError> {
+        if self.prepared {
+            return Err(graphforge_core::GfError::Execution(
+                "mutation transaction already prepared".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn admit(
+        &mut self,
+        resource: &crate::write_resource::BoundWriteResource,
+    ) -> Result<(), graphforge_core::GfError> {
+        resource.health.check()?;
+        let catalog = self.catalog.lock().expect("mutation catalog poisoned");
+        let snapshot = catalog.to_record_batch();
+        if let Some((admitted, expected)) = &self.admitted {
+            admitted.health.check()?;
+            if !admitted.same_authority(resource) || *expected != snapshot {
+                return Err(graphforge_core::GfError::Execution(
+                    "GF_WRITE_RESOURCE_INCOMPATIBLE: mutation authority or catalog changed".into(),
+                ));
+            }
+        } else {
+            if self.validate_catalog {
+                resource
+                    .validate_catalog(&catalog)
+                    .map_err(graphforge_core::GfError::from_plan_error)?;
+            }
+            self.admitted = Some((resource.clone(), snapshot));
+        }
+        Ok(())
+    }
+
+    /// The working identity snapshot used by mutation binding and execution.
+    #[must_use]
+    pub fn catalog(&self) -> std::sync::Arc<std::sync::Mutex<graphforge_ir::RuntimeCatalog>> {
+        std::sync::Arc::clone(&self.catalog)
+    }
+
+    /// Observe an analyst property through the same catalog owner as Cypher.
+    ///
+    /// # Errors
+    /// Returns an error if the runtime catalog cannot allocate the identity.
+    pub fn intern_property(
+        &self,
+        name: &str,
+        owner: Option<&str>,
+    ) -> Result<(), graphforge_core::GfError> {
+        self.catalog
+            .lock()
+            .expect("mutation catalog poisoned")
+            .intern_property(name, owner)?;
+        Ok(())
+    }
+
+    /// Stage property updates under explicit write authority and accumulate the
+    /// same entity/property counters and neutral effects used by Cypher SET.
+    ///
+    /// # Errors
+    /// Returns an error if the authenticated property rewrite cannot be staged.
+    pub fn stage_node_properties(
+        &mut self,
+        resource: &crate::write_resource::BoundWriteResource,
+        inventory: &graphforge_storage::AuthenticatedPropertyInventory,
+        stem: &str,
+        updates: &std::collections::HashMap<
+            [u8; 16],
+            std::collections::HashMap<String, graphforge_ir::IrLiteral>,
+        >,
+    ) -> Result<u64, graphforge_core::GfError> {
+        self.admit(resource)?;
+        self.ensure_unprepared()?;
+        self.prepared = true;
+        let counts = graphforge_storage::stage_set_node_properties_authenticated_with_counts(
+            &mut self.staged,
+            resource.directory(),
+            inventory,
+            stem,
+            updates,
+        )?;
+        for (uuid, properties) in updates {
+            for name in properties.keys() {
+                self.state.record_property_set(false, *uuid, name);
+            }
+            self.state.record_mutation_output(
+                crate::MutationKind::SetProperty,
+                crate::MutationSubjectKind::Node,
+                *uuid,
+            );
+        }
+        self.state.counters.properties_removed += counts.properties_replaced;
+        self.prepared = true;
+        Ok(counts.entities_touched)
+    }
+
+    /// The shared receipt and counter result for this mutation.
+    #[must_use]
+    pub fn outcome(&self) -> MutationOutcome {
+        let c = self.state.counters;
+        MutationOutcome {
+            receipt: self.receipt(),
+            side_effects: crate::SideEffects {
+                nodes_created: c.nodes_created,
+                nodes_deleted: c.nodes_deleted,
+                relationships_created: c.edges_created,
+                relationships_deleted: c.edges_deleted,
+                properties_set: c.properties_set,
+                properties_removed: c.properties_removed,
+                labels_added: c.labels_added,
+                labels_removed: c.labels_removed,
+            },
+        }
+    }
+
+    /// Deterministically ordered effects accumulated by the mutation.
+    #[must_use]
+    pub fn receipt(&self) -> crate::MutationReceipt {
+        self.state.mutation_receipt()
+    }
+}
+
+impl MutationTransaction {
+    pub(crate) fn prepare_statement(
+        &mut self,
+        mut context: crate::write_driver::StatementWriteContext,
+        resource: &crate::write_resource::BoundWriteResource,
+    ) -> Result<(), graphforge_core::GfError> {
+        self.admit(resource)?;
+        self.ensure_unprepared()?;
+        self.prepared = true;
+        self.staged = crate::write_driver::stage_statement(&mut context, resource.directory())?;
+        self.prepared = true;
+        self.state = context.mutation;
+        self.topology = Some((
+            context.writer,
+            context.pending_node_deletes,
+            context.pending_edge_deletes,
+        ));
+        Ok(())
+    }
+
+    /// Stage the working catalog in the same rewrite as graph properties.
+    ///
+    /// # Errors
+    /// Returns a storage error if the catalog cannot be staged.
+    pub fn stage_catalog(
+        &mut self,
+        resource: &crate::write_resource::BoundWriteResource,
+    ) -> Result<(), graphforge_core::GfError> {
+        self.admit(resource)?;
+        if !self.prepared {
+            return Err(graphforge_core::GfError::Execution(
+                "mutation transaction has not been prepared".into(),
+            ));
+        }
+        let batch = &self.admitted.as_ref().expect("admitted above").1;
+        self.staged.stage(
+            &resource
+                .directory()
+                .join("topology/runtime_catalog.parquet"),
+            batch.schema(),
+            batch,
+        )
+    }
+
+    pub(crate) fn commit_local(
+        &mut self,
+        resource: &crate::write_resource::BoundWriteResource,
+    ) -> Result<(), graphforge_core::GfError> {
+        self.admit(resource)?;
+        let staged = std::mem::replace(&mut self.staged, graphforge_storage::RewriteBatch::new());
+        match &mut self.topology {
+            Some((writer, nodes, edges)) => {
+                self.state
+                    .commit_topology(staged, writer, resource.directory(), nodes, edges)
+            }
+            None => staged.commit_at(resource.directory()),
+        }
+    }
+}
+
+/// The generation owner supplies publication and recovery without exposing
+/// facade internals to the statement driver or analyst staging code.
+pub trait MutationLifecycle {
+    /// Publish the locally committed graph and its working catalog.
+    fn publish(
+        &mut self,
+        outcome: &MutationOutcome,
+        catalog: &graphforge_ir::RuntimeCatalog,
+    ) -> Result<(), graphforge_core::GfError>;
+    /// Refresh retained resources after a successful mutation.
+    fn complete(&mut self) -> Result<(), graphforge_core::GfError>;
+    /// Restore the prior state, or reconcile an already published generation.
+    /// Implementations must determine authority before restoring any files.
+    fn abort(&mut self) -> Result<(), graphforge_core::GfError>;
+}
+
+impl MutationTransaction {
+    /// Commit staged graph/catalog files and publish through the generation
+    /// owner. Every failure, including local rewrite failure, shares one abort.
+    ///
+    /// # Errors
+    /// Returns staging, local commit, publication or recovery errors.
+    pub fn commit(
+        mut self,
+        resource: &crate::write_resource::BoundWriteResource,
+        persist_catalog: bool,
+        lifecycle: &mut impl MutationLifecycle,
+    ) -> Result<(), graphforge_core::GfError> {
+        let result = (|| {
+            self.admit(resource)?;
+            if !self.prepared {
+                return Err(graphforge_core::GfError::Execution(
+                    "mutation transaction has not been prepared".into(),
+                ));
+            }
+            if persist_catalog {
+                self.stage_catalog(resource)?;
+            }
+            self.commit_local(resource)?;
+            let catalog = graphforge_ir::RuntimeCatalog::from_record_batch(
+                &self.admitted.as_ref().expect("admitted above").1,
+            )?;
+            lifecycle.publish(&self.outcome(), &catalog)?;
+            lifecycle.complete()
+        })();
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) => self.abort(lifecycle, error),
+        }
+    }
+
+    /// Abort a preparation failure through the same generation-aware recovery
+    /// path used for commit errors. Uninstalled temporary files are discarded.
+    ///
+    /// # Errors
+    /// Returns the original error unless recovery itself fails.
+    pub fn abort<T>(
+        mut self,
+        lifecycle: &mut impl MutationLifecycle,
+        error: graphforge_core::GfError,
+    ) -> Result<T, graphforge_core::GfError> {
+        self.staged = graphforge_storage::RewriteBatch::new();
+        self.topology = None;
+        lifecycle.abort()?;
+        Err(error)
+    }
+}
+
+pub(crate) struct LocalMutationLifecycle<'a> {
+    checkpoint: graphforge_storage::GraphWorkspaceCheckpoint,
+    session: &'a crate::ExecutionSession,
+    resource: crate::write_resource::BoundWriteResource,
+}
+
+impl<'a> LocalMutationLifecycle<'a> {
+    pub(crate) fn new(
+        session: &'a crate::ExecutionSession,
+        resource: crate::write_resource::BoundWriteResource,
+    ) -> Result<Self, graphforge_core::GfError> {
+        // Preserve GraphWriter::open_at's fresh-target behavior after explicit
+        // resource admission, before capturing the empty rollback baseline.
+        std::fs::create_dir_all(resource.directory())
+            .map_err(|error| graphforge_core::GfError::Storage(error.to_string()))?;
+        Ok(Self {
+            checkpoint: graphforge_storage::GraphWorkspaceCheckpoint::capture(
+                resource.directory(),
+            )?,
+            session,
+            resource,
+        })
+    }
+}
+
+impl MutationLifecycle for LocalMutationLifecycle<'_> {
+    fn publish(
+        &mut self,
+        _: &MutationOutcome,
+        _: &graphforge_ir::RuntimeCatalog,
+    ) -> Result<(), graphforge_core::GfError> {
+        Ok(())
+    }
+    fn complete(&mut self) -> Result<(), graphforge_core::GfError> {
+        self.session
+            .catalog
+            .refresh_property_inventory(self.resource.directory())
+            .map_err(graphforge_core::GfError::from_execution_error)?;
+        self.session.adjacency_provider.invalidate();
+        Ok(())
+    }
+    fn abort(&mut self) -> Result<(), graphforge_core::GfError> {
+        let health = self.session.mutation_health.clone();
+        health.recover(|| {
+            self.checkpoint.restore(self.resource.directory())?;
+            self.complete()
+        })
+    }
+}
+
+/// Shared availability of mutable execution resources during and after recovery.
+/// Recovery invalidates existing lazy streams. A failed recovery permanently
+/// denies this owner; reopening establishes a fresh owner from durable authority.
+#[derive(Debug, Clone, Default)]
+pub struct MutationHealth(std::sync::Arc<std::sync::Mutex<MutationHealthState>>);
+
+#[derive(Debug, Default)]
+struct MutationHealthState {
+    epoch: u64,
+    recovering: bool,
+    failure: Option<String>,
+}
+
+impl MutationHealthState {
+    fn check(&self) -> Result<(), graphforge_core::GfError> {
+        if let Some(reason) = &self.failure {
+            return Err(graphforge_core::GfError::Storage(format!(
+                "mutation workspace unavailable after failed recovery: {reason}"
+            )));
+        }
+        if self.recovering {
+            return Err(graphforge_core::GfError::Storage(
+                "mutation workspace unavailable during recovery".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl MutationHealth {
+    /// Deny subsequent mutation/read work and retained stream pulls.
+    pub fn fail(&self, error: &graphforge_core::GfError) {
+        self.0
+            .lock()
+            .expect("mutation health poisoned")
+            .failure
+            .get_or_insert_with(|| error.to_string());
+    }
+
+    /// Check whether workspace recovery has left resources usable.
+    ///
+    /// # Errors
+    /// Returns an error during recovery or after this owner becomes unavailable.
+    pub fn check(&self) -> Result<(), graphforge_core::GfError> {
+        self.0.lock().expect("mutation health poisoned").check()
+    }
+
+    /// Fence mutable resources for the entire restoration operation.
+    ///
+    /// # Errors
+    /// Rejects overlapping recovery and retains any restoration failure. Success
+    /// cannot clear a failure recorded by another operation on the same owner.
+    pub fn recover(
+        &self,
+        restore: impl FnOnce() -> Result<(), graphforge_core::GfError>,
+    ) -> Result<(), graphforge_core::GfError> {
+        let epoch = {
+            let mut state = self.0.lock().expect("mutation health poisoned");
+            state.check()?;
+            state.epoch = state.epoch.checked_add(1).ok_or_else(|| {
+                graphforge_core::GfError::Storage("mutation recovery epoch exhausted".into())
+            })?;
+            state.recovering = true;
+            state.epoch
+        };
+        let result = restore();
+        let mut state = self.0.lock().expect("mutation health poisoned");
+        if let Err(error) = &result {
+            state.failure.get_or_insert_with(|| error.to_string());
+        }
+        if state.epoch == epoch {
+            state.recovering = false;
+        }
+        result?;
+        state.check()
+    }
+
+    fn stream_epoch(&self) -> Result<u64, graphforge_core::GfError> {
+        let state = self.0.lock().expect("mutation health poisoned");
+        state.check()?;
+        Ok(state.epoch)
+    }
+
+    fn check_stream_epoch(&self, epoch: Option<u64>) -> Result<(), graphforge_core::GfError> {
+        if Some(self.stream_epoch()?) != epoch {
+            return Err(graphforge_core::GfError::Storage(
+                "mutation workspace stream invalidated by recovery".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Retain the same health owner and recovery epoch for every lazy pull.
+    #[must_use]
+    pub fn guard_stream(
+        &self,
+        mut stream: crate::SendableRecordBatchStream,
+    ) -> crate::SendableRecordBatchStream {
+        let schema = stream.schema();
+        let health = self.clone();
+        let epoch = health.stream_epoch().ok();
+        let mut failed = false;
+        let guarded = futures::stream::poll_fn(move |cx| {
+            if failed {
+                return std::task::Poll::Ready(None);
+            }
+            let result = health.check_stream_epoch(epoch).and_then(|()| {
+                let result = stream.as_mut().poll_next(cx);
+                // Recovery may have started while the inner poll read files.
+                // Never expose its batch, even when restoration already ended.
+                health.check_stream_epoch(epoch)?;
+                Ok(result)
+            });
+            match result {
+                Ok(result) => result,
+                Err(error) => {
+                    failed = true;
+                    std::task::Poll::Ready(Some(Err(
+                        datafusion::common::DataFusionError::External(Box::new(error)),
+                    )))
+                }
+            }
+        });
+        Box::pin(datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(schema, guarded))
+    }
+}
+
+#[cfg(test)]
+mod health_tests {
+    use super::MutationHealth;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn recovery_during_inner_poll_discards_batch_and_invalidates_old_stream() {
+        let health = MutationHealth::default();
+        let schema = std::sync::Arc::new(arrow::datatypes::Schema::empty());
+        let batch = arrow::record_batch::RecordBatch::new_empty(schema.clone());
+        let inner_health = health.clone();
+        let inner_batch = batch.clone();
+        let stream = futures::stream::poll_fn(move |_| {
+            inner_health.recover(|| Ok(())).unwrap();
+            std::task::Poll::Ready(Some(Ok(inner_batch.clone())))
+        });
+        let mut old = health.guard_stream(Box::pin(
+            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                schema.clone(),
+                stream,
+            ),
+        ));
+        assert!(
+            old.next()
+                .await
+                .unwrap()
+                .unwrap_err()
+                .to_string()
+                .contains("invalidated")
+        );
+        assert!(old.next().await.is_none());
+        health.check().unwrap();
+        let mut fresh = health.guard_stream(Box::pin(
+            datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                schema,
+                futures::stream::iter([Ok(batch)]),
+            ),
+        ));
+        assert!(fresh.next().await.unwrap().is_ok());
+    }
+
+    #[test]
+    fn successful_restore_cannot_clear_concurrent_failure_or_admit_nested_recovery() {
+        let health = MutationHealth::default();
+        let error = health
+            .recover(|| {
+                assert!(health.check().is_err());
+                assert!(
+                    health
+                        .recover(|| panic!("overlapping restore ran"))
+                        .is_err()
+                );
+                health.fail(&graphforge_core::GfError::Storage(
+                    "independent failure".into(),
+                ));
+                Ok(())
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("independent failure"));
+        assert!(health.check().is_err());
+    }
+}

--- a/crates/graphforge-exec/src/read_resource.rs
+++ b/crates/graphforge-exec/src/read_resource.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 /// Session-local authority. Logical plans never own this value.
 pub struct GraphReadContext {
+    pub(crate) health: crate::mutation::MutationHealth,
     pub(crate) dir: PathBuf,
     pub(crate) mode: OntologyMode,
     pub(crate) catalog: Arc<GraphCatalog>,
@@ -21,6 +22,9 @@ impl GraphReadContext {
         &self,
         contract: Option<&graphforge_plan::GraphReadContract>,
     ) -> Result<()> {
+        self.health
+            .check()
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         if let Some(contract) = contract {
             let actual = graphforge_rel::GraphPlanLowerer::new(
                 Some(

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -3471,7 +3471,10 @@ fn run_label_phase(
 /// A statement whose net batch stages topology files bumps the project
 /// `topology_generation` counter exactly once, before the commit (#759);
 /// SET/REMOVE-only statements do not bump.
-pub(crate) fn commit_statement(ctx: &mut StatementWriteContext, dir: &Path) -> Result<(), GfError> {
+pub(crate) fn stage_statement(
+    ctx: &mut StatementWriteContext,
+    dir: &Path,
+) -> Result<graphforge_storage::RewriteBatch, GfError> {
     // Writes to entities deleted later in the statement are unobservable —
     // they must not resurrect rows in the rewrite.
     ctx.set_acc.scrub(&ctx.deleted);
@@ -3490,14 +3493,7 @@ pub(crate) fn commit_statement(ctx: &mut StatementWriteContext, dir: &Path) -> R
     graphforge_storage::stage_delete_nodes(&mut staged, dir, &ctx.pending_node_deletes)?;
     ctx.writer.flush_into(&mut staged)?;
 
-    ctx.mutation.commit_topology(
-        staged,
-        &mut ctx.writer,
-        dir,
-        &ctx.pending_node_deletes,
-        &ctx.pending_edge_deletes,
-    )?;
-    Ok(())
+    Ok(staged)
 }
 
 /// The unified write-statement summary schema: six openCypher write counters.

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -18,7 +18,8 @@
 //! statement end — a failure in any phase aborts with the prior on-disk
 //! state fully intact.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use crate::mutation::WriteCounters;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -38,7 +39,7 @@ use datafusion::physical_plan::placeholder_row::PlaceholderRowExec;
 use datafusion::scalar::ScalarValue;
 use datafusion_datasource::memory::MemorySourceConfig;
 
-use graphforge_core::uuid::{Uuid, to_bytes};
+use graphforge_core::uuid::to_bytes;
 use graphforge_core::{GfError, OntologyMode};
 use graphforge_ir::plan::GraphOp;
 use graphforge_ir::{
@@ -233,19 +234,6 @@ fn collect_expr_vars(
 // Statement write context
 // ---------------------------------------------------------------------------
 
-/// The openCypher write counters a statement reports.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct WriteCounters {
-    pub nodes_created: u64,
-    pub edges_created: u64,
-    pub nodes_deleted: u64,
-    pub edges_deleted: u64,
-    pub properties_set: u64,
-    pub properties_removed: u64,
-    pub labels_added: u64,
-    pub labels_removed: u64,
-}
-
 /// Mutable state shared by every write phase of one statement.
 ///
 /// One [`GraphWriter`](graphforge_storage::GraphWriter) buffers every CREATE in the
@@ -270,16 +258,7 @@ pub(crate) struct StatementWriteContext {
     /// Label tokens already present before, or introduced during, this statement.
     pub known_labels: HashSet<EntityTypeId>,
     pub removed_label_tokens: HashSet<EntityTypeId>,
-    /// Entity/property pairs SET at least once in this statement.
-    pub property_sets: HashSet<(bool, [u8; 16], String)>,
-    pub counters: WriteCounters,
-    mutation_effects: BTreeMap<
-        crate::MutationKind,
-        (
-            HashSet<crate::MutationSubject>,
-            HashSet<crate::MutationSubject>,
-        ),
-    >,
+    pub mutation: crate::mutation::MutationState,
 }
 
 impl StatementWriteContext {
@@ -316,9 +295,7 @@ impl StatementWriteContext {
             label_removals: HashMap::new(),
             known_labels,
             removed_label_tokens: HashSet::new(),
-            property_sets: HashSet::new(),
-            counters: WriteCounters::default(),
-            mutation_effects: BTreeMap::new(),
+            mutation: crate::mutation::MutationState::default(),
         })
     }
 
@@ -339,14 +316,8 @@ impl StatementWriteContext {
         subject_kind: crate::MutationSubjectKind,
         uuid: [u8; 16],
     ) {
-        self.mutation_effects
-            .entry(kind)
-            .or_default()
-            .0
-            .insert(crate::MutationSubject {
-                uuid,
-                kind: subject_kind,
-            });
+        self.mutation
+            .record_mutation_input(kind, subject_kind, uuid);
     }
 
     fn record_mutation_output(
@@ -355,44 +326,33 @@ impl StatementWriteContext {
         subject_kind: crate::MutationSubjectKind,
         uuid: [u8; 16],
     ) {
-        self.mutation_effects
-            .entry(kind)
-            .or_default()
-            .1
-            .insert(crate::MutationSubject {
-                uuid,
-                kind: subject_kind,
-            });
+        self.mutation
+            .record_mutation_output(kind, subject_kind, uuid);
     }
 
     pub(crate) fn mutation_receipt(&self) -> crate::MutationReceipt {
-        crate::MutationReceipt::from_accumulators(self.mutation_effects.clone())
+        self.mutation.mutation_receipt()
     }
 
     fn record_label_tokens(&mut self, labels: impl IntoIterator<Item = EntityTypeId>) {
         for label in labels {
             if self.removed_label_tokens.remove(&label) {
-                self.counters.labels_removed -= 1;
+                self.mutation.counters.labels_removed -= 1;
             }
             if self.known_labels.insert(label) {
-                self.counters.labels_added += 1;
+                self.mutation.counters.labels_added += 1;
             }
         }
     }
 
     fn record_property_set(&mut self, is_edge: bool, uuid: [u8; 16], name: &str) -> bool {
-        if self.property_sets.insert((is_edge, uuid, name.to_owned())) {
-            self.counters.properties_set += 1;
-            true
-        } else {
-            false
-        }
+        self.mutation.record_property_set(is_edge, uuid, name)
     }
 
     fn record_removed_label_tokens(&mut self, labels: impl IntoIterator<Item = EntityTypeId>) {
         for label in labels {
             if self.removed_label_tokens.insert(label) {
-                self.counters.labels_removed += 1;
+                self.mutation.counters.labels_removed += 1;
             }
         }
     }
@@ -1657,9 +1617,9 @@ fn run_create_phase(
                 .flat_map(|node| node.label_ids.iter().copied()),
         );
     }
-    ctx.counters.nodes_created += tally.nodes_created;
-    ctx.counters.edges_created += tally.edges_created;
-    ctx.counters.properties_set += tally.properties_set;
+    ctx.mutation.counters.nodes_created += tally.nodes_created;
+    ctx.mutation.counters.edges_created += tally.edges_created;
+    ctx.mutation.counters.properties_set += tally.properties_set;
     recorder.record_create_receipt(ctx);
     recorder.extend_frontier(
         frontier,
@@ -1767,8 +1727,8 @@ fn create_single_merge_node(
         spec.label_names.first().map(String::as_str),
         spec.properties.iter().cloned().collect(),
     )?;
-    ctx.counters.nodes_created += 1;
-    ctx.counters.properties_set += spec.properties.len() as u64;
+    ctx.mutation.counters.nodes_created += 1;
+    ctx.mutation.counters.properties_set += spec.properties.len() as u64;
     ctx.record_label_tokens(spec.label_ids.iter().copied());
     let type_id = spec.label_ids.first().copied().map_or_else(
         graphforge_value::PrimaryEntityTypeId::absent,
@@ -2087,8 +2047,8 @@ fn run_relationship_merge_phase(
             created.push(true);
             input_rows.push(input_row);
             input_row += 1;
-            ctx.counters.edges_created += 1;
-            ctx.counters.properties_set += row_spec.properties.len() as u64;
+            ctx.mutation.counters.edges_created += 1;
+            ctx.mutation.counters.properties_set += row_spec.properties.len() as u64;
         }
     }
     frontier.take_rows(&input_rows)?;
@@ -2623,17 +2583,17 @@ fn run_delete_phase(
         .collect();
     let committed_edges: HashSet<[u8; 16]> =
         edge_targets.difference(&pending_edges).copied().collect();
-    ctx.counters.properties_removed +=
+    ctx.mutation.counters.properties_removed +=
         graphforge_storage::count_entity_properties(env.dir, &committed_edges, true)?;
-    ctx.counters.edges_deleted += edge_targets.len() as u64;
+    ctx.mutation.counters.edges_deleted += edge_targets.len() as u64;
     ctx.writer.cancel_edges(&pending_edges);
     ctx.pending_edge_deletes.extend(&committed_edges);
     ctx.deleted.extend(edge_targets.iter().copied());
 
     // Nodes, likewise.
-    ctx.counters.properties_removed +=
+    ctx.mutation.counters.properties_removed +=
         graphforge_storage::count_entity_properties(env.dir, &committed_nodes, false)?;
-    ctx.counters.nodes_deleted += node_targets.len() as u64;
+    ctx.mutation.counters.nodes_deleted += node_targets.len() as u64;
     ctx.writer.cancel_nodes(&pending_nodes);
     ctx.pending_node_deletes.extend(committed_nodes);
     ctx.deleted.extend(node_targets);
@@ -2885,7 +2845,7 @@ fn run_set_phase_masked(
                         &HashSet::from([item.prop_name.clone()]),
                     );
                     if present {
-                        ctx.counters.properties_removed += 1;
+                        ctx.mutation.counters.properties_removed += 1;
                         ctx.record_mutation_output(
                             crate::MutationKind::RemoveProperty,
                             if is_edge {
@@ -2935,7 +2895,7 @@ fn run_set_phase_masked(
                     ctx.record_property_set(is_edge, uuid, &item.prop_name)
                 };
                 if recorded && replaced {
-                    ctx.counters.properties_removed += 1;
+                    ctx.mutation.counters.properties_removed += 1;
                 }
                 ctx.record_mutation_output(
                     crate::MutationKind::SetProperty,
@@ -3060,7 +3020,7 @@ fn run_set_map_phase_with_input(
                         0
                     };
                     remove_map_complement(ctx, is_edge, &uuid, &stem, &removals);
-                    ctx.counters.properties_removed += (removals.len() + replaced) as u64;
+                    ctx.mutation.counters.properties_removed += (removals.len() + replaced) as u64;
                     for name in updates.keys() {
                         let _ = ctx.record_property_set(is_edge, uuid, name);
                     }
@@ -3144,8 +3104,8 @@ fn run_set_map_phase_with_input(
                     );
                 }
                 remove_map_complement(ctx, is_edge, &uuid, &stem, &removals);
-                ctx.counters.properties_removed += replaced as u64;
-                ctx.counters.properties_set += updates.len() as u64;
+                ctx.mutation.counters.properties_removed += replaced as u64;
+                ctx.mutation.counters.properties_set += updates.len() as u64;
                 apply_map_updates(ctx, is_edge, &uuid, &stem, updates)?;
             }
         }
@@ -3371,7 +3331,7 @@ fn run_remove_phase(
                     ctx.remove_acc
                         .record(is_edge, stem, uuid, item.prop_name.clone());
                 }
-                ctx.counters.properties_removed += 1;
+                ctx.mutation.counters.properties_removed += 1;
                 ctx.record_mutation_output(
                     crate::MutationKind::RemoveProperty,
                     if is_edge {
@@ -3530,35 +3490,13 @@ pub(crate) fn commit_statement(ctx: &mut StatementWriteContext, dir: &Path) -> R
     graphforge_storage::stage_delete_nodes(&mut staged, dir, &ctx.pending_node_deletes)?;
     ctx.writer.flush_into(&mut staged)?;
 
-    // Adjacency delta segment (#765): a statement is pure-append iff it stages
-    // no deletes (SET/REMOVE never touch topology). Pure-append → record the
-    // created edges so the index serves them without a rebuild; otherwise the
-    // statement breaks the chain at this generation (a DELETE invalidates the
-    // incremental path), so write no segment and clear any stale file there.
-    let pure_append = ctx.pending_node_deletes.is_empty() && ctx.pending_edge_deletes.is_empty();
-    let pending = ctx.writer.take_pending_delta();
-    let deleted_nodes = ctx
-        .pending_node_deletes
-        .iter()
-        .copied()
-        .map(Uuid::from_bytes)
-        .collect::<Vec<_>>();
-    let deleted_edges = ctx
-        .pending_edge_deletes
-        .iter()
-        .copied()
-        .map(Uuid::from_bytes)
-        .collect::<Vec<_>>();
-    if let Some(generation) =
-        ctx.writer
-            .commit_topology_aware_with_uuid_index(staged, deleted_nodes, deleted_edges)?
-    {
-        if pure_append {
-            ctx.writer.write_segment_best_effort(generation, &pending);
-        } else {
-            graphforge_storage::adjacency_delta::discard_segment(dir, generation);
-        }
-    }
+    ctx.mutation.commit_topology(
+        staged,
+        &mut ctx.writer,
+        dir,
+        &ctx.pending_node_deletes,
+        &ctx.pending_edge_deletes,
+    )?;
     Ok(())
 }
 
@@ -3776,8 +3714,8 @@ mod tests {
         ctx.record_removed_label_tokens([EntityTypeId::decode(7).unwrap()]);
         ctx.record_label_tokens([EntityTypeId::decode(7).unwrap()]);
 
-        assert_eq!(ctx.counters.labels_removed, 0);
-        assert_eq!(ctx.counters.labels_added, 0);
+        assert_eq!(ctx.mutation.counters.labels_removed, 0);
+        assert_eq!(ctx.mutation.counters.labels_added, 0);
     }
 
     #[test]
@@ -4270,8 +4208,8 @@ mod tests {
                 "wrong accumulated value for is_edge={is_edge}"
             );
             assert_eq!(accumulated.len(), 1, "duplicate rows must coalesce");
-            assert_eq!(ctx.counters.properties_set, 1);
-            assert_eq!(ctx.counters.properties_removed, 1);
+            assert_eq!(ctx.mutation.counters.properties_set, 1);
+            assert_eq!(ctx.mutation.counters.properties_removed, 1);
         }
     }
 
@@ -4332,7 +4270,7 @@ mod tests {
             assert_eq!(accumulated[&[7; 16]], HashSet::from(["score".into()]));
             assert_eq!(accumulated[&[8; 16]], HashSet::from(["score".into()]));
             assert_eq!(accumulated.len(), 2);
-            assert_eq!(ctx.counters.properties_removed, 2);
+            assert_eq!(ctx.mutation.counters.properties_removed, 2);
         }
     }
 
@@ -4397,7 +4335,7 @@ mod tests {
         );
         assert!(ctx.set_acc.nodes.is_empty());
         assert!(ctx.set_acc.edges.is_empty());
-        assert_eq!(ctx.counters, WriteCounters::default());
+        assert_eq!(ctx.mutation.counters, WriteCounters::default());
 
         let mut malformed_route = write_frontier(true);
         malformed_route.batches[0] = RecordBatch::try_new(
@@ -4431,7 +4369,7 @@ mod tests {
         );
         assert!(ctx.remove_acc.nodes.is_empty());
         assert!(ctx.remove_acc.edges.is_empty());
-        assert_eq!(ctx.counters, WriteCounters::default());
+        assert_eq!(ctx.mutation.counters, WriteCounters::default());
 
         let mut pending_ctx =
             StatementWriteContext::new(dir.path(), OntologyMode::Exploratory).unwrap();
@@ -4479,7 +4417,7 @@ mod tests {
             err.to_string(),
             "execution error: rel_type_name is not a string column"
         );
-        assert_eq!(pending_ctx.counters, WriteCounters::default());
+        assert_eq!(pending_ctx.mutation.counters, WriteCounters::default());
     }
 
     #[test]
@@ -4584,7 +4522,7 @@ mod tests {
                 &mut ctx,
             )
             .unwrap();
-            assert_eq!(ctx.counters.properties_removed, 2);
+            assert_eq!(ctx.mutation.counters.properties_removed, 2);
         }
     }
 

--- a/crates/graphforge-exec/src/write_resource.rs
+++ b/crates/graphforge-exec/src/write_resource.rs
@@ -17,6 +17,7 @@ pub(crate) struct GraphWriteContext {
 /// An admitted target retained by physical write operators.
 #[derive(Debug, Clone)]
 pub struct BoundWriteResource {
+    pub(crate) health: crate::mutation::MutationHealth,
     pub(crate) dir: PathBuf,
     pub(crate) mode: OntologyMode,
     contract: GraphReadContract,
@@ -26,6 +27,9 @@ pub struct BoundWriteResource {
 
 impl BoundWriteResource {
     pub(crate) fn validate(&self, expected: Option<&GraphReadContract>) -> Result<()> {
+        self.health
+            .check()
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         if expected.is_some_and(|expected| *expected != self.contract) {
             return Err(DataFusionError::Plan(
                 "GF_WRITE_RESOURCE_INCOMPATIBLE: logical identities".into(),
@@ -38,6 +42,50 @@ impl BoundWriteResource {
         if expected.is_some() && expected != self.composition.as_deref() {
             return Err(DataFusionError::Plan(
                 "GF_WRITE_RESOURCE_INCOMPATIBLE: semantic composition".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn same_authority(&self, other: &Self) -> bool {
+        self.dir == other.dir
+            && self.mode == other.mode
+            && self.contract == other.contract
+            && self.composition == other.composition
+            && self.type_map == other.type_map
+    }
+
+    pub(crate) fn validate_catalog(&self, catalog: &graphforge_ir::RuntimeCatalog) -> Result<()> {
+        let labels: std::collections::HashMap<_, _> = catalog
+            .entity_type_names_with_ids()
+            .map(|(id, name)| (graphforge_value::EntityTypeId::runtime(id), name.to_owned()))
+            .collect();
+        let relations: std::collections::HashMap<_, _> = catalog
+            .relation_type_names_with_ids()
+            .map(|(id, name)| {
+                (
+                    graphforge_value::RelationTypeId::runtime(id),
+                    name.to_owned(),
+                )
+            })
+            .collect();
+        let actual_labels: std::collections::HashMap<_, _> = self
+            .contract
+            .labels
+            .iter()
+            .filter(|(id, _)| id.tagged().runtime_entity_id().is_some())
+            .cloned()
+            .collect();
+        let actual_relations: std::collections::HashMap<_, _> = self
+            .contract
+            .relations
+            .iter()
+            .filter(|(id, _)| id.tagged().runtime_relation_id().is_some())
+            .cloned()
+            .collect();
+        if labels != actual_labels || relations != actual_relations {
+            return Err(DataFusionError::Plan(
+                "GF_WRITE_RESOURCE_INCOMPATIBLE: mutation catalog identities".into(),
             ));
         }
         Ok(())
@@ -85,6 +133,7 @@ pub(crate) fn required(
     )
     .map_err(|e| DataFusionError::Plan(e.to_string()))?;
     Ok(BoundWriteResource {
+        health: binding.resource.health.clone(),
         dir: binding.resource.dir.clone(),
         mode: binding.resource.mode,
         contract: lowerer.read_contract(),

--- a/crates/graphforge-exec/tests/write_statement.rs
+++ b/crates/graphforge-exec/tests/write_statement.rs
@@ -601,3 +601,133 @@ async fn mixed_create_set_merge_preserves_buffered_visibility_and_atomic_rollbac
         }
     }
 }
+
+#[tokio::test]
+async fn mutation_transaction_rejects_changed_destination_and_catalog_before_staging() {
+    use graphforge_exec::mutation::MutationTransaction;
+    let left = TempDir::new().unwrap();
+    let right = TempDir::new().unwrap();
+    let prior = RuntimeCatalog::new();
+    let mut transaction = MutationTransaction::new(&prior);
+    let working = transaction.catalog();
+    let plan = bind("CREATE (:Person {name: 'selected'})", &working);
+    let left_session = session(left.path(), &working);
+    left_session
+        .prepare_write_statement_with_params(&plan, &Default::default(), &mut transaction)
+        .await
+        .unwrap();
+    let first_receipt = transaction.receipt();
+    let error = left_session
+        .prepare_write_statement_with_params(&plan, &Default::default(), &mut transaction)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("already prepared"), "{error}");
+    assert_eq!(transaction.receipt(), first_receipt);
+    let right_resource = session(right.path(), &working).write_resource().unwrap();
+    let before = std::fs::read_dir(right.path()).unwrap().count();
+    let error = transaction.stage_catalog(&right_resource).unwrap_err();
+    assert!(
+        error.to_string().contains("GF_WRITE_RESOURCE_INCOMPATIBLE"),
+        "{error}"
+    );
+    assert_eq!(std::fs::read_dir(right.path()).unwrap().count(), before);
+    assert_eq!(rows(&left.path().join("topology/nodes.parquet")), 0);
+
+    let mut other = RuntimeCatalog::new();
+    other.intern_label("DifferentName").unwrap();
+    let mut wrong_catalog = MutationTransaction::new(&other);
+    let error = wrong_catalog
+        .stage_catalog(&left_session.write_resource().unwrap())
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("mutation catalog identities"),
+        "{error}"
+    );
+    assert!(
+        !left
+            .path()
+            .join("topology/runtime_catalog.parquet")
+            .exists()
+    );
+
+    working
+        .lock()
+        .unwrap()
+        .intern_label("LaterIdentity")
+        .unwrap();
+    let error = transaction
+        .stage_catalog(&left_session.write_resource().unwrap())
+        .unwrap_err();
+    assert!(error.to_string().contains("catalog changed"), "{error}");
+    assert!(
+        !left
+            .path()
+            .join("topology/runtime_catalog.parquet")
+            .exists()
+    );
+}
+
+#[tokio::test]
+async fn rejected_second_preparation_preserves_first_committed_data_and_receipt() {
+    use graphforge_exec::mutation::{MutationLifecycle, MutationOutcome, MutationTransaction};
+    struct LocalPublication(Option<MutationOutcome>);
+    impl MutationLifecycle for LocalPublication {
+        fn publish(
+            &mut self,
+            outcome: &MutationOutcome,
+            _: &RuntimeCatalog,
+        ) -> Result<(), GfError> {
+            self.0 = Some(outcome.clone());
+            Ok(())
+        }
+        fn complete(&mut self) -> Result<(), GfError> {
+            Ok(())
+        }
+        fn abort(&mut self) -> Result<(), GfError> {
+            panic!("successful local publication must not abort")
+        }
+    }
+    let dir = TempDir::new().unwrap();
+    let mut transaction = MutationTransaction::new(&RuntimeCatalog::new());
+    let working = transaction.catalog();
+    let first = bind("CREATE (:Person {name:'first'})", &working);
+    let second = bind("CREATE (:Person {name:'second'})", &working);
+    let session = session(dir.path(), &working);
+    let result = session
+        .prepare_write_statement_with_params(&first, &Default::default(), &mut transaction)
+        .await
+        .unwrap();
+    let receipt = transaction.receipt();
+    assert_eq!(result.mutation_receipt.as_ref(), Some(&receipt));
+    let error = session
+        .prepare_write_statement_with_params(&second, &Default::default(), &mut transaction)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("already prepared"), "{error}");
+    assert_eq!(transaction.receipt(), receipt);
+    let mut publication = LocalPublication(None);
+    transaction
+        .commit(&session.write_resource().unwrap(), true, &mut publication)
+        .unwrap();
+    assert_eq!(publication.0.unwrap().receipt, receipt);
+    assert_eq!(rows(&dir.path().join("topology/nodes.parquet")), 1);
+    let properties = logical_property_rows(dir.path(), "_untyped");
+    assert_eq!(properties.len(), 1);
+    assert_eq!(
+        properties[0].values.get("name"),
+        Some(&IrLiteral::Str("first".into()))
+    );
+}
+
+#[tokio::test]
+async fn shared_transaction_preserves_fresh_standalone_target_creation() {
+    let parent = TempDir::new().unwrap();
+    let target = parent.path().join("new-graph");
+    let catalog = Arc::new(Mutex::new(RuntimeCatalog::new()));
+    assert!(!target.exists());
+    let result = run(&target, &catalog, "CREATE (:Person {name:'first'})")
+        .await
+        .unwrap();
+    assert_eq!(result.side_effects.unwrap().nodes_created, 1);
+    assert_eq!(rows(&target.join("topology/nodes.parquet")), 1);
+}

--- a/crates/graphforge-exec/tests/write_statement.rs
+++ b/crates/graphforge-exec/tests/write_statement.rs
@@ -731,3 +731,61 @@ async fn shared_transaction_preserves_fresh_standalone_target_creation() {
     assert_eq!(result.side_effects.unwrap().nodes_created, 1);
     assert_eq!(rows(&target.join("topology/nodes.parquet")), 1);
 }
+
+#[tokio::test]
+async fn shared_transaction_aborts_first_write_to_absent_target_then_accepts_new_write() {
+    let parent = TempDir::new().unwrap();
+    let target = parent.path().join("new-graph");
+    let catalog = Arc::new(Mutex::new(RuntimeCatalog::new()));
+    assert!(!target.exists());
+    let error = run(
+        &target,
+        &catalog,
+        "CREATE (a:Person {name:'discarded'}) DELETE a SET a.name='invalid'",
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("entity deleted in this statement"),
+        "{error}"
+    );
+    assert!(
+        target.is_dir(),
+        "the writer created the target before rollback"
+    );
+    assert_eq!(rows(&target.join("topology/nodes.parquet")), 0);
+    let result = run(&target, &catalog, "CREATE (:Person {name:'retained'})")
+        .await
+        .unwrap();
+    assert_eq!(result.side_effects.unwrap().nodes_created, 1);
+    assert_eq!(rows(&target.join("topology/nodes.parquet")), 1);
+}
+
+#[tokio::test]
+async fn absent_target_prefix_error_preserves_original_error_and_same_session_health() {
+    use graphforge_exec::mutation::MutationTransaction;
+    let parent = TempDir::new().unwrap();
+    let target = parent.path().join("new-graph");
+    let catalog = Arc::new(Mutex::new(RuntimeCatalog::new()));
+    let failed = bind(
+        "WITH $missing AS value CREATE (:Person {name:value})",
+        &catalog,
+    );
+    let valid = bind("CREATE (:Person {name:'retained'})", &catalog);
+    let session = session(&target, &catalog);
+    let mut probe = MutationTransaction::new(&catalog.lock().unwrap());
+    let expected = session
+        .prepare_write_statement_with_params(&failed, &Default::default(), &mut probe)
+        .await
+        .unwrap_err();
+    assert!(expected.to_string().contains("missing"), "{expected}");
+    assert!(!target.exists());
+    let actual = session.execute_write_statement(&failed).await.unwrap_err();
+    assert_eq!(actual.to_string(), expected.to_string());
+    assert!(!target.exists());
+    let result = session.execute_write_statement(&valid).await.unwrap();
+    assert_eq!(result.side_effects.unwrap().nodes_created, 1);
+    assert_eq!(rows(&target.join("topology/nodes.parquet")), 1);
+}

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -1993,3 +1993,94 @@ mod tests {
         );
     }
 }
+
+/// Disposable, file-backed rollback state for a private graph workspace.
+///
+/// This is not a durable recovery protocol. Generation owners use their
+/// authoritative parent instead; unpublished workspaces use this streaming-copy
+/// fallback so abort never needs to materialize all graph bytes in memory.
+/// The copy bounds memory, not total scratch-disk consumption.
+pub struct GraphWorkspaceCheckpoint {
+    source: PathBuf,
+    backup: Option<tempfile::TempDir>,
+    inventory: GraphFilesInventory,
+}
+
+impl GraphWorkspaceCheckpoint {
+    /// Copy an admitted workspace using the existing validated graph inventory.
+    ///
+    /// # Errors
+    /// Rejects links, invalid inventory and copy failures.
+    pub fn capture(source: &Path) -> Result<Self, GfError> {
+        let (inventory, _) = capture_graph_files(source)?;
+        let backup = tempfile::Builder::new()
+            .prefix("graphforge-mutation-rollback-")
+            .tempdir()
+            .map_err(|error| storage("create mutation rollback directory", source, error))?;
+        materialize_graph_tree(source, &inventory, backup.path())?;
+        Ok(Self {
+            source: source.to_path_buf(),
+            backup: Some(backup),
+            inventory,
+        })
+    }
+
+    /// Restore data files while preserving operational lock/cache files.
+    /// Callers must hold mutation admission and establish publication authority
+    /// before invoking this method.
+    ///
+    /// # Errors
+    /// Fails closed if the backup, destination or restoration cannot be verified.
+    pub fn restore(&mut self, target: &Path) -> Result<(), GfError> {
+        if target != self.source {
+            return Err(validation(
+                "mutation checkpoint target differs from captured workspace",
+            ));
+        }
+        let result = self.restore_inner(target);
+        if let Err(error) = result {
+            let Some(backup) = self.backup.take() else {
+                return Err(error);
+            };
+            let backup = backup.keep();
+            return Err(GfError::Storage(format!(
+                "mutation restore failed; rollback backup retained at {}: {error}",
+                backup.display()
+            )));
+        }
+        Ok(())
+    }
+
+    fn restore_inner(&self, target: &Path) -> Result<(), GfError> {
+        let backup = self
+            .backup
+            .as_ref()
+            .ok_or_else(|| validation("mutation checkpoint already retained after failure"))?;
+        verify_graph_tree(backup.path(), &self.inventory)?;
+        let mut current = Vec::new();
+        collect_source_files(target, &mut current)?;
+        for path in current {
+            fs::remove_file(&path)
+                .map_err(|error| storage("remove aborted mutation file", &path, error))?;
+        }
+        for entry in &self.inventory.files {
+            let relative = canonical_inventory_relative_path(&entry.relative_path)?;
+            let source = backup.path().join(&relative);
+            let destination = target.join(relative);
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| storage("restore mutation directory", parent, error))?;
+            }
+            copy_regular_file(&source, &destination)?;
+            make_private_copy_owner_writable(&destination)?;
+            crate::project_failpoint::hit(
+                "mutation.restore.after_copy",
+                None,
+                None,
+                "MUTATION_RESTORE",
+                false,
+            )?;
+        }
+        verify_graph_tree(target, &self.inventory)
+    }
+}

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -1734,6 +1734,59 @@ mod tests {
         assert!(verify_graph_tree(&graph_tree_root(generation.path()), &inventory).is_err());
     }
 
+    #[test]
+    fn checkpoint_does_not_treat_disappeared_existing_target_as_originally_absent() {
+        let parent = tempfile::tempdir().unwrap();
+        let target = parent.path().join("existing");
+        fs::create_dir(&target).unwrap();
+        let mut checkpoint = GraphWorkspaceCheckpoint::capture(&target).unwrap();
+        let backup = checkpoint.backup.as_ref().unwrap().path().to_path_buf();
+        fs::remove_dir(&target).unwrap();
+        let error = checkpoint.restore(&target).unwrap_err();
+        assert!(
+            error.to_string().contains("rollback backup retained"),
+            "{error}"
+        );
+        drop(checkpoint);
+        assert!(backup.exists());
+        fs::remove_dir_all(backup).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn checkpoint_rejects_substituted_root_symlink_before_touching_outside_files() {
+        use std::os::unix::fs::symlink;
+        for originally_absent in [false, true] {
+            let parent = tempfile::tempdir().unwrap();
+            let target = parent.path().join("target");
+            if !originally_absent {
+                fs::create_dir(&target).unwrap();
+            }
+            let mut checkpoint = GraphWorkspaceCheckpoint::capture(&target).unwrap();
+            let backup = checkpoint.backup.as_ref().unwrap().path().to_path_buf();
+            if !originally_absent {
+                fs::remove_dir(&target).unwrap();
+            }
+            let outside = parent.path().join("outside");
+            fs::create_dir(&outside).unwrap();
+            let sentinel = outside.join("sentinel");
+            fs::write(&sentinel, b"outside remains unchanged").unwrap();
+            symlink(&outside, &target).unwrap();
+            let error = checkpoint.restore(&target).unwrap_err();
+            assert!(error.to_string().contains("symbolic link"), "{error}");
+            assert_eq!(
+                fs::read(&sentinel).ok(),
+                Some(b"outside remains unchanged".to_vec())
+            );
+            drop(checkpoint);
+            assert!(
+                backup.exists(),
+                "failed restore retains the recoverable backup after owner drop"
+            );
+            fs::remove_dir_all(backup).unwrap();
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn capture_rejects_symlinks() {
@@ -2004,6 +2057,16 @@ pub struct GraphWorkspaceCheckpoint {
     source: PathBuf,
     backup: Option<tempfile::TempDir>,
     inventory: GraphFilesInventory,
+    source_was_absent: bool,
+}
+
+/// Whether restoration retained an untouched absent target or restored a tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphWorkspaceRestoration {
+    /// The source was absent at capture and remains absent after an early error.
+    Absent,
+    /// A workspace tree was verified after restoration, possibly empty.
+    Materialized,
 }
 
 impl GraphWorkspaceCheckpoint {
@@ -2012,16 +2075,28 @@ impl GraphWorkspaceCheckpoint {
     /// # Errors
     /// Rejects links, invalid inventory and copy failures.
     pub fn capture(source: &Path) -> Result<Self, GfError> {
-        let (inventory, _) = capture_graph_files(source)?;
         let backup = tempfile::Builder::new()
             .prefix("graphforge-mutation-rollback-")
             .tempdir()
             .map_err(|error| storage("create mutation rollback directory", source, error))?;
-        materialize_graph_tree(source, &inventory, backup.path())?;
+        let (inventory, source_was_absent) = match fs::symlink_metadata(source) {
+            Ok(_) => {
+                let (inventory, _) = capture_graph_files(source)?;
+                materialize_graph_tree(source, &inventory, backup.path())?;
+                (inventory, false)
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // Keep a fresh target absent until lowering captures its empty
+                // schema. GraphWriter creates it only after that boundary.
+                (capture_graph_files(backup.path())?.0, true)
+            }
+            Err(error) => return Err(storage("inspect mutation workspace", source, error)),
+        };
         Ok(Self {
             source: source.to_path_buf(),
             backup: Some(backup),
             inventory,
+            source_was_absent,
         })
     }
 
@@ -2031,32 +2106,48 @@ impl GraphWorkspaceCheckpoint {
     ///
     /// # Errors
     /// Fails closed if the backup, destination or restoration cannot be verified.
-    pub fn restore(&mut self, target: &Path) -> Result<(), GfError> {
+    pub fn restore(&mut self, target: &Path) -> Result<GraphWorkspaceRestoration, GfError> {
         if target != self.source {
             return Err(validation(
                 "mutation checkpoint target differs from captured workspace",
             ));
         }
-        let result = self.restore_inner(target);
-        if let Err(error) = result {
-            let Some(backup) = self.backup.take() else {
-                return Err(error);
-            };
-            let backup = backup.keep();
-            return Err(GfError::Storage(format!(
-                "mutation restore failed; rollback backup retained at {}: {error}",
-                backup.display()
-            )));
+        match self.restore_inner(target) {
+            Ok(restoration) => Ok(restoration),
+            Err(error) => {
+                let Some(backup) = self.backup.take() else {
+                    return Err(error);
+                };
+                let backup = backup.keep();
+                Err(GfError::Storage(format!(
+                    "mutation restore failed; rollback backup retained at {}: {error}",
+                    backup.display()
+                )))
+            }
         }
-        Ok(())
     }
 
-    fn restore_inner(&self, target: &Path) -> Result<(), GfError> {
+    fn restore_inner(&self, target: &Path) -> Result<GraphWorkspaceRestoration, GfError> {
         let backup = self
             .backup
             .as_ref()
             .ok_or_else(|| validation("mutation checkpoint already retained after failure"))?;
         verify_graph_tree(backup.path(), &self.inventory)?;
+        let metadata = match fs::symlink_metadata(target) {
+            Err(error)
+                if self.source_was_absent && error.kind() == std::io::ErrorKind::NotFound =>
+            {
+                return Ok(GraphWorkspaceRestoration::Absent);
+            }
+            Err(error) => return Err(storage("inspect mutation restore target", target, error)),
+            Ok(metadata) => metadata,
+        };
+        // Validate the root before read_dir can follow a substituted link and
+        // before removing any current file, including on originally absent roots.
+        reject_link(target)?;
+        if !metadata.is_dir() {
+            return Err(validation("mutation restore target must be a directory"));
+        }
         let mut current = Vec::new();
         collect_source_files(target, &mut current)?;
         for path in current {
@@ -2081,6 +2172,7 @@ impl GraphWorkspaceCheckpoint {
                 false,
             )?;
         }
-        verify_graph_tree(target, &self.inventory)
+        verify_graph_tree(target, &self.inventory)?;
+        Ok(GraphWorkspaceRestoration::Materialized)
     }
 }

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -64,9 +64,9 @@ pub use graph_files::{
     GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GRAPH_FILES_FAMILY, GRAPH_FILES_IO_BUFFER_BYTES,
     GRAPH_FILES_RECORD_VERSION, GRAPH_FILES_V2_RECORD_VERSION, GRAPH_TREE_DIR, GraphFileEntry,
     GraphFileRole, GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy,
-    GraphWorkspaceCheckpoint, capture_graph_files, decode_inventory, encode_inventory,
-    graph_tree_root, inventory_participant, materialize_graph_tree, pinned_open_evidence,
-    stage_graph_tree, verify_graph_tree,
+    GraphWorkspaceCheckpoint, GraphWorkspaceRestoration, capture_graph_files, decode_inventory,
+    encode_inventory, graph_tree_root, inventory_participant, materialize_graph_tree,
+    pinned_open_evidence, stage_graph_tree, verify_graph_tree,
 };
 pub(crate) use graph_files::{GraphFilesParticipant, decode_versioned_graph_files_participant};
 

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -64,9 +64,9 @@ pub use graph_files::{
     GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GRAPH_FILES_FAMILY, GRAPH_FILES_IO_BUFFER_BYTES,
     GRAPH_FILES_RECORD_VERSION, GRAPH_FILES_V2_RECORD_VERSION, GRAPH_TREE_DIR, GraphFileEntry,
     GraphFileRole, GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy,
-    capture_graph_files, decode_inventory, encode_inventory, graph_tree_root,
-    inventory_participant, materialize_graph_tree, pinned_open_evidence, stage_graph_tree,
-    verify_graph_tree,
+    GraphWorkspaceCheckpoint, capture_graph_files, decode_inventory, encode_inventory,
+    graph_tree_root, inventory_participant, materialize_graph_tree, pinned_open_evidence,
+    stage_graph_tree, verify_graph_tree,
 };
 pub(crate) use graph_files::{GraphFilesParticipant, decode_versioned_graph_files_participant};
 
@@ -438,14 +438,14 @@ pub use schemas::{
 
 pub mod writer;
 pub use writer::{
-    GraphWriter, GraphWriterLimits, count_entity_properties, decode_spatial_property_value,
-    read_entity_properties, read_entity_property_keys, read_node_property_rows,
-    remove_edge_properties, remove_node_properties, set_edge_properties_rewrite,
-    set_node_properties, stage_property_tombstones_authenticated, stage_remove_edge_properties,
-    stage_remove_edge_properties_authenticated, stage_remove_node_properties,
-    stage_remove_node_properties_authenticated, stage_set_edge_properties,
-    stage_set_edge_properties_authenticated, stage_set_node_properties,
-    stage_set_node_properties_authenticated,
+    GraphWriter, GraphWriterLimits, NodePropertySetCounts, count_entity_properties,
+    decode_spatial_property_value, read_entity_properties, read_entity_property_keys,
+    read_node_property_rows, remove_edge_properties, remove_node_properties,
+    set_edge_properties_rewrite, set_node_properties, stage_property_tombstones_authenticated,
+    stage_remove_edge_properties, stage_remove_edge_properties_authenticated,
+    stage_remove_node_properties, stage_remove_node_properties_authenticated,
+    stage_set_edge_properties, stage_set_edge_properties_authenticated, stage_set_node_properties,
+    stage_set_node_properties_authenticated, stage_set_node_properties_authenticated_with_counts,
 };
 
 pub mod mutator;

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -4984,6 +4984,7 @@ pub fn stage_set_node_properties(
     updates: &HashMap<[u8; 16], HashMap<String, IrLiteral>>,
 ) -> Result<u64, GfError> {
     stage_set_node_properties_from_inventory(staged, dir, None, stem, updates)
+        .map(|counts| counts.entities_touched)
 }
 
 #[allow(clippy::implicit_hasher)]
@@ -4996,6 +4997,28 @@ pub fn stage_set_node_properties_authenticated(
     updates: &HashMap<[u8; 16], HashMap<String, IrLiteral>>,
 ) -> Result<u64, GfError> {
     stage_set_node_properties_from_inventory(staged, dir, Some(inventory), stem, updates)
+        .map(|counts| counts.entities_touched)
+}
+
+/// Data-level facts from a staged node property update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NodePropertySetCounts {
+    /// Distinct node rows touched by the update.
+    pub entities_touched: u64,
+    /// Non-null existing property values replaced by supplied keys.
+    pub properties_replaced: u64,
+}
+
+/// Stage authenticated node properties and report existing-value replacements.
+/// Uses the same before-map required by the rewrite, without another read pass.
+pub fn stage_set_node_properties_authenticated_with_counts(
+    staged: &mut RewriteBatch,
+    dir: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    stem: &str,
+    updates: &HashMap<[u8; 16], HashMap<String, IrLiteral>>,
+) -> Result<NodePropertySetCounts, GfError> {
+    stage_set_node_properties_from_inventory(staged, dir, Some(inventory), stem, updates)
 }
 
 fn stage_set_node_properties_from_inventory(
@@ -5004,7 +5027,7 @@ fn stage_set_node_properties_from_inventory(
     inventory: Option<&crate::AuthenticatedPropertyInventory>,
     stem: &str,
     updates: &HashMap<[u8; 16], HashMap<String, IrLiteral>>,
-) -> Result<u64, GfError> {
+) -> Result<NodePropertySetCounts, GfError> {
     let targets = updates.keys().copied().collect();
     let owned_inventory;
     let inventory = if let Some(inventory) = inventory {
@@ -5031,6 +5054,21 @@ fn stage_set_node_properties_from_inventory(
         stem,
     )?);
     existing.retain(|uuid, _| targets.contains(uuid));
+    let properties_replaced = existing
+        .iter()
+        .map(|(uuid, row)| {
+            updates.get(uuid).map_or(0, |properties| {
+                properties
+                    .keys()
+                    .filter(|name| {
+                        row.values
+                            .get(*name)
+                            .is_some_and(|value| !matches!(value, IrLiteral::Null))
+                    })
+                    .count() as u64
+            })
+        })
+        .sum();
     let before = existing.clone();
     let rows = existing
         .into_values()
@@ -5056,7 +5094,10 @@ fn stage_set_node_properties_from_inventory(
         inventory.generation_authority(),
         Some(&before),
     )?;
-    Ok(touched)
+    Ok(NodePropertySetCounts {
+        entities_touched: touched,
+        properties_replaced,
+    })
 }
 
 #[allow(

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -5011,6 +5011,7 @@ pub struct NodePropertySetCounts {
 
 /// Stage authenticated node properties and report existing-value replacements.
 /// Uses the same before-map required by the rewrite, without another read pass.
+#[allow(clippy::implicit_hasher)] // same execution accumulator contract as the SET wrappers above
 pub fn stage_set_node_properties_authenticated_with_counts(
     staged: &mut RewriteBatch,
     dir: &Path,

--- a/docs/adr/0028-shared-mutation-transaction.md
+++ b/docs/adr/0028-shared-mutation-transaction.md
@@ -1,0 +1,107 @@
+# ADR 0028: One transaction owns graph mutation effects
+
+**Status:** Proposed
+**Date:** 2026-09-07
+**Related:** #1010; ADRs 0025 and 0026
+
+## Context
+
+Cypher's statement driver buffers writes, stages one rewrite, and assembles
+counters and receipts. Its facade separately persists the observed runtime
+catalog and publishes a generation. Analyst write-back duplicates catalog
+interning, property staging, receipt construction, snapshot capture and rollback.
+A property-write staging failure and an error after CURRENT publication must not
+be handled as the same transaction outcome.
+
+This is a correctness-first durable mutation boundary. Existing public Arrow
+results, receipt meanings, checked identities and durable formats must remain
+compatible. Clause order, pending-write visibility and pure-append adjacency
+segments must also survive the extraction.
+
+## Options
+
+1. Share only the API publication wrapper. Small, but leaves duplicated staging,
+   catalog, counters and receipt invariants; it does not satisfy #1010.
+2. Extract a supported execution-owned mutation transaction and supply an API
+   publication adapter. Reuses existing owners without a reverse dependency.
+3. Move all transaction policy into storage. This would pull execution receipts,
+   runtime observation policy and API domain publication into the wrong layer.
+
+## Decision
+
+Choose option 2, without adding a crate or a durable transaction format.
+
+`graphforge-exec::mutation` owns a `MutationTransaction`: the working catalog
+snapshot, neutral effect/counter accumulation, staged rewrite, and commit/abort
+state. Both entry points use its property-write recording and receipt builder.
+The Cypher statement context retains only clause/frontier evaluation and
+pending-write visibility; its buffered topology/property operations feed this
+same transaction. A property-only analyst transaction does not open a topology
+writer or scan all label memberships merely to use the shared machinery.
+
+Catalog interning occurs against a transaction-owned working catalog. Cypher's
+binder receives that catalog before mutation binding; analyst property
+interning uses the same owner. The catalog's persisted batch joins the graph
+rewrite, rather than being written independently after a successful Cypher
+commit. The live catalog is installed according to the final publication
+outcome. Ordinary read-query observation policy is unchanged.
+
+The API supplies a small publication adapter using its existing generation and
+domain-participant methods. It does not call private executor phase functions.
+The adapter captures the authoritative parent generation, publishes the neutral
+receipt, restores or reconciles the workspace when required, and installs the
+resulting property/ordinal authority. Transaction orchestration, rather than
+each verb, invokes these operations. Standalone execution retains its existing
+local staged-commit behavior through the same core without API publication.
+
+The shared transaction owns the complete sequence:
+
+1. Acquire existing write admission and establish parent/catalog state.
+2. Bind or validate against the working catalog; accumulate graph operations,
+   existing property-counter semantics and deterministically ordered neutral effects.
+3. Stage graph and catalog changes together. Reuse existing RewriteBatch and
+   topology/UUID-index commit primitives, including adjacency delta behavior.
+4. Commit the local rewrite, then publish through the API adapter when present.
+5. On success, install the catalog and refresh/invalidate retained graph
+   resources through one completion path. Preserve selected-resource authority.
+6. On any error, including a local rewrite commit failure, use the same abort
+   path. Restore the parent workspace/catalog only while the parent remains
+   authoritative. If publication already advanced CURRENT, preserve committed
+   data and reconcile the live catalog/resource authority; never undo a
+   published generation because a later operation returned an error.
+
+Every GraphForge facade, including in-memory construction, initializes a
+project generation before executing writes. Its ordinary publishing operations
+therefore have an authoritative parent, including the first write to an empty
+graph. Standalone exec targets and unpublished transaction workspaces can lack
+an authoritative snapshot of their current contents. Those paths require a
+private disk-backed rollback copy of the admitted workspace, with validated
+file inventory and streaming/reflink materialization, before any local commit.
+They must never silently run without rollback merely because CURRENT is absent.
+This fallback does not build a whole-graph Arrow byte envelope in memory.
+
+Rollback uses the authoritative committed generation where available; analyst
+write-back no longer captures a whole-workspace Arrow snapshot for this purpose.
+Errors determining publication state fail closed; they do not authorize a
+speculative restoration. Existing project publication remains the durable
+atomicity boundary, rather than a second commit protocol in exec.
+
+## Validation and consequences
+
+Baseline tests first pin repeated SET, CREATE-then-SET and no-op counter behavior.
+A shared Rust-facade test runs equivalent Cypher SET and real rank/cluster
+write-back on matching seeded graphs. It compares normalized receipt fields,
+existing property counters (including repeated SET and CREATE-then-SET), catalog entries, stored values and generation effects.
+Receipt capture stays test-internal; no new public facade result is introduced.
+
+The same matrix injects failures during staging/local commit, before CURRENT,
+and after CURRENT. It checks pre-publication rollback of both data and catalog,
+post-publication preservation, resource invalidation and durable reopen. Include
+an existing nonempty graph, no-op/empty write-back, repeated SETs, mixed Cypher
+CREATE/SET/REMOVE/DELETE/MERGE, and semantic composition routing. Existing query
+parity and bounded cache tests remain required.
+
+This is one concern under #1010. Implement the shared state/staging core first,
+route both entry points through it, then delete the duplicated catalog/receipt/
+rollback paths only after the common acceptance matrix passes. The API remains
+the owner of generation/domain publication and exec remains independent of API.

--- a/docs/adr/0028-shared-mutation-transaction.md
+++ b/docs/adr/0028-shared-mutation-transaction.md
@@ -105,3 +105,39 @@ This is one concern under #1010. Implement the shared state/staging core first,
 route both entry points through it, then delete the duplicated catalog/receipt/
 rollback paths only after the common acceptance matrix passes. The API remains
 the owner of generation/domain publication and exec remains independent of API.
+
+
+## Compatibility details verified during implementation
+
+Exploratory Cypher SET/property-reference observation uses an unowned runtime
+property entry; CREATE property literals alone do not intern a property entry.
+Analyst write-back already supplies its selected label as owner. The transaction
+preserves these caller inputs while owning their private catalog and publication.
+Tests check each exact owner and persistence; they do not claim these catalog
+entries are identical. Neutral receipts and all side-effect counters are compared
+exactly for equivalent preexisting property state, including Cypher's replacement
+counter. The property rewrite reports replacement facts from its existing
+before-map without adding a read pass.
+
+Admission pins one destination, mode, semantic contract and immutable catalog
+batch. A transaction prepares one statement or one analyst update; a second
+preparation fails before evaluation and leaves the first prepared state intact.
+Catalog staging and final installation use the admitted batch, not a later read
+of a mutable catalog alias.
+
+A failed restoration retains its rollback directory and marks the shared
+execution-resource health owner unavailable. New reads/writes and already-returned
+lazy streams check that owner. The facade and standalone session paths use the
+same health semantics. A fresh facade can reopen the untouched durable parent;
+the failed owner does not silently resume. Checkpoint copying bounds memory, not
+total scratch-disk use. It adds no durable record or recovery protocol.
+
+Recovery advances an owner-local epoch before touching workspace files. Existing
+lazy streams check that epoch before and after each inner poll, so a poll that
+overlaps restoration cannot emit a partially read batch. Successful restoration
+admits new work but invalidates old streams; failure remains permanent for that
+owner. Overlapping recovery is rejected, and completion cannot clear a separately
+recorded failure. The explicit multi-statement facade transaction uses the same
+abort adapter around its existing publication boundary, including errors after
+an earlier unpublished statement. Composite domain publication and its receipt
+remain owned by the existing facade publisher.

--- a/docs/adr/0028-shared-mutation-transaction.md
+++ b/docs/adr/0028-shared-mutation-transaction.md
@@ -141,3 +141,11 @@ recorded failure. The explicit multi-statement facade transaction uses the same
 abort adapter around its existing publication boundary, including errors after
 an earlier unpublished statement. Composite domain publication and its receipt
 remain owned by the existing facade publisher.
+
+A standalone target that did not exist at capture stays absent until its writer
+runs, preserving the lowering snapshot's empty-target contract. An early failure
+restores that absence without replacing the original inventory-less catalog;
+after writer creation, rollback verifies an empty materialized tree instead.
+Restoration validates the destination root as a non-link directory before any
+destructive walk. A substituted root is rejected and its rollback backup survives
+owner drop.


### PR DESCRIPTION
Cypher statements and analyst property write-back now use one mutation transaction for the private catalog, rewrite staging, receipts, counters, commit, and recovery. The facade retains generation publication, while both entry points share authority-aware rollback and adjacency invalidation. Explicit multi-statement transactions use the same abort adapter after unpublished writes.

Recovery follows the actual selected generation after publication errors. Failed restoration retains its backup after owner drop and denies further use of the affected owner; retained streams check a recovery epoch before and after each pull. Absent targets preserve their empty snapshot contract, and substituted rollback-root links are rejected before touching outside files. Existing caller-specific catalog observation and counter semantics are preserved. ADR 0028 records the boundary; no durable or public result format changes.

Validation:
- Real Degree/Components versus Cypher receipt, counter, value, and reopen parity; eight rewrite/publication fault cases; semantic post-publication reconciliation; ephemeral and standalone rollback; retained-stream recovery checks.
- Full AST, executor, API (703 unit tests), structured-stage and storage suites passed. After snapshot integration, executor units, read/write transactions, lowering goldens, composition and recovery checks passed again, including 21 write-statement tests.
- API BDD 118/118 and openCypher TCK 3,897/3,897 passed with zero regressions. Advisory timing warnings remain; no performance claim.
- Workspace Clippy, formatting, and `make pre-push-fast` passed. Exact-head CI remains required.

Closes #1010

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791395879&installation_model_id=20486&pr_number=1151&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1151&signature=caaa4a4880195b4872de79c59a4dd73028e03fef41fccff67215571bd9b0f16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->