### PR TITLE
fix(storage): preserve complete ordinal authority across construction appends

### DIFF
--- a/crates/graphforge-api/src/construction_ordinal_tests.rs
+++ b/crates/graphforge-api/src/construction_ordinal_tests.rs
@@ -1,0 +1,130 @@
+//! Storage publication followed by actual facade reopen, independent of import
+//! session phase accounting. The public import-session case belongs to #1156.
+
+use std::sync::Arc;
+
+use arrow::array::{FixedSizeBinaryArray, StringArray};
+use arrow::record_batch::RecordBatch;
+use graphforge_storage::filesystem_admission::ProjectLifecycleMode;
+use graphforge_storage::{ConstructionChunkKind, GraphConstructionSession};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use crate::{
+    CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, GraphConstructionBudgets, GraphForge,
+};
+
+fn ids(values: &[u128]) -> FixedSizeBinaryArray {
+    FixedSizeBinaryArray::try_from_iter(values.iter().map(|value| value.to_be_bytes())).unwrap()
+}
+
+#[test]
+fn construction_ordinal_append_reopens_with_exact_nodes_and_edge_endpoints() {
+    let root = TempDir::new().unwrap();
+    let project = root.path().join("project");
+    drop(GraphForge::new(project.to_str()).unwrap());
+    for generation in 1..=4_u64 {
+        let selected = graphforge_storage::resolve_project_generation(&project).unwrap();
+        let source = TempDir::new().unwrap();
+        let graph_root = source.path().join("graph");
+        std::fs::create_dir(&graph_root).unwrap();
+        if let Some(inventory) = selected.graph_files_inventory().unwrap() {
+            graphforge_storage::materialize_graph_objects(&project, &inventory, &graph_root)
+                .unwrap();
+        }
+        let mut session = GraphConstructionSession::open_with_mode_and_lifecycle_from_graph(
+            &project,
+            &graph_root,
+            Uuid::new_v4(),
+            generation - 1,
+            graphforge_core::OntologyMode::Exploratory,
+            GraphConstructionBudgets {
+                max_batch_rows: 2,
+                max_run_records: 8,
+                ..Default::default()
+            },
+            ProjectLifecycleMode::Durable,
+        )
+        .unwrap();
+        let node = RecordBatch::try_new(
+            CONSTRUCTION_NODE_SCHEMA.clone(),
+            vec![
+                Arc::new(ids(&[u128::from(generation)])),
+                Arc::new(StringArray::from(vec!["Person"])),
+            ],
+        )
+        .unwrap();
+        session
+            .append(ConstructionChunkKind::Node, "node", &node)
+            .unwrap();
+        if generation > 1 {
+            let edge = RecordBatch::try_new(
+                CONSTRUCTION_EDGE_SCHEMA.clone(),
+                vec![
+                    Arc::new(ids(&[100 + u128::from(generation)])),
+                    Arc::new(StringArray::from(vec!["R"])),
+                    Arc::new(ids(&[u128::from(generation - 1)])),
+                    Arc::new(ids(&[u128::from(generation)])),
+                ],
+            )
+            .unwrap();
+            session
+                .append(ConstructionChunkKind::Edge, "edge", &edge)
+                .unwrap();
+        }
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        assert_eq!(shape.node_count, generation);
+        assert_eq!(shape.edge_count, generation - 1);
+        let encoded = session.encode_canonical(&shape, generation).unwrap();
+        session
+            .publish_canonical(&encoded, Uuid::new_v4(), Uuid::new_v4())
+            .unwrap();
+        drop(session);
+        drop(selected);
+
+        let reopened = GraphForge::new(project.to_str()).unwrap();
+        assert_eq!(reopened.node_count("Person").unwrap(), generation);
+        let rows = reopened.execute("MATCH (a:Person)-[r:R]->(b:Person) RETURN a.node_uuid AS source, r.edge_uuid AS edge, b.node_uuid AS target ORDER BY edge").unwrap();
+        let actual = rows
+            .batches
+            .iter()
+            .flat_map(|batch| {
+                let source = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
+                let edge = batch
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
+                let target = batch
+                    .column(2)
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
+                (0..batch.num_rows())
+                    .map(|row| {
+                        (
+                            Uuid::from_slice(source.value(row)).unwrap(),
+                            Uuid::from_slice(edge.value(row)).unwrap(),
+                            Uuid::from_slice(target.value(row)).unwrap(),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let expected = (2..=generation)
+            .map(|id| {
+                (
+                    Uuid::from_u128(u128::from(id - 1)),
+                    Uuid::from_u128(100 + u128::from(id)),
+                    Uuid::from_u128(u128::from(id)),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -82,6 +82,8 @@ mod construction;
 #[cfg(test)]
 mod construction_concurrency_tests;
 #[cfg(test)]
+mod construction_ordinal_tests;
+#[cfg(test)]
 mod durability_certification_tests;
 mod embedding_freshness;
 mod embedding_publication;

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -113,8 +113,18 @@ fn storage(error: impl std::fmt::Display) -> GfError {
 }
 
 fn current_parent_generation_authority(project_dir: &Path) -> Result<(Uuid, String), GfError> {
+    current_parent_generation(project_dir).map(|(uuid, digest, _)| (uuid, digest))
+}
+
+fn current_parent_generation(
+    project_dir: &Path,
+) -> Result<(Uuid, String, Option<crate::ResolvedProjectGeneration>), GfError> {
     match crate::resolve_project_generation(project_dir) {
-        Ok(parent) => Ok((parent.generation_uuid(), hex(&parent.manifest_sha256()))),
+        Ok(parent) => Ok((
+            parent.generation_uuid(),
+            hex(&parent.manifest_sha256()),
+            Some(parent),
+        )),
         Err(error) => {
             #[cfg(test)]
             {
@@ -132,7 +142,7 @@ fn current_parent_generation_authority(project_dir: &Path) -> Result<(Uuid, Stri
                 let mut uuid_bytes = [0_u8; 16];
                 uuid_bytes.copy_from_slice(&bytes[..16]);
                 uuid_bytes[0] |= 1;
-                return Ok((Uuid::from_bytes(uuid_bytes), hex(&bytes)));
+                return Ok((Uuid::from_bytes(uuid_bytes), hex(&bytes), None));
             }
             #[cfg(not(test))]
             return Err(storage(format!(
@@ -140,6 +150,126 @@ fn current_parent_generation_authority(project_dir: &Path) -> Result<(Uuid, Stri
             )));
         }
     }
+}
+
+/// Authenticate the exact ordinal overlay before CAS publication. Only prior
+/// descriptor paths superseded by the new manifest are removed from this generation.
+fn ordinal_publication_tombstones(
+    parent: &crate::ResolvedProjectGeneration,
+    state: &crate::graph_object_store::GraphManifestState,
+    graph: &StableDirectory,
+    encoding: &GraphConstructionEncoding,
+) -> Result<(Vec<String>, crate::GraphObjectIoTotals), GfError> {
+    const MANIFEST: &str = "topology/uuid-membership/ordinal-v4-manifest.json";
+    let mut io = crate::GraphObjectIoTotals::default();
+    let prior = parent.authenticated_v4_ordinal_manifest(&mut io)?;
+    let Some(expected) = encoding
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.path == MANIFEST)
+    else {
+        if prior.is_some() {
+            return Err(storage(
+                "construction append omitted selected ordinal authority",
+            ));
+        }
+        return Ok((Vec::new(), io));
+    };
+    if expected.bytes > crate::ordinal_identity_v4::MAX_MANIFEST_BYTES {
+        return Err(storage("ordinal publication manifest exceeds bound"));
+    }
+    let index = graph
+        .open_child_directory(OsStr::new("topology"))
+        .and_then(|topology| topology.open_child_directory(OsStr::new("uuid-membership")))
+        .map_err(storage)?;
+    let mut file = index
+        .open_child_file(OsStr::new("ordinal-v4-manifest.json"))
+        .map_err(storage)?;
+    let mut bytes = Vec::new();
+    let mut buffer = vec![0; 64 * 1024];
+    loop {
+        let count = file.read(&mut buffer).map_err(storage)?;
+        if count == 0 {
+            break;
+        }
+        io.read_bytes = io
+            .read_bytes
+            .checked_add(count as u64)
+            .ok_or_else(|| storage("ordinal read bytes overflow"))?;
+        io.read_calls = io
+            .read_calls
+            .checked_add(1)
+            .ok_or_else(|| storage("ordinal read calls overflow"))?;
+        if (bytes.len() as u64)
+            .checked_add(count as u64)
+            .is_none_or(|size| size > expected.bytes)
+        {
+            return Err(storage("ordinal publication manifest changed length"));
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+    }
+    if bytes.len() as u64 != expected.bytes || hex(&Sha256::digest(&bytes)) != expected.sha256 {
+        return Err(storage(
+            "ordinal publication manifest differs from encoding receipt",
+        ));
+    }
+    let manifest = crate::ordinal_identity_v4::decode_construction_ordinal_manifest(
+        &bytes,
+        encoding.generation,
+    )
+    .map_err(storage)?;
+    let old = prior.as_ref().map_or_else(BTreeMap::new, |(_, manifest)| {
+        ordinal_manifest_descriptors(manifest)
+    });
+    for (path, (bytes, digest)) in &old {
+        if !state
+            .entry(path.as_str())
+            .is_some_and(|entry| entry.byte_length == *bytes && entry.content_sha256 == *digest)
+        {
+            return Err(storage(
+                "selected ordinal artifact differs from parent inventory",
+            ));
+        }
+    }
+    let new = ordinal_manifest_descriptors(&manifest);
+    for (path, (bytes, digest)) in &new {
+        let owned = encoding
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.path == *path);
+        if let Some(owned) = owned {
+            if owned.bytes != *bytes || owned.sha256 != *digest {
+                return Err(storage("encoded ordinal artifact differs from manifest"));
+            }
+        } else if old.get(path) != Some(&(*bytes, digest.clone())) {
+            return Err(storage(
+                "ordinal manifest references an unauthenticated retained artifact",
+            ));
+        }
+    }
+    Ok((
+        old.into_keys()
+            .filter(|path| !new.contains_key(path))
+            .collect(),
+        io,
+    ))
+}
+
+fn ordinal_manifest_descriptors(
+    manifest: &crate::V4OrdinalIdentityManifest,
+) -> BTreeMap<String, (u64, String)> {
+    manifest
+        .forward_identities
+        .iter()
+        .chain(manifest.ordinal_ranges.iter().map(|range| &range.artifact))
+        .chain(manifest.tombstones.iter().map(|run| &run.artifact))
+        .map(|artifact| {
+            (
+                format!("topology/uuid-membership/{}", artifact.name),
+                (artifact.bytes, artifact.sha256.clone()),
+            )
+        })
+        .collect::<BTreeMap<_, _>>()
 }
 
 fn compact_parent_inventory(
@@ -1262,12 +1392,19 @@ impl GraphConstructionSession {
         if self.checkpoint.shape_authority_sha256.as_deref() != Some(&shape_authority) {
             return Err(storage("encoder shape authority differs from checkpoint"));
         }
+        let (parent_uuid, parent_digest, parent) = current_parent_generation(&self.project_path)?;
+        if parent_uuid != self.checkpoint.parent_generation_uuid
+            || parent_digest != self.checkpoint.parent_generation_manifest_sha256
+        {
+            return Err(storage("construction ordinal parent is no longer CURRENT"));
+        }
         let encoded = crate::graph_construction_encoding::encode(
             &self.root,
             shape,
             generation,
             self.checkpoint.ontology_mode,
             self.base_snapshot.as_ref(),
+            parent.as_ref(),
             self.semantic_authority.as_ref(),
             &shape_outputs,
             &shape_authority,
@@ -1481,13 +1618,29 @@ impl GraphConstructionSession {
                 },
             )
             .collect::<Vec<_>>();
+        let (ordinal_tombstones, ordinal_io) =
+            ordinal_publication_tombstones(&parent, &manifest_state, &encoded_directory, encoding)?;
+        self.checkpoint.evidence.publication_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .publication_application_read_bytes
+            .checked_add(ordinal_io.read_bytes)
+            .ok_or_else(|| storage("ordinal publication read bytes overflow"))?;
+        self.checkpoint
+            .evidence
+            .publication_application_read_operations = self
+            .checkpoint
+            .evidence
+            .publication_application_read_operations
+            .checked_add(ordinal_io.read_calls)
+            .ok_or_else(|| storage("ordinal publication read calls overflow"))?;
         let (graph_root, cas_evidence) =
             crate::graph_object_store::append_authenticated_graph_files_v2(
                 &lease,
                 &workspace,
                 &mut manifest_state,
                 &sealed_files,
-                &[],
+                &ordinal_tombstones,
             )?;
         self.checkpoint.evidence.cas_application_read_bytes = self
             .checkpoint
@@ -12580,6 +12733,295 @@ mod tests {
                 .contains("published construction belongs to generation recovery")
         );
         assert!(private_root.exists());
+    }
+
+    fn ordinal_append_session(
+        root: &TempDir,
+        generation: u64,
+        first: u128,
+        rows: usize,
+    ) -> (TempDir, GraphConstructionSession, ConstructionShape) {
+        let source = TempDir::new().unwrap();
+        let source_graph = source.path().join("graph");
+        std::fs::create_dir(&source_graph).unwrap();
+        if let Some(inventory) = crate::resolve_project_generation(root.path())
+            .unwrap()
+            .graph_files_inventory()
+            .unwrap()
+        {
+            crate::materialize_graph_objects(root.path(), &inventory, &source_graph).unwrap();
+        }
+        let mut session = GraphConstructionSession::open_with_mode_and_lifecycle_from_graph(
+            root.path(),
+            &source_graph,
+            Uuid::new_v4(),
+            generation - 1,
+            graphforge_core::OntologyMode::Exploratory,
+            GraphConstructionBudgets::default(),
+            crate::filesystem_admission::ProjectLifecycleMode::Durable,
+        )
+        .unwrap();
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "nodes",
+                &node_batch(first, rows),
+            )
+            .unwrap();
+        session.seal().unwrap();
+        let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+        (source, session, shape)
+    }
+
+    #[test]
+    fn construction_append_publishes_current_complete_ordinal_authority() {
+        let root = TempDir::new().unwrap();
+        crate::open_or_initialize_project(root.path()).unwrap();
+        let mut retained = Vec::new();
+        for generation in 1..=8_u64 {
+            let total = 255 + generation;
+            let (_source, mut session, shape) = ordinal_append_session(
+                &root,
+                generation,
+                if generation == 1 {
+                    1
+                } else {
+                    u128::from(total)
+                },
+                if generation == 1 { 256 } else { 1 },
+            );
+            let pins = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+            let recorded = pins.clone();
+            crate::uuid_membership::set_construction_ordinal_hook(Some(Box::new(
+                move |phase, generation| {
+                    if phase == "pin" {
+                        recorded.borrow_mut().push(generation);
+                    }
+                },
+            )));
+            let encoding = session.encode_canonical(&shape, generation);
+            crate::uuid_membership::set_construction_ordinal_hook(None);
+            let encoding = encoding.unwrap();
+            assert!(
+                pins.borrow().iter().all(|generation| *generation > 1),
+                "the base must never be reread by ordinal compaction"
+            );
+            if generation <= 2 {
+                assert!(pins.borrow().is_empty());
+            }
+            if generation == 3 {
+                assert!(
+                    !pins.borrow().is_empty(),
+                    "the fixture must cross an actual carry"
+                );
+            }
+            assert_eq!(encoding.evidence.prior_topology_rows_decoded, 0);
+            assert_eq!(encoding.evidence.retained_topology_bytes_copied, 0);
+            session
+                .publish_canonical(
+                    &encoding,
+                    Uuid::from_u128(98_100 + u128::from(generation)),
+                    Uuid::from_u128(98_200 + u128::from(generation)),
+                )
+                .unwrap();
+            drop(session);
+            let selected = crate::resolve_project_generation(root.path()).unwrap();
+            let authority = selected
+                .authenticated_v4_ordinal_authority()
+                .unwrap()
+                .unwrap();
+            let inventory = selected.graph_files_inventory().unwrap().unwrap();
+            let materialized = TempDir::new().unwrap();
+            let graph = materialized.path().join("graph");
+            std::fs::create_dir(&graph).unwrap();
+            crate::materialize_graph_objects(root.path(), &inventory, &graph).unwrap();
+            let crate::V4OrdinalIdentityOpen::Ready(mut handle) = authority
+                .open(&graph, crate::V4OrdinalIdentityLimits::default())
+                .unwrap()
+            else {
+                panic!("published construction must retain complete v4 authority");
+            };
+            let (_, manifest) = selected
+                .authenticated_v4_ordinal_manifest(&mut crate::GraphObjectIoTotals::default())
+                .unwrap()
+                .unwrap();
+            assert!(manifest.forward_identities.len() <= 1 + generation.ilog2() as usize);
+            let declared = manifest
+                .forward_identities
+                .iter()
+                .chain(manifest.ordinal_ranges.iter().map(|range| &range.artifact))
+                .chain(manifest.tombstones.iter().map(|run| &run.artifact))
+                .map(|artifact| artifact.name.clone())
+                .collect::<BTreeSet<_>>();
+            let installed = inventory
+                .files
+                .iter()
+                .filter_map(|entry| {
+                    let name = entry.relative_path.rsplit('/').next().unwrap();
+                    (name.contains("-v4-") && name.ends_with(".uuidx")).then(|| name.to_owned())
+                })
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                installed, declared,
+                "superseded ordinal paths must leave the selected inventory"
+            );
+            assert_eq!(handle.topology_generation(), generation);
+            let ids = (1..=total).collect::<Vec<_>>();
+            assert_eq!(
+                handle.lookup_node_uuids(&ids).unwrap().values,
+                ids.iter()
+                    .map(|id| Some(Uuid::from_u128(u128::from(*id))))
+                    .collect::<Vec<_>>()
+            );
+            let mut membership = crate::UuidMembershipIndex::open(&graph).unwrap();
+            let uuids = ids
+                .iter()
+                .map(|id| Uuid::from_u128(u128::from(*id)))
+                .collect::<Vec<_>>();
+            assert_eq!(membership.count(crate::UuidIndexKind::Node), total);
+            assert_eq!(
+                membership.lookup_node_surrogates(&uuids).unwrap().0,
+                ids.iter().copied().map(Some).collect::<Vec<_>>()
+            );
+            retained.push((selected, materialized, handle, total));
+        }
+        for (selected, _materialized, mut handle, total) in retained {
+            selected
+                .authenticated_v4_ordinal_authority()
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                handle.lookup_node_uuids(&[1, total]).unwrap().values,
+                [
+                    Some(Uuid::from_u128(1)),
+                    Some(Uuid::from_u128(u128::from(total)))
+                ]
+            );
+        }
+    }
+
+    fn publish_ordinal_fixture(root: &TempDir, generation: u64) {
+        let (_source, mut session, shape) =
+            ordinal_append_session(root, generation, u128::from(generation), 1);
+        let encoding = session.encode_canonical(&shape, generation).unwrap();
+        session
+            .publish_canonical(&encoding, Uuid::new_v4(), Uuid::new_v4())
+            .unwrap();
+    }
+
+    #[test]
+    fn construction_ordinal_cancellation_cleans_owned_outputs_and_retries() {
+        let root = TempDir::new().unwrap();
+        crate::open_or_initialize_project(root.path()).unwrap();
+        publish_ordinal_fixture(&root, 1);
+        publish_ordinal_fixture(&root, 2);
+        let current = std::fs::read(root.path().join("CURRENT")).unwrap();
+        let (_source, mut session, shape) = ordinal_append_session(&root, 3, 3, 4096);
+        let cancelled = std::rc::Rc::new(std::cell::Cell::new(false));
+        let signal = cancelled.clone();
+        crate::uuid_membership::set_construction_ordinal_hook(Some(Box::new(move |phase, _| {
+            if phase == "forward" {
+                signal.set(true);
+            }
+        })));
+        let result = session.encode_canonical_with_cancellation(&shape, 3, || cancelled.get());
+        crate::uuid_membership::set_construction_ordinal_hook(None);
+        assert!(
+            cancelled.get(),
+            "cancel only after actual compaction output"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("ordinal compaction cancelled")
+        );
+        assert_eq!(std::fs::read(root.path().join("CURRENT")).unwrap(), current);
+        let index = session
+            .root
+            .path()
+            .join("encoded-v1/graph/topology/uuid-membership");
+        let residual = std::fs::read_dir(&index)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains("v4") || name.contains("compact"))
+            .collect::<Vec<_>>();
+        assert!(
+            residual.is_empty(),
+            "owned ordinal outputs left after cancellation: {residual:?}"
+        );
+        let encoding = session.encode_canonical(&shape, 3).unwrap();
+        session
+            .publish_canonical(&encoding, Uuid::new_v4(), Uuid::new_v4())
+            .unwrap();
+        let selected = crate::resolve_project_generation(root.path()).unwrap();
+        let authority = selected
+            .authenticated_v4_ordinal_authority()
+            .unwrap()
+            .unwrap();
+        let inventory = selected.graph_files_inventory().unwrap().unwrap();
+        let materialized = TempDir::new().unwrap();
+        let graph = materialized.path().join("graph");
+        std::fs::create_dir(&graph).unwrap();
+        crate::materialize_graph_objects(root.path(), &inventory, &graph).unwrap();
+        let crate::V4OrdinalIdentityOpen::Ready(mut handle) = authority
+            .open(&graph, crate::V4OrdinalIdentityLimits::default())
+            .unwrap()
+        else {
+            panic!("v4 required")
+        };
+        assert_eq!(
+            handle.lookup_node_uuids(&[1, 2, 3, 4098]).unwrap().values,
+            [1_u128, 2, 3, 4098].map(|id| Some(Uuid::from_u128(id)))
+        );
+    }
+
+    #[test]
+    fn construction_ordinal_parent_corruption_fails_before_publication() {
+        let root = TempDir::new().unwrap();
+        crate::open_or_initialize_project(root.path()).unwrap();
+        publish_ordinal_fixture(&root, 1);
+        let (_source, mut session, shape) = ordinal_append_session(&root, 2, 2, 1);
+        let selected = crate::resolve_project_generation(root.path()).unwrap();
+        let inventory = selected.graph_files_inventory().unwrap().unwrap();
+        let manifest = inventory
+            .files
+            .iter()
+            .find(|entry| entry.relative_path.ends_with("ordinal-v4-manifest.json"))
+            .unwrap();
+        let path = crate::graph_object_path(root.path(), &manifest.content_sha256).unwrap();
+        let original = std::fs::read(&path).unwrap();
+        let permissions = std::fs::metadata(&path).unwrap().permissions();
+        let mut writable = permissions.clone();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            writable.set_mode(0o600);
+        }
+        #[cfg(not(unix))]
+        writable.set_readonly(false);
+        std::fs::set_permissions(&path, writable).unwrap();
+        let mut damaged = original.clone();
+        damaged[0] ^= 1;
+        std::fs::write(&path, damaged).unwrap();
+        std::fs::set_permissions(&path, permissions.clone()).unwrap();
+        let current = std::fs::read(root.path().join("CURRENT")).unwrap();
+        let result = session.encode_canonical(&shape, 2);
+        assert!(result.unwrap_err().to_string().contains("digest"));
+        assert_eq!(std::fs::read(root.path().join("CURRENT")).unwrap(), current);
+        // Restore fixture authority so its cleanup never leaves damaged CAS objects.
+        let mut writable = permissions.clone();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            writable.set_mode(0o600);
+        }
+        #[cfg(not(unix))]
+        writable.set_readonly(false);
+        std::fs::set_permissions(&path, writable).unwrap();
+        std::fs::write(&path, original).unwrap();
+        std::fs::set_permissions(&path, permissions).unwrap();
+        session.encode_canonical(&shape, 2).unwrap();
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -544,6 +544,7 @@ pub(crate) fn encode(
     generation: u64,
     ontology_mode: OntologyMode,
     parent_index: Option<&AuthenticatedUuidIndexSnapshot>,
+    parent_generation: Option<&crate::ResolvedProjectGeneration>,
     semantic_authority: Option<&ConstructionSemanticAuthority>,
     shape_outputs: &[ArtifactReceipt],
     shape_authority_sha256: &str,
@@ -677,6 +678,31 @@ pub(crate) fn encode(
         )?;
     }
 
+    let mut ordinal_control_io = crate::GraphObjectIoTotals::default();
+    let parent_ordinal = if shape.parent_topology_generation != 0 {
+        parent_generation
+            .map(|parent| parent.authenticated_v4_ordinal_manifest(&mut ordinal_control_io))
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    if parent_ordinal.as_ref().is_some_and(|(_, manifest)| {
+        manifest.topology_generation != shape.parent_topology_generation
+    }) {
+        return Err(storage("construction ordinal parent differs from shape"));
+    }
+    add_evidence_counter(
+        &mut evidence.input_read_bytes,
+        ordinal_control_io.read_bytes,
+        "ordinal control reads",
+    )?;
+    add_evidence_counter(
+        &mut evidence.input_read_operations,
+        ordinal_control_io.read_calls,
+        "ordinal control calls",
+    )?;
+
     let identities_sha256 = shaped_output_sha256(shape_outputs, &shape.identities)?;
     let mut index = crate::uuid_membership::encode_construction_index(
         source,
@@ -702,14 +728,18 @@ pub(crate) fn encode(
         semantic_authority.map(|authority| &authority.bindings),
         budgets,
         generation,
-        shape.parent_topology_generation == 0,
+        shape.parent_topology_generation == 0 || parent_ordinal.is_some(),
         cancelled,
         &mut artifacts,
         &mut evidence,
     )?;
     if let Some(bundle) = v4 {
         let metrics = &bundle.metrics;
-        if metrics.input_records != shape.node_count {
+        let expected_delta_nodes = shape
+            .node_count
+            .checked_sub(parent_index.map_or(0, |parent| parent.count(crate::UuidIndexKind::Node)))
+            .ok_or_else(|| storage("shaped node count is smaller than parent"))?;
+        if metrics.input_records != expected_delta_nodes {
             return Err(storage("v4 construction count differs from shaped nodes"));
         }
         evidence.ordinal_records = metrics.input_records;
@@ -725,7 +755,24 @@ pub(crate) fn encode(
                 bundle,
                 generation,
                 identities_sha256,
+                parent_ordinal
+                    .as_ref()
+                    .and_then(|(_, manifest)| parent_generation.map(|parent| (parent, manifest))),
+                cancelled,
             )?;
+        add_evidence_counter(
+            &mut evidence.input_read_bytes,
+            publication.read_bytes,
+            "ordinal compaction reads",
+        )?;
+        add_evidence_counter(
+            &mut evidence.input_read_operations,
+            publication.read_operations,
+            "ordinal compaction calls",
+        )?;
+        evidence.ordinal_artifact_write_bytes = metrics.artifact_bytes;
+        evidence.ordinal_artifact_write_operations = metrics.write_blocks;
+        evidence.ordinal_peak_buffer_bytes = metrics.peak_buffer_bytes as u64;
         evidence.ordinal_publication_write_bytes = publication.write_bytes;
         evidence.ordinal_publication_write_operations = publication.write_operations;
         evidence.ordinal_fsync_operations = metrics

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -819,6 +819,10 @@ impl GraphManifestState {
         self.root.as_ref()
     }
 
+    pub(crate) fn entry(&self, path: &str) -> Option<&crate::GraphFileEntry> {
+        self.entries.get(path)
+    }
+
     /// Current entries in canonical logical-path order.
     #[must_use]
     pub fn entries(&self) -> impl ExactSizeIterator<Item = &crate::GraphFileEntry> {
@@ -2846,6 +2850,104 @@ pub(crate) fn begin_graph_object_read(root: &Path) -> Result<GraphObjectReadLeas
 }
 
 impl GraphObjectReadLease {
+    /// Authenticate only a construction compaction input, retaining its CAS lease.
+    pub(crate) fn open_for_construction(
+        &self,
+        digest: &str,
+        expected_length: u64,
+        cancelled: &mut impl FnMut() -> bool,
+    ) -> Result<
+        (
+            AuthenticatedGraphObject,
+            GraphObjectIoTotals,
+            graphforge_filesystem::FileCacheReleaseEvidence,
+        ),
+        GfError,
+    > {
+        let file = self.cas.open_digest(digest)?;
+        let metadata = file.metadata().map_err(|error| {
+            storage(
+                "inspect construction input",
+                &self.cas.diagnostic_root,
+                error,
+            )
+        })?;
+        if !metadata.is_file()
+            || metadata.len() != expected_length
+            || !metadata.permissions().readonly()
+        {
+            return Err(validation("construction object authority changed"));
+        }
+        let retained = file
+            .try_clone()
+            .map_err(|error| storage("pin construction input", &self.cas.diagnostic_root, error))?;
+        let mut reader =
+            graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(|error| {
+                storage("bound construction input", &self.cas.diagnostic_root, error)
+            })?;
+        let mut totals = GraphObjectIoTotals::default();
+        let mut digest_state = Sha256::new();
+        let mut buffer = vec![0; 64 * 1024];
+        let verified = (|| {
+            loop {
+                if cancelled() {
+                    return Err(validation("construction ordinal authentication cancelled"));
+                }
+                let count = reader.read(&mut buffer).map_err(|error| {
+                    storage(
+                        "authenticate construction input",
+                        &self.cas.diagnostic_root,
+                        error,
+                    )
+                })?;
+                if count == 0 {
+                    break;
+                }
+                totals.read_bytes = totals
+                    .read_bytes
+                    .checked_add(count as u64)
+                    .ok_or_else(|| validation("construction read bytes overflow"))?;
+                totals.read_calls = totals
+                    .read_calls
+                    .checked_add(1)
+                    .ok_or_else(|| validation("construction read calls overflow"))?;
+                digest_state.update(&buffer[..count]);
+            }
+            if totals.read_bytes != expected_length
+                || hex_digest(digest_state.finalize().into()) != digest
+            {
+                return Err(validation(
+                    "construction object digest does not match its address",
+                ));
+            }
+            Ok(())
+        })();
+        let released = reader.finish().map_err(|error| {
+            storage(
+                "release construction input",
+                &self.cas.diagnostic_root,
+                error,
+            )
+        });
+        let cache = match (verified, released) {
+            (Ok(()), Ok(cache)) => cache,
+            (Err(primary), Ok(_)) => return Err(primary),
+            (Ok(()), Err(error)) => return Err(error),
+            (Err(primary), Err(cleanup)) => {
+                return Err(validation(format!("{primary}; {cleanup}")));
+            }
+        };
+        Ok((
+            AuthenticatedGraphObject {
+                file: retained,
+                authenticated_length: expected_length,
+                _cas: std::sync::Arc::clone(&self.cas),
+            },
+            totals,
+            cache,
+        ))
+    }
+
     pub(crate) fn open(
         &self,
         digest: &str,
@@ -2971,6 +3073,30 @@ fn open_graph_object_with_read_lease(
         authenticated_length: expected_length,
         _cas: std::sync::Arc::clone(&lease.cas),
     })
+}
+
+pub(crate) fn read_graph_object_counted(
+    root: &Path,
+    digest: &str,
+    maximum: u64,
+    totals: &mut GraphObjectIoTotals,
+) -> Result<Vec<u8>, GfError> {
+    let cas = ReadOnlyCasRoot::open(root)?;
+    let (bytes, io) = read_graph_object_by_digest_file_counted(
+        cas.open_digest(digest)?,
+        digest,
+        maximum,
+        &cas.diagnostic_root,
+    )?;
+    totals.read_bytes = totals
+        .read_bytes
+        .checked_add(io.bytes)
+        .ok_or_else(|| validation("object read byte count overflows"))?;
+    totals.read_calls = totals
+        .read_calls
+        .checked_add(io.calls)
+        .ok_or_else(|| validation("object read call count overflows"))?;
+    Ok(bytes)
 }
 
 fn read_graph_object_by_digest_from_read_only_cas(

--- a/crates/graphforge-storage/src/ordinal_identity_v4.rs
+++ b/crates/graphforge-storage/src/ordinal_identity_v4.rs
@@ -222,16 +222,32 @@ impl crate::ResolvedProjectGeneration {
     pub fn authenticated_v4_ordinal_authority(
         &self,
     ) -> Result<Option<AuthenticatedV4OrdinalIdentityAuthority>, graphforge_core::GfError> {
+        self.authenticated_v4_ordinal_manifest(&mut crate::GraphObjectIoTotals::default())
+            .map(|value| value.map(|(authority, _)| authority))
+    }
+
+    pub(crate) fn authenticated_v4_ordinal_manifest(
+        &self,
+        io: &mut crate::GraphObjectIoTotals,
+    ) -> Result<
+        Option<(
+            AuthenticatedV4OrdinalIdentityAuthority,
+            V4OrdinalIdentityManifest,
+        )>,
+        graphforge_core::GfError,
+    > {
         let mut targeted_state = crate::graph_manifest::GraphManifestTargetedState::default();
-        let receipt = self.authenticated_graph_file_bytes_with_state(
+        let receipt = self.authenticated_graph_file_bytes_counted(
             RECEIPT_NAME,
             MAX_MANIFEST_BYTES,
             Some(&mut targeted_state),
+            io,
         )?;
-        let manifest = self.authenticated_graph_file_bytes_with_state(
+        let manifest = self.authenticated_graph_file_bytes_counted(
             ORDINAL_IDENTITY_MANIFEST,
             MAX_MANIFEST_BYTES,
             Some(&mut targeted_state),
+            io,
         )?;
         match (receipt, manifest) {
             (None, None) => Ok(None),
@@ -246,10 +262,11 @@ impl crate::ResolvedProjectGeneration {
                         )
                     })?;
                 let generation = self
-                    .authenticated_graph_file_bytes_with_state(
+                    .authenticated_graph_file_bytes_counted(
                         GENERATION_NAME,
                         MAX_MANIFEST_BYTES,
                         Some(&mut targeted_state),
+                        io,
                     )?
                     .ok_or_else(|| {
                         graphforge_core::GfError::Validation(
@@ -287,12 +304,31 @@ impl crate::ResolvedProjectGeneration {
                         "selected ordinal receipt does not authenticate its manifest".into(),
                     ));
                 }
-                Ok(Some(AuthenticatedV4OrdinalIdentityAuthority {
-                    authority: V4OrdinalIdentityAuthority {
-                        topology_generation: selected_generation,
-                        manifest_sha256: manifest_digest,
+                let parsed = parse_manifest(&manifest_bytes, selected_generation)
+                    .map_err(|error| graphforge_core::GfError::Storage(error.to_string()))?
+                    .ok_or_else(|| {
+                        graphforge_core::GfError::Validation(
+                            "selected v4 manifest is legacy".into(),
+                        )
+                    })?;
+                validate_manifest(&parsed, selected_generation)
+                    .map_err(|error| graphforge_core::GfError::Storage(error.to_string()))?;
+                initial_admission_metrics(
+                    &parsed,
+                    manifest_bytes.len(),
+                    manifest_bytes.capacity(),
+                    V4OrdinalIdentityLimits::default(),
+                )
+                .map_err(|error| graphforge_core::GfError::Storage(error.to_string()))?;
+                Ok(Some((
+                    AuthenticatedV4OrdinalIdentityAuthority {
+                        authority: V4OrdinalIdentityAuthority {
+                            topology_generation: selected_generation,
+                            manifest_sha256: manifest_digest,
+                        },
                     },
-                }))
+                    parsed,
+                )))
             }
         }
     }
@@ -965,6 +1001,28 @@ impl V4OrdinalIdentityHandle {
     }
 }
 
+pub(crate) fn decode_construction_ordinal_manifest(
+    bytes: &[u8],
+    generation: u64,
+) -> Result<V4OrdinalIdentityManifest, V4OrdinalIdentityError> {
+    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        return Err(V4OrdinalIdentityError::InvalidDescriptor(
+            "manifest exceeds admission bound",
+        ));
+    }
+    let manifest = parse_manifest(bytes, generation)?.ok_or(
+        V4OrdinalIdentityError::InvalidDescriptor("construction ordinal manifest is legacy"),
+    )?;
+    validate_manifest(&manifest, generation)?;
+    initial_admission_metrics(
+        &manifest,
+        bytes.len(),
+        bytes.len(),
+        V4OrdinalIdentityLimits::default(),
+    )?;
+    Ok(manifest)
+}
+
 fn authenticate_manifest_authority(
     body: &[u8],
     authority: &V4OrdinalIdentityAuthority,
@@ -1080,6 +1138,19 @@ fn validate_manifest(
             expected: expected_generation,
             found: manifest.topology_generation,
         });
+    }
+    let mut names = BTreeSet::new();
+    for artifact in manifest
+        .forward_identities
+        .iter()
+        .chain(manifest.ordinal_ranges.iter().map(|range| &range.artifact))
+        .chain(manifest.tombstones.iter().map(|run| &run.artifact))
+    {
+        if !names.insert(artifact.name.as_str()) {
+            return Err(V4OrdinalIdentityError::InvalidDescriptor(
+                "artifact filename is reused",
+            ));
+        }
     }
     if manifest.forward_identities.is_empty() {
         return Err(V4OrdinalIdentityError::InvalidDescriptor(
@@ -2742,6 +2813,22 @@ mod tests {
                 "descriptor metadata exceeds admission bound"
             ))
         ));
+    }
+
+    #[test]
+    fn construction_metadata_rejects_disjoint_ranges_reusing_one_artifact() {
+        let fixture = Fixture::new(&[1], &[]);
+        let mut manifest = fixture.manifest.clone();
+        let mut duplicate = manifest.ordinal_ranges[0].clone();
+        duplicate.first_node_id = 2;
+        manifest.ordinal_ranges.push(duplicate);
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        let error =
+            decode_construction_ordinal_manifest(&bytes, manifest.topology_generation).unwrap_err();
+        assert_eq!(
+            error,
+            V4OrdinalIdentityError::InvalidDescriptor("artifact filename is reused")
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -188,6 +188,21 @@ impl ResolvedProjectGeneration {
         maximum: u64,
         targeted_state: Option<&mut crate::graph_manifest::GraphManifestTargetedState>,
     ) -> Result<Option<(crate::GraphFileEntry, Vec<u8>)>, GfError> {
+        self.authenticated_graph_file_bytes_counted(
+            relative_path,
+            maximum,
+            targeted_state,
+            &mut crate::GraphObjectIoTotals::default(),
+        )
+    }
+
+    pub(crate) fn authenticated_graph_file_bytes_counted(
+        &self,
+        relative_path: &str,
+        maximum: u64,
+        targeted_state: Option<&mut crate::graph_manifest::GraphManifestTargetedState>,
+        io: &mut crate::GraphObjectIoTotals,
+    ) -> Result<Option<(crate::GraphFileEntry, Vec<u8>)>, GfError> {
         let Some(participant) = self.declared_graph_files_participant()? else {
             return Ok(None);
         };
@@ -229,10 +244,11 @@ impl ResolvedProjectGeneration {
                     limits,
                     state,
                     |digest| {
-                        crate::read_graph_object_by_digest(
+                        crate::graph_object_store::read_graph_object_counted(
                             self.container_root(),
                             digest,
                             4 * 1024 * 1024,
+                            io,
                         )
                     },
                 )?
@@ -249,13 +265,16 @@ impl ResolvedProjectGeneration {
                 let relative = path
                     .strip_prefix(&graph_root)
                     .map_err(|_| corrupt("selected graph control escaped graph root"))?;
-                read_stable_graph_control(&graph_root, relative, entry.byte_length, maximum)?
+                read_stable_graph_control(&graph_root, relative, entry.byte_length, maximum, io)?
             }
-            crate::GraphFilesParticipant::V2(_) => crate::read_graph_object_by_digest(
-                self.container_root(),
-                &entry.content_sha256,
-                maximum,
-            )?,
+            crate::GraphFilesParticipant::V2(_) => {
+                crate::graph_object_store::read_graph_object_counted(
+                    self.container_root(),
+                    &entry.content_sha256,
+                    maximum,
+                    io,
+                )?
+            }
         };
         crate::graph_manifest::verify_object_bytes(
             &entry.content_sha256,
@@ -1655,6 +1674,7 @@ fn read_stable_graph_control(
     relative: &Path,
     expected_length: u64,
     maximum: u64,
+    io: &mut crate::GraphObjectIoTotals,
 ) -> Result<Vec<u8>, GfError> {
     let mut directory = graphforge_filesystem::StableDirectory::open(graph_root)
         .map_err(|_| corrupt("selected graph root cannot be retained"))?;
@@ -1688,9 +1708,25 @@ fn read_stable_graph_control(
     let capacity = usize::try_from(expected_length)
         .map_err(|_| corrupt("selected graph control length exceeds address space"))?;
     let mut bytes = Vec::with_capacity(capacity);
-    file.take(expected_length.saturating_add(1))
-        .read_to_end(&mut bytes)
-        .map_err(|_| corrupt("selected graph control cannot be read"))?;
+    let mut reader = file.take(expected_length.saturating_add(1));
+    let mut buffer = vec![0; 64 * 1024];
+    loop {
+        let count = reader
+            .read(&mut buffer)
+            .map_err(|_| corrupt("selected graph control cannot be read"))?;
+        if count == 0 {
+            break;
+        }
+        io.read_bytes = io
+            .read_bytes
+            .checked_add(count as u64)
+            .ok_or_else(|| corrupt("control read bytes overflow"))?;
+        io.read_calls = io
+            .read_calls
+            .checked_add(1)
+            .ok_or_else(|| corrupt("control read calls overflow"))?;
+        bytes.extend_from_slice(&buffer[..count]);
+    }
     if bytes.len() as u64 != expected_length {
         return Err(corrupt("selected graph control changed while reading"));
     }
@@ -1824,7 +1860,19 @@ mod tests {
         let index = graph.join("topology/uuid-membership");
         fs::create_dir_all(&index).unwrap();
         fs::write(generation_root.join(LEASE_FILE), []).unwrap();
-        let manifest_bytes = format!("{{\"format_version\":4,\"topology_generation\":{generation},\"forward_identities\":[],\"ordinal_ranges\":[],\"tombstones\":[]}}").into_bytes();
+        let manifest_bytes = if include_v4 {
+            let directory = graphforge_filesystem::StableDirectory::open(&index).unwrap();
+            let (manifest, _) = crate::uuid_membership::stage_v4_ordinal_artifacts(
+                std::iter::empty::<(Uuid, u64)>(),
+                generation,
+                &directory,
+                || false,
+            )
+            .unwrap();
+            serde_json::to_vec(&manifest).unwrap()
+        } else {
+            Vec::new()
+        };
         let manifest_digest = sha256_hex(Sha256::digest(&manifest_bytes).into());
         if include_v4 {
             fs::write(index.join("ordinal-v4-manifest.json"), &manifest_bytes).unwrap();

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -1530,6 +1530,8 @@ pub(crate) struct ConstructionIndexEncoding {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct V4OrdinalPublicationMetrics {
+    pub(crate) read_bytes: u64,
+    pub(crate) read_operations: u64,
     pub(crate) write_bytes: u64,
     pub(crate) write_operations: u64,
     pub(crate) fsync_operations: u64,
@@ -1541,6 +1543,11 @@ pub(crate) fn publish_v4_construction_artifacts(
     bundle: V4ConstructionArtifactBundle,
     generation: u64,
     topology_delta_sha256: &str,
+    parent: Option<(
+        &crate::ResolvedProjectGeneration,
+        &crate::V4OrdinalIdentityManifest,
+    )>,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<
     (
         Vec<ConstructionIndexOutput>,
@@ -1550,18 +1557,41 @@ pub(crate) fn publish_v4_construction_artifacts(
     GfError,
 > {
     let V4ConstructionArtifactBundle {
-        manifest,
-        metrics,
+        mut manifest,
+        mut metrics,
         mut publications,
     } = bundle;
-    let published = publish_v4_construction_artifacts_inner(
-        encoded,
-        &manifest,
-        &metrics,
-        &mut publications,
-        generation,
-        topology_delta_sha256,
-    );
+    let mut local_names = v4_manifest_artifact_names(&manifest);
+    let published = (|| {
+        let (read_bytes, read_operations) = match parent {
+            Some((selected, prior)) => merge_construction_v4_delta(
+                encoded,
+                selected,
+                prior,
+                &mut manifest,
+                &mut metrics,
+                &mut publications,
+                &mut local_names,
+                cancelled,
+            )?,
+            None => (0, 0),
+        };
+        if cancelled() {
+            return Err(storage_err("construction ordinal publication cancelled"));
+        }
+        let (outputs, mut publication, metrics) = publish_v4_construction_artifacts_inner(
+            encoded,
+            &manifest,
+            &metrics,
+            &mut publications,
+            generation,
+            topology_delta_sha256,
+            &local_names,
+        )?;
+        publication.read_bytes = read_bytes;
+        publication.read_operations = read_operations;
+        Ok((outputs, publication, metrics))
+    })();
     match published {
         Ok(published) => {
             commit_v4_publications(publications, V4AuthorityTransactionProof)?;
@@ -1572,6 +1602,171 @@ pub(crate) fn publish_v4_construction_artifacts(
             combine_v4_cleanup(Err(primary), cleanup, "v4 authority transaction cleanup")
         }
     }
+}
+
+#[cfg(test)]
+type ConstructionOrdinalHook = Box<dyn FnMut(&str, u64)>;
+#[cfg(test)]
+thread_local! {
+    static CONSTRUCTION_ORDINAL_HOOK: std::cell::RefCell<Option<ConstructionOrdinalHook>> = const { std::cell::RefCell::new(None) };
+}
+#[cfg(test)]
+pub(crate) fn set_construction_ordinal_hook(hook: Option<ConstructionOrdinalHook>) {
+    CONSTRUCTION_ORDINAL_HOOK.with(|slot| *slot.borrow_mut() = hook);
+}
+fn construction_ordinal_event(_phase: &str, _generation: u64) {
+    #[cfg(test)]
+    CONSTRUCTION_ORDINAL_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().as_mut() {
+            hook(_phase, _generation);
+        }
+    });
+}
+
+/// Combine a streamed construction delta with selected parent descriptors. Only
+/// binary-carry inputs are opened; an ordinary append never rereads the base.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn merge_construction_v4_delta(
+    encoded: &graphforge_filesystem::StableDirectory,
+    selected: &crate::ResolvedProjectGeneration,
+    prior: &crate::V4OrdinalIdentityManifest,
+    delta: &mut crate::V4OrdinalIdentityManifest,
+    metrics: &mut V4OrdinalBuildMetrics,
+    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    local_names: &mut BTreeSet<String>,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<(u64, u64), GfError> {
+    if prior.topology_generation.checked_add(1) != Some(delta.topology_generation) {
+        return Err(storage_err(
+            "construction ordinal parent generation changed",
+        ));
+    }
+    let prior_end = match prior.ordinal_ranges.last() {
+        Some(range) => range
+            .first_node_id
+            .checked_add(range.count - 1)
+            .ok_or_else(|| storage_err("ordinal parent range overflows"))?,
+        None => 0,
+    };
+    if delta
+        .ordinal_ranges
+        .first()
+        .is_some_and(|range| range.first_node_id <= prior_end)
+    {
+        return Err(storage_err(
+            "construction ordinal delta reuses retained node IDs",
+        ));
+    }
+    let index = encoded
+        .open_child_directory(std::ffi::OsStr::new("graph"))
+        .and_then(|graph| graph.open_child_directory(std::ffi::OsStr::new("topology")))
+        .and_then(|topology| topology.open_child_directory(std::ffi::OsStr::new("uuid-membership")))
+        .map_err(storage_err)?;
+    let mut created = local_names
+        .iter()
+        .map(|name| (name.clone(), index.path().join(name)))
+        .collect::<HashMap<_, _>>();
+    let mut combined = prior.clone();
+    combined.topology_generation = delta.topology_generation;
+    combined
+        .forward_identities
+        .extend(delta.forward_identities.clone());
+    combined.ordinal_ranges.extend(delta.ordinal_ranges.clone());
+    combined.tombstones.extend(delta.tombstones.clone());
+    let mut intervals = v4_forward_intervals(&combined.forward_identities)?;
+    let mut first_consumed = None;
+    while intervals.len() >= 3 {
+        let right = intervals[intervals.len() - 1];
+        let left = intervals[intervals.len() - 2];
+        if right.1 - right.0 != left.1 - left.0 {
+            break;
+        }
+        first_consumed = Some(left.0);
+        intervals.pop();
+        intervals.pop();
+        intervals.push((left.0, right.1, left.2));
+    }
+    let lease = crate::graph_object_store::begin_graph_object_read(selected.container_root())?;
+    let mut objects = Vec::new();
+    let mut pinned = crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs {
+        manifest: prior.clone(),
+        artifacts: Vec::new(),
+    };
+    let mut read_bytes = 0_u64;
+    let mut read_calls = 0_u64;
+    for descriptor in prior
+        .forward_identities
+        .iter()
+        .chain(prior.ordinal_ranges.iter().map(|range| &range.artifact))
+        .chain(prior.tombstones.iter().map(|run| &run.artifact))
+        .filter(|artifact| first_consumed.is_some_and(|first| artifact.generation >= first))
+    {
+        construction_ordinal_event("pin", descriptor.generation);
+        let (object, io, cache) =
+            lease.open_for_construction(&descriptor.sha256, descriptor.bytes, cancelled)?;
+        read_bytes = read_bytes
+            .checked_add(io.read_bytes)
+            .ok_or_else(|| storage_err("ordinal authentication bytes overflow"))?;
+        read_calls = read_calls
+            .checked_add(io.read_calls)
+            .ok_or_else(|| storage_err("ordinal authentication calls overflow"))?;
+        merge_cache_release_evidence(&mut metrics.cache_release, cache);
+        pinned
+            .artifacts
+            .push(crate::ordinal_identity_v4::PinnedV4OrdinalArtifact {
+                descriptor: descriptor.clone(),
+                file: object.try_clone_file().map_err(storage_err)?,
+            });
+        objects.push(object);
+    }
+    construction_ordinal_event("compaction", combined.topology_generation);
+    let mut compaction = compact_v4_binary_carry_with_cancellation(
+        &pinned,
+        &index,
+        index.path(),
+        &mut combined,
+        &mut created,
+        cancelled,
+    )?;
+    metrics.artifact_bytes = metrics
+        .artifact_bytes
+        .checked_add(compaction.write_bytes)
+        .ok_or_else(|| storage_err("ordinal writes overflow"))?;
+    metrics.write_blocks = metrics
+        .write_blocks
+        .checked_add(compaction.write_blocks)
+        .ok_or_else(|| storage_err("ordinal writes overflow"))?;
+    metrics.fsync_operations = metrics
+        .fsync_operations
+        .checked_add(compaction.fsync_operations)
+        .ok_or_else(|| storage_err("ordinal fsyncs overflow"))?;
+    merge_cache_release_evidence(&mut metrics.cache_release, compaction.cache_release);
+    metrics.peak_buffer_bytes = metrics.peak_buffer_bytes.max(4 * V4_ORDINAL_BLOCK_BYTES);
+    publications.append(&mut compaction.publications);
+    let retained = v4_manifest_artifact_names(&combined);
+    let mut current = Vec::new();
+    for (name, mut publication) in publications.drain(..) {
+        if retained.contains(&name) {
+            current.push((name, publication));
+        } else {
+            cleanup_v4_publication(&mut publication)?;
+        }
+    }
+    *publications = current;
+    *local_names = created
+        .into_keys()
+        .filter(|name| retained.contains(name))
+        .collect();
+    admit_v4_construction_manifest(&combined)?;
+    *delta = combined;
+    Ok((
+        read_bytes
+            .checked_add(compaction.read_bytes)
+            .ok_or_else(|| storage_err("ordinal read bytes overflow"))?,
+        read_calls
+            .checked_add(compaction.read_calls)
+            .ok_or_else(|| storage_err("ordinal read calls overflow"))?,
+    ))
 }
 
 fn cleanup_v4_publications(
@@ -1596,6 +1791,7 @@ fn publish_v4_construction_artifacts_inner(
     publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
     generation: u64,
     topology_delta_sha256: &str,
+    local_names: &BTreeSet<String>,
 ) -> Result<
     (
         Vec<ConstructionIndexOutput>,
@@ -1627,6 +1823,7 @@ fn publish_v4_construction_artifacts_inner(
         .iter()
         .chain(manifest.ordinal_ranges.iter().map(|range| &range.artifact))
         .chain(manifest.tombstones.iter().map(|run| &run.artifact))
+        .filter(|artifact| local_names.contains(&artifact.name))
         .map(|artifact| ConstructionIndexOutput {
             name: artifact.name.clone(),
             bytes: artifact.bytes,
@@ -1668,6 +1865,8 @@ fn publish_v4_construction_artifacts_inner(
     v4_authority_failure("directory_sync")?;
     work.fsync_operations = work.fsync_operations.saturating_add(4);
     let publication_metrics = V4OrdinalPublicationMetrics {
+        read_bytes: 0,
+        read_operations: 0,
         write_bytes: work.write_bytes,
         write_operations: work.write_operations,
         fsync_operations: work.fsync_operations,
@@ -7599,9 +7798,34 @@ fn compact_v4_binary_carry(
     manifest: &mut crate::V4OrdinalIdentityManifest,
     created: &mut HashMap<String, PathBuf>,
 ) -> Result<V4CompactionWork, GfError> {
+    compact_v4_binary_carry_with_cancellation(
+        pinned,
+        artifacts,
+        artifacts_path,
+        manifest,
+        created,
+        &mut || false,
+    )
+}
+
+fn compact_v4_binary_carry_with_cancellation(
+    pinned: &crate::ordinal_identity_v4::V4OrdinalPinnedUpdateInputs,
+    artifacts: &graphforge_filesystem::StableDirectory,
+    artifacts_path: &Path,
+    manifest: &mut crate::V4OrdinalIdentityManifest,
+    created: &mut HashMap<String, PathBuf>,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<V4CompactionWork, GfError> {
     let prior_manifest = manifest.clone();
     let prior_created = created.clone();
-    match compact_v4_binary_carry_inner(pinned, artifacts, artifacts_path, manifest, created) {
+    match compact_v4_binary_carry_inner(
+        pinned,
+        artifacts,
+        artifacts_path,
+        manifest,
+        created,
+        cancelled,
+    ) {
         Ok(work) => Ok(work),
         Err(error) => {
             *manifest = prior_manifest;
@@ -7617,9 +7841,13 @@ fn compact_v4_binary_carry_inner(
     artifacts_path: &Path,
     manifest: &mut crate::V4OrdinalIdentityManifest,
     created: &mut HashMap<String, PathBuf>,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<V4CompactionWork, GfError> {
     let mut work = V4CompactionWork::default();
     loop {
+        if cancelled() {
+            return Err(storage_err("construction ordinal compaction cancelled"));
+        }
         let intervals = v4_forward_intervals(&manifest.forward_identities)?;
         if intervals.len() < 3 {
             break;
@@ -7637,6 +7865,7 @@ fn compact_v4_binary_carry_inner(
             artifacts,
             right.1,
             &mut work,
+            cancelled,
         )?;
         created.insert(
             merged_forward.artifact.name.clone(),
@@ -7661,6 +7890,7 @@ fn compact_v4_binary_carry_inner(
             left.0,
             right.1,
             &mut work,
+            cancelled,
         )?;
         compact_v4_tombstone_interval(
             pinned,
@@ -7671,6 +7901,7 @@ fn compact_v4_binary_carry_inner(
             left.0,
             right.1,
             &mut work,
+            cancelled,
         )?;
         work.compactions = work.compactions.saturating_add(1);
     }
@@ -7856,6 +8087,7 @@ fn take_v4_output_cleanup_failure() -> Result<(), GfError> {
 
 #[allow(clippy::unnecessary_wraps)]
 fn v4_compaction_post_write_failure(point: &str) -> Result<(), GfError> {
+    construction_ordinal_event(point, 0);
     #[cfg(test)]
     V4_COMPACTION_POST_WRITE_FAILURE.with(|failure| {
         if failure
@@ -7892,6 +8124,7 @@ fn merge_v4_forward_artifacts(
     index: &graphforge_filesystem::StableDirectory,
     generation: u64,
     work: &mut V4CompactionWork,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<GuardedV4Artifact, GfError> {
     let cache_window =
         graphforge_filesystem::cache_release_window_for_streams(3).map_err(storage_err)?;
@@ -7947,6 +8180,9 @@ fn merge_v4_forward_artifacts(
         ];
         let mut previous = None;
         loop {
+            if cancelled() {
+                return Err(storage_err("construction ordinal compaction cancelled"));
+            }
             let source = match (heads[0], heads[1]) {
                 (None, None) => break,
                 (Some(_), None) => 0,
@@ -8051,6 +8287,7 @@ fn compact_v4_ordinal_interval(
     first_generation: u64,
     last_generation: u64,
     work: &mut V4CompactionWork,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<(), GfError> {
     let mut replacement = Vec::new();
     let mut cursor = 0;
@@ -8110,6 +8347,11 @@ fn compact_v4_ordinal_interval(
                     )
                     .and_then(|()| {
                         while let Some(uuid) = read_exact_record::<16>(&mut readers[0])? {
+                            if cancelled() {
+                                return Err(storage_err(
+                                    "construction ordinal compaction cancelled",
+                                ));
+                            }
                             writer.push(uuid)?;
                             v4_compaction_post_write_failure("ordinal")?;
                         }
@@ -8196,6 +8438,7 @@ fn compact_v4_tombstone_interval(
     first_generation: u64,
     last_generation: u64,
     work: &mut V4CompactionWork,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<(), GfError> {
     let selected = manifest
         .tombstones
@@ -8240,6 +8483,9 @@ fn compact_v4_tombstone_interval(
         }
         let mut previous = None;
         while let Some(Reverse((id, source))) = heap.pop() {
+            if cancelled() {
+                return Err(storage_err("construction ordinal compaction cancelled"));
+            }
             if previous != Some(id) {
                 merged.push(id)?;
                 v4_compaction_post_write_failure("tombstone")?;
@@ -9907,6 +10153,7 @@ pub(crate) mod tests {
             &index,
             2,
             &mut work,
+            &mut || false,
         )
         .unwrap_err()
         .to_string();
@@ -9980,6 +10227,7 @@ pub(crate) mod tests {
             &index,
             2,
             &mut work,
+            &mut || false,
         )
         .unwrap_err()
         .to_string();
@@ -10007,6 +10255,7 @@ pub(crate) mod tests {
             &index,
             3,
             &mut release_work,
+            &mut || false,
         )
         .unwrap_err()
         .to_string();
@@ -10105,9 +10354,16 @@ pub(crate) mod tests {
         let reused = stage_v4_ordinal_bundle(mappings, 1, &index, &mut || false).unwrap();
         assert!(reused.publications.is_empty());
         inject_v4_authority_failure("after_artifacts");
-        let error = publish_v4_construction_artifacts(&encoded, reused, 1, &hex_sha256(b"delta"))
-            .unwrap_err()
-            .to_string();
+        let error = publish_v4_construction_artifacts(
+            &encoded,
+            reused,
+            1,
+            &hex_sha256(b"delta"),
+            None,
+            &mut || false,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(error.contains("injected v4 authority failure at after_artifacts"));
         for (name, identity, bytes) in &originals {
             let file = index.open_child_file(std::ffi::OsStr::new(name)).unwrap();
@@ -10123,6 +10379,31 @@ pub(crate) mod tests {
                 )
                 .unwrap(),
                 *bytes
+            );
+        }
+
+        let reused = stage_v4_ordinal_bundle(mappings, 1, &index, &mut || false).unwrap();
+        assert!(reused.publications.is_empty());
+        let (outputs, _, _) = publish_v4_construction_artifacts(
+            &encoded,
+            reused,
+            1,
+            &hex_sha256(b"delta"),
+            None,
+            &mut || false,
+        )
+        .unwrap();
+        for (name, identity, bytes) in &originals {
+            let output = outputs
+                .iter()
+                .find(|output| output.name == *name)
+                .expect("reused payload remains in the complete publication inventory");
+            assert_eq!(output.bytes, bytes.len() as u64);
+            assert_eq!(output.sha256, hex_sha256(bytes));
+            let file = index.open_child_file(std::ffi::OsStr::new(name)).unwrap();
+            assert_eq!(
+                graphforge_filesystem::file_identity(&file).unwrap(),
+                *identity
             );
         }
 
@@ -10214,6 +10495,7 @@ pub(crate) mod tests {
             1,
             2,
             &mut work,
+            &mut || false,
         )
         .unwrap_err()
         .to_string();
@@ -10281,6 +10563,7 @@ pub(crate) mod tests {
             1,
             2,
             &mut work,
+            &mut || false,
         )
         .unwrap_err()
         .to_string();
@@ -10706,7 +10989,15 @@ pub(crate) mod tests {
             .unwrap();
         let mappings = [(Uuid::from_u128(1), 1_u64), (Uuid::from_u128(2), 3_u64)];
         let bundle = stage_v4_ordinal_bundle(mappings, 1, &index, &mut || false).unwrap();
-        publish_v4_construction_artifacts(&encoded, bundle, 1, &hex_sha256(b"delta")).unwrap();
+        publish_v4_construction_artifacts(
+            &encoded,
+            bundle,
+            1,
+            &hex_sha256(b"delta"),
+            None,
+            &mut || false,
+        )
+        .unwrap();
 
         cleanup_private_construction_index(&encoded).unwrap();
         assert!(index.child_names().unwrap().is_empty());


### PR DESCRIPTION
Construction append retained the preceding generation’s ordinal manifest and receipt, so a successfully published append could fail durable reopen. This change publishes complete ordinal authority for the appended generation while preserving existing node ordinals and node/edge identities.

The encoder combines authenticated parent descriptors with the new delta, opens only the inputs consumed by bounded binary-carry compaction, and replaces superseded paths in the selected generation. Older generations retain their CAS objects. Reused private artifacts remain in the publication inventory independently of cleanup ownership. Shared metadata validation rejects duplicate artifact names before publication.

Validation:
- The original construction regression reproduced the stale ordinal authority failure.
- Four actual Rust facade append/publication/reopen cycles passed with exact edge identities and endpoints.
- Cancellation after compaction output, owned-output cleanup, same-session retry, and corrupt-parent rejection passed.
- The duplicate-name regression failed against the previous validator and passes with the fix.
- Eight construction generations passed exact forward/inverse identity mappings, bounded carry checks, selected-inventory cleanup, and retained old-generation checks.
- Byte-identical reused artifacts retain their original file identity and complete publication inventory; conflicting files remain protected.

- Full API library suite: 719 passed.
- Full storage library census: 975 passed, with two invalid fixtures and one unsupported-host-filesystem failure identified; both corrected fixtures, three receipt-negative cases, and the filesystem test on ext4 subsequently passed. The two pre-existing ignored tests were unchanged.
- Workspace Clippy passed; independent LOW source review is clear.

Formatting, fast pre-push checks and gate-registry validation passed. Refreshed onto current main with an unchanged patch; the direct facade regression and fast checks passed again on the integrated head.

Closes #1158

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791407366&installation_model_id=20486&pr_number=1159&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1159&signature=6fece619bf77844f91bf3b8ea6593cc720e4ea629d6ed774a8648416c202f8c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->