### PR TITLE
fix(rel): preserve endpoint property shapes in fixed-hop paths

### DIFF
--- a/crates/graphforge-api/tests/e2e_baseline.rs
+++ b/crates/graphforge-api/tests/e2e_baseline.rs
@@ -5467,3 +5467,93 @@ fn shared_value_codec_keeps_ordinary_property_names_deletable() {
         0
     );
 }
+
+fn assert_endpoint_marks(result: &ExecutionResult, ids: &[[u8; 16]], marks: [Option<i64>; 2]) {
+    assert_eq!(result.stats.rows_produced, 1);
+    assert_eq!(
+        node_uuid_seq(&result.batches[0], "ns", 0),
+        Some(ids.to_vec())
+    );
+    let values = result.batches[0]
+        .column_by_name("ns")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .value(0);
+    let nodes = values.as_any().downcast_ref::<StructArray>().unwrap();
+    let actual = nodes
+        .column_by_name("mark")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(actual.iter().collect::<Vec<_>>(), marks);
+}
+
+#[test]
+fn fixed_hop_new_endpoint_property_survives_write_and_reopen() {
+    for (target, marks) in [("a", [Some(1), None]), ("b", [None, Some(1)])] {
+        let dir = tempfile::tempdir().unwrap();
+        let gf = GraphForge::new(dir.path().to_str()).unwrap();
+        gf.execute("CREATE (a:Person {name:'a'}), (b:Person {name:'b'}), (a)-[:KNOWS]->(b)")
+            .unwrap();
+        let ids = vec![person_uuid(&gf, "a"), person_uuid(&gf, "b")];
+        let topology_query = "MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN a.node_uuid AS a, r.edge_uuid AS r, b.node_uuid AS b";
+        let topology = gf.execute(topology_query).unwrap().batches[0]
+            .columns()
+            .to_vec();
+        let result = gf
+            .execute(&format!(
+                "MATCH p=(a:Person)-[:KNOWS]->(b:Person) SET {target}.mark=1 RETURN nodes(p) AS ns"
+            ))
+            .unwrap();
+        assert_endpoint_marks(&result, &ids, marks);
+        assert_eq!(
+            result.side_effects.as_ref().unwrap(),
+            &graphforge_exec::SideEffects {
+                properties_set: 1,
+                ..Default::default()
+            }
+        );
+        let effects = &result.mutation_receipt.as_ref().unwrap().effects;
+        assert_eq!(effects.len(), 1);
+        assert_eq!(effects[0].kind, graphforge_exec::MutationKind::SetProperty);
+        assert_eq!(
+            effects[0].outputs,
+            vec![graphforge_exec::MutationSubject {
+                uuid: ids[usize::from(target == "b")],
+                kind: graphforge_exec::MutationSubjectKind::Node
+            }]
+        );
+        let fixed = "MATCH p=(a:Person)-[:KNOWS]->(b:Person) RETURN nodes(p) AS ns";
+        let variable = "MATCH p=(a:Person)-[:KNOWS*1..1]->(b:Person) RETURN nodes(p) AS ns";
+        for query in [fixed, variable] {
+            assert_endpoint_marks(&gf.execute(query).unwrap(), &ids, marks);
+        }
+        assert_eq!(
+            gf.execute(topology_query).unwrap().batches[0].columns(),
+            &topology
+        );
+        drop(gf);
+        let reopened = GraphForge::new(dir.path().to_str()).unwrap();
+        for query in [fixed, variable] {
+            assert_endpoint_marks(&reopened.execute(query).unwrap(), &ids, marks);
+        }
+        assert_eq!(
+            reopened.execute(topology_query).unwrap().batches[0].columns(),
+            &topology
+        );
+        let existing = reopened
+            .execute(&format!(
+                "MATCH p=(a:Person)-[:KNOWS]->(b:Person) SET {target}.mark=2 RETURN nodes(p) AS ns"
+            ))
+            .unwrap();
+        let changed = marks.map(|value| value.map(|_| 2));
+        assert_endpoint_marks(&existing, &ids, changed);
+        assert_eq!(existing.side_effects.as_ref().unwrap().properties_set, 1);
+        for query in [fixed, variable] {
+            assert_endpoint_marks(&reopened.execute(query).unwrap(), &ids, changed);
+        }
+    }
+}

--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -2304,15 +2304,26 @@ impl<'a> ExprLowerer<'a> {
         let nodes = node_vars
             .iter()
             .map(|var| {
+                use datafusion::functions::core::expr_fn::named_struct;
                 let base = self
                     .var_map
                     .get(*var)
                     .ok_or(LoweringError::UnboundVar(var.0))?;
-                Ok(node_value_struct(
-                    base,
-                    None,
-                    &self.type_id_to_entity_name,
-                    &prop_names,
+                let mut fields = vec![
+                    lit("node_uuid"),
+                    qualified_col(base, "node_uuid"),
+                    lit("labels"),
+                    node_labels_list(base, None, &self.type_id_to_entity_name),
+                ];
+                for name in &prop_names {
+                    fields.extend([
+                        lit(name.as_str()),
+                        self.path_node_property(base, name, &node_vars)?,
+                    ]);
+                }
+                Ok(null_unless(
+                    qualified_col(base, "node_uuid").is_not_null(),
+                    named_struct(fields),
                 ))
             })
             .collect::<Result<Vec<_>, LoweringError>>()?;
@@ -2323,6 +2334,42 @@ impl<'a> ExprLowerer<'a> {
             )
         })?;
         Ok(null_unless(present, make_array(nodes)))
+    }
+
+    /// Fixed-hop nodes share a property shape, but SET can add a column to only
+    /// one endpoint. Preserve available values and type missing values from the
+    /// other endpoint rather than referencing a nonexistent qualified column.
+    fn path_node_property(
+        &self,
+        base: &str,
+        name: &str,
+        nodes: &[VarId],
+    ) -> Result<DfExpr, LoweringError> {
+        let value = qualified_col(base, name);
+        let Some(schema) = &self.input_schema else {
+            return Ok(value);
+        };
+        let qualifier = datafusion::common::TableReference::bare(base);
+        if schema
+            .index_of_column_by_name(Some(&qualifier), name)
+            .is_some()
+        {
+            return Ok(value);
+        }
+        let data_type = nodes
+            .iter()
+            .find_map(|other| {
+                let other_base = self.var_map.get(*other)?;
+                self.expr_data_type(&qualified_col(other_base, name))
+            })
+            .ok_or_else(|| {
+                LoweringError::UnsupportedExpr(format!(
+                    "path node property `{name}` has no available column"
+                ))
+            })?;
+        let null = ScalarValue::try_from(&data_type)
+            .map_err(|error| LoweringError::UnsupportedExpr(error.to_string()))?;
+        Ok(lit(null))
     }
 
     fn lower_rel_struct(&self, args: &[ExprId]) -> Result<DfExpr, LoweringError> {


### PR DESCRIPTION
`MATCH p=(a:Person)-[:KNOWS]->(b:Person) SET a.mark=1 RETURN nodes(p)` failed when `mark` was absent from the other endpoint's schema. Fixed-hop path rendering now preserves each available property expression and supplies a null of the matching Arrow type only where that endpoint's qualified column is missing. Endpoint order, labels, existing values and null-node behavior remain intact.

The real facade regression fails before the fix and covers updates to either endpoint, ordered node UUIDs, `[1, null]`/`[null, 1]` values, exact initial SideEffects, receipt effect count/kind/output UUID, fixed/variable one-hop parity, unchanged topology, durable reopen and subsequent updates. It does not assert complete receipt input identity.

Validation:

- Fixed-hop facade group: 14 passed on the final rebased head with locked dependencies.
- Rel: 236 unit + 2 matrix + 15 golden tests passed; exec write-statement: 21 passed.
- Production Clippy for rel/API passed. Optional all-target Clippy exposed existing unchanged test-lint debt; no suppression or unrelated cleanup.
- Final rebase onto current main preserves the patch exactly; fast gate, gate registry, formatting and diff checks passed.

Closes #1153

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791404051&installation_model_id=20486&pr_number=1157&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1157&signature=6c087982ea5663be5474052733e3d4031da40e59b70dc9cd2ebb0f2ad0f5c1c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->