### PR TITLE
fix(storage): reconcile append phase and recovery observations

### DIFF
--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -178,7 +178,8 @@ pub struct ImportConstructionEvidence {
     pub write_bytes: u64,
     /// Application write submissions by construction artifact writers.
     pub write_operations: u64,
-    /// File and directory durability barriers completed by construction.
+    /// Durability barriers for accepted construction artifacts. Full phase
+    /// synchronization, including recovery checkpoints, is in `application_io`.
     pub fsync_operations: u64,
     /// Successful file-level page-cache release boundaries.
     #[serde(default)]
@@ -1384,6 +1385,89 @@ mod tests {
             0
         );
         assert_eq!(portable.node_count("Person").unwrap(), 2);
+    }
+
+    #[test]
+    fn ordinary_reopened_append_reconciles_preseal_progress() {
+        check_reopened_append_progress(false);
+    }
+
+    #[test]
+    fn resumed_reopened_append_reconciles_preseal_progress() {
+        check_reopened_append_progress(true);
+    }
+
+    fn check_reopened_append_progress(resume: bool) {
+        let (_directory, project, graph) = fixture();
+        let ids = [Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7()];
+        let mut initial = graph
+            .begin_import_session(OperationId(Uuid::now_v7()), ImportSessionLimits::default())
+            .unwrap();
+        initial
+            .append_arrow(BulkInputKind::Node, &[nodes(&ids[..2])])
+            .unwrap();
+        initial
+            .append_arrow(
+                BulkInputKind::Edge,
+                &[edges(Uuid::now_v7(), ids[0], ids[1])],
+            )
+            .unwrap();
+        initial.validate(&graph).unwrap();
+        initial.commit(&graph, None).unwrap();
+        drop(initial);
+        drop(graph);
+        let graph = GraphForge::new(project.to_str()).unwrap();
+        let mut append = graph
+            .begin_import_session(OperationId(Uuid::now_v7()), ImportSessionLimits::default())
+            .unwrap();
+        append
+            .append_arrow(BulkInputKind::Node, &[nodes(&ids[2..])])
+            .unwrap();
+        append
+            .append_arrow(
+                BulkInputKind::Edge,
+                &[edges(Uuid::now_v7(), ids[1], ids[2])],
+            )
+            .unwrap();
+        let progress = append.validate(&graph).unwrap();
+        assert_eq!(progress.rows_accepted, 2);
+        let phases = &progress.construction.as_ref().unwrap().application_io;
+        phases.validate_for_qualification().unwrap();
+        for phase in [
+            graphforge_storage::StorageIoPhase::SealAuthentication,
+            graphforge_storage::StorageIoPhase::ShapeConsumeReauthentication,
+        ] {
+            assert!(phases.phases[&phase].read_bytes > 0);
+            assert!(phases.phases[&phase].read_calls > 0);
+        }
+        if resume {
+            append.checkpoint().unwrap();
+            let id = append.session_uuid();
+            drop(append);
+            append = graph.resume_import_session(id).unwrap();
+            let resumed = append.validate(&graph).unwrap();
+            resumed
+                .construction
+                .as_ref()
+                .unwrap()
+                .application_io
+                .validate_for_qualification()
+                .unwrap();
+            assert_eq!(resumed.rows_accepted, 2);
+        }
+        append.commit(&graph, None).unwrap();
+        drop(append);
+        drop(graph);
+        let graph = GraphForge::new(project.to_str()).unwrap();
+        assert_eq!(graph.node_count("Person").unwrap(), 3);
+        assert_eq!(
+            graph
+                .execute("MATCH ()-[r:KNOWS]->() RETURN r")
+                .unwrap()
+                .stats
+                .rows_produced,
+            2
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -545,6 +545,9 @@ pub struct GraphConstructionEvidence {
     /// Bounded artifact reads used by interrupted-append recovery.
     #[serde(default)]
     pub recovery_application_read_operations: u64,
+    /// Synchronization barriers for checkpointing newly observed resume reads.
+    #[serde(default)]
+    pub recovery_checkpoint_fsync_operations: u64,
     /// New canonical graph payload bytes emitted by encoding.
     #[serde(default)]
     pub canonical_output_bytes: u64,
@@ -2187,10 +2190,27 @@ impl GraphConstructionSession {
             let graph_source = StableDirectory::open(graph_source_dir).map_err(storage)?;
             load_parent_runtime_catalog(&graph_source, parent_topology_generation, budgets)?
         };
+        let resumed_parent_work = if recovered_checkpoint.is_some() && !publication_replay {
+            ReadWork {
+                bytes: base_work
+                    .authentication_bytes
+                    .checked_add(parent_catalog_work.bytes)
+                    .ok_or_else(|| storage("resumed parent read bytes overflow"))?,
+                operations: base_work
+                    .authentication_blocks
+                    .checked_add(parent_catalog_work.operations)
+                    .ok_or_else(|| storage("resumed parent read operations overflow"))?,
+                ..ReadWork::default()
+            }
+        } else {
+            ReadWork::default()
+        };
         let checkpoint = if let Some(checkpoint) = recovered_checkpoint {
             checkpoint
         } else {
             let evidence = GraphConstructionEvidence {
+                seal_application_read_bytes: base_work.authentication_bytes,
+                shape_application_read_bytes: parent_catalog_work.bytes,
                 authentication_read_bytes: base_work.authentication_bytes,
                 authentication_read_operations: base_work.authentication_blocks,
                 parent_catalog_read_bytes: parent_catalog_work.bytes,
@@ -2314,6 +2334,37 @@ impl GraphConstructionSession {
                 });
         }
         session.revalidate_authority()?;
+        let repaired_parent_phases = repair_unshaped_parent_phase_bytes(&mut session.checkpoint)?;
+        if repaired_parent_phases
+            || resumed_parent_work.bytes != 0
+            || resumed_parent_work.operations != 0
+        {
+            session.checkpoint.evidence.recovery_application_read_bytes = session
+                .checkpoint
+                .evidence
+                .recovery_application_read_bytes
+                .checked_add(resumed_parent_work.bytes)
+                .ok_or_else(|| storage("recovery read bytes overflow"))?;
+            session
+                .checkpoint
+                .evidence
+                .recovery_application_read_operations = session
+                .checkpoint
+                .evidence
+                .recovery_application_read_operations
+                .checked_add(resumed_parent_work.operations)
+                .ok_or_else(|| storage("recovery read operations overflow"))?;
+            session
+                .checkpoint
+                .evidence
+                .recovery_checkpoint_fsync_operations = session
+                .checkpoint
+                .evidence
+                .recovery_checkpoint_fsync_operations
+                .checked_add(3)
+                .ok_or_else(|| storage("recovery checkpoint sync count overflow"))?;
+            replace_checkpoint_control(&session.root, &session.checkpoint)?;
+        }
         if session.checkpoint.next_sequence != 0
             && session.checkpoint.evidence.immutable_artifacts == 0
         {
@@ -4373,6 +4424,58 @@ fn recover_shape_intent(
     unlink_named(root, SHAPE_INTENT)
 }
 
+/// Restore only the known omitted parent contribution before shape authority
+/// exists. Authenticated shaped evidence is never rewritten during recovery.
+fn repair_unshaped_parent_phase_bytes(checkpoint: &mut Checkpoint) -> Result<bool, GfError> {
+    let evidence = &mut checkpoint.evidence;
+    let missing_seal = evidence.seal_application_read_bytes != evidence.authentication_read_bytes;
+    let shape_contributors = [
+        evidence.shape_input_validation_read_bytes,
+        evidence.merge_read_bytes,
+        evidence.parquet_read_bytes,
+        evidence.shaped_output_authentication_bytes,
+        evidence.retained_probe_read_bytes,
+    ];
+    let expected_shape = checked_evidence_sum(
+        "parent shape phase bytes",
+        evidence.parent_catalog_read_bytes,
+        &shape_contributors,
+    )?;
+    let missing_shape = evidence.shape_application_read_bytes != expected_shape;
+    if !missing_seal && !missing_shape {
+        return Ok(false);
+    }
+    if checkpoint.shape_authority_sha256.is_some() || checkpoint.encoding_inventory_sha256.is_some()
+    {
+        return Err(storage(
+            "legacy construction parent phase attribution is bound to shape authority",
+        ));
+    }
+    if missing_seal
+        && evidence
+            .seal_application_read_bytes
+            .checked_add(checkpoint.base_work.authentication_bytes)
+            != Some(evidence.authentication_read_bytes)
+    {
+        return Err(storage(
+            "construction parent authentication phase bytes disagree",
+        ));
+    }
+    if missing_shape
+        && (evidence.shape_application_read_bytes != 0
+            || shape_contributors.iter().any(|value| *value != 0))
+    {
+        return Err(storage("construction parent catalog phase bytes disagree"));
+    }
+    if missing_seal {
+        evidence.seal_application_read_bytes = evidence.authentication_read_bytes;
+    }
+    if missing_shape {
+        evidence.shape_application_read_bytes = evidence.parent_catalog_read_bytes;
+    }
+    Ok(true)
+}
+
 fn recover_final_shape_evidence(
     root: &StableDirectory,
     checkpoint: &mut Checkpoint,
@@ -4409,6 +4512,9 @@ fn persisted_evidence_equivalent(
 }
 
 fn copy_post_shape_io(target: &mut GraphConstructionEvidence, source: &GraphConstructionEvidence) {
+    target.recovery_application_read_bytes = source.recovery_application_read_bytes;
+    target.recovery_application_read_operations = source.recovery_application_read_operations;
+    target.recovery_checkpoint_fsync_operations = source.recovery_checkpoint_fsync_operations;
     target.storage_current = source.storage_current.clone();
     target.storage_receipt_category_authorities =
         source.storage_receipt_category_authorities.clone();
@@ -12498,6 +12604,144 @@ mod tests {
         }
         let opened = crate::UuidMembershipIndex::open(&assembled).unwrap();
         assert_eq!(opened.count(crate::UuidIndexKind::Node), 4);
+    }
+
+    #[test]
+    fn legacy_unshaped_parent_phase_checkpoint_repairs_only_exact_omission() {
+        let project = nonempty_project_generation_two();
+        let operation = Uuid::from_u128(1157);
+        let open = || {
+            GraphConstructionSession::open_with_mode(
+                project.path(),
+                operation,
+                2,
+                graphforge_core::OntologyMode::Exploratory,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap()
+        };
+        let mut session = open();
+        let bytes = session.evidence().authentication_read_bytes;
+        assert!(bytes > 0);
+        session.checkpoint.evidence.seal_application_read_bytes = 0;
+        replace_checkpoint_control(&session.root, &session.checkpoint).unwrap();
+        drop(session);
+        let session = open();
+        assert_eq!(session.evidence().seal_application_read_bytes, bytes);
+        let mut malformed = session.checkpoint.clone();
+        malformed.evidence.seal_application_read_bytes = bytes + 1;
+        assert!(repair_unshaped_parent_phase_bytes(&mut malformed).is_err());
+        let mut wrong_shape = session.checkpoint.clone();
+        wrong_shape.evidence.shape_application_read_bytes =
+            wrong_shape.evidence.parent_catalog_read_bytes + 1;
+        assert!(repair_unshaped_parent_phase_bytes(&mut wrong_shape).is_err());
+        let mut bound = session.checkpoint.clone();
+        bound.evidence.seal_application_read_bytes = 0;
+        bound.shape_authority_sha256 = Some("0".repeat(64));
+        assert!(repair_unshaped_parent_phase_bytes(&mut bound).is_err());
+        assert_eq!(bound.evidence.seal_application_read_bytes, 0);
+    }
+
+    #[test]
+    fn parent_phase_observations_survive_staging_sealed_and_shaped_resumes() {
+        let project = nonempty_project_generation_two();
+        let mut catalog = RuntimeCatalog::new();
+        catalog.intern_label_at("Person", 1).unwrap();
+        let batch = catalog.to_record_batch();
+        let mut writer = ArrowWriter::try_new(
+            File::create(project.path().join("topology/runtime_catalog.parquet")).unwrap(),
+            batch.schema(),
+            None,
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let operation = Uuid::from_u128(1156);
+        let open = || {
+            GraphConstructionSession::open_with_mode(
+                project.path(),
+                operation,
+                2,
+                graphforge_core::OntologyMode::Exploratory,
+                GraphConstructionBudgets::default(),
+            )
+            .unwrap()
+        };
+        let mut session = open();
+        let initial = session.evidence().clone();
+        assert!(initial.authentication_read_bytes > 0);
+        assert!(initial.parent_catalog_read_bytes > 0);
+        assert_eq!(
+            initial.seal_application_read_bytes,
+            initial.authentication_read_bytes
+        );
+        assert_eq!(
+            initial.shape_application_read_bytes,
+            initial.parent_catalog_read_bytes
+        );
+        let parent_bytes = initial.authentication_read_bytes + initial.parent_catalog_read_bytes;
+        let parent_calls =
+            initial.authentication_read_operations + initial.parent_catalog_read_operations;
+        session
+            .append(ConstructionChunkKind::Node, "delta", &node_batch(4, 1))
+            .unwrap();
+        for stage in 0..3 {
+            if stage == 1 {
+                session.seal().unwrap();
+            }
+            if stage == 2 {
+                session.shape_canonical_with_cancellation(|| false).unwrap();
+            }
+            for _ in 0..2 {
+                let before = session.evidence().clone();
+                drop(session);
+                session = open();
+                let after = session.evidence();
+                assert_eq!(
+                    after.authentication_read_bytes,
+                    before.authentication_read_bytes
+                );
+                assert_eq!(
+                    after.authentication_read_operations,
+                    before.authentication_read_operations
+                );
+                assert_eq!(
+                    after.parent_catalog_read_bytes,
+                    initial.parent_catalog_read_bytes
+                );
+                assert_eq!(
+                    after.parent_catalog_read_operations,
+                    initial.parent_catalog_read_operations
+                );
+                assert_eq!(
+                    after.seal_application_read_bytes,
+                    before.seal_application_read_bytes
+                );
+                assert_eq!(
+                    after.shape_application_read_bytes,
+                    before.shape_application_read_bytes
+                );
+                assert_eq!(
+                    after.recovery_application_read_bytes - before.recovery_application_read_bytes,
+                    parent_bytes
+                );
+                assert_eq!(
+                    after.recovery_application_read_operations
+                        - before.recovery_application_read_operations,
+                    parent_calls
+                );
+                assert_eq!(
+                    after.recovery_checkpoint_fsync_operations
+                        - before.recovery_checkpoint_fsync_operations,
+                    3
+                );
+                assert_eq!(after.fsync_operations, before.fsync_operations);
+                crate::ConstructionPhaseAttribution::from_construction(after)
+                    .unwrap()
+                    .validate_for_qualification()
+                    .unwrap();
+            }
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/storage_attribution.rs
+++ b/crates/graphforge-storage/src/storage_attribution.rs
@@ -196,7 +196,10 @@ impl ConstructionPhaseAttribution {
             StorageIoPhase::FsyncSynchronization,
             PhaseIoTotals {
                 fsync_calls: checked_add(
-                    evidence.fsync_operations,
+                    checked_add(
+                        evidence.fsync_operations,
+                        evidence.recovery_checkpoint_fsync_operations,
+                    )?,
                     evidence.merge_fsync_operations,
                 )?,
                 ..Default::default()


### PR DESCRIPTION
Appending to a reopened project performed parent authentication and catalog reads without recording their matching phase bytes. Public import-session validation then rejected the otherwise valid append. This change reconciles initial phase observations and accounts for fresh resume work separately, allowing ordinary and resumed append sessions to validate, commit, and reopen successfully.

Resume accounting records only reads actually performed, excludes publication replay, and keeps checkpoint synchronization separate from artifact fsync authority. Legacy repair accepts only the exact known omission before shape authority is bound; inconsistent shaped or encoded evidence still fails closed.

Validation on current main with the ordinal repair merged:
- All 17 import-session tests passed, including strict ordinary/resumed append and durable reopen.
- Repeated resume and legacy-refusal tests: 2 passed; attribution: 16 passed; ordinal append regression: 1 passed.
- Existing 1×/2×/4× lifecycle and tiny restart/linear-work tests passed.
- Changed-surface Clippy, formatting, fast pre-push checks, and gate-registry validation passed.
- Independent LOW review: clear.

This closes the bounded accounting defect. #951 retains its full attribution and host-qualification acceptance criteria.

Closes #1156

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791409055&installation_model_id=20486&pr_number=1161&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1161&signature=201b4a26f5fbbc67075b538c23daf58073ee21f6610ae40deabaf7a33284fd19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->