### PR TITLE
fix(scale): account for complete lifecycle storage ownership

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -642,8 +642,11 @@ Ordinary `storage-attribution --json` receipts preserve source and clean-import
 allocated and logical-EOF components separately. Construction evidence owns
 logical I/O, reader-call, transient-construction, and publication-work
 components; it is not relabeled as a whole-lifecycle storage peak. Passed rung
-evidence therefore also requires an authenticated `graphforge-lifecycle-storage/1`
-owner-union receipt for retained and transient lifecycle maxima. The controller
+evidence therefore also requires a `graphforge-lifecycle-storage/2`
+owner-union receipt for retained and transient lifecycle maxima, including raw
+reference, logical-EOF, physical-object, and allocated-byte facts for all 15
+published, private, control, and artifact owner views. The source denominator
+remains the authenticated published-project union. The controller
 fails closed while that ordinary receipt is absent rather than summing project
 owners or treating portable logical payload bytes as allocated storage.
 Newly assembled rungs identify `graphforge-progressive-rung-assembly/3`; for

--- a/benchmarks/fixtures/progressive/tiny-executable.json
+++ b/benchmarks/fixtures/progressive/tiny-executable.json
@@ -6,7 +6,7 @@
     "mechanics": "public-certification-v1",
     "phases": ["admission", "generate", "ingest", "reopen", "recount", "query", "export", "verify", "clean_import", "reopen_proof"],
     "evidence_schema": "graphforge-public-certification/1",
-    "storage_receipt": "graphforge-lifecycle-storage/1"
+    "storage_receipt": "graphforge-lifecycle-storage/2"
   },
   "phases": [
     {

--- a/benchmarks/harness/graphforge_bench/progressive_run.py
+++ b/benchmarks/harness/graphforge_bench/progressive_run.py
@@ -57,6 +57,23 @@ STORAGE_CATEGORY_FIELDS = (
     "physical_logical_bytes",
     "allocated_bytes",
 )
+RETAINED_OWNER_NAMES = (
+    "source-project-construction",
+    "source-project-import",
+    "source-project-transactions",
+    "source-project-locks",
+    "source-project-admission_lock",
+    "source-project-published",
+    "imported-project-construction",
+    "imported-project-import",
+    "imported-project-transactions",
+    "imported-project-locks",
+    "imported-project-admission_lock",
+    "imported-project-published",
+    "generated-inputs",
+    "query-results",
+    "portable-package",
+)
 APPLICATION_IO_PHASES = (
     "append_merge",
     "seal_authentication",
@@ -81,6 +98,52 @@ APPLICATION_IO_FIELDS = (
 
 class ControllerError(ValueError):
     """The requested run is unsafe, out of order, or lacks valid evidence."""
+
+
+def validate_lifecycle_storage_receipt(receipt: Mapping[str, Any]) -> None:
+    """Reconcile complete owner views without treating aliases as separate allocation."""
+    fields = (
+        "source_project_current_allocated_bytes",
+        "retained_storage_bytes",
+        "transient_peak_storage_bytes",
+    )
+    if receipt.get("contract") != "graphforge-lifecycle-storage/2":
+        raise ControllerError("lifecycle storage requires complete version-2 owner evidence")
+    for field in fields:
+        value = receipt.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ControllerError(f"lifecycle storage receipt omitted {field}")
+    if set(receipt) != {"contract", "retained_owners", *fields}:
+        raise ControllerError("lifecycle storage fields must be complete and closed")
+    owners = receipt["retained_owners"]
+    if not isinstance(owners, Mapping) or set(owners) != set(RETAINED_OWNER_NAMES):
+        raise ControllerError("lifecycle retained owners must be complete and closed")
+    allocations = []
+    for name, owner in owners.items():
+        if not isinstance(owner, Mapping) or set(owner) != {"totals"}:
+            raise ControllerError(f"lifecycle retained owner is malformed: {name}")
+        totals = owner["totals"]
+        if not isinstance(totals, Mapping) or set(totals) != set(STORAGE_CATEGORY_FIELDS):
+            raise ControllerError(f"lifecycle retained owner totals are malformed: {name}")
+        if any(isinstance(n, bool) or not isinstance(n, int) or n < 0 for n in totals.values()):
+            raise ControllerError(f"lifecycle retained owner totals are not exact integers: {name}")
+        if (
+            totals["physical_objects"] > totals["logical_references"]
+            or totals["physical_logical_bytes"] > totals["logical_bytes"]
+            or (totals["physical_objects"] == 0 and any(totals.values()))
+        ):
+            raise ControllerError(f"lifecycle retained owner alias facts contradict: {name}")
+        allocations.append(totals["allocated_bytes"])
+    retained = receipt["retained_storage_bytes"]
+    if not max(allocations) <= retained <= sum(allocations):
+        raise ControllerError("lifecycle retained union is inconsistent with owner views")
+    if receipt["transient_peak_storage_bytes"] < retained:
+        raise ControllerError("lifecycle peak is below current retained allocation")
+    if (
+        receipt["source_project_current_allocated_bytes"]
+        != owners["source-project-published"]["totals"]["allocated_bytes"]
+    ):
+        raise ControllerError("published source denominator disagrees with its owner union")
 
 
 class BenchExecRunError(ControllerError):
@@ -976,7 +1039,7 @@ def assemble_rung_evidence(
     source_storage = _storage_receipt(graphforge, "reopen")
     imported_storage = _storage_receipt(graphforge, "reopen_proof")
     lifecycle_storage = _phase_bound_receipt(
-        graphforge, "reopen_proof", "graphforge-lifecycle-storage/1"
+        graphforge, "reopen_proof", "graphforge-lifecycle-storage/2"
     )
     construction, application_io, construction_staging, staging_peak = _construction_metrics(
         committed_import
@@ -1007,13 +1070,7 @@ def assemble_rung_evidence(
     ):
         raise ControllerError("source/imported query evidence contradicts the selected rung")
     lifecycle_names = ("retained_storage_bytes", "transient_peak_storage_bytes")
-    for name in ("source_project_current_allocated_bytes", *lifecycle_names):
-        if (
-            isinstance(lifecycle_storage.get(name), bool)
-            or not isinstance(lifecycle_storage.get(name), int)
-            or lifecycle_storage[name] < 0
-        ):
-            raise ControllerError(f"lifecycle storage receipt omitted {name}")
+    validate_lifecycle_storage_receipt(lifecycle_storage)
     authority = benchexec.get("authority")
     if not isinstance(authority, Mapping):
         raise ControllerError("BenchExec authority is missing")

--- a/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
+++ b/benchmarks/harness/graphforge_bench/progressive_storage_qualification.py
@@ -14,7 +14,12 @@ from typing import Any
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
-from graphforge_bench.progressive_run import publish_json_no_clobber
+from graphforge_bench.progressive_run import (
+    RETAINED_OWNER_NAMES,
+    ControllerError,
+    publish_json_no_clobber,
+    validate_lifecycle_storage_receipt,
+)
 
 BENCHMARK_ROOT = Path(__file__).resolve().parents[2]
 REPOSITORY_ROOT = BENCHMARK_ROOT.parent
@@ -25,7 +30,7 @@ QUALIFICATION_SCHEMA = (
 PROVIDER_RESULT_SCHEMA = BENCHMARK_ROOT / "schemas/progressive-provider-run-result.json"
 PROVIDER_PLAN_SCHEMA = BENCHMARK_ROOT / "schemas/progressive-provider-run-plan.json"
 ASSEMBLY_CONTRACT = "graphforge-progressive-rung-assembly/3"
-QUALIFICATION_CONTRACT = "graphforge-g500-ladder-qualification/3"
+QUALIFICATION_CONTRACT = "graphforge-g500-ladder-qualification/4"
 S26_EDGES = 1 << 30
 S26_NODES = 1 << 26
 SOURCE_CATEGORIES = (
@@ -190,6 +195,10 @@ def validate_source_rung(value: Mapping[str, Any]) -> None:
     if value.get("status") != "passed" or value.get("correctness") is not True:
         raise StorageQualificationError("storage qualification requires passed correct rungs")
     storage = value["storage_attribution"]
+    try:
+        validate_lifecycle_storage_receipt(storage["lifecycle"])
+    except ControllerError as error:
+        raise StorageQualificationError(str(error)) from error
     _validate_snapshot(storage["source"], "source")
     _validate_snapshot(storage["imported"], "imported")
     construction = storage["construction"]
@@ -267,6 +276,10 @@ def adapt_rung(value: Mapping[str, Any]) -> dict[str, Any]:
         _artifact(name, source["categories"][category], owner)
         for name, category, owner in SOURCE_CATEGORIES
     ]
+    artifacts.extend(
+        _artifact(name, lifecycle["retained_owners"][name]["totals"], "lifecycle_owner_snapshot")
+        for name in RETAINED_OWNER_NAMES
+    )
     artifacts.append(
         _artifact(
             "construction_staging_spill",

--- a/benchmarks/profiles/graph500/s18-local.json
+++ b/benchmarks/profiles/graph500/s18-local.json
@@ -292,7 +292,7 @@
       "reopen_proof"
     ],
     "evidence_schema": "graphforge-public-certification/1",
-    "storage_receipt": "graphforge-lifecycle-storage/1"
+    "storage_receipt": "graphforge-lifecycle-storage/2"
   },
   "gate": {
     "requires_previous_pass": true,

--- a/benchmarks/profiles/graph500/s19-local.json
+++ b/benchmarks/profiles/graph500/s19-local.json
@@ -292,7 +292,7 @@
       "reopen_proof"
     ],
     "evidence_schema": "graphforge-public-certification/1",
-    "storage_receipt": "graphforge-lifecycle-storage/1"
+    "storage_receipt": "graphforge-lifecycle-storage/2"
   },
   "gate": {
     "requires_previous_pass": true,

--- a/benchmarks/profiles/graph500/s20-provider.json
+++ b/benchmarks/profiles/graph500/s20-provider.json
@@ -292,7 +292,7 @@
       "reopen_proof"
     ],
     "evidence_schema": "graphforge-public-certification/1",
-    "storage_receipt": "graphforge-lifecycle-storage/1"
+    "storage_receipt": "graphforge-lifecycle-storage/2"
   },
   "gate": {
     "requires_previous_pass": true,

--- a/benchmarks/profiles/graph500/s22-provider.json
+++ b/benchmarks/profiles/graph500/s22-provider.json
@@ -292,7 +292,7 @@
       "reopen_proof"
     ],
     "evidence_schema": "graphforge-public-certification/1",
-    "storage_receipt": "graphforge-lifecycle-storage/1"
+    "storage_receipt": "graphforge-lifecycle-storage/2"
   },
   "gate": {
     "requires_previous_pass": true,

--- a/benchmarks/profiles/graph500/s24-provider.json
+++ b/benchmarks/profiles/graph500/s24-provider.json
@@ -292,7 +292,7 @@
       "reopen_proof"
     ],
     "evidence_schema": "graphforge-public-certification/1",
-    "storage_receipt": "graphforge-lifecycle-storage/1"
+    "storage_receipt": "graphforge-lifecycle-storage/2"
   },
   "gate": {
     "requires_previous_pass": true,

--- a/benchmarks/profiles/graph500/s25-provider.json
+++ b/benchmarks/profiles/graph500/s25-provider.json
@@ -292,7 +292,7 @@
       "reopen_proof"
     ],
     "evidence_schema": "graphforge-public-certification/1",
-    "storage_receipt": "graphforge-lifecycle-storage/1"
+    "storage_receipt": "graphforge-lifecycle-storage/2"
   },
   "gate": {
     "requires_previous_pass": true,

--- a/benchmarks/profiles/graph500/s26-provider.json
+++ b/benchmarks/profiles/graph500/s26-provider.json
@@ -292,7 +292,7 @@
       "reopen_proof"
     ],
     "evidence_schema": "graphforge-public-certification/1",
-    "storage_receipt": "graphforge-lifecycle-storage/1"
+    "storage_receipt": "graphforge-lifecycle-storage/2"
   },
   "gate": {
     "requires_previous_pass": true,

--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -159,7 +159,7 @@ impl Profile {
             && lifecycle.mechanics == "public-certification-v1"
             && lifecycle.phases == Phase::ALL
             && lifecycle.evidence_schema == EVIDENCE_SCHEMA
-            && lifecycle.storage_receipt == "graphforge-lifecycle-storage/1"
+            && lifecycle.storage_receipt == "graphforge-lifecycle-storage/2"
             && gate.requires_previous_pass
             && gate.projection_source_scales == expected.1
             && gate.limits.wall_seconds == 14_400
@@ -179,7 +179,7 @@ impl Profile {
             lifecycle.mechanics == "public-certification-v1"
                 && lifecycle.phases == Phase::ALL
                 && lifecycle.evidence_schema == EVIDENCE_SCHEMA
-                && lifecycle.storage_receipt == "graphforge-lifecycle-storage/1"
+                && lifecycle.storage_receipt == "graphforge-lifecycle-storage/2"
         })
     }
 }
@@ -277,6 +277,7 @@ pub trait PhaseExecutor {
 #[derive(Default)]
 pub struct PublicProcessExecutor {
     lifecycle: LifecycleStorageSession,
+    allocation_paths: std::collections::BTreeSet<std::path::PathBuf>,
 }
 
 #[derive(Default)]
@@ -291,6 +292,8 @@ struct LifecycleStorageSession {
     portable_import_peak_observed: bool,
     imported_project_observed: bool,
     finalized: bool,
+    retained_owner_facts: BTreeMap<String, graphforge_storage::PrivateStorageOwner>,
+    artifact_paths: BTreeMap<String, std::collections::BTreeSet<std::path::PathBuf>>,
 }
 
 impl LifecycleStorageSession {
@@ -303,7 +306,6 @@ impl LifecycleStorageSession {
         if self.finalized {
             return Err("lifecycle storage session was already finalized".to_owned());
         }
-        let phase_baseline_allocated_bytes = self.allocation.current_allocated_bytes();
         let commands: Vec<&[String]> = match &command.action {
             PhaseAction::BenchmarkGenerator { args, .. } | PhaseAction::GraphForgeCli { args } => {
                 vec![args]
@@ -312,27 +314,35 @@ impl LifecycleStorageSession {
                 commands.iter().map(Vec::as_slice).collect()
             }
         };
-        let mut files = BTreeMap::new();
+        let artifact_owner = if phase == Phase::Generate {
+            "generated-inputs"
+        } else if phase == Phase::Export {
+            "portable-package"
+        } else {
+            "query-results"
+        };
+        let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
         for args in &commands {
             for flag in ["--nodes", "--edges", "--output"] {
                 if let Some(path) = argument_path(args, flag) {
-                    if path.is_file() {
-                        merge_file_identity(&mut files, path)?;
-                    } else if flag == "--output" && path.is_dir() {
-                        merge_directory_identities(&mut files, path)?;
+                    if path.exists() {
+                        self.artifact_paths
+                            .entry(artifact_owner.to_owned())
+                            .or_default()
+                            .insert(if path.is_absolute() {
+                                path.to_path_buf()
+                            } else {
+                                cwd.join(path)
+                            });
                     }
                 }
             }
         }
-        if !files.is_empty() {
-            self.allocation
-                .replace_owner(format!("phase-{phase}"), &files)
-                .map_err(|error| error.to_string())?;
-            if phase == Phase::Generate {
-                self.generator_observed = true;
-            } else if phase == Phase::Export {
-                self.portable_package_observed = true;
-            }
+        if phase == Phase::Generate {
+            self.generator_observed = true;
+        }
+        if phase == Phase::Export {
+            self.portable_package_observed = true;
         }
         if let Some(project) = commands
             .iter()
@@ -353,9 +363,16 @@ impl LifecycleStorageSession {
                     }
                     "source-project"
                 };
-                self.allocation
-                    .replace_owner(owner, &union.physical_identity_allocated_bytes)
+                let published = graphforge_storage::capture_published_storage_ownership(&selected)
                     .map_err(|error| error.to_string())?;
+                self.retained_owner_facts
+                    .insert(format!("{owner}-published"), published);
+                let private = graphforge_storage::capture_private_storage_ownership(project)
+                    .map_err(|error| error.to_string())?;
+                for (name, (_, snapshot)) in private.owners {
+                    let name = format!("{owner}-{name}");
+                    self.retained_owner_facts.insert(name, snapshot);
+                }
             }
         }
         for receipt in receipts {
@@ -363,36 +380,14 @@ impl LifecycleStorageSession {
                 == Some("graphforge-import-session/1")
                 && receipt.get("outcome").and_then(serde_json::Value::as_str) == Some("committed")
             {
-                let transient = receipt
-                    .get("construction")
-                    .and_then(|value| value.get("transient_peak_allocated_bytes"))
-                    .and_then(serde_json::Value::as_u64)
-                    .ok_or_else(|| {
-                        "committed import omitted transient allocation evidence".to_owned()
-                    })?;
-                self.transient_peak_storage_bytes = self
-                    .transient_peak_storage_bytes
-                    .max(phase_baseline_allocated_bytes.saturating_add(transient));
                 self.construction_peak_observed = true;
             }
             if receipt.get("contract").and_then(serde_json::Value::as_str)
                 == Some("graphforge-portable-import/2")
             {
-                let transient = receipt
-                    .get("transient_peak_allocated_bytes")
-                    .and_then(serde_json::Value::as_u64)
-                    .ok_or_else(|| {
-                        "portable import omitted transient allocation evidence".to_owned()
-                    })?;
-                self.transient_peak_storage_bytes = self
-                    .transient_peak_storage_bytes
-                    .max(phase_baseline_allocated_bytes.saturating_add(transient));
                 self.portable_import_peak_observed = true;
             }
         }
-        self.transient_peak_storage_bytes = self
-            .transient_peak_storage_bytes
-            .max(self.allocation.peak_allocated_bytes());
         if phase != Phase::ReopenProof {
             return Ok(None);
         }
@@ -412,16 +407,65 @@ impl LifecycleStorageSession {
         let source_project_current_allocated_bytes = self
             .source_project_current_allocated_bytes
             .ok_or_else(|| "source-project reopen allocation was not captured".to_owned())?;
-        self.finalized = true;
         let retained = self.allocation.current_allocated_bytes();
-        let peak = self.transient_peak_storage_bytes.max(retained);
+        let peak = self.transient_peak_storage_bytes;
+        if peak < retained {
+            return Err("observed operation peak is below final retained allocation".to_owned());
+        }
+        for name in ["generated-inputs", "query-results", "portable-package"] {
+            let paths = self
+                .artifact_paths
+                .get(name)
+                .ok_or_else(|| format!("missing raw owner {name}"))?
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            let snapshot = graphforge_storage::capture_artifact_storage_ownership(&paths)
+                .map_err(|error| error.to_string())?;
+            self.retained_owner_facts.insert(name.to_owned(), snapshot);
+        }
+        validate_retained_owner_facts(&self.allocation, &self.retained_owner_facts)?;
+        self.finalized = true;
+        let retained_owners = self
+            .retained_owner_facts
+            .iter()
+            .map(|(name, snapshot)| (name.clone(), serde_json::json!({"totals": snapshot.totals})))
+            .collect::<serde_json::Map<_, _>>();
         Ok(Some(serde_json::json!({
-            "contract": "graphforge-lifecycle-storage/1",
+            "contract": "graphforge-lifecycle-storage/2",
             "source_project_current_allocated_bytes": source_project_current_allocated_bytes,
             "retained_storage_bytes": retained,
             "transient_peak_storage_bytes": peak,
+            "retained_owners": retained_owners,
         })))
     }
+}
+
+fn validate_retained_owner_facts(
+    allocation: &graphforge_storage::StorageAllocationLifecycle,
+    owners: &BTreeMap<String, graphforge_storage::PrivateStorageOwner>,
+) -> Result<(), String> {
+    let mut identities = BTreeMap::new();
+    let mut references = 0_u64;
+    for snapshot in owners.values() {
+        references = references
+            .checked_add(snapshot.totals.logical_references)
+            .ok_or_else(|| "raw owner reference count overflow".to_owned())?;
+        for (identity, allocated) in &snapshot.physical_identity_allocated_bytes {
+            if identities
+                .insert(identity.clone(), *allocated)
+                .is_some_and(|previous| previous != *allocated)
+            {
+                return Err("raw owners disagree on physical allocation".to_owned());
+            }
+        }
+    }
+    if !allocation.matches_file_inventory(&identities, references) {
+        return Err(
+            "raw owner identities or file references do not match retained baseline".to_owned(),
+        );
+    }
+    Ok(())
 }
 
 fn argument_path<'a>(args: &'a [String], flag: &str) -> Option<&'a Path> {
@@ -430,77 +474,90 @@ fn argument_path<'a>(args: &'a [String], flag: &str) -> Option<&'a Path> {
         .map(|values| Path::new(&values[1]))
 }
 
-fn merge_file_identity(identities: &mut BTreeMap<String, u64>, path: &Path) -> Result<(), String> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| "lifecycle allocation path has no parent".to_owned())?;
-    let name = path
-        .file_name()
-        .ok_or_else(|| "lifecycle allocation path has no file name".to_owned())?;
-    let directory = graphforge_filesystem::StableDirectory::open(parent)
-        .map_err(|_| "lifecycle allocation parent could not be retained".to_owned())?;
-    let file = directory
-        .open_child_file(name)
-        .map_err(|_| "lifecycle allocation owner is not a stable regular file".to_owned())?;
-    merge_open_file_identity(identities, &file)
-}
-
-fn merge_directory_identities(
-    identities: &mut BTreeMap<String, u64>,
-    path: &Path,
-) -> Result<(), String> {
-    let directory = graphforge_filesystem::StableDirectory::open(path)
-        .map_err(|_| "lifecycle allocation directory could not be retained".to_owned())?;
-    let mut remaining = 1_000_000_usize;
-    merge_stable_directory_identities(identities, &directory, &mut remaining)
-}
-
-fn merge_stable_directory_identities(
-    identities: &mut BTreeMap<String, u64>,
-    directory: &graphforge_filesystem::StableDirectory,
-    remaining: &mut usize,
-) -> Result<(), String> {
-    let names = directory
-        .child_names_bounded(*remaining)
-        .map_err(|_| "lifecycle allocation directory exceeds identity bound".to_owned())?;
-    *remaining = remaining.saturating_sub(names.len());
-    for name in names {
-        match directory.open_child_directory(&name) {
-            Ok(child) => merge_stable_directory_identities(identities, &child, remaining)?,
-            Err(_) => {
-                let file = directory.open_child_file(&name).map_err(|_| {
-                    "lifecycle allocation entry is not an authenticated file or directory"
-                        .to_owned()
-                })?;
-                merge_open_file_identity(identities, &file)?;
+impl PublicProcessExecutor {
+    fn execute_cli_observed(
+        &mut self,
+        executable: &str,
+        args: &[String],
+    ) -> Result<Execution, String> {
+        if args == ["--info"] {
+            return execute_process(executable, args);
+        }
+        let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+        for flag in ["--input", "--nodes", "--edges", "--path", "--output"] {
+            if let Some(path) = argument_path(args, flag) {
+                self.allocation_paths.insert(if path.is_absolute() {
+                    path.to_path_buf()
+                } else {
+                    cwd.join(path)
+                });
             }
         }
-    }
-    Ok(())
-}
-
-fn merge_open_file_identity(
-    identities: &mut BTreeMap<String, u64>,
-    file: &fs::File,
-) -> Result<(), String> {
-    let identity = graphforge_filesystem::file_identity(file)
-        .map_err(|_| "lifecycle allocation identity unavailable".to_owned())?;
-    let usage = graphforge_filesystem::file_space_usage(file)
-        .map_err(|_| "lifecycle allocation usage unavailable".to_owned())?;
-    let key = format!(
-        "{:016x}:{}",
-        identity.volume_serial,
-        identity
-            .file_id
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>()
-    );
-    match identities.insert(key, usage.allocated_bytes) {
-        Some(existing) if existing != usage.allocated_bytes => {
-            Err("lifecycle allocation changed during observation".to_owned())
+        if let Some(project) = argument_path(args, "--project") {
+            self.allocation_paths.extend(
+                graphforge_storage::StorageAllocationOperation::project_paths(project)
+                    .map_err(|error| error.to_string())?,
+            );
         }
-        _ => Ok(()),
+        let paths = self.allocation_paths.iter().cloned().collect::<Vec<_>>();
+        let baseline = graphforge_storage::StorageAllocationOperation::from_paths(&paths)
+            .map_err(|error| error.to_string())?;
+        let baseline_current = baseline.totals().map_err(|error| error.to_string())?.0;
+        let input = serde_json::to_vec(&baseline.snapshot().map_err(|error| error.to_string())?)
+            .map_err(|error| error.to_string())?;
+        let mut result = execute_process_with_allocation(executable, args, Some(input))?;
+        if result.exit_code != Some(0) || result.failure.is_some() {
+            result.receipts.retain(|receipt| {
+                receipt.get("contract").and_then(serde_json::Value::as_str)
+                    != Some("graphforge-allocation-operation/1")
+            });
+            return Ok(result);
+        }
+        let reports = result
+            .receipts
+            .iter()
+            .filter(|receipt| {
+                receipt.get("contract").and_then(serde_json::Value::as_str)
+                    == Some("graphforge-allocation-operation/1")
+            })
+            .collect::<Vec<_>>();
+        let validation = (|| -> Result<bool, String> {
+            let valid = if let [report] = reports.as_slice() {
+                let current = report
+                    .get("current_allocated_bytes")
+                    .and_then(serde_json::Value::as_u64);
+                let peak = report
+                    .get("peak_allocated_bytes")
+                    .and_then(serde_json::Value::as_u64);
+                let final_state =
+                    graphforge_storage::StorageAllocationOperation::from_paths(&paths)
+                        .map_err(|error| error.to_string())?;
+                let (actual, _) = final_state.totals().map_err(|error| error.to_string())?;
+                match (current, peak) {
+                    (Some(current), Some(peak))
+                        if current == actual && peak >= current && peak >= baseline_current =>
+                    {
+                        self.lifecycle.transient_peak_storage_bytes =
+                            self.lifecycle.transient_peak_storage_bytes.max(peak);
+                        self.lifecycle.allocation =
+                            final_state.snapshot().map_err(|error| error.to_string())?;
+                        true
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            };
+            Ok(valid)
+        })();
+        if !matches!(validation, Ok(true)) {
+            result.failure = Some(FailureKind::EvidenceInvalid);
+        }
+        result.receipts.retain(|receipt| {
+            receipt.get("contract").and_then(serde_json::Value::as_str)
+                != Some("graphforge-allocation-operation/1")
+        });
+        Ok(result)
     }
 }
 
@@ -512,7 +569,11 @@ impl PhaseExecutor for PublicProcessExecutor {
             let mut peak_rss_bytes = None;
             let mut receipts = Vec::new();
             for args in commands {
-                let execution = match execute_process(&profile.executable, args) {
+                let execution = match if produce_lifecycle_storage {
+                    self.execute_cli_observed(&profile.executable, args)
+                } else {
+                    execute_process(&profile.executable, args)
+                } {
                     Ok(execution) => execution,
                     Err(_) => {
                         return Ok(Execution {
@@ -565,8 +626,26 @@ impl PhaseExecutor for PublicProcessExecutor {
             PhaseAction::GraphForgeCli { args } => (profile.executable.as_str(), args.as_slice()),
             PhaseAction::GraphForgeCliWorkflow { .. } => unreachable!("handled above"),
         };
-        let mut result = execute_process(executable, args)?;
+        let mut result = if produce_lifecycle_storage
+            && matches!(&command.action, PhaseAction::GraphForgeCli { .. })
+        {
+            self.execute_cli_observed(executable, args)?
+        } else {
+            execute_process(executable, args)?
+        };
         if result.exit_code == Some(0) && produce_lifecycle_storage {
+            if matches!(&command.action, PhaseAction::BenchmarkGenerator { .. }) {
+                let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+                for flag in ["--nodes", "--edges", "--output"] {
+                    if let Some(path) = argument_path(args, flag) {
+                        self.allocation_paths.insert(if path.is_absolute() {
+                            path.to_path_buf()
+                        } else {
+                            cwd.join(path)
+                        });
+                    }
+                }
+            }
             match self
                 .lifecycle
                 .observe(command.phase, command, &result.receipts)
@@ -581,10 +660,27 @@ impl PhaseExecutor for PublicProcessExecutor {
 }
 
 fn execute_process(executable: &str, args: &[String]) -> Result<Execution, String> {
+    execute_process_with_allocation(executable, args, None)
+}
+
+fn execute_process_with_allocation(
+    executable: &str,
+    args: &[String],
+    baseline: Option<Vec<u8>>,
+) -> Result<Execution, String> {
     let started = Instant::now();
-    let mut child = Command::new(executable)
-        .args(args)
-        .stdin(Stdio::null())
+    let diagnostic = baseline.is_some();
+    let mut command = Command::new(executable);
+    command.args(args);
+    if diagnostic {
+        command.arg("--allocation-diagnostics");
+    }
+    let mut child = command
+        .stdin(if diagnostic {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
@@ -594,6 +690,20 @@ fn execute_process(executable: &str, args: &[String]) -> Result<Execution, Strin
         .take()
         .ok_or_else(|| "public command stdout unavailable".to_owned())?;
     let stdout_reader = thread::spawn(move || read_bounded(stdout, 1_048_576));
+    let stdin_writer = if let Some(bytes) = baseline {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "private allocation stdin unavailable".to_owned())?;
+        Some(thread::spawn(move || {
+            use std::io::Write as _;
+            stdin
+                .write_all(&bytes)
+                .map_err(|_| "private allocation input write failed".to_owned())
+        }))
+    } else {
+        None
+    };
     let mut peak_rss_bytes = None;
     loop {
         peak_rss_bytes = max_optional(peak_rss_bytes, resident_bytes(child.id()));
@@ -604,13 +714,21 @@ fn execute_process(executable: &str, args: &[String]) -> Result<Execution, Strin
             let stdout = stdout_reader
                 .join()
                 .map_err(|_| "public command stdout reader failed".to_owned())??;
+            let input_result = stdin_writer
+                .map(|writer| {
+                    writer
+                        .join()
+                        .map_err(|_| "private allocation writer failed".to_owned())
+                        .and_then(|result| result)
+                })
+                .unwrap_or(Ok(()));
             let receipts = parse_receipts(
                 &stdout,
                 status.success() && args.iter().any(|argument| argument == "--json"),
             );
             let released = release_command_owned_file_cache(args);
             if !status.success() {
-                let cleanup_failure = match (receipts.as_ref().err(), released.as_ref().err()) {
+                let mut cleanup_failure = match (receipts.as_ref().err(), released.as_ref().err()) {
                     (None, None) => None,
                     (Some(receipts), None) => Some(format!(
                         "child exit preserved; receipt cleanup also failed: {receipts}"
@@ -622,12 +740,28 @@ fn execute_process(executable: &str, args: &[String]) -> Result<Execution, Strin
                         "child exit preserved; receipt cleanup also failed: {receipts}; command-owned cache release also failed: {release}"
                     )),
                 };
+                if let Err(error) = input_result {
+                    cleanup_failure = Some(match cleanup_failure {
+                        Some(existing) => format!("{existing}; {error}"),
+                        None => error,
+                    });
+                }
                 return Ok(Execution {
                     exit_code: status.code(),
                     duration_ms: millis(started.elapsed()),
                     peak_rss_bytes,
                     failure: Some(FailureKind::CommandFailed),
                     cleanup_failure,
+                    receipts: receipts.unwrap_or_default(),
+                });
+            }
+            if input_result.is_err() {
+                return Ok(Execution {
+                    exit_code: status.code(),
+                    duration_ms: millis(started.elapsed()),
+                    peak_rss_bytes,
+                    failure: Some(FailureKind::EvidenceInvalid),
+                    cleanup_failure: input_result.err(),
                     receipts: receipts.unwrap_or_default(),
                 });
             }
@@ -887,13 +1021,28 @@ fn sanitize_receipt(value: &serde_json::Value) -> Option<serde_json::Value> {
         Some("graphforge-result-sink/1") => sanitize_legacy_result_sink(object),
         Some("graphforge-result-sink/2") => sanitize_result_sink(object),
         Some("graphforge-storage-attribution-command/1") => sanitize_storage_command(object),
-        Some("graphforge-lifecycle-storage/1") => copy_closed_receipt(
+        Some("graphforge-allocation-operation/1") => copy_closed_receipt(
+            object,
+            &[
+                "contract",
+                "current_allocated_bytes",
+                "peak_allocated_bytes",
+            ],
+        )
+        .filter(|receipt| {
+            sanitized_numeric_fields(
+                receipt,
+                &["current_allocated_bytes", "peak_allocated_bytes"],
+            )
+        }),
+        Some("graphforge-lifecycle-storage/2") => copy_closed_receipt(
             object,
             &[
                 "contract",
                 "source_project_current_allocated_bytes",
                 "retained_storage_bytes",
                 "transient_peak_storage_bytes",
+                "retained_owners",
             ],
         )
         .filter(|receipt| {
@@ -904,7 +1053,7 @@ fn sanitize_receipt(value: &serde_json::Value) -> Option<serde_json::Value> {
                     "retained_storage_bytes",
                     "transient_peak_storage_bytes",
                 ],
-            )
+            ) && valid_retained_owners(receipt)
         }),
         Some("graphforge-query-qualification/1") => copy_closed_receipt(
             object,
@@ -1320,6 +1469,56 @@ fn sanitized_storage_categories(value: &serde_json::Value) -> bool {
                 })
             })
     })
+}
+
+fn valid_retained_owners(receipt: &serde_json::Value) -> bool {
+    const NAMES: [&str; 15] = [
+        "source-project-construction",
+        "source-project-import",
+        "source-project-transactions",
+        "source-project-locks",
+        "source-project-admission_lock",
+        "source-project-published",
+        "imported-project-construction",
+        "imported-project-import",
+        "imported-project-transactions",
+        "imported-project-locks",
+        "imported-project-admission_lock",
+        "imported-project-published",
+        "generated-inputs",
+        "query-results",
+        "portable-package",
+    ];
+    const FIELDS: [&str; 5] = [
+        "logical_references",
+        "logical_bytes",
+        "physical_objects",
+        "physical_logical_bytes",
+        "allocated_bytes",
+    ];
+    let Some(owners) = receipt
+        .get("retained_owners")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return false;
+    };
+    owners.len() == NAMES.len()
+        && NAMES.iter().all(|name| {
+            let Some(owner) = owners.get(*name).and_then(serde_json::Value::as_object) else {
+                return false;
+            };
+            let Some(totals) = owner.get("totals").and_then(serde_json::Value::as_object) else {
+                return false;
+            };
+            owner.len() == 1
+                && totals.len() == FIELDS.len()
+                && FIELDS.iter().all(|field| {
+                    totals
+                        .get(*field)
+                        .and_then(serde_json::Value::as_u64)
+                        .is_some()
+                })
+        })
 }
 
 fn copy_closed_receipt(
@@ -1785,6 +1984,48 @@ fn resident_bytes(_pid: u32) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn raw_owner_closure_refuses_unknown_zero_nonzero_and_alias_files() {
+        for unknown in ["zero", "nonzero", "alias"] {
+            let root = tempfile::tempdir().unwrap();
+            let known = root.path().join("known");
+            std::fs::write(&known, vec![1_u8; 8192]).unwrap();
+            let known_alias = root.path().join("known-alias");
+            std::fs::hard_link(&known, &known_alias).unwrap();
+            let paths = vec![known.clone(), known_alias];
+            let snapshot = graphforge_storage::capture_artifact_storage_ownership(&paths).unwrap();
+            let owners = std::collections::BTreeMap::from([("known".to_owned(), snapshot)]);
+            let baseline =
+                graphforge_storage::StorageAllocationOperation::from_paths(&paths).unwrap();
+            super::validate_retained_owner_facts(&baseline.snapshot().unwrap(), &owners).unwrap();
+            let missing = root.path().join("unknown");
+            match unknown {
+                "zero" => std::fs::write(&missing, []).unwrap(),
+                "nonzero" => std::fs::write(&missing, vec![2_u8; 4096]).unwrap(),
+                "alias" => std::fs::hard_link(&known, &missing).unwrap(),
+                _ => unreachable!(),
+            }
+            let baseline = graphforge_storage::StorageAllocationOperation::from_paths(&[root
+                .path()
+                .to_path_buf()])
+            .unwrap();
+            assert!(
+                super::validate_retained_owner_facts(&baseline.snapshot().unwrap(), &owners)
+                    .is_err(),
+                "{unknown}"
+            );
+            let complete = graphforge_storage::capture_artifact_storage_ownership(&[root
+                .path()
+                .to_path_buf()])
+            .unwrap();
+            super::validate_retained_owner_facts(
+                &baseline.snapshot().unwrap(),
+                &std::collections::BTreeMap::from([("complete".to_owned(), complete)]),
+            )
+            .unwrap();
+        }
+    }
+
     use super::*;
     use std::collections::VecDeque;
 
@@ -1968,8 +2209,34 @@ mod tests {
         let encoded = serde_json::to_vec(&leaked).expect("leaked receipt JSON");
         assert!(parse_receipts(&encoded, true).is_err());
 
+        let owners = [
+            "source-project-construction",
+            "source-project-import",
+            "source-project-transactions",
+            "source-project-locks",
+            "source-project-admission_lock",
+            "source-project-published",
+            "imported-project-construction",
+            "imported-project-import",
+            "imported-project-transactions",
+            "imported-project-locks",
+            "imported-project-admission_lock",
+            "imported-project-published",
+            "generated-inputs",
+            "query-results",
+            "portable-package",
+        ]
+        .into_iter()
+        .map(|name| {
+            (
+                name.to_owned(),
+                serde_json::json!({"totals": totals.clone()}),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
         let lifecycle = serde_json::json!({
-            "contract": "graphforge-lifecycle-storage/1",
+            "retained_owners": owners,
+            "contract": "graphforge-lifecycle-storage/2",
             "source_project_current_allocated_bytes": 256,
             "retained_storage_bytes": 384,
             "transient_peak_storage_bytes": 512
@@ -1988,6 +2255,18 @@ mod tests {
             let encoded = serde_json::to_vec(&malformed).expect("malformed lifecycle receipt JSON");
             assert!(parse_receipts(&encoded, true).is_err());
         }
+        for owner in lifecycle["retained_owners"].as_object().unwrap().keys() {
+            let mut malformed = lifecycle.clone();
+            malformed["retained_owners"]
+                .as_object_mut()
+                .unwrap()
+                .remove(owner);
+            assert!(parse_receipts(&serde_json::to_vec(&malformed).unwrap(), true).is_err());
+        }
+        let mut leaked_owner = lifecycle.clone();
+        leaked_owner["retained_owners"]["source-project-published"]["identity"] =
+            serde_json::json!("private");
+        assert!(parse_receipts(&serde_json::to_vec(&leaked_owner).unwrap(), true).is_err());
         let mut missing = lifecycle;
         missing
             .as_object_mut()
@@ -2109,7 +2388,7 @@ mod tests {
             "mechanics": "public-certification-v1",
             "phases": Phase::ALL,
             "evidence_schema": EVIDENCE_SCHEMA,
-            "storage_receipt": "graphforge-lifecycle-storage/1"
+            "storage_receipt": "graphforge-lifecycle-storage/2"
         }));
         profile.gate = Some(serde_json::json!({
             "requires_previous_pass": true,
@@ -2585,32 +2864,19 @@ fi
                 .unwrap()
                 .is_none()
         );
-        session.generator_observed = true;
-        session.construction_peak_observed = true;
-        session.portable_package_observed = true;
-        session.portable_import_peak_observed = true;
-        session.imported_project_observed = true;
-        let final_command = PhaseCommand {
-            phase: Phase::ReopenProof,
-            action: PhaseAction::GraphForgeCli { args: Vec::new() },
-        };
-        let receipt = session
-            .observe(Phase::ReopenProof, &final_command, &[])
-            .unwrap()
-            .unwrap();
         assert_eq!(
-            receipt["source_project_current_allocated_bytes"].as_u64(),
+            session.source_project_current_allocated_bytes,
             Some(union.allocated_bytes)
         );
         assert_ne!(
-            receipt["source_project_current_allocated_bytes"].as_u64(),
+            session.source_project_current_allocated_bytes,
             Some(selected.allocated_bytes)
         );
         fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
-    fn lifecycle_storage_deduplicates_aliases_and_finalizes_once() {
+    fn lifecycle_storage_preserves_raw_aliases_and_refuses_legacy_scalar_peak() {
         let root =
             std::env::temp_dir().join(format!("gf-certify-lifecycle-{}", std::process::id()));
         let _ = fs::remove_dir_all(&root);
@@ -2639,8 +2905,15 @@ fi
                 .unwrap()
                 .is_none()
         );
-        let one_identity_allocation = session.allocation.current_allocated_bytes();
+        let raw =
+            graphforge_storage::capture_artifact_storage_ownership(&[nodes.clone(), alias.clone()])
+                .unwrap();
+        assert_eq!(raw.totals.logical_references, 2);
+        assert_eq!(raw.totals.physical_objects, 1);
+        let one_identity_allocation = raw.totals.allocated_bytes;
         assert!(one_identity_allocation > 0);
+        // Quiescent raw facts are not an operation peak or trusted continuation.
+        assert_eq!(session.allocation.current_allocated_bytes(), 0);
 
         let ingest = PhaseCommand {
             phase: Phase::Ingest,
@@ -2669,34 +2942,81 @@ fi
         };
         session.observe(Phase::Export, &export, &[]).unwrap();
         assert!(session.portable_package_observed);
-        session.source_project_observed = true;
-        session.source_project_current_allocated_bytes = Some(one_identity_allocation);
-        session.portable_import_peak_observed = true;
-        session.imported_project_observed = true;
-
+        assert_eq!(session.transient_peak_storage_bytes, 0);
+        assert_eq!(session.allocation.current_allocated_bytes(), 0);
         let final_command = PhaseCommand {
             phase: Phase::ReopenProof,
             action: PhaseAction::GraphForgeCli { args: Vec::new() },
         };
-        let receipt = session
-            .observe(Phase::ReopenProof, &final_command, &[])
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            receipt["source_project_current_allocated_bytes"].as_u64(),
-            Some(one_identity_allocation)
-        );
-        assert_eq!(
-            receipt["retained_storage_bytes"].as_u64(),
-            Some(one_identity_allocation)
-        );
-        assert_eq!(
-            receipt["transient_peak_storage_bytes"].as_u64(),
-            Some(one_identity_allocation.saturating_add(4_096))
-        );
         assert!(
             session
                 .observe(Phase::ReopenProof, &final_command, &[])
+                .unwrap_err()
+                .contains("missing an authenticated owner or transient phase")
+        );
+        let source = root.join("source");
+        let imported = root.join("imported");
+        graphforge_storage::open_or_initialize_ephemeral_project(&source).unwrap();
+        graphforge_storage::open_or_initialize_ephemeral_project(&imported).unwrap();
+        let query_output = root.join("query.arrow");
+        fs::hard_link(&nodes, &query_output).unwrap();
+        let source_command = PhaseCommand {
+            phase: Phase::Reopen,
+            action: PhaseAction::GraphForgeCli {
+                args: vec![
+                    "--project".into(),
+                    source.to_string_lossy().into_owned(),
+                    "--output".into(),
+                    query_output.to_string_lossy().into_owned(),
+                ],
+            },
+        };
+        session
+            .observe(Phase::Reopen, &source_command, &[])
+            .unwrap();
+        let operation =
+            graphforge_storage::StorageAllocationOperation::from_paths(&[root.clone()]).unwrap();
+        let baseline_current = operation.totals().unwrap().0;
+        let temporary = root.join("transient");
+        let file = fs::File::create(&temporary).unwrap();
+        file.set_len(4096).unwrap();
+        // Write actual blocks rather than assuming sparse set_len allocation.
+        use std::io::Write as _;
+        (&file).write_all(&[7; 4096]).unwrap();
+        file.sync_all().unwrap();
+        let temporary_allocated = graphforge_filesystem::file_space_usage(&file)
+            .unwrap()
+            .allocated_bytes;
+        operation.replace_file_at(&temporary, &file).unwrap();
+        drop(file);
+        fs::remove_file(&temporary).unwrap();
+        operation.remove_file_at(&temporary).unwrap();
+        assert_eq!(
+            operation.totals().unwrap(),
+            (baseline_current, baseline_current + temporary_allocated)
+        );
+        session.allocation = operation.snapshot().unwrap();
+        session.transient_peak_storage_bytes = operation.totals().unwrap().1;
+        session.portable_import_peak_observed = true;
+        let imported_command = PhaseCommand {
+            phase: Phase::ReopenProof,
+            action: PhaseAction::GraphForgeCli {
+                args: vec!["--project".into(), imported.to_string_lossy().into_owned()],
+            },
+        };
+        let receipt = session
+            .observe(Phase::ReopenProof, &imported_command, &[])
+            .unwrap()
+            .unwrap();
+        assert_eq!(receipt["retained_storage_bytes"], baseline_current);
+        assert_eq!(
+            receipt["transient_peak_storage_bytes"],
+            baseline_current + temporary_allocated
+        );
+        assert!(valid_retained_owners(&receipt));
+        assert!(
+            session
+                .observe(Phase::ReopenProof, &imported_command, &[])
                 .unwrap_err()
                 .contains("already finalized")
         );

--- a/benchmarks/schemas/certification-evidence.json
+++ b/benchmarks/schemas/certification-evidence.json
@@ -66,9 +66,167 @@
           "items": {
             "type": "object",
             "propertyNames": {
-              "enum": ["contract", "outcome", "rows_accepted", "rows_rejected", "bytes_accepted", "construction", "format", "rows", "batches", "bytes", "complete", "result_sha256", "scalar_u64", "query_evidence", "storage", "reopen_agrees", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "transient_peak_allocated_bytes", "logical_read_bytes", "logical_write_bytes", "reader_calls", "publication_work_units", "live_nodes", "live_edges", "one_hop_rows", "two_hop_rows", "source_fingerprint", "imported_fingerprint", "equivalent", "kind", "selected_generation_class", "work_detected", "repaired_journals", "aborted_journals", "removed_generations", "preserved_unknown_entries", "deferred", "elapsed_ms", "package_digest", "transport_digest", "entry_count", "payload_bytes", "representation", "selection_fingerprint", "allocation_logical_bytes", "allocation_allocated_bytes", "allocation_physical_objects", "integrity", "compatibility", "idempotent_replay"]
+              "enum": ["retained_owners", "contract", "outcome", "rows_accepted", "rows_rejected", "bytes_accepted", "construction", "format", "rows", "batches", "bytes", "complete", "result_sha256", "scalar_u64", "query_evidence", "storage", "reopen_agrees", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "transient_peak_allocated_bytes", "logical_read_bytes", "logical_write_bytes", "reader_calls", "publication_work_units", "live_nodes", "live_edges", "one_hop_rows", "two_hop_rows", "source_fingerprint", "imported_fingerprint", "equivalent", "kind", "selected_generation_class", "work_detected", "repaired_journals", "aborted_journals", "removed_generations", "preserved_unknown_entries", "deferred", "elapsed_ms", "package_digest", "transport_digest", "entry_count", "payload_bytes", "representation", "selection_fingerprint", "allocation_logical_bytes", "allocation_allocated_bytes", "allocation_physical_objects", "integrity", "compatibility", "idempotent_replay"]
             },
             "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "contract": {
+                      "const": "graphforge-lifecycle-storage/2"
+                    }
+                  },
+                  "required": [
+                    "contract"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "contract",
+                    "source_project_current_allocated_bytes",
+                    "retained_storage_bytes",
+                    "transient_peak_storage_bytes",
+                    "retained_owners"
+                  ],
+                  "propertyNames": {
+                    "enum": [
+                      "contract",
+                      "source_project_current_allocated_bytes",
+                      "retained_storage_bytes",
+                      "transient_peak_storage_bytes",
+                      "retained_owners"
+                    ]
+                  },
+                  "properties": {
+                    "source_project_current_allocated_bytes": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "retained_storage_bytes": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "transient_peak_storage_bytes": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "retained_owners": {
+                      "type": "object",
+                      "required": [
+                        "source-project-construction",
+                        "source-project-import",
+                        "source-project-transactions",
+                        "source-project-locks",
+                        "source-project-admission_lock",
+                        "source-project-published",
+                        "imported-project-construction",
+                        "imported-project-import",
+                        "imported-project-transactions",
+                        "imported-project-locks",
+                        "imported-project-admission_lock",
+                        "imported-project-published",
+                        "generated-inputs",
+                        "query-results",
+                        "portable-package"
+                      ],
+                      "propertyNames": {
+                        "enum": [
+                          "source-project-construction",
+                          "source-project-import",
+                          "source-project-transactions",
+                          "source-project-locks",
+                          "source-project-admission_lock",
+                          "source-project-published",
+                          "imported-project-construction",
+                          "imported-project-import",
+                          "imported-project-transactions",
+                          "imported-project-locks",
+                          "imported-project-admission_lock",
+                          "imported-project-published",
+                          "generated-inputs",
+                          "query-results",
+                          "portable-package"
+                        ]
+                      },
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "totals"
+                        ],
+                        "properties": {
+                          "totals": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "logical_references",
+                              "logical_bytes",
+                              "physical_objects",
+                              "physical_logical_bytes",
+                              "allocated_bytes"
+                            ],
+                            "properties": {
+                              "logical_references": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "logical_bytes": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "physical_objects": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "physical_logical_bytes": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "allocated_bytes": {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            },
+                            "allOf": [
+                              {
+                                "if": {
+                                  "properties": {
+                                    "physical_objects": {
+                                      "const": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "physical_objects"
+                                  ]
+                                },
+                                "then": {
+                                  "properties": {
+                                    "logical_references": {
+                                      "const": 0
+                                    },
+                                    "logical_bytes": {
+                                      "const": 0
+                                    },
+                                    "physical_objects": {
+                                      "const": 0
+                                    },
+                                    "physical_logical_bytes": {
+                                      "const": 0
+                                    },
+                                    "allocated_bytes": {
+                                      "const": 0
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
               {
                 "if": {
                   "properties": {

--- a/benchmarks/schemas/certification-profile.json
+++ b/benchmarks/schemas/certification-profile.json
@@ -52,7 +52,7 @@
           "const": ["admission", "generate", "ingest", "reopen", "recount", "query", "export", "verify", "clean_import", "reopen_proof"]
         },
         "evidence_schema": { "const": "graphforge-public-certification/1" },
-        "storage_receipt": { "const": "graphforge-lifecycle-storage/1" }
+        "storage_receipt": { "const": "graphforge-lifecycle-storage/2" }
       },
       "required": ["mechanics", "phases", "evidence_schema", "storage_receipt"],
       "additionalProperties": false

--- a/benchmarks/schemas/progressive-qualification-profile.json
+++ b/benchmarks/schemas/progressive-qualification-profile.json
@@ -36,7 +36,7 @@
       "properties": {
         "mechanics": {"const": "public-certification-v1"},
         "evidence_schema": {"const": "graphforge-public-certification/1"},
-        "storage_receipt": {"const": "graphforge-lifecycle-storage/1"},
+        "storage_receipt": {"const": "graphforge-lifecycle-storage/2"},
         "phases": {
           "const": ["admission", "generate", "ingest", "reopen", "recount", "query", "export", "verify", "clean_import", "reopen_proof"]
         }

--- a/benchmarks/schemas/progressive-qualification-rung-evidence.json
+++ b/benchmarks/schemas/progressive-qualification-rung-evidence.json
@@ -80,9 +80,123 @@
         },
         "lifecycle": {
           "type": "object", "additionalProperties": false,
-          "required": ["contract", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes"],
+          "required": ["contract", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "retained_owners"],
           "properties": {
-            "contract": {"const": "graphforge-lifecycle-storage/1"},
+            "contract": {"const": "graphforge-lifecycle-storage/2"},
+            "retained_owners": {
+              "type": "object",
+              "required": [
+                "source-project-construction",
+                "source-project-import",
+                "source-project-transactions",
+                "source-project-locks",
+                "source-project-admission_lock",
+                "source-project-published",
+                "imported-project-construction",
+                "imported-project-import",
+                "imported-project-transactions",
+                "imported-project-locks",
+                "imported-project-admission_lock",
+                "imported-project-published",
+                "generated-inputs",
+                "query-results",
+                "portable-package"
+              ],
+              "propertyNames": {
+                "enum": [
+                  "source-project-construction",
+                  "source-project-import",
+                  "source-project-transactions",
+                  "source-project-locks",
+                  "source-project-admission_lock",
+                  "source-project-published",
+                  "imported-project-construction",
+                  "imported-project-import",
+                  "imported-project-transactions",
+                  "imported-project-locks",
+                  "imported-project-admission_lock",
+                  "imported-project-published",
+                  "generated-inputs",
+                  "query-results",
+                  "portable-package"
+                ]
+              },
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "totals"
+                ],
+                "properties": {
+                  "totals": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "logical_references",
+                      "logical_bytes",
+                      "physical_objects",
+                      "physical_logical_bytes",
+                      "allocated_bytes"
+                    ],
+                    "properties": {
+                      "logical_references": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "logical_bytes": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "physical_objects": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "physical_logical_bytes": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "allocated_bytes": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    },
+                    "allOf": [
+                      {
+                        "if": {
+                          "properties": {
+                            "physical_objects": {
+                              "const": 0
+                            }
+                          },
+                          "required": [
+                            "physical_objects"
+                          ]
+                        },
+                        "then": {
+                          "properties": {
+                            "logical_references": {
+                              "const": 0
+                            },
+                            "logical_bytes": {
+                              "const": 0
+                            },
+                            "physical_objects": {
+                              "const": 0
+                            },
+                            "physical_logical_bytes": {
+                              "const": 0
+                            },
+                            "allocated_bytes": {
+                              "const": 0
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
             "source_project_current_allocated_bytes": {"$ref": "#/$defs/nonnegative"},
             "retained_storage_bytes": {"$ref": "#/$defs/nonnegative"},
             "transient_peak_storage_bytes": {"$ref": "#/$defs/nonnegative"}

--- a/benchmarks/scripts/test-tiny-lifecycle-certification.py
+++ b/benchmarks/scripts/test-tiny-lifecycle-certification.py
@@ -4,10 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import os
 from pathlib import Path
+import stat
 import subprocess
+import sys
 import tempfile
 
 import jsonschema
@@ -30,6 +33,61 @@ def decoded_objects(text: str) -> list[dict[str, object]]:
         if isinstance(value, dict):
             objects.append(value)
     return objects
+
+
+def storage_totals(root: Path) -> dict[str, int]:
+    """Independent regular-file oracle, used only after every child has exited.
+
+    Directories are not data objects. Hardlinked references count once by the
+    host's device/inode identity; allocation comes from stat blocks, not EOF.
+    This final inventory cannot establish an operation's historical peak.
+    """
+    identities: dict[tuple[int, int], tuple[int, int]] = {}
+    references = logical_bytes = 0
+    if not stat.S_ISDIR(root.lstat().st_mode):
+        raise SystemExit("allocation oracle requires a non-linked directory")
+    for directory, directories, files in os.walk(root, followlinks=False):
+        for name in directories:
+            if not stat.S_ISDIR((Path(directory) / name).lstat().st_mode):
+                raise SystemExit("allocation oracle encountered a linked directory")
+        for name in files:
+            path = Path(directory) / name
+            before = path.lstat()
+            if not stat.S_ISREG(before.st_mode):
+                raise SystemExit("allocation oracle encountered a non-regular file")
+            descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+            try:
+                observed = os.fstat(descriptor)
+                after = path.lstat()
+            finally:
+                os.close(descriptor)
+            facts = [
+                (
+                    value.st_dev,
+                    value.st_ino,
+                    value.st_size,
+                    value.st_blocks,
+                    value.st_mtime_ns,
+                    value.st_ctime_ns,
+                )
+                for value in (before, observed, after)
+            ]
+            if facts[0] != facts[1] or facts[1] != facts[2]:
+                raise SystemExit("allocation oracle requires a quiescent inventory")
+            identity = (observed.st_dev, observed.st_ino)
+            physical = (observed.st_size, observed.st_blocks * 512)
+            if identity in identities and identities[identity] != physical:
+                raise SystemExit("allocation oracle found inconsistent alias facts")
+            identities[identity] = physical
+            references += 1
+            logical_bytes += observed.st_size
+    return {
+        "logical_references": references,
+        "logical_bytes": logical_bytes,
+        "physical_objects": len(identities),
+        "physical_logical_bytes": sum(logical for logical, _ in identities.values()),
+        "allocated_bytes": sum(allocated for _, allocated in identities.values()),
+    }
 
 
 def main() -> None:
@@ -62,6 +120,10 @@ def main() -> None:
     )
     with tempfile.TemporaryDirectory(prefix="gf-tiny-lifecycle-", dir=workspace_root) as directory:
         work = Path(directory)
+        # Native refresh materializations must share the admitted project volume.
+        runtime_tmp = work / "runtime-tmp"
+        runtime_tmp.mkdir()
+        environment["TMPDIR"] = str(runtime_tmp)
         evidence_path = work / "evidence.json"
         completed = subprocess.run(
             [
@@ -161,15 +223,31 @@ def main() -> None:
                 or source.get("result_sha256") != imported.get("result_sha256")
             ):
                 raise SystemExit("tiny source/imported result fingerprints differ")
+        snapshots = [
+            receipt["storage"]
+            for phase in evidence["phases"]
+            for receipt in phase.get("receipts", [])
+            if receipt.get("contract") == "graphforge-storage-attribution-command/1"
+        ]
+        if len(snapshots) != 2 or any(
+            not 0 < snapshot["physical_objects"] < snapshot["logical_references"]
+            for snapshot in snapshots
+        ):
+            raise SystemExit(
+                "tiny source/imported snapshots did not prove shared-object deduplication"
+            )
         receipts = [
             (phase["phase"], receipt)
             for phase in evidence["phases"]
             for receipt in phase.get("receipts", [])
-            if receipt.get("contract") == "graphforge-lifecycle-storage/1"
+            if receipt.get("contract") == "graphforge-lifecycle-storage/2"
         ]
         if len(receipts) != 1 or receipts[0][0] != "reopen_proof":
             raise SystemExit("expected exactly one lifecycle receipt at reopen_proof")
         receipt = receipts[0][1]
+        sys.path.insert(0, str(root / "harness"))
+        consumer = importlib.import_module("graphforge_bench.progressive_run")
+        consumer.validate_lifecycle_storage_receipt(receipt)
         retained = receipt.get("retained_storage_bytes")
         peak = receipt.get("transient_peak_storage_bytes")
         if (
@@ -179,6 +257,24 @@ def main() -> None:
             or peak < retained
         ):
             raise SystemExit("lifecycle receipt is not a closed allocation high-water")
+        workspace = work / "workspace" / "tiny"
+        measured = storage_totals(workspace)["allocated_bytes"]
+        if retained != measured:
+            raise SystemExit(
+                f"lifecycle retained allocation {retained} "
+                f"differs from independent union {measured}"
+            )
+        for name, private in {
+            "source-project-construction": workspace / "source" / ".graphforge-construction",
+            "source-project-import": workspace / "source" / "import-sessions",
+            "source-project-transactions": workspace / "source" / "transactions",
+            "imported-project-transactions": workspace / "imported" / "transactions",
+        }.items():
+            measured_owner = storage_totals(private)
+            if measured_owner["allocated_bytes"] <= 0:
+                raise SystemExit("tiny lifecycle omitted live private/control allocation")
+            if receipt["retained_owners"][name]["totals"] != measured_owner:
+                raise SystemExit(f"lifecycle owner {name} differs from independent raw facts")
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/host_run_fixture.py
+++ b/benchmarks/tests/host_run_fixture.py
@@ -67,6 +67,9 @@ def write_host_bundle(output: Path, scale: int, plan: dict | None = None) -> Non
     # Keep its native union above every owner view and below their sum.
     receipts["reopen_proof"][-1]["retained_storage_bytes"] = 500
     receipts["reopen_proof"][-1]["transient_peak_storage_bytes"] = 600
+    receipts["reopen_proof"][-1]["retained_owners"]["source-project-construction"]["totals"] = dict(
+        receipts["ingest"][0]["construction"]["construction_staging"]
+    )
     gf = graphforge(scale, receipts)
     gf["profile_id"] = plan["identities"]["profile_id"]
     authority = benchexec(gf)

--- a/benchmarks/tests/lifecycle_storage_fixture.py
+++ b/benchmarks/tests/lifecycle_storage_fixture.py
@@ -1,0 +1,24 @@
+"""Synthetic owner views for adapter tests; never used as measured evidence."""
+
+from graphforge_bench.progressive_run import RETAINED_OWNER_NAMES
+
+
+def retained_owners(source: int, imported: int, portable: int, staging: int = 0) -> dict:
+    allocations = {
+        "source-project-published": source,
+        "imported-project-published": imported,
+        "portable-package": portable,
+        "source-project-construction": staging,
+    }
+    return {
+        name: {
+            "totals": {
+                "logical_references": int(allocations.get(name, 0) > 0),
+                "logical_bytes": allocations.get(name, 0),
+                "physical_objects": int(allocations.get(name, 0) > 0),
+                "physical_logical_bytes": allocations.get(name, 0),
+                "allocated_bytes": allocations.get(name, 0),
+            }
+        }
+        for name in RETAINED_OWNER_NAMES
+    }

--- a/benchmarks/tests/test_native_ladder_controller.py
+++ b/benchmarks/tests/test_native_ladder_controller.py
@@ -289,7 +289,7 @@ class NativeLadderControllerTests(unittest.TestCase):
             write_host_bundle(output, 22)
             paths = [output / "s20-rung.json", output / "s22-rung.json"]
             qualification = build_native(paths, work_root=work, reserved_headroom_bytes=1)
-            self.assertEqual(qualification["schema"], "graphforge-g500-ladder-qualification/3")
+            self.assertEqual(qualification["schema"], "graphforge-g500-ladder-qualification/4")
             retained = work / "workspace" / "s20"
             retained.mkdir(parents=True)
             with self.assertRaisesRegex(StorageQualificationError, "not been reclaimed"):

--- a/benchmarks/tests/test_progressive_provider_plan.py
+++ b/benchmarks/tests/test_progressive_provider_plan.py
@@ -14,6 +14,7 @@ from graphforge_bench.progressive_provider_plan import (
     plan_provider_ladder,
     require_execution_authority,
 )
+from tests.lifecycle_storage_fixture import retained_owners
 
 ROOT = Path(__file__).resolve().parents[1]
 COMMIT = subprocess.run(
@@ -95,7 +96,8 @@ def storage_attribution(scale: int) -> dict:
             "allocation_physical_objects": 0,
         },
         "lifecycle": {
-            "contract": "graphforge-lifecycle-storage/1",
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": retained_owners(105, 120, 0),
             "source_project_current_allocated_bytes": 105,
             "retained_storage_bytes": 200,
             "transient_peak_storage_bytes": 300,

--- a/benchmarks/tests/test_progressive_qualification.py
+++ b/benchmarks/tests/test_progressive_qualification.py
@@ -18,6 +18,7 @@ from graphforge_bench.progressive_qualification import (
     select_next,
 )
 from jsonschema import Draft202012Validator
+from tests.lifecycle_storage_fixture import retained_owners
 
 ROOT = Path(__file__).resolve().parents[1]
 CAPACITY = {
@@ -130,7 +131,13 @@ def storage_attribution(scale: int, multiplier: int) -> dict:
             "allocation_physical_objects": 1,
         },
         "lifecycle": {
-            "contract": "graphforge-lifecycle-storage/1",
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": retained_owners(
+                450_000 * multiplier,
+                450_000 * multiplier,
+                300_000 * multiplier,
+                120_000 * multiplier,
+            ),
             "source_project_current_allocated_bytes": 450_000 * multiplier,
             "retained_storage_bytes": 1_000_000 * multiplier,
             "transient_peak_storage_bytes": 1_500_000 * multiplier,

--- a/benchmarks/tests/test_progressive_run.py
+++ b/benchmarks/tests/test_progressive_run.py
@@ -31,9 +31,11 @@ from graphforge_bench.progressive_run import (
     resolve_executables,
     run,
     validate_fixture_bundle,
+    validate_lifecycle_storage_receipt,
     write_plan,
     write_s20_projection,
 )
+from tests.lifecycle_storage_fixture import retained_owners
 
 ROOT = Path(__file__).resolve().parents[1]
 COMMIT = "78b75aed8fef71cfa3e4700b80a05d6b71e64f22"
@@ -231,7 +233,8 @@ def authoritative_receipts(scale: int) -> dict[str, list[dict]]:
             two_hop,
             imported_storage,
             {
-                "contract": "graphforge-lifecycle-storage/1",
+                "contract": "graphforge-lifecycle-storage/2",
+                "retained_owners": retained_owners(105, 120, 150, 50),
                 "source_project_current_allocated_bytes": 105,
                 "retained_storage_bytes": 200,
                 "transient_peak_storage_bytes": 300,
@@ -343,6 +346,56 @@ def rung_storage_attribution(scale: int) -> dict:
 
 
 class ProgressiveRunControllerTests(unittest.TestCase):
+    def test_lifecycle_owner_reconciliation_preserves_aliases_and_rejects_omissions(self) -> None:
+        receipt = authoritative_receipts(18)["reopen_proof"][-1]
+        # Overlapping owner views sum above the actual union; no additive estimate is used.
+        validate_lifecycle_storage_receipt(receipt)
+        for name in receipt["retained_owners"]:
+            with self.subTest(missing_owner=name):
+                missing = copy.deepcopy(receipt)
+                del missing["retained_owners"][name]
+                with self.assertRaises(ControllerError):
+                    validate_lifecycle_storage_receipt(missing)
+        for field, value in (
+            ("retained_storage_bytes", 149),
+            ("retained_storage_bytes", 426),
+            ("transient_peak_storage_bytes", 199),
+            ("source_project_current_allocated_bytes", 104),
+            ("contract", "graphforge-lifecycle-storage/1"),
+        ):
+            with self.subTest(field=field, value=value):
+                invalid = copy.deepcopy(receipt)
+                invalid[field] = value
+                with self.assertRaises(ControllerError):
+                    validate_lifecycle_storage_receipt(invalid)
+        for field in (
+            "allocated_bytes",
+            "physical_logical_bytes",
+            "logical_bytes",
+            "logical_references",
+        ):
+            with self.subTest(empty_owner_field=field):
+                invalid = copy.deepcopy(receipt)
+                invalid["retained_owners"]["source-project-locks"]["totals"][field] = 1
+                with self.assertRaises(ControllerError):
+                    validate_lifecycle_storage_receipt(invalid)
+        empty_file = copy.deepcopy(receipt)
+        empty_file["retained_owners"]["source-project-locks"]["totals"].update(
+            logical_references=1, physical_objects=1
+        )
+        validate_lifecycle_storage_receipt(empty_file)
+        for field, value in (
+            ("logical_references", 0),
+            ("physical_logical_bytes", 151),
+            ("allocated_bytes", True),
+            ("native_identity", "must-not-be-exposed"),
+        ):
+            with self.subTest(owner_field=field):
+                invalid = copy.deepcopy(receipt)
+                invalid["retained_owners"]["portable-package"]["totals"][field] = value
+                with self.assertRaises(ControllerError):
+                    validate_lifecycle_storage_receipt(invalid)
+
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.base = Path(self.temporary.name)
@@ -630,7 +683,7 @@ class ProgressiveRunControllerTests(unittest.TestCase):
         missing_lifecycle = authoritative_receipts(18)
         missing_lifecycle["reopen_proof"] = missing_lifecycle["reopen_proof"][:-1]
         changed_gf = graphforge(18, missing_lifecycle)
-        with self.assertRaisesRegex(ControllerError, "graphforge-lifecycle-storage/1"):
+        with self.assertRaisesRegex(ControllerError, "graphforge-lifecycle-storage/2"):
             assemble_rung_evidence(
                 root=ROOT, scale=18, graphforge=changed_gf, benchexec=benchexec(changed_gf)
             )

--- a/benchmarks/tests/test_progressive_storage_qualification.py
+++ b/benchmarks/tests/test_progressive_storage_qualification.py
@@ -135,11 +135,11 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
             reserved_headroom_bytes=overrides.get("reserved_headroom_bytes", RESERVED_BYTES),
         )
 
-    def test_two_complete_adjacent_rungs_produce_valid_exact_v3_evidence(self) -> None:
+    def test_two_complete_adjacent_rungs_produce_valid_exact_v4_evidence(self) -> None:
         low, high = self.source_pair()
         evidence = self.build_pair()
         validate(evidence)
-        self.assertEqual(evidence["schema"], "graphforge-g500-ladder-qualification/3")
+        self.assertEqual(evidence["schema"], "graphforge-g500-ladder-qualification/4")
         self.assertEqual(evidence["projection"]["source_rungs"], ["S20", "S22"])
         self.assertEqual(
             evidence["projection"]["rate"],
@@ -150,7 +150,7 @@ class ProgressiveStorageQualificationTests(unittest.TestCase):
                 "denominator_count": high["storage_attribution"]["counts"]["source_edges"],
             },
         )
-        self.assertEqual(len(evidence["rungs"][0]["artifacts"]), 9)
+        self.assertEqual(len(evidence["rungs"][0]["artifacts"]), 24)
         self.assertEqual(len(evidence["rungs"][0]["phases"]), 9)
         staging = next(
             item

--- a/benchmarks/tests/test_smoke.py
+++ b/benchmarks/tests/test_smoke.py
@@ -7,6 +7,7 @@ import unittest
 
 from graphforge_bench.smoke import FIXTURE_DIRECTORIES, discover_fixtures, workspace_root
 from jsonschema import Draft202012Validator
+from tests.lifecycle_storage_fixture import retained_owners
 
 
 class WorkspaceSmokeTests(unittest.TestCase):
@@ -58,7 +59,8 @@ class WorkspaceSmokeTests(unittest.TestCase):
         )
         validator = Draft202012Validator(schema)
         receipt = {
-            "contract": "graphforge-lifecycle-storage/1",
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": retained_owners(1024, 1024, 1024),
             "source_project_current_allocated_bytes": 1024,
             "retained_storage_bytes": 2048,
             "transient_peak_storage_bytes": 4096,
@@ -83,6 +85,17 @@ class WorkspaceSmokeTests(unittest.TestCase):
             }
 
         validator.validate(evidence(receipt))
+        historical = {key: value for key, value in receipt.items() if key != "retained_owners"}
+        historical["contract"] = "graphforge-lifecycle-storage/1"
+        validator.validate(evidence(historical))
+        self.assertFalse(validator.is_valid(evidence({**receipt, "storage": {"identity": "raw"}})))
+        for name in receipt["retained_owners"]:
+            invalid = {**receipt, "retained_owners": dict(receipt["retained_owners"])}
+            del invalid["retained_owners"][name]
+            self.assertFalse(validator.is_valid(evidence(invalid)))
+        invalid = {**receipt, "retained_owners": retained_owners(1024, 1024, 1024)}
+        invalid["retained_owners"]["source-project-locks"]["totals"]["allocated_bytes"] = 1
+        self.assertFalse(validator.is_valid(evidence(invalid)))
         for missing in (
             "source_project_current_allocated_bytes",
             "retained_storage_bytes",

--- a/crates/graphforge-api/src/allocation_diagnostics.rs
+++ b/crates/graphforge-api/src/allocation_diagnostics.rs
@@ -1,0 +1,59 @@
+//! First-party, explicit storage qualification context. This is not a public
+//! receipt format and does not change ordinary facade options or requests.
+use crate::{GfError, GraphForge, PortableV2ImportRequest, PortableV2ImportResult};
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+
+#[doc(hidden)]
+pub struct StorageAllocationDiagnostics {
+    allocation: graphforge_storage::StorageAllocationOperation,
+}
+impl StorageAllocationDiagnostics {
+    /// Admit a bounded private owner continuation before opening a project.
+    ///
+    /// # Errors
+    /// Rejects missing, malformed, inconsistent, or oversized input.
+    pub fn read(input: impl std::io::Read) -> Result<Self, GfError> {
+        Ok(Self {
+            allocation: graphforge_storage::StorageAllocationOperation::read_private(input)?,
+        })
+    }
+    /// Open through the ordinary facade with explicit allocation diagnostics.
+    ///
+    /// # Errors
+    /// Returns ordinary open and diagnostic ownership errors.
+    pub fn open(&self, path: &Path) -> Result<GraphForge, GfError> {
+        GraphForge::open_with_allocation_diagnostics(path, self.allocation.clone())
+    }
+    /// Import through the ordinary static facade with explicit diagnostics.
+    ///
+    /// # Errors
+    /// Returns ordinary portable import and diagnostic ownership errors.
+    pub fn import(
+        &self,
+        path: &Path,
+        request: &PortableV2ImportRequest,
+        cancelled: Option<&AtomicBool>,
+    ) -> Result<PortableV2ImportResult, graphforge_core::portable::PortableV2Error> {
+        let path = graphforge_storage::StorageAllocationOperation::resolve_project_path(path)
+            .map_err(|_| {
+                graphforge_core::portable::PortableV2Error::new(
+                    graphforge_core::portable::PortableV2ErrorCode::InvalidPath,
+                    "invalid diagnostic import target path",
+                )
+            })?;
+        GraphForge::import_portable_v2_with_allocation(
+            &path,
+            request,
+            cancelled,
+            Some(&self.allocation),
+        )
+    }
+    /// Return identity-free current and peak allocation for the private consumer.
+    ///
+    /// # Errors
+    /// Refuses a poisoned accounting context.
+    pub fn totals(&self) -> Result<(u64, u64), GfError> {
+        self.allocation.totals()
+    }
+}

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -250,6 +250,7 @@ impl GraphForge {
 
     fn refresh_worker_handle(&self) -> Self {
         Self {
+            allocation_operation: self.allocation_operation.clone(),
             #[cfg(test)]
             last_mutation_outcome: std::sync::Mutex::new(None),
             identity: self.identity.clone(),

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -330,6 +330,7 @@ struct SessionManifest {
 
 /// Owned handle for a durable staged import. The handle contains no live rows.
 pub struct GraphImportSession {
+    allocation_operation: Option<graphforge_storage::StorageAllocationOperation>,
     root: PathBuf,
     manifest: SessionManifest,
     observed: Instant,
@@ -369,8 +370,9 @@ impl GraphForge {
             construction_session_uuid: None,
             updated_unix_millis: unix_millis()?,
         };
-        write_manifest(&root, &manifest)?;
+        write_manifest_with_allocation(&root, &manifest, self.allocation_operation.as_ref())?;
         Ok(GraphImportSession {
+            allocation_operation: self.allocation_operation.clone(),
             root,
             manifest,
             observed: Instant::now(),
@@ -391,6 +393,7 @@ impl GraphForge {
             return Err(validation("terminal import sessions cannot be resumed"));
         }
         Ok(GraphImportSession {
+            allocation_operation: self.allocation_operation.clone(),
             root,
             manifest,
             observed: Instant::now(),
@@ -438,6 +441,7 @@ impl GraphForge {
                 continue;
             }
             GraphImportSession {
+                allocation_operation: self.allocation_operation.clone(),
                 root,
                 manifest,
                 observed: Instant::now(),
@@ -450,6 +454,52 @@ impl GraphForge {
 }
 
 impl GraphImportSession {
+    fn publish_source(&self, temporary: &Path, destination: &Path) -> Result<(), GfError> {
+        let observed = if let Some(allocation) = &self.allocation_operation {
+            let directory = graphforge_filesystem::StableDirectory::open(
+                temporary
+                    .parent()
+                    .ok_or_else(|| storage("import temporary has no parent"))?,
+            )
+            .map_err(storage)?;
+            let file = directory
+                .open_child_file(
+                    temporary
+                        .file_name()
+                        .ok_or_else(|| storage("import temporary has no name"))?,
+                )
+                .map_err(storage)?;
+            allocation.replace_file_at(temporary, &file)?;
+            Some(file)
+        } else {
+            None
+        };
+        fs::rename(temporary, destination).map_err(storage)?;
+        if let (Some(allocation), Some(file)) = (&self.allocation_operation, observed) {
+            allocation.remove_file_at(destination)?;
+            allocation.replace_file_at(destination, &file)?;
+            allocation.remove_file_at(temporary)?;
+        }
+        Ok(())
+    }
+
+    fn persist_manifest(&self) -> Result<(), GfError> {
+        write_manifest_with_allocation(
+            &self.root,
+            &self.manifest,
+            self.allocation_operation.as_ref(),
+        )
+    }
+
+    fn cleanup_source(&self, destination: &Path) -> Result<(), GfError> {
+        if fs::remove_file(destination).is_ok()
+            && let Some(allocation) = &self.allocation_operation
+        {
+            allocation.remove_file_at(destination)?;
+        }
+        Ok(())
+    }
+
     /// Durable identifier used for resume.
     #[must_use]
     pub const fn session_uuid(&self) -> Uuid {
@@ -506,7 +556,7 @@ impl GraphImportSession {
             .get_mut()
             .sync_all_and_release()
             .map_err(storage)?;
-        fs::rename(&temporary, &destination).map_err(storage)?;
+        self.publish_source(&temporary, &destination)?;
         let result = self.register_record(
             source_kind,
             name,
@@ -514,7 +564,7 @@ impl GraphImportSession {
             rows,
         );
         if result.is_err() {
-            let _ = fs::remove_file(destination);
+            self.cleanup_source(&destination)?;
         }
         result
     }
@@ -562,7 +612,7 @@ impl GraphImportSession {
             let _ = fs::remove_file(&temporary);
             return Err(storage("Parquet source length changed while copying"));
         }
-        fs::rename(&temporary, &destination).map_err(storage)?;
+        self.publish_source(&temporary, &destination)?;
         let result = self.register_record(
             match kind {
                 BulkInputKind::Node => ImportSourceKind::ParquetNodes,
@@ -573,7 +623,7 @@ impl GraphImportSession {
             0,
         );
         if result.is_err() {
-            let _ = fs::remove_file(destination);
+            self.cleanup_source(&destination)?;
         }
         result
     }
@@ -586,7 +636,7 @@ impl GraphImportSession {
             );
         self.observed = Instant::now();
         self.manifest.updated_unix_millis = unix_millis()?;
-        write_manifest(&self.root, &self.manifest)?;
+        self.persist_manifest()?;
         Ok(self.manifest.progress.clone())
     }
 
@@ -635,13 +685,13 @@ impl GraphImportSession {
                         batch_index += 1;
                         self.manifest.sources[source_index].batches_staged = batch_index;
                         self.manifest.sources[source_index].inflight_batch = None;
-                        write_manifest(&self.root, &self.manifest)?;
+                        self.persist_manifest()?;
                         return Ok(());
                     }
                     let recovering = source.inflight_batch == Some(batch_index);
                     if !recovering {
                         self.manifest.sources[source_index].inflight_batch = Some(batch_index);
-                        write_manifest(&self.root, &self.manifest)?;
+                        self.persist_manifest()?;
                     }
                     let chunk_id = format!("import-{:020}-{:020}", source.sequence, batch_index);
                     let staged = match (input_kind, cancellation) {
@@ -666,7 +716,7 @@ impl GraphImportSession {
                             .progress
                             .rows_rejected
                             .saturating_add((batch.num_rows() as u64).min(remaining));
-                        write_manifest(&self.root, &self.manifest)?;
+                        self.persist_manifest()?;
                         return Err(error);
                     }
                     batch_index += 1;
@@ -683,13 +733,13 @@ impl GraphImportSession {
                         .peak_batch_rows
                         .max(batch.num_rows() as u64);
                     self.update_construction_progress(&construction.progress())?;
-                    write_manifest(&self.root, &self.manifest)?;
+                    self.persist_manifest()?;
                     Ok(())
                 })?;
                 self.manifest.sources[source_index].staged = true;
                 self.manifest.progress.files_pending =
                     self.manifest.progress.files_pending.saturating_sub(1);
-                write_manifest(&self.root, &self.manifest)?;
+                self.persist_manifest()?;
             }
         }
         construction.validate_and_seal(cancellation)?;
@@ -723,7 +773,7 @@ impl GraphImportSession {
             }
             Err(error) => {
                 self.manifest.phase = ImportPhase::Quarantined;
-                let _ = write_manifest(&self.root, &self.manifest);
+                let _ = self.persist_manifest();
                 Err(error)
             }
         }
@@ -793,7 +843,7 @@ impl GraphImportSession {
         }
         let session = graph.begin_graph_construction(budgets)?;
         self.manifest.construction_session_uuid = Some(session.session_uuid());
-        write_manifest(&self.root, &self.manifest)?;
+        self.persist_manifest()?;
         Ok(session)
     }
 
@@ -1151,14 +1201,36 @@ fn import_root(graph: &GraphForge, session_uuid: Uuid) -> Result<PathBuf, GfErro
     Ok(sessions.join(session_uuid.hyphenated().to_string()))
 }
 
+#[cfg(test)]
 fn write_manifest(root: &Path, manifest: &SessionManifest) -> Result<(), GfError> {
+    write_manifest_with_allocation(root, manifest, None)
+}
+
+fn write_manifest_with_allocation(
+    root: &Path,
+    manifest: &SessionManifest,
+    allocation: Option<&graphforge_storage::StorageAllocationOperation>,
+) -> Result<(), GfError> {
     let temporary = root.join("manifest.tmp");
     let mut file = BufWriter::new(File::create(&temporary).map_err(storage)?);
     serde_json::to_writer(&mut file, manifest).map_err(storage)?;
     file.flush().map_err(storage)?;
     file.get_ref().sync_all().map_err(storage)?;
+    let observed = if let Some(allocation) = allocation {
+        allocation.replace_file_at(&temporary, file.get_ref())?;
+        Some(file.get_ref().try_clone().map_err(storage)?)
+    } else {
+        None
+    };
     drop(file);
-    fs::rename(temporary, root.join(MANIFEST)).map_err(storage)
+    let target = root.join(MANIFEST);
+    fs::rename(&temporary, &target).map_err(storage)?;
+    if let (Some(allocation), Some(file)) = (allocation, observed) {
+        allocation.remove_file_at(&target)?;
+        allocation.replace_file_at(&target, &file)?;
+        allocation.remove_file_at(&temporary)?;
+    }
+    Ok(())
 }
 
 fn read_manifest(root: &Path) -> Result<SessionManifest, GfError> {

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -421,6 +421,7 @@ struct GenerationPropertyAuthority {
 /// resolved [`OntologyMode`], an optional compiled ontology, and a shared
 /// [`RuntimeCatalog`] that the binder grows as it observes new labels/properties.
 pub struct GraphForge {
+    allocation_operation: Option<graphforge_storage::StorageAllocationOperation>,
     /// Opaque ownership token for public handles created by this instance.
     identity: GraphIdentity,
     /// The configured path, if the instance is Parquet-backed; `None` for an
@@ -605,6 +606,32 @@ impl GraphForge {
         Self::new_with_options(path, GraphForgeOptions::default())
     }
 
+    /// Open a project for first-party allocation qualification using an explicit
+    /// pre-operation owner context. Ordinary facade options remain unchanged.
+    ///
+    /// # Errors
+    /// Returns ordinary project-open errors and allocation evidence errors.
+    #[doc(hidden)]
+    pub(crate) fn open_with_allocation_diagnostics(
+        path: &std::path::Path,
+        allocation: graphforge_storage::StorageAllocationOperation,
+    ) -> Result<Self, GfError> {
+        let path = graphforge_storage::StorageAllocationOperation::resolve_project_path(path)?;
+        let (options, policy) = GraphForgeOptions::default().validate()?;
+        let (resolved, recovery) =
+            graphforge_storage::open_or_initialize_project_with_allocation(&path, &allocation)?;
+        let mut graph = Self::open_resolved_with_options(
+            path.clone(),
+            resolved,
+            false,
+            options,
+            policy,
+            recovery,
+        )?;
+        graph.allocation_operation = Some(allocation);
+        Ok(graph)
+    }
+
     /// Create a facade with an explicit embedded project-write policy.
     ///
     /// # Errors
@@ -658,6 +685,7 @@ impl GraphForge {
             last_mutation_outcome: Mutex::new(None),
             graph_visibility: Arc::new(write_modes::WriteCoordinator::new(&options)),
             write_options: options,
+            allocation_operation: None,
             heavy_query_admission: Arc::new(resource_policy::HeavyQueryAdmission::new(
                 resource_policy.max_concurrent_heavy_queries,
             )),
@@ -867,6 +895,7 @@ impl GraphForge {
             last_mutation_outcome: Mutex::new(None),
             graph_visibility: Arc::new(write_modes::WriteCoordinator::new(&write_options)),
             write_options,
+            allocation_operation: None,
             resource_policy,
             compute_pool,
             heavy_query_admission,
@@ -3457,13 +3486,30 @@ impl GraphForge {
         let stream = self.execute_stream_with_params(cypher, params)?;
         let schema = stream.schema();
         let result = self.block_on(async {
-            graphforge_io::sink_record_batch_stream(
+            graphforge_io::sink_record_batch_stream_observed(
                 stream,
                 schema,
                 std::path::Path::new(path),
                 format,
                 options,
                 || cancellation.is_some_and(CancellationToken::is_cancelled),
+                |path, file| {
+                    let Some(allocation) = &self.allocation_operation else {
+                        return Ok(());
+                    };
+                    let path = if path.is_absolute() {
+                        path.to_path_buf()
+                    } else {
+                        std::env::current_dir()
+                            .map_err(|error| error.to_string())?
+                            .join(path)
+                    };
+                    match file {
+                        Some(file) => allocation.replace_file_at(&path, file),
+                        None => allocation.remove_file_at(&path),
+                    }
+                    .map_err(|error| error.to_string())
+                },
             )
             .await
             .map_err(|error| {
@@ -20765,3 +20811,7 @@ pub use graphforge_core::portable::{
 };
 pub use graphforge_portable_oci::{HttpOciRegistry, MemoryOciRegistry, PortableV2OciRegistry};
 pub use portable_oci::{PortableV2OciPublishRequest, PortableV2OciPullRequest};
+
+mod allocation_diagnostics;
+#[doc(hidden)]
+pub use allocation_diagnostics::StorageAllocationDiagnostics;

--- a/crates/graphforge-api/src/portable.rs
+++ b/crates/graphforge-api/src/portable.rs
@@ -448,13 +448,14 @@ impl GraphForge {
         };
         let default_cancelled = AtomicBool::new(false);
         let cancelled = cancelled.unwrap_or(&default_cancelled);
-        let receipt = graphforge_storage::export_complete_portable_v2(
+        let receipt = graphforge_storage::export_complete_portable_v2_with_allocation(
             &plan,
             &request.output_path,
             request.representation,
             request.limits,
             cancelled,
             progress,
+            self.allocation_operation.as_ref(),
         )?;
         Ok(PortableV2ExportFacadeResult {
             contract: "graphforge-portable-export/2",
@@ -541,9 +542,18 @@ impl GraphForge {
         request: &PortableV2ImportRequest,
         cancelled: Option<&AtomicBool>,
     ) -> Result<PortableV2ImportResult, graphforge_core::portable::PortableV2Error> {
+        Self::import_portable_v2_with_allocation(project_root, request, cancelled, None)
+    }
+
+    pub(crate) fn import_portable_v2_with_allocation(
+        project_root: &Path,
+        request: &PortableV2ImportRequest,
+        cancelled: Option<&AtomicBool>,
+        allocation: Option<&graphforge_storage::StorageAllocationOperation>,
+    ) -> Result<PortableV2ImportResult, graphforge_core::portable::PortableV2Error> {
         let generation_uuid =
             graphforge_core::uuid::portable_v2_import_generation(&request.operation_id.0);
-        let receipt = graphforge_storage::import_complete_portable_v2(
+        let receipt = graphforge_storage::import_complete_portable_v2_with_allocation(
             &request.input,
             project_root,
             request.operation_id.0,
@@ -551,6 +561,8 @@ impl GraphForge {
             &supported_capabilities(),
             request.limits,
             cancelled,
+            |_| {},
+            allocation,
         )?;
         let root = project_root.to_str().ok_or_else(|| {
             graphforge_core::portable::PortableV2Error::new(
@@ -558,7 +570,13 @@ impl GraphForge {
                 "invalid project path",
             )
         })?;
-        let reopened = Self::new(Some(root)).map_err(|_| {
+        let reopened = match allocation {
+            Some(allocation) => {
+                Self::open_with_allocation_diagnostics(project_root, allocation.clone())
+            }
+            None => Self::new(Some(root)),
+        }
+        .map_err(|_| {
             graphforge_core::portable::PortableV2Error::new(
                 graphforge_core::portable::PortableV2ErrorCode::Io,
                 "imported project did not reopen",

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -72,7 +72,35 @@ impl GraphForge {
         }
         let parent_topology_generation = graphforge_storage::read_topology_generation(&self.dir)?;
         let project = self.resolved_generation.container_root();
-        let inner = if self.ontology_mode == OntologyMode::Exploratory {
+        let inner = if let Some(allocation) = &self.allocation_operation {
+            let authority = if self.ontology_mode == OntologyMode::Exploratory {
+                None
+            } else {
+                Some(graphforge_storage::ConstructionSemanticAuthority {
+                    composition: self
+                        .workspace_ontology_composition()?
+                        .ok_or_else(|| validation("construction semantic composition is absent"))?,
+                    bindings: self
+                        .semantic_storage_bindings
+                        .lock()
+                        .expect("semantic storage binding lock poisoned")
+                        .clone()
+                        .ok_or_else(|| validation("construction semantic bindings are absent"))?,
+                })
+            };
+            graphforge_storage::GraphConstructionSession::open_with_allocation(
+                project,
+                &self.dir,
+                session_uuid,
+                parent_topology_generation,
+                self.ontology_mode,
+                authority,
+                budgets,
+                self.lifecycle_mode,
+                resume,
+                allocation,
+            )?
+        } else if self.ontology_mode == OntologyMode::Exploratory {
             if resume {
                 graphforge_storage::GraphConstructionSession::resume_with_mode_and_lifecycle_from_graph(
                     project,

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "2e9d24ea3fc8ae0300399f986a947c72a7b5df7cf77e592f54d24237c226c8b2"
+EXPECTED_RUST_DIGEST = "c07b80a5bb8c6d907d1c02d0862702965c94730e21bd71302e0288ba2c7af4b1"
 EXPECTED_RELEASE_DIGEST = "88063e340c9fe29d290dda9442a4e8aa8311d0515a3154ed69340b23c3bfc4ae"
 
 PYTHON_ONLY_METHODS = frozenset(

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -221,6 +221,10 @@ fn load_skill_bundle(root: &Path) -> Result<OwnedSkillBundle, graphforge_api::Gf
 #[derive(Parser)]
 #[command(name = "graphforge", version, about = "GraphForge CLI")]
 struct Cli {
+    /// First-party qualification channel; input contains no graph payload.
+    #[arg(long, global = true, hide = true)]
+    allocation_diagnostics: bool,
+
     /// Print version info and exit.
     #[arg(long)]
     info: bool,
@@ -329,6 +333,7 @@ fn run_storage_attribution(
     path: &Path,
     json: bool,
     output: &mut dyn Write,
+    allocation: Option<&graphforge_api::StorageAllocationDiagnostics>,
 ) -> Result<(), graphforge_api::GfError> {
     let storage = graph.storage_attribution_receipt()?;
     storage.validate_reconciliation()?;
@@ -336,7 +341,7 @@ fn run_storage_attribution(
     let path_text = path.to_str().ok_or_else(|| {
         graphforge_api::GfError::Validation("--project must be valid UTF-8".into())
     })?;
-    let reopened = GraphForge::new(Some(path_text))?;
+    let reopened = open_cli_graph(Path::new(path_text), allocation)?;
     let reopened_storage = reopened.storage_attribution_receipt()?;
     reopened_storage.validate_reconciliation()?;
     if reopened_storage != storage {
@@ -1226,6 +1231,48 @@ impl From<graphforge_api::MultiOntologyError> for CliRuntimeError {
 
 #[allow(clippy::too_many_lines)]
 fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, CliRuntimeError> {
+    let allocation = if cli.allocation_diagnostics {
+        if !cli.json {
+            return Err(graphforge_api::GfError::Validation(
+                "allocation diagnostics require --json".into(),
+            )
+            .into());
+        }
+        Some(graphforge_api::StorageAllocationDiagnostics::read(
+            std::io::stdin().lock(),
+        )?)
+    } else {
+        None
+    };
+    let result = run_with_allocation(cli, output, allocation.as_ref())?;
+    if let Some(allocation) = allocation {
+        let (current, peak) = allocation.totals()?;
+        serde_json::to_writer(&mut *output, &serde_json::json!({"contract":"graphforge-allocation-operation/1", "current_allocated_bytes":current, "peak_allocated_bytes":peak})).map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
+        writeln!(output).map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
+    }
+    Ok(result)
+}
+
+fn open_cli_graph(
+    path: &Path,
+    allocation: Option<&graphforge_api::StorageAllocationDiagnostics>,
+) -> Result<GraphForge, graphforge_api::GfError> {
+    if let Some(allocation) = allocation {
+        allocation.open(path)
+    } else {
+        let path = path.to_str().ok_or_else(|| {
+            graphforge_api::GfError::Validation("--project must be valid UTF-8".into())
+        })?;
+        GraphForge::new(Some(path))
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_with_allocation(
+    cli: Cli,
+    output: &mut dyn Write,
+    allocation: Option<&graphforge_api::StorageAllocationDiagnostics>,
+) -> Result<i32, CliRuntimeError> {
     if cli.info {
         writeln!(output, "graphforge {}", env!("CARGO_PKG_VERSION"))
             .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))?;
@@ -1266,22 +1313,27 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, CliRuntimeError> {
                     command,
                     cli.json,
                     output,
+                    allocation,
                 )
                 .map(|()| 0);
             }
             portable_cli::PortableCommand::Import(_) => {
                 let path = resolve_project_path(cli.project, cli.project_dir)?;
-                return portable_cli::run_portable_without_graph(&path, command, cli.json, output)
-                    .map(|()| 0);
+                return portable_cli::run_portable_without_graph(
+                    &path, command, cli.json, output, allocation,
+                )
+                .map(|()| 0);
             }
             command => {
                 let path = resolve_project_path(cli.project, cli.project_dir)?;
                 let path_text = path.to_str().ok_or_else(|| {
                     graphforge_api::GfError::Validation("--project must be valid UTF-8".into())
                 })?;
-                let mut graph = GraphForge::new(Some(path_text))?;
-                return portable_cli::run_portable(&mut graph, &path, command, cli.json, output)
-                    .map(|()| 0);
+                let mut graph = open_cli_graph(Path::new(path_text), allocation)?;
+                return portable_cli::run_portable(
+                    &mut graph, &path, command, cli.json, output, allocation,
+                )
+                .map(|()| 0);
             }
         }
     }
@@ -1300,7 +1352,7 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, CliRuntimeError> {
     let path_text = path.to_str().ok_or_else(|| {
         graphforge_api::GfError::Validation("--project must be valid UTF-8".into())
     })?;
-    let mut graph = GraphForge::new(Some(path_text))?;
+    let mut graph = open_cli_graph(Path::new(path_text), allocation)?;
     let command = match command {
         Command::Export(args) => {
             return run_export(&graph, args, cli.json, output)
@@ -1323,7 +1375,7 @@ fn run(cli: Cli, output: &mut dyn Write) -> Result<i32, CliRuntimeError> {
                 .map_err(Into::into);
         }
         Command::StorageAttribution => {
-            return run_storage_attribution(graph, &path, cli.json, output)
+            return run_storage_attribution(graph, &path, cli.json, output, allocation)
                 .map(|()| 0)
                 .map_err(Into::into);
         }

--- a/crates/graphforge-cli/src/portable_cli.rs
+++ b/crates/graphforge-cli/src/portable_cli.rs
@@ -218,6 +218,7 @@ pub(crate) fn run_portable(
     command: PortableCommand,
     json: bool,
     output: &mut dyn Write,
+    allocation: Option<&graphforge_api::StorageAllocationDiagnostics>,
 ) -> Result<(), crate::CliRuntimeError> {
     match command {
         PortableCommand::Preview(args) => {
@@ -288,7 +289,7 @@ pub(crate) fn run_portable(
             }
         },
         command => {
-            return run_portable_without_graph(project_root, command, json, output);
+            return run_portable_without_graph(project_root, command, json, output, allocation);
         }
     }
     Ok(())
@@ -309,6 +310,7 @@ pub(crate) fn run_portable_without_graph(
     command: PortableCommand,
     json: bool,
     output: &mut dyn Write,
+    allocation: Option<&graphforge_api::StorageAllocationDiagnostics>,
 ) -> Result<(), crate::CliRuntimeError> {
     match command {
         PortableCommand::Preview(_)
@@ -340,15 +342,15 @@ pub(crate) fn run_portable_without_graph(
             Ok(())
         }
         PortableCommand::Import(args) => {
-            let result = GraphForge::import_portable_v2(
-                project_root,
-                &PortableV2ImportRequest {
-                    input: args.input,
-                    operation_id: OperationId(canonical_uuid(&args.idempotency_key)?),
-                    limits: PortableV2Limits::default(),
-                },
-                None,
-            )
+            let request = PortableV2ImportRequest {
+                input: args.input,
+                operation_id: OperationId(canonical_uuid(&args.idempotency_key)?),
+                limits: PortableV2Limits::default(),
+            };
+            let result = match allocation {
+                Some(allocation) => allocation.import(project_root, &request, None),
+                None => GraphForge::import_portable_v2(project_root, &request, None),
+            }
             .map_err(map_portable)?;
             let transient_peak_allocated_bytes = import_transient_peak(&result)?;
             if json {

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -633,6 +633,13 @@ impl io::Seek for WindowsCasWriter {
 
 #[cfg(windows)]
 impl WindowsCasWriter {
+    /// Borrow the owned writer for first-party metadata accounting.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn as_file(&self) -> &File {
+        &self.file
+    }
+
     /// Flush the exact retained writer.
     pub fn sync_all(&self) -> io::Result<()> {
         self.file.sync_all()

--- a/crates/graphforge-io/src/lib.rs
+++ b/crates/graphforge-io/src/lib.rs
@@ -163,32 +163,50 @@ fn temp_bytes(temporary: &tempfile::NamedTempFile) -> u64 {
         .map_or(0, |metadata| metadata.len())
 }
 
-async fn drain_stream<E, F>(
+fn check_sink_cancellation(
+    cancelled: bool,
+    started: Instant,
+    rows: u64,
+    batches: u64,
+    temporary: &tempfile::NamedTempFile,
+) -> Result<(), ResultSinkError> {
+    if cancelled {
+        Err(failure(
+            started,
+            "cancelled",
+            rows,
+            batches,
+            temp_bytes(temporary),
+            "operation was cancelled",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+async fn drain_stream<E, F, O>(
     stream: &mut Pin<Box<dyn Stream<Item = Result<RecordBatch, E>> + Send>>,
     writer: &mut IncrementalWriter,
     schema: &SchemaRef,
     options: &ResultSinkOptions,
-    temporary: &tempfile::NamedTempFile,
+    ownership: &mut ObservedSinkGuard<O>,
     started: Instant,
     cancelled: &mut F,
 ) -> Result<(u64, u64), ResultSinkError>
 where
     E: Display,
     F: FnMut() -> bool,
+    O: FnMut(&Path, Option<&std::fs::File>) -> Result<(), String>,
 {
+    let temporary = ownership
+        .temporary
+        .as_ref()
+        .expect("retained sink temporary");
+    let observed = &mut ownership.observed;
     let mut rows = 0_u64;
     let mut batches = 0_u64;
     loop {
-        if cancelled() {
-            return Err(failure(
-                started,
-                "cancelled",
-                rows,
-                batches,
-                temp_bytes(temporary),
-                "operation was cancelled",
-            ));
-        }
+        check_sink_cancellation(cancelled(), started, rows, batches, temporary)?;
         let Some(item) = stream.next().await else {
             break;
         };
@@ -226,16 +244,7 @@ where
                 ),
             ));
         }
-        if cancelled() {
-            return Err(failure(
-                started,
-                "cancelled",
-                rows,
-                batches,
-                temp_bytes(temporary),
-                "operation was cancelled",
-            ));
-        }
+        check_sink_cancellation(cancelled(), started, rows, batches, temporary)?;
         #[cfg(test)]
         if FAIL_WRITE_AFTER_BATCHES.with(|limit| batches >= limit.get()) {
             return Err(failure(
@@ -251,6 +260,16 @@ where
             failure(
                 started,
                 "write",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                error,
+            )
+        })?;
+        observed(temporary.path(), Some(temporary.as_file())).map_err(|error| {
+            failure(
+                started,
+                "observe",
                 rows,
                 batches,
                 temp_bytes(temporary),
@@ -285,16 +304,44 @@ impl IncrementalWriter {
 /// successful writer close and file sync. Pulling only after each write gives
 /// the writer natural backpressure over query execution.
 pub async fn sink_record_batch_stream<E, F>(
+    stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, E>> + Send>>,
+    schema: SchemaRef,
+    destination: &Path,
+    format: ResultSinkFormat,
+    options: &ResultSinkOptions,
+    cancelled: F,
+) -> Result<ResultSinkReceipt, ResultSinkError>
+where
+    E: Display,
+    F: FnMut() -> bool,
+{
+    sink_record_batch_stream_observed(
+        stream,
+        schema,
+        destination,
+        format,
+        options,
+        cancelled,
+        |_, _| Ok(()),
+    )
+    .await
+}
+
+/// First-party file ownership observations at the existing result writer boundaries.
+#[doc(hidden)]
+pub async fn sink_record_batch_stream_observed<E, F, O>(
     mut stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, E>> + Send>>,
     schema: SchemaRef,
     destination: &Path,
     format: ResultSinkFormat,
     options: &ResultSinkOptions,
     mut cancelled: F,
+    observed: O,
 ) -> Result<ResultSinkReceipt, ResultSinkError>
 where
     E: Display,
     F: FnMut() -> bool,
+    O: FnMut(&Path, Option<&std::fs::File>) -> Result<(), String>,
 {
     let started = Instant::now();
     if options.max_row_group_rows == 0 || options.max_batch_rows == 0 {
@@ -315,50 +362,61 @@ where
         .prefix(".graphforge-result-")
         .tempfile_in(parent)
         .map_err(|error| failure(started, "create", 0, 0, 0, error.to_string()))?;
-    let writer_file = temporary
-        .reopen()
-        .map_err(|error| failure(started, "create", 0, 0, 0, error.to_string()))?;
-    let mut writer = create_writer(writer_file, &schema, format, options)
-        .map_err(|error| failure(started, "create", 0, 0, 0, error))?;
-    let (rows, batches) = drain_stream(
-        &mut stream,
-        &mut writer,
-        &schema,
-        options,
-        &temporary,
-        started,
-        &mut cancelled,
-    )
-    .await?;
-    writer.finish().map_err(|error| {
-        failure(
+    let mut ownership = ObservedSinkGuard {
+        temporary: Some(temporary),
+        observed,
+    };
+    let (rows, batches) = ownership
+        .write_stream(
+            &mut stream,
+            &schema,
+            format,
+            options,
+            &mut cancelled,
             started,
-            "finish",
-            rows,
-            batches,
-            temp_bytes(&temporary),
-            error,
         )
-    })?;
-    temporary.as_file().sync_all().map_err(|error| {
+        .await?;
+    let temporary = ownership
+        .temporary
+        .as_ref()
+        .expect("retained sink temporary");
+    let mut observed = &mut ownership.observed;
+    let temporary_path = temporary.path().to_path_buf();
+    let final_bytes = temp_bytes(temporary);
+    let temporary = ownership.temporary.take().expect("retained sink temporary");
+    let published = match temporary.persist(destination) {
+        Ok(published) => published,
+        Err(error) => {
+            let failure = failure(
+                started,
+                "publish",
+                rows,
+                batches,
+                final_bytes,
+                error.error.to_string(),
+            );
+            cleanup_observed_sink(error.file, &mut observed);
+            return Err(failure);
+        }
+    };
+    observed(&temporary_path, None).map_err(|error| {
         failure(
             started,
-            "sync",
-            rows,
-            batches,
-            temp_bytes(&temporary),
-            error.to_string(),
-        )
-    })?;
-    let final_bytes = temp_bytes(&temporary);
-    temporary.persist(destination).map_err(|error| {
-        failure(
-            started,
-            "publish",
+            "published-observe",
             rows,
             batches,
             final_bytes,
-            error.error.to_string(),
+            error,
+        )
+    })?;
+    observed(destination, Some(&published)).map_err(|error| {
+        failure(
+            started,
+            "published-observe",
+            rows,
+            batches,
+            final_bytes,
+            error,
         )
     })?;
     Ok(ResultSinkReceipt {
@@ -373,6 +431,93 @@ where
             complete: true,
         },
     })
+}
+
+struct ObservedSinkGuard<O: FnMut(&Path, Option<&std::fs::File>) -> Result<(), String>> {
+    temporary: Option<tempfile::NamedTempFile>,
+    observed: O,
+}
+impl<O: FnMut(&Path, Option<&std::fs::File>) -> Result<(), String>> ObservedSinkGuard<O> {
+    async fn write_stream<E: Display, F: FnMut() -> bool>(
+        &mut self,
+        stream: &mut Pin<Box<dyn Stream<Item = Result<RecordBatch, E>> + Send>>,
+        schema: &SchemaRef,
+        format: ResultSinkFormat,
+        options: &ResultSinkOptions,
+        cancelled: &mut F,
+        started: Instant,
+    ) -> Result<(u64, u64), ResultSinkError> {
+        let writer_file = self
+            .temporary
+            .as_ref()
+            .expect("retained sink temporary")
+            .reopen()
+            .map_err(|error| failure(started, "create", 0, 0, 0, error.to_string()))?;
+        let mut writer = create_writer(writer_file, schema, format, options)
+            .map_err(|error| failure(started, "create", 0, 0, 0, error))?;
+        let (rows, batches) = drain_stream(
+            stream,
+            &mut writer,
+            schema,
+            options,
+            self,
+            started,
+            cancelled,
+        )
+        .await?;
+        let temporary = self.temporary.as_ref().expect("retained sink temporary");
+        writer.finish().map_err(|error| {
+            failure(
+                started,
+                "finish",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                error,
+            )
+        })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            failure(
+                started,
+                "sync",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                error.to_string(),
+            )
+        })?;
+        (self.observed)(temporary.path(), Some(temporary.as_file())).map_err(|error| {
+            failure(
+                started,
+                "observe",
+                rows,
+                batches,
+                temp_bytes(temporary),
+                error,
+            )
+        })?;
+        Ok((rows, batches))
+    }
+}
+
+impl<O: FnMut(&Path, Option<&std::fs::File>) -> Result<(), String>> Drop for ObservedSinkGuard<O> {
+    fn drop(&mut self) {
+        if let Some(temporary) = self.temporary.take() {
+            cleanup_observed_sink(temporary, &mut self.observed);
+        }
+    }
+}
+
+fn cleanup_observed_sink(
+    temporary: tempfile::NamedTempFile,
+    observed: &mut impl FnMut(&Path, Option<&std::fs::File>) -> Result<(), String>,
+) {
+    let path = temporary.path().to_path_buf();
+    let _ = observed(&path, Some(temporary.as_file()));
+    // Never remove evidence for a retained file after a failed unlink.
+    if temporary.close().is_ok() {
+        let _ = observed(&path, None);
+    }
 }
 
 #[must_use]
@@ -426,6 +571,95 @@ mod tests {
         batches: Vec<RecordBatch>,
     ) -> Pin<Box<dyn Stream<Item = Result<RecordBatch, String>> + Send>> {
         Box::pin(stream::iter(batches.into_iter().map(Ok)))
+    }
+
+    #[test]
+    fn dropping_pending_observed_sink_releases_temporary_ownership() {
+        use std::future::Future;
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("result.arrow");
+        let (schema, batches) = fixture();
+        let input =
+            stream::iter(vec![Ok::<_, String>(batches[0].clone())]).chain(stream::pending());
+        let live = Arc::new(std::sync::Mutex::new(std::collections::BTreeMap::new()));
+        let reported = Arc::clone(&live);
+        let options = ResultSinkOptions::default();
+        let mut future = Box::pin(sink_record_batch_stream_observed(
+            Box::pin(input),
+            schema,
+            &destination,
+            ResultSinkFormat::ArrowIpc,
+            &options,
+            || false,
+            move |path, file| {
+                let mut live = reported.lock().unwrap();
+                if let Some(file) = file {
+                    live.insert(path.to_path_buf(), file.metadata().unwrap().len());
+                } else {
+                    assert!(!path.exists());
+                    live.remove(path);
+                }
+                Ok(())
+            },
+        ));
+        let waker = futures::task::noop_waker();
+        let mut context = std::task::Context::from_waker(&waker);
+        assert!(future.as_mut().poll(&mut context).is_pending());
+        assert!(live.lock().unwrap().values().any(|bytes| *bytes > 0));
+        drop(future);
+        assert!(live.lock().unwrap().is_empty());
+        assert!(!destination.exists());
+        assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn observed_partial_failure_and_cancellation_release_only_removed_temporary() {
+        for cancel in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let destination = root.path().join("result.arrow");
+            std::fs::write(&destination, b"original destination").unwrap();
+            let (schema, batches) = fixture();
+            let stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, String>> + Send>> =
+                Box::pin(stream::iter(vec![
+                    Ok(batches[0].clone()),
+                    Err("intentional execution failure".to_owned()),
+                ]));
+            let seen_write = std::cell::Cell::new(false);
+            let mut live = std::collections::BTreeMap::new();
+            let mut observed_nonempty = false;
+            let error = futures::executor::block_on(sink_record_batch_stream_observed(
+                stream,
+                schema,
+                &destination,
+                ResultSinkFormat::ArrowIpc,
+                &ResultSinkOptions::default(),
+                || cancel && seen_write.get(),
+                |path, file| {
+                    if let Some(file) = file {
+                        let bytes = file.metadata().unwrap().len();
+                        observed_nonempty |= bytes > 0;
+                        live.insert(path.to_path_buf(), bytes);
+                        seen_write.set(true);
+                    } else {
+                        assert!(!path.exists());
+                        assert!(live.remove(path).is_some());
+                    }
+                    Ok(())
+                },
+            ))
+            .unwrap_err();
+            assert_eq!(error.phase, if cancel { "cancelled" } else { "execute" });
+            if !cancel {
+                assert!(error.to_string().contains("intentional execution failure"));
+            }
+            assert!(observed_nonempty);
+            assert!(live.is_empty());
+            assert_eq!(
+                std::fs::read(&destination).unwrap(),
+                b"original destination"
+            );
+            assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 1);
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/allocation_operation.rs
+++ b/crates/graphforge-storage/src/allocation_operation.rs
@@ -1,0 +1,374 @@
+//! Explicit, operation-scoped allocation accounting for first-party diagnostics.
+//!
+//! The context retains the current owner union and a numeric high-water mark,
+//! never an event history. Writers report actual file facts at their existing
+//! installation/removal boundaries. No process-global observer is installed.
+
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use graphforge_core::GfError;
+
+use crate::{StorageAllocationLifecycle, StorageAllocationTransition};
+
+/// First-party operation evidence context. Native identities must remain on
+/// the private diagnostic channel and must not enter ordinary CLI receipts.
+#[doc(hidden)]
+#[derive(Clone, Debug, Default)]
+pub struct StorageAllocationOperation {
+    state: Arc<Mutex<StorageAllocationLifecycle>>,
+}
+
+impl StorageAllocationOperation {
+    /// Resolve the project and its exact sibling admission control for a private baseline.
+    ///
+    /// # Errors
+    /// Rejects paths that cannot use the normal filesystem admission resolution.
+    pub fn project_paths(path: &Path) -> Result<[std::path::PathBuf; 2], GfError> {
+        let (root, parent, lock) =
+            crate::filesystem_admission::retained_project_control_paths(path)?;
+        Ok([root, parent.join(lock)])
+    }
+
+    /// Capture a quiescent baseline from explicitly declared artifact paths.
+    /// This never runs during an active writer and never reads payload bytes.
+    ///
+    /// # Errors
+    /// Rejects links, special files, unresolved paths, and oversized inventories.
+    pub fn from_paths(paths: &[std::path::PathBuf]) -> Result<Self, GfError> {
+        let operation = Self::default();
+        let mut directories = Vec::new();
+        let mut remaining = 1_000_000_usize;
+        for path in paths {
+            Self::file_owner(path)?;
+            let metadata = match std::fs::symlink_metadata(path) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(GfError::Storage(error.to_string())),
+            };
+            if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                directories.push(
+                    graphforge_filesystem::StableDirectory::open(path)
+                        .map_err(|error| GfError::Storage(error.to_string()))?,
+                );
+            } else if metadata.is_file() && !metadata.file_type().is_symlink() {
+                let parent = path
+                    .parent()
+                    .ok_or_else(|| GfError::Storage("allocation path has no parent".into()))?;
+                let directory = graphforge_filesystem::StableDirectory::open(parent)
+                    .map_err(|error| GfError::Storage(error.to_string()))?;
+                let file =
+                    directory
+                        .open_child_file(path.file_name().ok_or_else(|| {
+                            GfError::Storage("allocation path has no name".into())
+                        })?)
+                        .map_err(|error| GfError::Storage(error.to_string()))?;
+                operation.replace_file_at(path, &file)?;
+            } else {
+                return Err(GfError::Storage(
+                    "allocation baseline contains a link or special file".into(),
+                ));
+            }
+        }
+        while let Some(directory) = directories.pop() {
+            let names = directory
+                .child_names_bounded(remaining)
+                .map_err(|error| GfError::Storage(error.to_string()))?;
+            remaining = remaining.checked_sub(names.len()).ok_or_else(|| {
+                GfError::Storage("allocation baseline exceeds entry bound".into())
+            })?;
+            for name in names {
+                if let Ok(child) = directory.open_child_directory(&name) {
+                    directories.push(child);
+                } else {
+                    let file = directory
+                        .open_child_file(&name)
+                        .map_err(|error| GfError::Storage(error.to_string()))?;
+                    operation.replace_file_at(&directory.path().join(&name), &file)?;
+                }
+            }
+        }
+        Ok(operation)
+    }
+
+    /// Read a bounded private continuation before any project mutation.
+    ///
+    /// # Errors
+    /// Rejects missing, oversized, malformed, or inconsistent ownership input.
+    pub fn read_private(input: impl std::io::Read) -> Result<Self, GfError> {
+        Self::read_private_bounded(input, 256 * 1024 * 1024)
+    }
+
+    fn read_private_bounded(
+        mut input: impl std::io::Read,
+        max_bytes: u64,
+    ) -> Result<Self, GfError> {
+        use std::io::Read as _;
+        // One million bounded owner references plus active identities fit this
+        // channel limit; this is not a graph payload or public receipt channel.
+        let mut bytes = Vec::new();
+        input
+            .by_ref()
+            .take(max_bytes + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|error| GfError::Storage(error.to_string()))?;
+        if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > max_bytes {
+            return Err(GfError::Storage(
+                "private allocation input exceeds bound".into(),
+            ));
+        }
+        let state = serde_json::from_slice(&bytes)
+            .map_err(|_| GfError::Storage("private allocation input is malformed".into()))?;
+        Self::from_lifecycle(state)
+    }
+
+    /// Retain the first-party certifier's existing union across one subprocess.
+    pub fn from_lifecycle(state: StorageAllocationLifecycle) -> Result<Self, GfError> {
+        state.validate_continuation()?;
+        Ok(Self {
+            state: Arc::new(Mutex::new(state)),
+        })
+    }
+
+    /// Return bounded state for the private first-party continuation channel.
+    ///
+    /// # Errors
+    /// Refuses a poisoned accounting context.
+    pub fn snapshot(&self) -> Result<StorageAllocationLifecycle, GfError> {
+        Ok(self.state.lock().map_err(poisoned)?.clone())
+    }
+
+    /// Start from the actual owners retained immediately before the operation.
+    ///
+    /// # Errors
+    /// Rejects inconsistent native identity facts and allocation overflow.
+    pub fn from_owners(owners: &BTreeMap<String, BTreeMap<String, u64>>) -> Result<Self, GfError> {
+        let mut state = StorageAllocationLifecycle::default();
+        for (owner, identities) in owners {
+            state.replace_owner(owner, identities)?;
+        }
+        Ok(Self {
+            state: Arc::new(Mutex::new(state)),
+        })
+    }
+
+    /// Record an actual writer transition, retaining aliases held by other owners.
+    ///
+    /// # Errors
+    /// Rejects inconsistent native identity facts and allocation overflow.
+    pub fn transition(
+        &self,
+        owner: &str,
+        transition: &StorageAllocationTransition,
+    ) -> Result<(), GfError> {
+        self.state
+            .lock()
+            .map_err(poisoned)?
+            .apply_owner_transition(owner, transition)
+    }
+
+    /// Resolve the project using the ordinary admission path authority.
+    ///
+    /// # Errors
+    /// Rejects unsafe paths using ordinary admission rules.
+    pub fn resolve_project_path(path: &Path) -> Result<std::path::PathBuf, GfError> {
+        crate::filesystem_admission::retained_project_control_paths(path).map(|(root, _, _)| root)
+    }
+
+    /// Stable private owner key for one resolved file route.
+    ///
+    /// # Errors
+    /// Rejects unresolved relative routes.
+    pub fn file_owner(path: &Path) -> Result<String, GfError> {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        if !path.is_absolute() {
+            return Err(GfError::Storage(
+                "allocation file owner requires a resolved absolute path".into(),
+            ));
+        }
+        let digest = Sha256::digest(path.as_os_str().as_encoded_bytes());
+        let mut key = String::with_capacity(69);
+        key.push_str("file:");
+        for byte in digest {
+            key.push(char::from(HEX[usize::from(byte >> 4)]));
+            key.push(char::from(HEX[usize::from(byte & 15)]));
+        }
+        Ok(key)
+    }
+
+    /// Snapshot one resolved writer route without following its pathname.
+    ///
+    /// # Errors
+    /// Requires an absolute route and consistent actual file metadata.
+    pub fn replace_file_at(&self, path: &Path, file: &File) -> Result<(), GfError> {
+        self.replace_file(&Self::file_owner(path)?, file)
+    }
+
+    /// Remove a successfully unlinked resolved writer route.
+    ///
+    /// # Errors
+    /// Requires an absolute route and a healthy accounting context.
+    pub fn remove_file_at(&self, path: &Path) -> Result<(), GfError> {
+        self.remove_owner(&Self::file_owner(path)?)
+    }
+
+    /// Record the allocated bytes of an open file before its installation.
+    ///
+    /// # Errors
+    /// Returns metadata, identity reconciliation, and accounting errors.
+    pub fn replace_file(&self, owner: &str, file: &File) -> Result<(), GfError> {
+        let usage = graphforge_filesystem::file_space_usage(file)
+            .map_err(|error| GfError::Storage(error.to_string()))?;
+        let identity = graphforge_filesystem::file_identity(file)
+            .map_err(|error| GfError::Storage(error.to_string()))?;
+        let identity = crate::storage_attribution::native_identity_key(
+            identity.volume_serial,
+            &identity.file_id,
+        );
+        self.state
+            .lock()
+            .map_err(poisoned)?
+            .replace_owner(owner, &BTreeMap::from([(identity, usage.allocated_bytes)]))
+    }
+
+    /// Remove a writer's reference after successful unlink/replacement.
+    ///
+    /// # Errors
+    /// Returns accounting errors without discarding other owners' aliases.
+    pub fn remove_owner(&self, owner: &str) -> Result<(), GfError> {
+        self.state.lock().map_err(poisoned)?.remove_owner(owner)
+    }
+
+    /// Return the exact current union and ordered high-water mark.
+    ///
+    /// # Errors
+    /// Refuses a poisoned accounting context.
+    pub fn totals(&self) -> Result<(u64, u64), GfError> {
+        let state = self.state.lock().map_err(poisoned)?;
+        Ok((
+            state.current_allocated_bytes(),
+            state.peak_allocated_bytes(),
+        ))
+    }
+}
+
+fn poisoned<T>(_: std::sync::PoisonError<T>) -> GfError {
+    GfError::Storage("operation allocation accounting lock poisoned".into())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn private_continuation_rejects_missing_malformed_and_oversized_input() {
+        use super::StorageAllocationOperation;
+        assert!(StorageAllocationOperation::read_private(&b""[..]).is_err());
+        assert!(StorageAllocationOperation::read_private(&b"not-json"[..]).is_err());
+        assert!(
+            StorageAllocationOperation::read_private_bounded(std::io::repeat(b' '), 32)
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds bound")
+        );
+        let original = StorageAllocationOperation::default();
+        let encoded = serde_json::to_vec(&original.snapshot().unwrap()).unwrap();
+        let admitted = StorageAllocationOperation::read_private(encoded.as_slice()).unwrap();
+        assert_eq!(admitted.totals().unwrap(), (0, 0));
+        let mut invalid = serde_json::to_value(original.snapshot().unwrap()).unwrap();
+        invalid["current_allocated_bytes"] = serde_json::json!(1);
+        assert!(
+            StorageAllocationOperation::read_private(
+                serde_json::to_vec(&invalid).unwrap().as_slice()
+            )
+            .is_err()
+        );
+    }
+
+    use super::*;
+
+    #[test]
+    fn atomic_control_replacement_removes_the_actual_baseline_owner() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("CURRENT");
+        let temporary = root.path().join("CURRENT.tmp");
+        std::fs::write(&target, vec![0_u8; 8192]).unwrap();
+        let before = StorageAllocationOperation::default();
+        let old = File::open(&target).unwrap();
+        let old_bytes = graphforge_filesystem::file_space_usage(&old)
+            .unwrap()
+            .allocated_bytes;
+        before
+            .replace_file("project-control-CURRENT", &old)
+            .unwrap();
+        drop(old);
+        let operation =
+            StorageAllocationOperation::from_lifecycle(before.snapshot().unwrap()).unwrap();
+        std::fs::write(&temporary, vec![1_u8; 16384]).unwrap();
+        let new = File::open(&temporary).unwrap();
+        let new_bytes = graphforge_filesystem::file_space_usage(&new)
+            .unwrap()
+            .allocated_bytes;
+        operation
+            .replace_file("project-control-CURRENT.tmp", &new)
+            .unwrap();
+        assert_eq!(
+            operation.totals().unwrap(),
+            (old_bytes + new_bytes, old_bytes + new_bytes)
+        );
+        std::fs::rename(&temporary, &target).unwrap();
+        operation.remove_owner("project-control-CURRENT").unwrap();
+        operation
+            .replace_file("project-control-CURRENT", &new)
+            .unwrap();
+        operation
+            .remove_owner("project-control-CURRENT.tmp")
+            .unwrap();
+        assert_eq!(
+            operation.totals().unwrap(),
+            (new_bytes, old_bytes + new_bytes)
+        );
+        let actual = File::open(&target).unwrap();
+        assert_eq!(
+            graphforge_filesystem::file_space_usage(&actual)
+                .unwrap()
+                .allocated_bytes,
+            operation.totals().unwrap().0
+        );
+    }
+
+    #[test]
+    fn operation_peak_preserves_aliases_and_transition_order() {
+        let baseline = BTreeMap::from([("baseline".into(), BTreeMap::from([("a".into(), 4096)]))]);
+        let early = StorageAllocationOperation::from_owners(&baseline).unwrap();
+        let late = StorageAllocationOperation::from_owners(&baseline).unwrap();
+        let alias_temp = StorageAllocationTransition {
+            installed: BTreeMap::from([("a".into(), 4096), ("t".into(), 32768)]),
+            removed: Default::default(),
+        };
+        let final_file = StorageAllocationTransition {
+            installed: BTreeMap::from([("f".into(), 16384)]),
+            removed: Default::default(),
+        };
+        let remove_temp = StorageAllocationTransition {
+            installed: BTreeMap::new(),
+            removed: ["t".into()].into_iter().collect(),
+        };
+        for operation in [&early, &late] {
+            operation.transition("construction", &alias_temp).unwrap();
+        }
+        early.transition("construction", &remove_temp).unwrap();
+        early.transition("construction", &final_file).unwrap();
+        late.transition("construction", &final_file).unwrap();
+        late.transition("construction", &remove_temp).unwrap();
+        assert_eq!(early.totals().unwrap(), (20480, 36864));
+        assert_eq!(late.totals().unwrap(), (20480, 53248));
+        let resumed =
+            StorageAllocationOperation::from_lifecycle(early.snapshot().unwrap()).unwrap();
+        assert_eq!(resumed.totals().unwrap(), (20480, 36864));
+        resumed.remove_owner("construction").unwrap();
+        assert_eq!(resumed.totals().unwrap(), (4096, 36864));
+        assert_eq!(early.totals().unwrap(), (20480, 36864));
+    }
+}

--- a/crates/graphforge-storage/src/construction_directory.rs
+++ b/crates/graphforge-storage/src/construction_directory.rs
@@ -1,0 +1,172 @@
+//! Construction-local retained directory plus explicit diagnostic ownership.
+//! Reads preserve the underlying no-follow authority; observed mutations are
+//! named methods rather than implicit dereferencing or ambient callbacks.
+use crate::StorageAllocationOperation;
+use graphforge_filesystem::{FileIdentity, StableDirectory};
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+pub(crate) struct ConstructionDirectory {
+    directory: StableDirectory,
+    allocation: Option<StorageAllocationOperation>,
+}
+impl ConstructionDirectory {
+    pub(crate) fn from_physical(
+        directory: &StableDirectory,
+        allocation: Option<&StorageAllocationOperation>,
+    ) -> io::Result<Self> {
+        Ok(Self {
+            directory: directory.try_clone()?,
+            allocation: allocation.cloned(),
+        })
+    }
+
+    pub(crate) fn open(path: &Path) -> io::Result<Self> {
+        Ok(Self {
+            directory: StableDirectory::open(path)?,
+            allocation: None,
+        })
+    }
+    pub(crate) fn with_allocation(
+        mut self,
+        allocation: Option<StorageAllocationOperation>,
+    ) -> Self {
+        self.allocation = allocation;
+        self
+    }
+    pub(crate) fn allocation(&self) -> Option<&StorageAllocationOperation> {
+        self.allocation.as_ref()
+    }
+    pub(crate) fn physical(&self) -> &StableDirectory {
+        &self.directory
+    }
+    pub(crate) fn path(&self) -> &Path {
+        self.directory.path()
+    }
+    pub(crate) fn identity(&self) -> FileIdentity {
+        self.directory.identity()
+    }
+    pub(crate) fn revalidate_named(&self) -> io::Result<()> {
+        self.directory.revalidate_named()
+    }
+    pub(crate) fn sync(&self) -> io::Result<()> {
+        self.directory.sync()
+    }
+    pub(crate) fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            directory: self.directory.try_clone()?,
+            allocation: self.allocation.clone(),
+        })
+    }
+    pub(crate) fn open_child_directory(&self, name: &OsStr) -> io::Result<Self> {
+        Ok(Self {
+            directory: self.directory.open_child_directory(name)?,
+            allocation: self.allocation.clone(),
+        })
+    }
+    pub(crate) fn create_child_directory(&self, name: &OsStr) -> io::Result<Self> {
+        Ok(Self {
+            directory: self.directory.create_child_directory(name)?,
+            allocation: self.allocation.clone(),
+        })
+    }
+    pub(crate) fn open_child_file(&self, name: &OsStr) -> io::Result<File> {
+        self.directory.open_child_file(name)
+    }
+    pub(crate) fn create_replaceable_child_file(&self, name: &OsStr) -> io::Result<File> {
+        self.directory.create_replaceable_child_file(name)
+    }
+    pub(crate) fn open_or_create_child_file(&self, name: &OsStr) -> io::Result<File> {
+        let file = self.directory.open_or_create_child_file(name)?;
+        self.observe_file(name, &file)?;
+        Ok(file)
+    }
+    pub(crate) fn child_names_bounded(&self, bound: usize) -> io::Result<Vec<OsString>> {
+        self.directory.child_names_bounded(bound)
+    }
+    pub(crate) fn remove_child_directory_if_identity(
+        &self,
+        name: &OsStr,
+        identity: FileIdentity,
+    ) -> io::Result<()> {
+        self.directory
+            .remove_child_directory_if_identity(name, identity)
+    }
+    pub(crate) fn create_unpublished_replaceable_child(
+        &self,
+        name: &OsStr,
+    ) -> io::Result<graphforge_filesystem::UnpublishedArtifactGuard> {
+        self.directory.create_unpublished_replaceable_child(name)
+    }
+    pub(crate) fn child_names(&self) -> io::Result<Vec<OsString>> {
+        self.directory.child_names()
+    }
+    pub(crate) fn observe_file(&self, name: &OsStr, file: &File) -> io::Result<()> {
+        if let Some(allocation) = &self.allocation {
+            allocation
+                .replace_file_at(&self.path().join(name), file)
+                .map_err(io::Error::other)?;
+        }
+        Ok(())
+    }
+    pub(crate) fn install_child(
+        &self,
+        temporary: &OsStr,
+        identity: FileIdentity,
+        target: &OsStr,
+    ) -> io::Result<()> {
+        if self.allocation.is_none() {
+            return self.directory.install_child(temporary, identity, target);
+        }
+        let file = self.directory.open_child_file(temporary)?;
+        self.observe_file(temporary, &file)?;
+        self.directory.install_child(temporary, identity, target)?;
+        self.record_replacement(temporary, target, &file)
+    }
+    pub(crate) fn replace_child(
+        &self,
+        temporary: &OsStr,
+        identity: FileIdentity,
+        target: &OsStr,
+    ) -> io::Result<()> {
+        if self.allocation.is_none() {
+            return self.directory.replace_child(temporary, identity, target);
+        }
+        let file = self.directory.open_child_file(temporary)?;
+        self.observe_file(temporary, &file)?;
+        self.directory.replace_child(temporary, identity, target)?;
+        self.record_replacement(temporary, target, &file)
+    }
+    pub(crate) fn record_replacement(
+        &self,
+        temporary: &OsStr,
+        target: &OsStr,
+        file: &File,
+    ) -> io::Result<()> {
+        if let Some(allocation) = &self.allocation {
+            allocation
+                .remove_file_at(&self.path().join(target))
+                .map_err(io::Error::other)?;
+            self.observe_file(target, file)?;
+            allocation
+                .remove_file_at(&self.path().join(temporary))
+                .map_err(io::Error::other)?;
+        }
+        Ok(())
+    }
+    pub(crate) fn unlink_child_if_identity(
+        &self,
+        name: &OsStr,
+        identity: FileIdentity,
+    ) -> io::Result<()> {
+        self.directory.unlink_child_if_identity(name, identity)?;
+        if let Some(allocation) = &self.allocation {
+            allocation
+                .remove_file_at(&self.path().join(name))
+                .map_err(io::Error::other)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/graphforge-storage/src/filesystem_admission.rs
+++ b/crates/graphforge-storage/src/filesystem_admission.rs
@@ -607,6 +607,18 @@ impl Drop for LifecycleLock {
     }
 }
 
+pub(crate) fn retained_project_control_paths(
+    root: &Path,
+) -> Result<(PathBuf, PathBuf, String), GfError> {
+    let resolved = resolve_project_path(root)?;
+    let lock_name = lifecycle_lock_name(resolved.parent.path(), &resolved.target_name);
+    Ok((
+        resolved.root,
+        resolved.parent.path().to_path_buf(),
+        lock_name,
+    ))
+}
+
 fn lifecycle_lock_name(parent: &Path, target_name: &std::ffi::OsStr) -> String {
     let mut digest = Sha256::new();
     digest.update(b"graphforge-project-lifecycle-lock/v1\0");

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::construction_directory::ConstructionDirectory as StableDirectory;
 use arrow::array::{
     Array, FixedSizeBinaryArray, MutableArrayData, RecordBatch, StringArray, UInt32Array,
     make_array,
@@ -24,7 +25,7 @@ use arrow::array::{
 use arrow::compute::take;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use graphforge_core::GfError;
-use graphforge_filesystem::{FileIdentity, StableDirectory, file_identity, file_link_count};
+use graphforge_filesystem::{FileIdentity, file_identity, file_link_count};
 use graphforge_ir::{CompositionBindingContext, CompositionBindingLimits, RuntimeCatalog};
 use graphforge_ontology::ActivationMode;
 use parquet::arrow::ArrowWriter;
@@ -1544,7 +1545,8 @@ impl GraphConstructionSession {
             return Err(storage("construction parent is no longer CURRENT"));
         }
 
-        let lease = crate::begin_graph_object_publication(admission.root())?;
+        let mut lease = crate::begin_graph_object_publication(admission.root())?;
+        lease.set_allocation_operation(self.root.allocation().cloned());
         let (mut manifest_state, manifest_read_bytes, manifest_read_calls) =
             match parent.declared_graph_files_participant()? {
                 Some(crate::GraphFilesParticipant::V2(root)) => {
@@ -1745,7 +1747,11 @@ impl GraphConstructionSession {
         };
         let publication =
             match crate::project_publication::stage_project_generation_from_admitted_parent(
-                admission, parent, &request, None,
+                admission,
+                parent,
+                &request,
+                None,
+                self.root.allocation(),
             )? {
                 crate::ProjectStageOutcome::Staged(staged) => staged
                     .validate(|_| Ok(()), |_, _| Ok(()))?
@@ -2005,12 +2011,79 @@ impl GraphConstructionSession {
         budgets: GraphConstructionBudgets,
         lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
     ) -> Result<Self, GfError> {
+        Self::open_internal_with_allocation(
+            project_dir,
+            graph_source_dir,
+            operation_uuid,
+            parent_topology_generation,
+            ontology_mode,
+            semantic_authority,
+            budgets,
+            lifecycle_mode,
+            None,
+        )
+    }
+
+    /// First-party diagnostic construction using the ordinary authority checks.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn open_with_allocation(
+        project_dir: &Path,
+        graph_source_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        ontology_mode: graphforge_core::OntologyMode,
+        semantic_authority: Option<ConstructionSemanticAuthority>,
+        budgets: GraphConstructionBudgets,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+        resume: bool,
+        allocation: &crate::StorageAllocationOperation,
+    ) -> Result<Self, GfError> {
+        if ontology_mode != graphforge_core::OntologyMode::Exploratory
+            && semantic_authority.is_none()
+        {
+            return Err(storage(
+                "strict or advisory construction requires pinned semantic authority",
+            ));
+        }
+        let parent = if resume {
+            resume_parent_topology_generation(project_dir, operation_uuid)?
+        } else {
+            parent_topology_generation
+        };
+        Self::open_internal_with_allocation(
+            project_dir,
+            graph_source_dir,
+            operation_uuid,
+            parent,
+            ontology_mode,
+            semantic_authority,
+            budgets,
+            lifecycle_mode,
+            Some(allocation),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+    fn open_internal_with_allocation(
+        project_dir: &Path,
+        graph_source_dir: &Path,
+        operation_uuid: Uuid,
+        parent_topology_generation: u64,
+        ontology_mode: graphforge_core::OntologyMode,
+        semantic_authority: Option<ConstructionSemanticAuthority>,
+        budgets: GraphConstructionBudgets,
+        lifecycle_mode: crate::filesystem_admission::ProjectLifecycleMode,
+        allocation: Option<&crate::StorageAllocationOperation>,
+    ) -> Result<Self, GfError> {
         let budgets = budgets.validate()?;
         let semantic_authority_sha256 = semantic_authority
             .as_ref()
             .map(ConstructionSemanticAuthority::digest)
             .transpose()?;
-        let project = StableDirectory::open(project_dir).map_err(storage)?;
+        let project = StableDirectory::open(project_dir)
+            .map_err(storage)?
+            .with_allocation(allocation.cloned());
         let project_identity = project.identity();
         let key = format!(
             "{}:{}:{}",
@@ -5961,9 +6034,24 @@ fn convert_identity_run(
     drop(writer);
     let published = (|| -> Result<(), GfError> {
         shape_publication_failure("install_child")?;
+        let allocation_file = if root.allocation().is_some() {
+            let file = root
+                .open_child_file(OsStr::new(&temporary))
+                .map_err(storage)?;
+            root.observe_file(OsStr::new(&temporary), &file)
+                .map_err(storage)?;
+            Some(file)
+        } else {
+            None
+        };
         publication
             .install_child(OsStr::new(output))
             .map_err(storage)?;
+        if let Some(file) = &allocation_file {
+            root.record_replacement(OsStr::new(&temporary), OsStr::new(output), file)
+                .map_err(storage)?;
+        }
+        drop(allocation_file);
         publication.sync_parent().map_err(storage)?;
         shape_publication_failure("directory_sync")?;
         shape_publication_failure("post_publication_metric_overflow")?;
@@ -6158,9 +6246,24 @@ fn copy_authenticated_run<const N: usize>(
     drop(writer);
     let published = (|| -> Result<(), GfError> {
         shape_publication_failure("install_child")?;
+        let allocation_file = if root.allocation().is_some() {
+            let file = root
+                .open_child_file(OsStr::new(&temporary))
+                .map_err(storage)?;
+            root.observe_file(OsStr::new(&temporary), &file)
+                .map_err(storage)?;
+            Some(file)
+        } else {
+            None
+        };
         publication
             .install_child(OsStr::new(output))
             .map_err(storage)?;
+        if let Some(file) = &allocation_file {
+            root.record_replacement(OsStr::new(&temporary), OsStr::new(output), file)
+                .map_err(storage)?;
+        }
+        drop(allocation_file);
         publication.sync_parent().map_err(storage)?;
         shape_publication_failure("directory_sync")?;
         shape_publication_failure("post_publication_metric_overflow")?;

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 #[cfg(test)]
 use std::cell::RefCell;
 
+use crate::construction_directory::ConstructionDirectory as StableDirectory;
 use arrow::array::{
     Array, ArrayRef, BooleanArray, FixedSizeBinaryArray, ListArray, StringArray,
     TimestampMicrosecondArray, UInt32Array, UInt64Array,
@@ -23,7 +24,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use graphforge_core::GfError;
 use graphforge_core::OntologyMode;
-use graphforge_filesystem::{StableDirectory, file_identity, file_link_count};
+use graphforge_filesystem::{file_identity, file_link_count};
 use graphforge_ir::{CompositionBindingContext, SymbolBinding};
 use graphforge_ontology::{QualifiedSymbol, SymbolKind};
 use graphforge_value::{EntityTypeId, RelationTypeId, TaggedTypeId};
@@ -705,16 +706,17 @@ pub(crate) fn encode(
 
     let identities_sha256 = shaped_output_sha256(shape_outputs, &shape.identities)?;
     let mut index = crate::uuid_membership::encode_construction_index(
-        source,
+        source.physical(),
         &shape.identities,
         identities_sha256,
-        &output,
+        output.physical(),
         generation,
         shape.parent_topology_generation,
         parent_index,
         shape.node_count,
         shape.edge_count,
         cancelled,
+        output.allocation(),
     )?;
 
     let v4 = encode_nodes(
@@ -751,7 +753,7 @@ pub(crate) fn encode(
             u64::try_from(metrics.peak_buffer_bytes).map_err(storage)?;
         let (v4_artifacts, publication, metrics) =
             crate::uuid_membership::publish_v4_construction_artifacts(
-                &output,
+                output.physical(),
                 bundle,
                 generation,
                 identities_sha256,
@@ -759,6 +761,7 @@ pub(crate) fn encode(
                     .as_ref()
                     .and_then(|(_, manifest)| parent_generation.map(|parent| (parent, manifest))),
                 cancelled,
+                output.allocation(),
             )?;
         add_evidence_counter(
             &mut evidence.input_read_bytes,
@@ -1029,9 +1032,13 @@ fn encode_nodes(
         let index = topology
             .open_child_directory(OsStr::new("uuid-membership"))
             .map_err(storage)?;
-        return crate::uuid_membership::V4OrdinalConstructionWriter::start(generation, &index)?
-            .finish()
-            .map(Some);
+        return crate::uuid_membership::V4OrdinalConstructionWriter::start_with_allocation(
+            generation,
+            index.physical(),
+            index.allocation(),
+        )?
+        .finish()
+        .map(Some);
     }
     let details_name = shape
         .node_details
@@ -1065,8 +1072,9 @@ fn encode_nodes(
         .map(|index| {
             crate::uuid_membership::V4OrdinalConstructionWriter::start_with_cache_window(
                 generation,
-                index,
+                index.physical(),
                 cache_window,
+                index.allocation(),
             )
         })
         .transpose()?;

--- a/crates/graphforge-storage/src/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/src/graph_delta_compaction.rs
@@ -362,6 +362,7 @@ fn compact_graph_delta_after_prepare(
         parent,
         &generation_request,
         Some(staging.path()),
+        None,
     )? {
         ProjectStageOutcome::Staged(staged) => {
             // Pre-publication verification authenticates the exact bounded

--- a/crates/graphforge-storage/src/graph_delta_journal.rs
+++ b/crates/graphforge-storage/src/graph_delta_journal.rs
@@ -1491,6 +1491,7 @@ fn publish_graph_delta_after_prepare(
         parent,
         &generation_request,
         Some(prepared.graph_tree_root()),
+        None,
     )? {
         ProjectStageOutcome::Staged(staged) => {
             staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()?

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -314,6 +314,15 @@ pub fn stage_graph_tree(
     generation_root: &Path,
     inventory: &GraphFilesInventory,
 ) -> Result<GraphFilesOpenEvidence, GfError> {
+    stage_graph_tree_with_allocation(source_root, generation_root, inventory, None)
+}
+
+pub(crate) fn stage_graph_tree_with_allocation(
+    source_root: &Path,
+    generation_root: &Path,
+    inventory: &GraphFilesInventory,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<GraphFilesOpenEvidence, GfError> {
     validate_inventory_contract(inventory)?;
     let destination_root = graph_tree_root(generation_root);
     if destination_root.exists() {
@@ -347,7 +356,7 @@ pub fn stage_graph_tree(
             fs::create_dir_all(parent)
                 .map_err(|error| storage("create graph tree directory", parent, error))?;
         }
-        let copied = copy_regular_file(&source, &destination)?;
+        let copied = copy_regular_file_with_allocation(&source, &destination, allocation)?;
         let digest = copied.digest;
         evidence.application_read_bytes = evidence
             .application_read_bytes
@@ -895,6 +904,42 @@ struct CopyIoEvidence {
     write_bytes: u64,
     write_calls: u64,
     fsync_calls: u64,
+}
+
+fn copy_regular_file_with_allocation(
+    source: &Path,
+    destination: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<CopyIoEvidence, GfError> {
+    let result = copy_regular_file(source, destination);
+    let observed = if let Some(allocation) = allocation {
+        (|| {
+            let parent = destination
+                .parent()
+                .ok_or_else(|| validation("graph destination has no parent"))?;
+            let directory = graphforge_filesystem::StableDirectory::open(parent)
+                .map_err(|error| storage("observe graph destination", destination, error))?;
+            let name = destination
+                .file_name()
+                .ok_or_else(|| validation("graph destination has no name"))?;
+            match directory.open_child_file(name) {
+                Ok(file) => allocation.replace_file_at(destination, &file),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound && result.is_err() => {
+                    Ok(())
+                }
+                Err(error) => Err(storage("observe graph destination", destination, error)),
+            }
+        })()
+    } else {
+        Ok(())
+    };
+    match result {
+        Err(primary) => Err(primary),
+        Ok(copied) => {
+            observed?;
+            Ok(copied)
+        }
+    }
 }
 
 fn copy_regular_file(source: &Path, destination: &Path) -> Result<CopyIoEvidence, GfError> {

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -129,6 +129,7 @@ pub(crate) struct GraphObjectGcGuard {
 }
 
 struct CasRoot {
+    allocation: Option<crate::StorageAllocationOperation>,
     diagnostic_root: PathBuf,
     project: StableDirectory,
     objects: StableDirectory,
@@ -277,6 +278,7 @@ impl CasRoot {
         let lifecycle_identity = graphforge_filesystem::file_identity(&lifecycle)
             .map_err(|error| storage("inspect graph object lifecycle identity", root, error))?;
         Ok(Self {
+            allocation: None,
             diagnostic_root: root.to_path_buf(),
             project,
             objects,
@@ -444,6 +446,15 @@ impl Drop for GraphObjectPublicationLease {
 }
 
 impl GraphObjectPublicationLease {
+    /// Attach explicit private allocation evidence before this lease installs objects.
+    #[doc(hidden)]
+    pub fn set_allocation_operation(
+        &mut self,
+        allocation: Option<crate::StorageAllocationOperation>,
+    ) {
+        self.cas.allocation = allocation;
+    }
+
     /// Revalidate the stable CAS root immediately before publishing `CURRENT`.
     pub fn revalidate_for_publish(&self) -> Result<(), GfError> {
         validate_publication_identity(self)
@@ -3225,7 +3236,21 @@ where
     })?;
     #[cfg(windows)]
     let temporary_identity = temporary.identity();
-    let bytes_hashed = write_temporary(&mut temporary)?;
+    let written = write_temporary(&mut temporary);
+    let temporary_path = cas
+        .diagnostic_root
+        .join(GRAPH_OBJECTS_DIR)
+        .join(TEMP_DIR)
+        .join(&temporary_name);
+    #[cfg(unix)]
+    let observed_file = &temporary;
+    #[cfg(windows)]
+    let observed_file = temporary.as_file();
+    let observed = cas.allocation.as_ref().map_or(Ok(()), |allocation| {
+        allocation.replace_file_at(&temporary_path, observed_file)
+    });
+    let bytes_hashed = written?;
+    observed?;
     let preseal_io = if writer_authenticated || cfg!(windows) {
         ReadIoEvidence::default()
     } else {
@@ -3316,6 +3341,9 @@ fn try_reuse_existing_object(
         &graph_object_path(&cas.diagnostic_root, digest)?,
         &cas.diagnostic_root,
     )?;
+    if let Some(allocation) = &cas.allocation {
+        allocation.replace_file_at(&graph_object_path(&cas.diagnostic_root, digest)?, &file)?;
+    }
     Ok(Some(reused_object_evidence(expected_length, io)))
 }
 
@@ -3375,6 +3403,9 @@ fn try_reuse_existing_object(
         .calls
         .checked_add(io.calls)
         .ok_or_else(|| validation("reused object read call count overflows"))?;
+    if let Some(allocation) = &cas.allocation {
+        allocation.replace_file_at(&graph_object_path(&cas.diagnostic_root, digest)?, &file)?;
+    }
     Ok(Some(evidence))
 }
 
@@ -3411,17 +3442,26 @@ fn finalize_temporary_object(
         expected_length,
         &cas.diagnostic_root,
     )?;
+    if let Some(allocation) = &cas.allocation {
+        allocation.replace_file_at(&temporary_path, &temporary.file)?;
+    }
     let sealed_bytes_hashed = sealed_io.bytes;
     validate_sealed_temporary(&temporary, expected_length, &cas.diagnostic_root)?;
     returned_error_boundary("install:temp-sealed")?;
     let mut concurrent_io = ReadIoEvidence::default();
-    let installed = if let Ok((_installed, _identity)) = cas.tmp.link_child_into(
+    let installed = if let Ok((installed, _identity)) = cas.tmp.link_child_into(
         &temporary.name,
         &temporary.file,
         temporary.identity,
         bucket,
         destination_name,
     ) {
+        if let Some(allocation) = &cas.allocation {
+            allocation.replace_file_at(
+                &graph_object_path(&cas.diagnostic_root, digest)?,
+                &installed,
+            )?;
+        }
         true
     } else {
         #[cfg(unix)]
@@ -3444,6 +3484,10 @@ fn finalize_temporary_object(
             &graph_object_path(&cas.diagnostic_root, digest)?,
             &cas.diagnostic_root,
         )?;
+        if let Some(allocation) = &cas.allocation {
+            allocation
+                .replace_file_at(&graph_object_path(&cas.diagnostic_root, digest)?, &existing)?;
+        }
         false
     };
     returned_error_boundary("install:final-linked")?;
@@ -3463,15 +3507,7 @@ fn finalize_temporary_object(
     // winner authentication are complete, so release it before exact-identity
     // cleanup; the fresh CAS-owned inode remains sealed at its final name.
     drop(temporary.file);
-    cas.tmp
-        .unlink_child_if_identity(&temporary.name, temporary.identity)
-        .map_err(|error| {
-            storage(
-                "remove stable temporary graph object",
-                &cas.diagnostic_root,
-                error,
-            )
-        })?;
+    remove_finalized_temporary(cas, &temporary.name, temporary.identity, &temporary_path)?;
     returned_error_boundary("install:temp-unlinked")?;
     cas.tmp.sync().map_err(|error| {
         storage(
@@ -3485,6 +3521,27 @@ fn finalize_temporary_object(
         sealed_bytes_hashed,
         checked_read_io_sum(sealed_io, concurrent_io)?,
     ))
+}
+
+fn remove_finalized_temporary(
+    cas: &CasRoot,
+    name: &std::ffi::OsStr,
+    identity: graphforge_filesystem::FileIdentity,
+    path: &Path,
+) -> Result<(), GfError> {
+    cas.tmp
+        .unlink_child_if_identity(name, identity)
+        .map_err(|error| {
+            storage(
+                "remove stable temporary graph object",
+                &cas.diagnostic_root,
+                error,
+            )
+        })?;
+    if let Some(allocation) = &cas.allocation {
+        allocation.remove_file_at(path)?;
+    }
+    Ok(())
 }
 
 fn checked_read_io_sum(
@@ -3865,6 +3922,94 @@ mod tests {
                 format!("injected graph object returned error at {boundary}")
             ),
             other => panic!("unexpected injected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn allocation_observed_concurrent_cas_winner_keeps_real_temporary_peak() {
+        let root = tempfile::tempdir().unwrap();
+        let operation = crate::StorageAllocationOperation::default();
+        let winner_operation = operation.clone();
+        let winner_root = root.path().to_path_buf();
+        let payload = vec![8_u8; 16384];
+        let winner_payload = payload.clone();
+        BEFORE_OBJECT_LINK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                let mut winner = begin_graph_object_publication(&winner_root).unwrap();
+                winner.set_allocation_operation(Some(winner_operation));
+                install_graph_object_bytes_with_lease(&winner, &winner_payload).unwrap();
+            }));
+        });
+        let mut loser = begin_graph_object_publication(root.path()).unwrap();
+        loser.set_allocation_operation(Some(operation.clone()));
+        let (digest, evidence) = install_graph_object_bytes_with_lease(&loser, &payload).unwrap();
+        assert!(evidence.reused_existing);
+        assert!(evidence.attempted_install);
+        let final_file = File::open(graph_object_path(root.path(), &digest).unwrap()).unwrap();
+        let allocated = graphforge_filesystem::file_space_usage(&final_file)
+            .unwrap()
+            .allocated_bytes;
+        assert!(allocated > 0);
+        assert_eq!(operation.totals().unwrap(), (allocated, 2 * allocated));
+        assert_eq!(
+            fs::read_dir(root.path().join(GRAPH_OBJECTS_DIR).join(TEMP_DIR))
+                .unwrap()
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn allocation_observed_cas_install_reuse_and_returned_errors_match_real_union() {
+        for boundary in [
+            None,
+            Some("install:temp-sealed"),
+            Some("install:final-linked"),
+            Some("install:temp-unlinked"),
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let operation = crate::StorageAllocationOperation::default();
+            let mut lease = begin_graph_object_publication(root.path()).unwrap();
+            lease.set_allocation_operation(Some(operation.clone()));
+            let payload = vec![9_u8; 16384];
+            inject_returned_error(boundary);
+            let result = install_graph_object_bytes_with_lease(&lease, &payload);
+            inject_returned_error(None);
+            assert_eq!(result.is_err(), boundary.is_some());
+            let mut identities = BTreeMap::new();
+            for directory in [
+                root.path().join(GRAPH_OBJECTS_DIR).join(TEMP_DIR),
+                root.path().join(GRAPH_OBJECTS_DIR).join(SHA256_DIR),
+            ] {
+                // Only the bounded test fixture is walked after the install returned.
+                let mut pending = vec![directory.to_path_buf()];
+                while let Some(path) = pending.pop() {
+                    for entry in fs::read_dir(path).unwrap() {
+                        let entry = entry.unwrap();
+                        if entry.file_type().unwrap().is_dir() {
+                            pending.push(entry.path());
+                            continue;
+                        }
+                        let file = File::open(entry.path()).unwrap();
+                        let id = graphforge_filesystem::file_identity(&file).unwrap();
+                        identities.insert(
+                            (id.volume_serial, id.file_id),
+                            graphforge_filesystem::file_space_usage(&file)
+                                .unwrap()
+                                .allocated_bytes,
+                        );
+                    }
+                }
+            }
+            let actual: u64 = identities.values().sum();
+            assert!(actual > 0);
+            assert_eq!(operation.totals().unwrap(), (actual, actual));
+            if boundary.is_none() {
+                let before = operation.snapshot().unwrap();
+                let (_, reused) = install_graph_object_bytes_with_lease(&lease, &payload).unwrap();
+                assert!(reused.reused_existing);
+                assert_eq!(operation.snapshot().unwrap(), before);
+            }
         }
     }
 

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -23,7 +23,16 @@ pub mod filesystem_admission;
 pub mod adjacency;
 pub mod adjacency_delta;
 
+mod allocation_operation;
+mod construction_directory;
+#[doc(hidden)]
+pub use allocation_operation::StorageAllocationOperation;
+mod private_storage_ownership;
 pub mod storage_attribution;
+pub use private_storage_ownership::{
+    PrivateStorageOwner, PrivateStorageOwnership, capture_artifact_storage_ownership,
+    capture_private_storage_ownership, capture_published_storage_ownership,
+};
 pub use storage_attribution::{
     ArtifactCategory, ArtifactCategoryAuthorityContext, ArtifactStorageTotals,
     ConstructionPhaseAttribution, PhaseIoTotals, ProjectStorageIdentityUnion,
@@ -216,13 +225,15 @@ pub use project_portable::{
 pub use project_portable_v2_export::{
     PortableV2ExportLimits, PortableV2ExportPlan, PortableV2ExportProgress,
     PortableV2ExportReceipt, PortableV2Output, export_complete_portable_v2,
-    plan_complete_portable_v2, plan_selected_portable_v2, repack_verified_expanded_portable_v2,
+    export_complete_portable_v2_with_allocation, plan_complete_portable_v2,
+    plan_selected_portable_v2, repack_verified_expanded_portable_v2,
 };
 pub use project_portable_v2_import::{
     PortableV2ImportCleanupReceipt, PortableV2ImportPhase, PortableV2ImportProgress,
     PortableV2ImportReceipt, PortableV2SelectiveCandidate, PortableV2StagedCompositionReceipt,
     consume_selective_portable_v2, import_complete_portable_v2,
-    import_complete_portable_v2_with_progress, load_portable_ontology_staging,
+    import_complete_portable_v2_with_allocation, import_complete_portable_v2_with_progress,
+    load_portable_ontology_staging,
 };
 
 pub mod project_portable_v2;
@@ -445,3 +456,6 @@ pub use graphforge_core::GfError;
 
 mod lowering_snapshot;
 pub use lowering_snapshot::lowering_snapshot;
+
+#[doc(hidden)]
+pub use project_recovery::open_or_initialize_project_with_allocation;

--- a/crates/graphforge-storage/src/private_storage_ownership.rs
+++ b/crates/graphforge-storage/src/private_storage_ownership.rs
@@ -1,0 +1,495 @@
+//! Quiescent allocation ownership of retained private project state.
+//!
+//! This is separate from the authenticated published-project union. Callers
+//! must hold the lifecycle boundary quiescent; this inventory is not an ingest
+//! progress probe and does not read graph payload bytes.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::Path;
+
+use graphforge_core::GfError;
+use graphforge_filesystem::StableDirectory;
+
+use crate::{ArtifactCategory, ArtifactStorageTotals};
+
+/// Raw allocation facts for one live private owner. Native identities remain
+/// process-local and are deliberately not serializable.
+#[derive(Debug, Clone, Default)]
+pub struct PrivateStorageOwner {
+    /// Reconciled owner facts, including multiple references to shared files.
+    pub totals: ArtifactStorageTotals,
+    /// Physical identity allocation for cross-owner union accounting.
+    pub physical_identity_allocated_bytes: BTreeMap<String, u64>,
+    physical_identity_logical_bytes: BTreeMap<String, u64>,
+}
+
+/// Complete private/control owner inventory at one quiescent boundary.
+#[derive(Debug, Clone, Default)]
+pub struct PrivateStorageOwnership {
+    /// Canonical owner names and their category/facts. Names contain no paths
+    /// or operation identities.
+    pub owners: BTreeMap<String, (ArtifactCategory, PrivateStorageOwner)>,
+}
+
+impl PrivateStorageOwnership {
+    /// Aggregate category facts while deduplicating physical files shared by owners.
+    ///
+    /// # Errors
+    /// Refuses inconsistent physical facts or arithmetic overflow.
+    pub fn category_totals(
+        &self,
+    ) -> Result<BTreeMap<ArtifactCategory, ArtifactStorageTotals>, GfError> {
+        let mut categories = BTreeMap::<ArtifactCategory, PrivateStorageOwner>::new();
+        for (category, owner) in self.owners.values() {
+            let combined = categories.entry(*category).or_default();
+            combined.totals.logical_references = add(
+                combined.totals.logical_references,
+                owner.totals.logical_references,
+            )?;
+            combined.totals.logical_bytes =
+                add(combined.totals.logical_bytes, owner.totals.logical_bytes)?;
+            for (identity, allocated) in &owner.physical_identity_allocated_bytes {
+                let logical = owner
+                    .physical_identity_logical_bytes
+                    .get(identity)
+                    .ok_or_else(|| storage("private owner omitted physical logical bytes"))?;
+                if let Some(previous) = combined.physical_identity_allocated_bytes.get(identity) {
+                    if previous != allocated
+                        || combined.physical_identity_logical_bytes.get(identity) != Some(logical)
+                    {
+                        return Err(storage("private owners disagree on physical identity"));
+                    }
+                    continue;
+                }
+                combined
+                    .physical_identity_allocated_bytes
+                    .insert(identity.clone(), *allocated);
+                combined
+                    .physical_identity_logical_bytes
+                    .insert(identity.clone(), *logical);
+                combined.totals.physical_objects = add(combined.totals.physical_objects, 1)?;
+                combined.totals.physical_logical_bytes =
+                    add(combined.totals.physical_logical_bytes, *logical)?;
+                combined.totals.allocated_bytes = add(combined.totals.allocated_bytes, *allocated)?;
+            }
+        }
+        Ok(categories
+            .into_iter()
+            .map(|(category, owner)| (category, owner.totals))
+            .collect())
+    }
+}
+
+/// Capture raw facts for explicitly declared completed non-project artifacts.
+///
+/// # Errors
+/// Rejects missing paths, links, special files, and oversized inventories.
+pub fn capture_artifact_storage_ownership(
+    paths: &[std::path::PathBuf],
+) -> Result<PrivateStorageOwner, GfError> {
+    let mut owner = PrivateStorageOwner::default();
+    let mut remaining = 1_000_000;
+    for path in paths {
+        let metadata = std::fs::symlink_metadata(path).map_err(storage)?;
+        if metadata.is_dir() && !metadata.file_type().is_symlink() {
+            capture_directory(
+                StableDirectory::open(path).map_err(storage)?,
+                &mut owner,
+                &mut remaining,
+            )?;
+        } else if metadata.is_file() && !metadata.file_type().is_symlink() {
+            let parent = StableDirectory::open(
+                path.parent()
+                    .ok_or_else(|| storage("artifact has no parent"))?,
+            )
+            .map_err(storage)?;
+            capture_file(
+                &parent
+                    .open_child_file(
+                        path.file_name()
+                            .ok_or_else(|| storage("artifact has no name"))?,
+                    )
+                    .map_err(storage)?,
+                &mut owner,
+            )?;
+        } else {
+            return Err(storage("artifact is a link or special file"));
+        }
+    }
+    Ok(owner)
+}
+
+/// Capture published raw reference/object facts from the explicit published
+/// roots and require exact agreement with authenticated published ownership.
+///
+/// # Errors
+/// Rejects links, unknown/missing physical ownership, and changed allocation.
+pub fn capture_published_storage_ownership(
+    selected: &crate::ResolvedProjectGeneration,
+) -> Result<PrivateStorageOwner, GfError> {
+    let admitted = crate::capture_project_storage_identity_union(selected)?;
+    let root = StableDirectory::open(selected.container_root()).map_err(storage)?;
+    let mut owner = PrivateStorageOwner::default();
+    for name in ["FORMAT", "CURRENT"] {
+        capture_file(
+            &root.open_child_file(name.as_ref()).map_err(storage)?,
+            &mut owner,
+        )?;
+    }
+    let excluded = admitted
+        .retained_generation_uuids
+        .iter()
+        .map(|uuid| {
+            selected
+                .container_root()
+                .join("generations")
+                .join(uuid.to_string())
+                .join("lease.lock")
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut remaining = 1_000_000;
+    for name in ["generations", crate::graph_object_store::GRAPH_OBJECTS_DIR] {
+        match root.open_child_directory(name.as_ref()) {
+            Ok(directory) => {
+                capture_directory_skipping(directory, &mut owner, &mut remaining, &excluded)?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound && name != "generations" => {
+            }
+            Err(error) => return Err(storage(error)),
+        }
+    }
+    if owner.physical_identity_allocated_bytes != admitted.physical_identity_allocated_bytes {
+        return Err(storage(
+            "published raw ownership differs from authenticated identity union",
+        ));
+    }
+    Ok(owner)
+}
+
+/// Capture live construction, import and transaction-control files without
+/// following links. Published generations/CAS are intentionally not traversed.
+///
+/// # Errors
+/// Refuses links, special files, changed physical facts, overflow, and an
+/// inventory exceeding the bounded entry budget.
+pub fn capture_private_storage_ownership(
+    project: &Path,
+) -> Result<PrivateStorageOwnership, GfError> {
+    let (project, admission_parent, admission_name) =
+        crate::filesystem_admission::retained_project_control_paths(project)?;
+    let root = StableDirectory::open(&project).map_err(storage)?;
+    let names = root.child_names_bounded(4096).map_err(storage)?;
+    let mut result = PrivateStorageOwnership::default();
+    let mut remaining = 1_000_000_usize;
+    for (directory, owner, category) in [
+        (
+            ".graphforge-construction",
+            "construction",
+            ArtifactCategory::ConstructionStaging,
+        ),
+        (
+            "import-sessions",
+            "import",
+            ArtifactCategory::ConstructionStaging,
+        ),
+        (
+            "transactions",
+            "transactions",
+            ArtifactCategory::CatalogAndManifests,
+        ),
+        ("locks", "locks", ArtifactCategory::CatalogAndManifests),
+    ] {
+        let mut snapshot = PrivateStorageOwner::default();
+        if names.iter().any(|name| name == directory) {
+            let retained = root
+                .open_child_directory(directory.as_ref())
+                .map_err(storage)?;
+            capture_directory(retained, &mut snapshot, &mut remaining)?;
+        }
+        result.owners.insert(owner.to_owned(), (category, snapshot));
+    }
+    if names.iter().any(|name| name == "generations") {
+        let generations = root
+            .open_child_directory("generations".as_ref())
+            .map_err(storage)?;
+        for name in generations.child_names_bounded(4096).map_err(storage)? {
+            uuid::Uuid::parse_str(
+                name.to_str()
+                    .ok_or_else(|| storage("generation name is not UTF-8"))?,
+            )
+            .map_err(storage)?;
+            let generation = generations.open_child_directory(&name).map_err(storage)?;
+            let lease = generation
+                .open_child_file("lease.lock".as_ref())
+                .map_err(storage)?;
+            let (_, locks) = result
+                .owners
+                .get_mut("locks")
+                .ok_or_else(|| storage("lock owner missing"))?;
+            capture_file(&lease, locks)?;
+        }
+    }
+    let parent = StableDirectory::open(&admission_parent).map_err(storage)?;
+    let mut snapshot = PrivateStorageOwner::default();
+    match parent.open_child_file(admission_name.as_ref()) {
+        Ok(file) => capture_file(&file, &mut snapshot)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(storage(error)),
+    }
+    result.owners.insert(
+        "admission_lock".to_owned(),
+        (ArtifactCategory::CatalogAndManifests, snapshot),
+    );
+    Ok(result)
+}
+
+fn capture_directory(
+    directory: StableDirectory,
+    owner: &mut PrivateStorageOwner,
+    remaining: &mut usize,
+) -> Result<(), GfError> {
+    capture_directory_skipping(
+        directory,
+        owner,
+        remaining,
+        &std::collections::BTreeSet::new(),
+    )
+}
+
+fn capture_directory_skipping(
+    directory: StableDirectory,
+    owner: &mut PrivateStorageOwner,
+    remaining: &mut usize,
+    excluded: &std::collections::BTreeSet<std::path::PathBuf>,
+) -> Result<(), GfError> {
+    let mut pending = vec![directory];
+    while let Some(directory) = pending.pop() {
+        let names = directory.child_names_bounded(*remaining).map_err(storage)?;
+        *remaining = remaining
+            .checked_sub(names.len())
+            .ok_or_else(|| storage("private inventory exceeded entry bound"))?;
+        for name in names {
+            if excluded.contains(&directory.path().join(&name)) {
+                // Only exact, authenticated generation lease paths are controls.
+                // Still open the file to reject a substituted link/directory.
+                directory.open_child_file(&name).map_err(storage)?;
+                continue;
+            }
+            if let Ok(child) = directory.open_child_directory(&name) {
+                pending.push(child);
+            } else {
+                let file = directory.open_child_file(&name).map_err(storage)?;
+                capture_file(&file, owner)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn capture_file(file: &File, owner: &mut PrivateStorageOwner) -> Result<(), GfError> {
+    let identity = graphforge_filesystem::file_identity(file).map_err(storage)?;
+    let usage = graphforge_filesystem::file_space_usage(file).map_err(storage)?;
+    let key =
+        crate::storage_attribution::native_identity_key(identity.volume_serial, &identity.file_id);
+    owner.totals.logical_references = add(owner.totals.logical_references, 1)?;
+    owner.totals.logical_bytes = add(owner.totals.logical_bytes, usage.logical_bytes)?;
+    if let Some(existing) = owner.physical_identity_allocated_bytes.get(&key) {
+        if *existing != usage.allocated_bytes
+            || owner.physical_identity_logical_bytes.get(&key) != Some(&usage.logical_bytes)
+        {
+            return Err(storage("private physical identity changed during capture"));
+        }
+    } else {
+        owner
+            .physical_identity_allocated_bytes
+            .insert(key.clone(), usage.allocated_bytes);
+        owner
+            .physical_identity_logical_bytes
+            .insert(key, usage.logical_bytes);
+        owner.totals.physical_objects = add(owner.totals.physical_objects, 1)?;
+        owner.totals.physical_logical_bytes =
+            add(owner.totals.physical_logical_bytes, usage.logical_bytes)?;
+        owner.totals.allocated_bytes = add(owner.totals.allocated_bytes, usage.allocated_bytes)?;
+    }
+    Ok(())
+}
+
+fn add(left: u64, right: u64) -> Result<u64, GfError> {
+    left.checked_add(right)
+        .ok_or_else(|| storage("private storage allocation overflow"))
+}
+
+fn storage(error: impl std::fmt::Display) -> GfError {
+    GfError::Storage(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn published_raw_union_keeps_exact_authority_and_classifies_generation_lease() {
+        let root = tempfile::tempdir().unwrap();
+        let selected = crate::open_or_initialize_project(root.path()).unwrap();
+        let published = capture_published_storage_ownership(&selected).unwrap();
+        let authoritative = crate::capture_project_storage_identity_union(&selected).unwrap();
+        assert_eq!(
+            published.physical_identity_allocated_bytes,
+            authoritative.physical_identity_allocated_bytes
+        );
+        let controls = capture_private_storage_ownership(root.path()).unwrap();
+        assert!(controls.owners["locks"].1.totals.logical_references >= 1);
+        let lease = selected.generation_root().join("lease.lock");
+        let file = std::fs::File::open(lease).unwrap();
+        let mut expected = PrivateStorageOwner::default();
+        capture_file(&file, &mut expected).unwrap();
+        for identity in expected.physical_identity_allocated_bytes.keys() {
+            assert!(
+                controls.owners["locks"]
+                    .1
+                    .physical_identity_allocated_bytes
+                    .contains_key(identity)
+            );
+            assert!(
+                !published
+                    .physical_identity_allocated_bytes
+                    .contains_key(identity)
+            );
+        }
+        std::fs::write(
+            selected.generation_root().join("unknown.bin"),
+            b"unknown published file",
+        )
+        .unwrap();
+        assert!(
+            capture_published_storage_ownership(&selected)
+                .unwrap_err()
+                .to_string()
+                .contains("differs from authenticated")
+        );
+    }
+
+    #[test]
+    fn private_owners_preserve_raw_facts_and_deduplicate_shared_files() {
+        let root = tempfile::tempdir().unwrap();
+        for directory in [
+            ".graphforge-construction/session",
+            "import-sessions/session",
+            "transactions",
+            "locks",
+        ] {
+            std::fs::create_dir_all(root.path().join(directory)).unwrap();
+        }
+        let original = root.path().join(".graphforge-construction/session/data");
+        std::fs::write(&original, [7_u8; 8192]).unwrap();
+        std::fs::hard_link(
+            &original,
+            root.path().join(".graphforge-construction/session/alias"),
+        )
+        .unwrap();
+        std::fs::hard_link(
+            &original,
+            root.path().join("import-sessions/session/source"),
+        )
+        .unwrap();
+        std::fs::write(root.path().join("transactions/receipt.json"), b"{}").unwrap();
+        std::fs::write(root.path().join("locks/write.lock"), []).unwrap();
+        let snapshot = capture_private_storage_ownership(root.path()).unwrap();
+        let construction = &snapshot.owners["construction"].1;
+        assert_eq!(construction.totals.logical_references, 2);
+        assert_eq!(construction.totals.physical_objects, 1);
+        assert_eq!(construction.totals.logical_bytes, 16384);
+        assert_eq!(construction.totals.physical_logical_bytes, 8192);
+        assert_eq!(snapshot.owners["locks"].1.totals.physical_objects, 1);
+        let mut lifecycle = crate::StorageAllocationLifecycle::default();
+        for (name, (_, owner)) in &snapshot.owners {
+            lifecycle
+                .replace_owner(name, &owner.physical_identity_allocated_bytes)
+                .unwrap();
+        }
+        let categories = snapshot.category_totals().unwrap();
+        let staging = &categories[&ArtifactCategory::ConstructionStaging];
+        assert_eq!(staging.logical_references, 3);
+        assert_eq!(staging.logical_bytes, 24_576);
+        assert_eq!(staging.physical_objects, 1);
+        assert_eq!(staging.physical_logical_bytes, 8192);
+        assert_eq!(staging.allocated_bytes, construction.totals.allocated_bytes);
+        let expected = construction.totals.allocated_bytes
+            + snapshot.owners["transactions"].1.totals.allocated_bytes
+            + snapshot.owners["locks"].1.totals.allocated_bytes;
+        assert_eq!(lifecycle.current_allocated_bytes(), expected);
+        assert_eq!(
+            snapshot.owners["import"]
+                .1
+                .physical_identity_allocated_bytes,
+            construction.physical_identity_allocated_bytes
+        );
+    }
+
+    #[test]
+    fn relative_project_captures_only_its_resolved_admission_lock() {
+        let cwd = std::env::current_dir().unwrap();
+        let root = tempfile::tempdir_in(&cwd).unwrap();
+        let relative = root.path().strip_prefix(&cwd).unwrap();
+        let (_, parent, lock_name) =
+            crate::filesystem_admission::retained_project_control_paths(root.path()).unwrap();
+        let lock = parent.join(lock_name);
+        std::fs::write(&lock, b"").unwrap();
+        let neighbor = parent.join(format!(
+            "{}.unrelated",
+            lock.file_name().unwrap().to_str().unwrap()
+        ));
+        std::fs::write(&neighbor, b"unrelated").unwrap();
+        let absolute = capture_private_storage_ownership(root.path()).unwrap();
+        let relative = capture_private_storage_ownership(relative).unwrap();
+        std::fs::remove_file(lock).unwrap();
+        std::fs::remove_file(neighbor).unwrap();
+        let absolute = &absolute.owners["admission_lock"].1;
+        let relative = &relative.owners["admission_lock"].1;
+        assert_eq!(
+            absolute.physical_identity_allocated_bytes,
+            relative.physical_identity_allocated_bytes
+        );
+        assert_eq!(absolute.totals.physical_objects, 1);
+        assert_eq!(absolute.totals.logical_references, 1);
+        assert_eq!(absolute.totals.logical_bytes, 0);
+        assert_eq!(relative.totals, absolute.totals);
+    }
+
+    #[test]
+    fn deep_private_tree_uses_iterative_descriptor_walk() {
+        let root = tempfile::tempdir().unwrap();
+        let mut path = root.path().join("transactions");
+        for _ in 0..256 {
+            std::fs::create_dir(&path).unwrap();
+            path.push("d");
+        }
+        std::fs::write(path, b"deep").unwrap();
+        let snapshot = capture_private_storage_ownership(root.path()).unwrap();
+        assert_eq!(
+            snapshot.owners["transactions"].1.totals.logical_references,
+            1
+        );
+        assert_eq!(snapshot.owners["transactions"].1.totals.logical_bytes, 4);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_owner_capture_refuses_links() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("transactions")).unwrap();
+        std::fs::write(outside.path().join("receipt"), b"outside").unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("receipt"),
+            root.path().join("transactions/receipt"),
+        )
+        .unwrap();
+        assert!(capture_private_storage_ownership(root.path()).is_err());
+        std::fs::remove_file(root.path().join("transactions/receipt")).unwrap();
+        std::fs::remove_dir(root.path().join("transactions")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("transactions")).unwrap();
+        assert!(capture_private_storage_ownership(root.path()).is_err());
+    }
+}

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -923,6 +923,13 @@ pub(crate) fn open_or_initialize_project_for_mode(
 pub(crate) fn open_or_initialize_project_admitted(
     root: &Path,
 ) -> Result<ResolvedProjectGeneration, GfError> {
+    open_or_initialize_project_admitted_with_allocation(root, None)
+}
+
+pub(crate) fn open_or_initialize_project_admitted_with_allocation(
+    root: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<ResolvedProjectGeneration, GfError> {
     reject_root_link(root)?;
     let _root_lock = lock_project_root(root)?;
     let mut entries = std::fs::read_dir(root).map_err(|error| {
@@ -937,12 +944,12 @@ pub(crate) fn open_or_initialize_project_admitted(
         return match resolve_project_generation(root) {
             Err(error) if error.code() == "GF_PROJECT_UNINITIALIZED" => {
                 let generation_uuid = validate_resumable_uninitialized_layout(root)?;
-                initialize_empty_generation(root, false, Some(generation_uuid))
+                initialize_empty_generation(root, false, Some(generation_uuid), allocation)
             }
             result => result,
         };
     }
-    initialize_empty_generation(root, true, None)
+    initialize_empty_generation(root, true, None, allocation)
 }
 
 fn validate_resumable_uninitialized_layout(root: &Path) -> Result<Uuid, GfError> {
@@ -1141,6 +1148,7 @@ fn initialize_empty_generation(
     root: &Path,
     write_format: bool,
     generation_uuid: Option<Uuid>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<ResolvedProjectGeneration, GfError> {
     let generation_uuid = generation_uuid.unwrap_or_else(Uuid::now_v7);
     let transaction_uuid = Uuid::now_v7();
@@ -1152,7 +1160,12 @@ fn initialize_empty_generation(
         .map_err(|error| GfError::Storage(format!("failed to create project layout: {error}")))?;
     if write_format {
         let format_path = root.join(FORMAT_FILE);
-        write_new_synced(&format_path, PROJECT_FORMAT_BYTES, "project format")?;
+        write_new_synced(
+            &format_path,
+            PROJECT_FORMAT_BYTES,
+            "project format",
+            allocation,
+        )?;
         project_failpoint::hit(
             "project.after_format_fsync",
             Some(transaction_uuid),
@@ -1161,7 +1174,8 @@ fn initialize_empty_generation(
             false,
         )?;
     }
-    let participant_descriptors = install_empty_workspace_participants(&participants_root)?;
+    let participant_descriptors =
+        install_empty_workspace_participants(&participants_root, allocation)?;
     sync_directory(&participants_root)?;
     sync_directory(&generation_root)?;
     sync_directory(&root.join("generations"))?;
@@ -1175,7 +1189,12 @@ fn initialize_empty_generation(
             false,
         )?;
     }
-    write_new_synced(&generation_root.join(LEASE_FILE), &[], "generation lease")?;
+    write_new_synced(
+        &generation_root.join(LEASE_FILE),
+        &[],
+        "generation lease",
+        allocation,
+    )?;
     let manifest = GenerationManifest {
         format: "graphforge-generation".into(),
         format_version: 1,
@@ -1201,6 +1220,7 @@ fn initialize_empty_generation(
         &generation_root.join(MANIFEST_FILE),
         &manifest_bytes,
         "generation",
+        allocation,
     )?;
     sync_directory(&generation_root)?;
     sync_directory(&root.join("generations"))?;
@@ -1214,12 +1234,13 @@ fn initialize_empty_generation(
     let mut current_bytes = serde_json::to_vec(&current)
         .map_err(|error| GfError::Storage(format!("failed to encode CURRENT: {error}")))?;
     current_bytes.push(b'\n');
-    crate::project_publication::publish_atomic_bytes(
+    crate::project_publication::publish_atomic_bytes_with_allocation(
         &root.join(CURRENT_FILE),
         &current_bytes,
         || Ok(()),
         || Ok(()),
         || Ok(()),
+        allocation,
     )
     .map_err(|error| GfError::Storage(format!("failed to write CURRENT: {error}")))?;
     sync_directory(root)?;
@@ -1228,6 +1249,7 @@ fn initialize_empty_generation(
 
 fn install_empty_workspace_participants(
     participants_root: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<Vec<ParticipantDescriptor>, GfError> {
     let workspace_participants = crate::workspace_participants::empty_workspace_participants()?;
     let workspace_root = participants_root.join("workspace");
@@ -1243,6 +1265,7 @@ fn install_empty_workspace_participants(
             &participants_root.join(&relative_path),
             &participant.bytes,
             "workspace participant",
+            allocation,
         )?;
         descriptors.push(ParticipantDescriptor {
             capability_id: participant.capability_id,
@@ -1273,7 +1296,12 @@ fn install_empty_workspace_participants(
     Ok(descriptors)
 }
 
-fn write_new_synced(path: &Path, bytes: &[u8], name: &str) -> Result<(), GfError> {
+fn write_new_synced(
+    path: &Path,
+    bytes: &[u8],
+    name: &str,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), GfError> {
     use std::io::Write as _;
 
     let mut file = OpenOptions::new()
@@ -1283,7 +1311,11 @@ fn write_new_synced(path: &Path, bytes: &[u8], name: &str) -> Result<(), GfError
         .map_err(|error| GfError::Storage(format!("failed to create {name}: {error}")))?;
     file.write_all(bytes)
         .and_then(|()| file.sync_all())
-        .map_err(|error| GfError::Storage(format!("failed to write {name}: {error}")))
+        .map_err(|error| GfError::Storage(format!("failed to write {name}: {error}")))?;
+    if let Some(allocation) = allocation {
+        allocation.replace_file_at(path, &file)?;
+    }
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/crates/graphforge-storage/src/project_portable.rs
+++ b/crates/graphforge-storage/src/project_portable.rs
@@ -286,13 +286,14 @@ fn import_portable_project_after_prepare(
     };
     let target = target.to_owned();
     before_stage(&target)?;
-    let publication =
-        match stage_project_generation_from_admitted_parent(admission, parent, &request, None)? {
-            ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
-            ProjectStageOutcome::Staged(staged) => {
-                staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()?
-            }
-        };
+    let publication = match stage_project_generation_from_admitted_parent(
+        admission, parent, &request, None, None,
+    )? {
+        ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
+        ProjectStageOutcome::Staged(staged) => {
+            staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()?
+        }
+    };
     Ok(PortableImportReceipt {
         envelope_sha256: validated.envelope_sha256,
         source_generation_uuid: validated.source_generation_uuid,

--- a/crates/graphforge-storage/src/project_portable_v2.rs
+++ b/crates/graphforge-storage/src/project_portable_v2.rs
@@ -173,9 +173,21 @@ pub fn verify_portable_v2(
             )
         })?;
         if metadata.is_dir() {
-            materialize_expanded(source, staging.path(), limits, cancelled, &mut |_| Ok(()))?;
+            materialize_expanded(
+                source,
+                staging.path(),
+                limits,
+                cancelled,
+                &mut |_, _| Ok(()),
+            )?;
         } else {
-            materialize_bundle(source, staging.path(), limits, cancelled, &mut |_| Ok(()))?;
+            materialize_bundle(
+                source,
+                staging.path(),
+                limits,
+                cancelled,
+                &mut |_, _| Ok(()),
+            )?;
         }
         validate_materialized_ontology_composition(staging.path(), &report, limits, cancelled)?;
     }
@@ -627,8 +639,15 @@ pub fn materialize_verified_portable_v2(
     limits: PortableV2Limits,
     cancelled: Option<&AtomicBool>,
 ) -> Result<PortableV2Report, PortableV2Error> {
-    materialize_verified_portable_v2_observed(source, destination, limits, cancelled, |_| Ok(()))
-        .map(|materialized| materialized.report)
+    materialize_verified_portable_v2_observed(
+        source,
+        destination,
+        limits,
+        cancelled,
+        |_, _| Ok(()),
+        false,
+    )
+    .map(|materialized| materialized.report)
 }
 
 pub(crate) struct VerifiedMaterialization {
@@ -642,7 +661,8 @@ pub(crate) fn materialize_verified_portable_v2_observed(
     destination: impl AsRef<Path>,
     limits: PortableV2Limits,
     cancelled: Option<&AtomicBool>,
-    mut observed: impl FnMut(&File) -> Result<(), PortableV2Error>,
+    mut observed: impl FnMut(&Path, Option<&File>) -> Result<(), PortableV2Error>,
+    track_removals: bool,
 ) -> Result<VerifiedMaterialization, PortableV2Error> {
     let source = source.as_ref();
     let destination = destination.as_ref();
@@ -658,59 +678,64 @@ pub(crate) fn materialize_verified_portable_v2_observed(
     fs::create_dir(destination).map_err(|_| {
         PortableV2Error::new(PortableV2ErrorCode::Io, "cannot create materialization")
     })?;
-    let result = if before.is_dir() {
-        materialize_expanded(source, destination, limits, cancelled, &mut observed)
-    } else {
-        materialize_bundle(source, destination, limits, cancelled, &mut observed)
-    };
-    let (application_read_bytes, application_read_operations) = match result {
-        Ok(stats) => stats,
-        Err(error) => {
-            let _ = fs::remove_dir_all(destination);
-            return Err(error);
-        }
-    };
-    let after = fs::metadata(source).map_err(|_| {
-        PortableV2Error::new(
-            PortableV2ErrorCode::ConcurrentMutation,
-            "source disappeared",
-        )
-    })?;
-    if before.len() != after.len() || before.modified().ok() != after.modified().ok() {
-        let _ = fs::remove_dir_all(destination);
-        return Err(PortableV2Error::new(
-            PortableV2ErrorCode::ConcurrentMutation,
-            "source changed after verification",
-        ));
-    }
-    let after_report =
-        verify_portable_v2(source, PortableV2Mode::Full, limits, cancelled).map_err(|_| {
+    let mut routes = std::collections::BTreeSet::new();
+    let result = (|| {
+        let mut tracking = |path: &Path, file: Option<&File>| {
+            if track_removals {
+                routes.insert(path.to_path_buf());
+            }
+            observed(path, file)
+        };
+        let result = if before.is_dir() {
+            materialize_expanded(source, destination, limits, cancelled, &mut tracking)
+        } else {
+            materialize_bundle(source, destination, limits, cancelled, &mut tracking)
+        };
+        let (application_read_bytes, application_read_operations) = result?;
+        let after = fs::metadata(source).map_err(|_| {
             PortableV2Error::new(
                 PortableV2ErrorCode::ConcurrentMutation,
-                "source changed during materialization",
+                "source disappeared",
             )
-        });
-    let after_report = match after_report {
-        Ok(after_report) => after_report,
-        Err(error) => {
-            let _ = fs::remove_dir_all(destination);
-            return Err(error);
+        })?;
+        if before.len() != after.len() || before.modified().ok() != after.modified().ok() {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::ConcurrentMutation,
+                "source changed after verification",
+            ));
         }
-    };
-    if report.package_digest != after_report.package_digest
-        || report.transport_digest != after_report.transport_digest
-    {
+        let after_report = verify_portable_v2(source, PortableV2Mode::Full, limits, cancelled)
+            .map_err(|_| {
+                PortableV2Error::new(
+                    PortableV2ErrorCode::ConcurrentMutation,
+                    "source changed during materialization",
+                )
+            });
+        let after_report = after_report?;
+        if report.package_digest != after_report.package_digest
+            || report.transport_digest != after_report.transport_digest
+        {
+            return Err(PortableV2Error::new(
+                PortableV2ErrorCode::ConcurrentMutation,
+                "source changed during materialization",
+            ));
+        }
+        Ok(VerifiedMaterialization {
+            report,
+            application_read_bytes,
+            application_read_operations,
+        })
+    })();
+    if result.is_err() {
         let _ = fs::remove_dir_all(destination);
-        return Err(PortableV2Error::new(
-            PortableV2ErrorCode::ConcurrentMutation,
-            "source changed during materialization",
-        ));
+        for path in routes {
+            if matches!(fs::symlink_metadata(&path), Err(error) if error.kind() == std::io::ErrorKind::NotFound)
+            {
+                let _ = observed(&path, None);
+            }
+        }
     }
-    Ok(VerifiedMaterialization {
-        report,
-        application_read_bytes,
-        application_read_operations,
-    })
+    result
 }
 
 fn materialize_expanded(
@@ -718,7 +743,7 @@ fn materialize_expanded(
     destination: &Path,
     limits: PortableV2Limits,
     cancelled: Option<&AtomicBool>,
-    observed: &mut impl FnMut(&File) -> Result<(), PortableV2Error>,
+    observed: &mut impl FnMut(&Path, Option<&File>) -> Result<(), PortableV2Error>,
 ) -> Result<(u64, u64), PortableV2Error> {
     let mut read_bytes = 0_u64;
     let mut read_operations = 0_u64;
@@ -745,14 +770,20 @@ fn materialize_expanded(
             .map_err(|_| {
                 PortableV2Error::at(PortableV2ErrorCode::Io, &relative, "cannot stage entry")
             })?;
-        let (bytes, operations) =
-            copy_materialized(&mut input, &mut output, limits.copy_buffer_bytes, cancelled)?;
+        observed(&output_path, Some(&output))?;
+        let copied =
+            copy_materialized(&mut input, &mut output, limits.copy_buffer_bytes, cancelled);
+        let refreshed = observed(&output_path, Some(&output));
+        let (bytes, operations) = copied?;
+        refreshed?;
         read_bytes = read_bytes.saturating_add(bytes);
         read_operations = read_operations.saturating_add(operations);
-        output.sync_all().map_err(|_| {
+        let synced = output.sync_all().map_err(|_| {
             PortableV2Error::at(PortableV2ErrorCode::Io, &relative, "cannot sync entry")
-        })?;
-        observed(&output)?;
+        });
+        let refreshed = observed(&output_path, Some(&output));
+        synced?;
+        refreshed?;
         let after = fs::metadata(&input_path).map_err(|_| {
             PortableV2Error::at(
                 PortableV2ErrorCode::ConcurrentMutation,
@@ -777,7 +808,7 @@ fn materialize_bundle(
     destination: &Path,
     limits: PortableV2Limits,
     cancelled: Option<&AtomicBool>,
-    observed: &mut impl FnMut(&File) -> Result<(), PortableV2Error>,
+    observed: &mut impl FnMut(&Path, Option<&File>) -> Result<(), PortableV2Error>,
 ) -> Result<(u64, u64), PortableV2Error> {
     let mut read_bytes = 0_u64;
     let mut read_operations = 0_u64;
@@ -821,19 +852,25 @@ fn materialize_bundle(
                 .map_err(|_| {
                     PortableV2Error::at(PortableV2ErrorCode::Io, &path, "cannot stage entry")
                 })?;
-            let (bytes, operations) = copy_exact_materialized(
+            observed(&output_path, Some(&output))?;
+            let copied = copy_exact_materialized(
                 &mut input,
                 &mut output,
                 size,
                 limits.copy_buffer_bytes,
                 cancelled,
-            )?;
+            );
+            let refreshed = observed(&output_path, Some(&output));
+            let (bytes, operations) = copied?;
+            refreshed?;
             read_bytes = read_bytes.saturating_add(bytes);
             read_operations = read_operations.saturating_add(operations);
-            output.sync_all().map_err(|_| {
+            let synced = output.sync_all().map_err(|_| {
                 PortableV2Error::at(PortableV2ErrorCode::Io, &path, "cannot sync entry")
-            })?;
-            observed(&output)?;
+            });
+            let refreshed = observed(&output_path, Some(&output));
+            synced?;
+            refreshed?;
         } else {
             skip_exact(&mut input, size, limits.copy_buffer_bytes, cancelled)?;
         }
@@ -3341,6 +3378,96 @@ mod tests {
         assert_eq!(expanded.component_count, bundled.component_count);
         assert_eq!(bundled.representation, PortableV2Representation::Bundle);
         assert_ne!(expanded.transport_digest, bundled.transport_digest);
+    }
+
+    #[test]
+    fn observed_materialization_failure_and_cancel_cleanup_retry_both_forms() {
+        let source = package();
+        let mut paths = Vec::new();
+        walk(
+            source.path(),
+            source.path(),
+            &mut paths,
+            PortableV2Limits::default(),
+            None,
+        )
+        .unwrap();
+        paths.sort();
+        let mut bytes = Vec::new();
+        for path in paths {
+            bytes.extend(tar_entry(
+                &path,
+                &fs::read(source.path().join(&path)).unwrap(),
+            ));
+        }
+        bytes.extend([0_u8; 1024]);
+        let bundle = tempfile::NamedTempFile::new().unwrap();
+        fs::write(bundle.path(), bytes).unwrap();
+        for input in [source.path(), bundle.path()] {
+            for cancel in [false, true] {
+                let root = tempfile::tempdir().unwrap();
+                let destination = root.path().join("materialized");
+                let operation = crate::StorageAllocationOperation::default();
+                let cancelled = AtomicBool::new(false);
+                let mut injected = false;
+                let result = materialize_verified_portable_v2_observed(
+                    input,
+                    &destination,
+                    PortableV2Limits::default(),
+                    Some(&cancelled),
+                    |path, file| {
+                        match file {
+                            Some(file) => {
+                                operation.replace_file_at(path, file).unwrap();
+                                if !injected && file.metadata().unwrap().len() > 0 {
+                                    injected = true;
+                                    if cancel {
+                                        cancelled.store(true, Ordering::Relaxed);
+                                    } else {
+                                        return Err(PortableV2Error::new(
+                                            PortableV2ErrorCode::Io,
+                                            "injected observed write failure",
+                                        ));
+                                    }
+                                }
+                            }
+                            None => {
+                                assert!(!path.exists());
+                                operation.remove_file_at(path).unwrap();
+                            }
+                        }
+                        Ok(())
+                    },
+                    true,
+                );
+                assert!(injected);
+                let error = result.err().expect("injected materialization must fail");
+                if !cancel {
+                    assert_eq!(error.code, PortableV2ErrorCode::Io);
+                }
+                assert!(!destination.exists());
+                assert_eq!(operation.totals().unwrap().0, 0);
+                assert!(operation.totals().unwrap().1 > 0);
+                cancelled.store(false, Ordering::Relaxed);
+                materialize_verified_portable_v2_observed(
+                    input,
+                    &destination,
+                    PortableV2Limits::default(),
+                    Some(&cancelled),
+                    |path, file| {
+                        match file {
+                            Some(file) => operation.replace_file_at(path, file).unwrap(),
+                            None => operation.remove_file_at(path).unwrap(),
+                        }
+                        Ok(())
+                    },
+                    true,
+                )
+                .unwrap();
+                let actual = crate::StorageAllocationOperation::from_paths(&[destination]).unwrap();
+                assert_eq!(operation.totals().unwrap().0, actual.totals().unwrap().0);
+            }
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -385,9 +385,78 @@ impl Eq for PortableV2ExportReceipt {}
 struct ExportAllocationObserver {
     allocated: BTreeMap<String, u64>,
     logical: BTreeMap<String, u64>,
+    operation: Option<crate::StorageAllocationOperation>,
+    routes: BTreeMap<String, PathBuf>,
+}
+
+// Refresh after a failed write before staging cleanup, preserving the original error.
+fn observed_write_result(
+    result: Result<(), ExportError>,
+    file: &File,
+    allocation: &mut ExportAllocationObserver,
+) -> Result<(), ExportError> {
+    if result.is_err() && allocation.operation.is_some() {
+        let _ = allocation.observe(file);
+    }
+    result
 }
 
 impl ExportAllocationObserver {
+    fn register(&mut self, path: &Path, file: &File) -> Result<(), ExportError> {
+        if self.operation.is_some() {
+            let identity = graphforge_filesystem::file_identity(file).map_err(storage)?;
+            let key = crate::storage_attribution::native_identity_key(
+                identity.volume_serial,
+                &identity.file_id,
+            );
+            self.routes.insert(key, path.to_path_buf());
+            self.observe(file)?;
+        }
+        Ok(())
+    }
+
+    fn remove(&self, path: &Path) {
+        remove(path);
+        if let Some(operation) = &self.operation {
+            for route in self.routes.values() {
+                if route.starts_with(path)
+                    && fs::symlink_metadata(route)
+                        .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+                {
+                    let _ = operation.remove_file_at(route);
+                }
+            }
+        }
+    }
+
+    fn published(&mut self, stage: &Path, destination: &Path) -> Result<(), ExportError> {
+        if let Some(operation) = &self.operation {
+            for (identity, route) in &mut self.routes {
+                let relative = route.strip_prefix(stage).map_err(storage)?;
+                let final_path = if relative.as_os_str().is_empty() {
+                    destination.to_path_buf()
+                } else {
+                    destination.join(relative)
+                };
+                operation
+                    .transition(
+                        &crate::StorageAllocationOperation::file_owner(&final_path)
+                            .map_err(storage)?,
+                        &crate::StorageAllocationTransition {
+                            installed: BTreeMap::from([(
+                                identity.clone(),
+                                self.allocated[identity],
+                            )]),
+                            removed: BTreeSet::default(),
+                        },
+                    )
+                    .map_err(storage)?;
+                operation.remove_file_at(route).map_err(storage)?;
+                *route = final_path;
+            }
+        }
+        Ok(())
+    }
     fn observe(&mut self, file: &File) -> Result<(), ExportError> {
         let identity = graphforge_filesystem::file_identity(file).map_err(storage)?;
         let usage = graphforge_filesystem::file_space_usage(file).map_err(storage)?;
@@ -397,6 +466,13 @@ impl ExportAllocationObserver {
             write!(&mut file_id, "{byte:02x}").expect("writing to String cannot fail");
         }
         let key = format!("{:016x}:{file_id}", identity.volume_serial);
+        if let Some(operation) = &self.operation {
+            let route = self
+                .routes
+                .get(&key)
+                .ok_or_else(|| err("GF_STORAGE_ERROR", "unregistered export allocation route"))?;
+            operation.replace_file_at(route, file).map_err(storage)?;
+        }
         self.allocated.insert(key.clone(), usage.allocated_bytes);
         self.logical.insert(key, usage.logical_bytes);
         Ok(())
@@ -1112,7 +1188,29 @@ pub fn export_complete_portable_v2(
     output: PortableV2Output,
     limits: PortableV2ExportLimits,
     cancelled: &AtomicBool,
+    progress: impl FnMut(PortableV2ExportProgress),
+) -> Result<PortableV2ExportReceipt, ExportError> {
+    export_complete_portable_v2_with_allocation(
+        plan,
+        destination,
+        output,
+        limits,
+        cancelled,
+        progress,
+        None,
+    )
+}
+
+/// Export with an explicit first-party allocation context.
+#[doc(hidden)]
+pub fn export_complete_portable_v2_with_allocation(
+    plan: &PortableV2ExportPlan,
+    destination: impl AsRef<Path>,
+    output: PortableV2Output,
+    limits: PortableV2ExportLimits,
+    cancelled: &AtomicBool,
     mut progress: impl FnMut(PortableV2ExportProgress),
+    operation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<PortableV2ExportReceipt, ExportError> {
     validate_limits(limits)?;
     if output == PortableV2Output::Bundle
@@ -1122,7 +1220,13 @@ pub fn export_complete_portable_v2(
     {
         return Err(limit("bundle entry exceeds ustar size field"));
     }
-    let dst = destination.as_ref();
+    let destination = destination.as_ref();
+    let resolved = if operation.is_some() && destination.is_relative() {
+        Some(std::env::current_dir().map_err(storage)?.join(destination))
+    } else {
+        None
+    };
+    let dst = resolved.as_deref().unwrap_or(destination);
     reject_destination(dst)?;
     let parent = dst
         .parent()
@@ -1133,7 +1237,10 @@ pub fn export_complete_portable_v2(
         .ok_or_else(|| err("GF_INVALID_DESTINATION", "invalid destination name"))?;
     let stage = parent.join(format!(".{name}.{}.partial", Uuid::new_v4()));
     let is_cancelled = || cancelled.load(Ordering::Relaxed);
-    let mut allocation = ExportAllocationObserver::default();
+    let mut allocation = ExportAllocationObserver {
+        operation: operation.cloned(),
+        ..Default::default()
+    };
     let result = match output {
         PortableV2Output::Expanded => expanded(
             plan,
@@ -1155,48 +1262,30 @@ pub fn export_complete_portable_v2(
     let digest = match result {
         Ok(d) => d,
         Err(e) => {
-            remove(&stage);
+            allocation.remove(&stage);
             return Err(e.with_allocation_identities(allocation.allocated));
         }
     };
     let allocation_logical_bytes = allocation.logical.values().copied().sum();
     let allocation_physical_objects = allocation.logical.len() as u64;
-    let staged_allocation = allocation.allocated;
+    let staged_allocation = allocation.allocated.clone();
     if is_cancelled() {
-        remove(&stage);
+        allocation.remove(&stage);
         return Err(err("GF_CANCELLED", "portable export cancelled")
             .with_allocation_identities(staged_allocation));
     }
-    let verified = verify_portable_v2(&stage, PortableV2Mode::Full, limits, Some(cancelled))
-        .map_err(|error| {
-            remove(&stage);
+    let verified =
+        verify_written_export(plan, &stage, digest, limits, cancelled).map_err(|error| {
+            allocation.remove(&stage);
             error.with_allocation_identities(staged_allocation.clone())
         })?;
-    let expected_transport = format!("sha256:{}", hex(digest));
-    if verified.package_class != plan.package_class
-        || verified.package_digest != format!("sha256:{}", hex(plan.package_digest))
-    {
-        remove(&stage);
-        return Err(PortableV2Error::new(
-            PortableV2ErrorCode::DigestMismatch,
-            "writer and verifier semantic receipts disagree",
-        )
-        .with_allocation_identities(staged_allocation.clone()));
-    }
-    if verified.transport_digest.as_deref() != Some(expected_transport.as_str()) {
-        remove(&stage);
-        return Err(PortableV2Error::new(
-            PortableV2ErrorCode::DigestMismatch,
-            "writer and verifier transport receipts disagree",
-        )
-        .with_allocation_identities(staged_allocation.clone()));
-    }
     publish_no_replace(&stage, dst).map_err(|error| {
-        remove(&stage);
+        allocation.remove(&stage);
         storage(error).with_allocation_identities(staged_allocation.clone())
     })?;
+    allocation.published(&stage, dst)?;
     if let Err(error) = sync_dir(parent) {
-        remove(dst);
+        allocation.remove(dst);
         return Err(error.with_allocation_identities(staged_allocation));
     }
     Ok(PortableV2ExportReceipt {
@@ -1212,6 +1301,32 @@ pub fn export_complete_portable_v2(
         allocation_logical_bytes,
         allocation_physical_objects,
     })
+}
+
+fn verify_written_export(
+    plan: &PortableV2ExportPlan,
+    stage: &Path,
+    digest: [u8; 32],
+    limits: PortableV2ExportLimits,
+    cancelled: &AtomicBool,
+) -> Result<crate::PortableV2Report, ExportError> {
+    let verified = verify_portable_v2(stage, PortableV2Mode::Full, limits, Some(cancelled))?;
+    let expected_transport = format!("sha256:{}", hex(digest));
+    if verified.package_class != plan.package_class
+        || verified.package_digest != format!("sha256:{}", hex(plan.package_digest))
+    {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::DigestMismatch,
+            "writer and verifier semantic receipts disagree",
+        ));
+    }
+    if verified.transport_digest.as_deref() != Some(expected_transport.as_str()) {
+        return Err(PortableV2Error::new(
+            PortableV2ErrorCode::DigestMismatch,
+            "writer and verifier transport receipts disagree",
+        ));
+    }
+    Ok(verified)
 }
 
 /// Repack a fully verified expanded portable-v2 package into canonical bundle bytes.
@@ -1503,17 +1618,18 @@ fn bundle(
         .write(true)
         .open(stage)
         .map_err(storage)?;
+    allocation.register(stage, &out)?;
     let mut h = Sha256::new();
     let mut done = 0;
     for (i, (path, src)) in items.iter().enumerate() {
         if cancelled() {
             return Err(err("GF_CANCELLED", "portable export cancelled"));
         }
-        header(&mut out, &mut h, path, src.len())?;
+        observed_write_result(header(&mut out, &mut h, path, src.len()), &out, allocation)?;
         allocation.observe(&out)?;
         match src {
             Src::Bytes(b) => {
-                emit(&mut out, &mut h, b)?;
+                observed_write_result(emit(&mut out, &mut h, b), &out, allocation)?;
                 allocation.observe(&out)?;
             }
             Src::File(f) => stream(
@@ -1534,7 +1650,7 @@ fn bundle(
                 },
             )?,
         }
-        pad(&mut out, &mut h, src.len())?;
+        observed_write_result(pad(&mut out, &mut h, src.len()), &out, allocation)?;
         allocation.observe(&out)?;
         progress(PortableV2ExportProgress {
             entries_completed: i + 1,
@@ -1544,7 +1660,7 @@ fn bundle(
         });
     }
     let end = [0u8; 1024];
-    out.write_all(&end).map_err(storage)?;
+    observed_write_result(out.write_all(&end).map_err(storage), &out, allocation)?;
     allocation.observe(&out)?;
     h.update(end);
     out.sync_all().map_err(storage)?;
@@ -1663,11 +1779,16 @@ fn copy(
         .write(true)
         .open(target)
         .map_err(storage)?;
+    allocation.register(target, &output)?;
     if let PlannedSource::Control(bytes) = &planned.source {
         if cancelled() {
             return Err(err("GF_CANCELLED", "portable export cancelled"));
         }
-        output.write_all(bytes).map_err(storage)?;
+        observed_write_result(
+            output.write_all(bytes).map_err(storage),
+            &output,
+            allocation,
+        )?;
         allocation.observe(&output)?;
         output.sync_all().map_err(storage)?;
         allocation.observe(&output)?;
@@ -1686,7 +1807,14 @@ fn copy(
         if count == 0 {
             break;
         }
-        output.write_all(&buffer[..count]).map_err(storage)?;
+        observed_write_result(
+            output.write_all(&buffer[..count]).map_err(storage),
+            &output,
+            allocation,
+        )?;
+        if allocation.operation.is_some() {
+            allocation.observe(&output)?;
+        }
         digest.update(&buffer[..count]);
         bytes_read += count as u64;
         tick(count as u64);
@@ -1716,7 +1844,7 @@ fn stream(
         if cancelled() {
             return Err(err("GF_CANCELLED", "portable export cancelled"));
         }
-        out.write_all(bytes).map_err(storage)?;
+        observed_write_result(out.write_all(bytes).map_err(storage), out, allocation)?;
         allocation.observe(out)?;
         transport.update(bytes);
         tick(bytes.len() as u64);
@@ -1734,7 +1862,14 @@ fn stream(
         if count == 0 {
             break;
         }
-        out.write_all(&buffer[..count]).map_err(storage)?;
+        observed_write_result(
+            out.write_all(&buffer[..count]).map_err(storage),
+            out,
+            allocation,
+        )?;
+        if allocation.operation.is_some() {
+            allocation.observe(out)?;
+        }
         transport.update(&buffer[..count]);
         digest.update(&buffer[..count]);
         bytes_read += count as u64;
@@ -2179,9 +2314,10 @@ fn write_bytes(
     let mut f = OpenOptions::new()
         .create_new(true)
         .write(true)
-        .open(p)
+        .open(&p)
         .map_err(storage)?;
-    f.write_all(b).map_err(storage)?;
+    allocation.register(&p, &f)?;
+    observed_write_result(f.write_all(b).map_err(storage), &f, allocation)?;
     allocation.observe(&f)?;
     f.sync_all().map_err(storage)?;
     allocation.observe(&f)
@@ -2728,6 +2864,88 @@ mod tests {
         )
         .unwrap();
         (expanded_path, bundle_path)
+    }
+
+    #[test]
+    fn export_failed_partial_write_is_observed_before_cleanup() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("partial");
+        let mut file = File::create(&path).unwrap();
+        let operation = crate::StorageAllocationOperation::default();
+        let mut allocation = ExportAllocationObserver {
+            operation: Some(operation.clone()),
+            ..Default::default()
+        };
+        allocation.register(&path, &file).unwrap();
+        file.write_all(&vec![1_u8; 32768]).unwrap();
+        file.sync_all().unwrap();
+        let actual = graphforge_filesystem::file_space_usage(&file)
+            .unwrap()
+            .allocated_bytes;
+        assert!(actual > 0);
+        let original = err("GF_CANCELLED", "injected error after partial write");
+        let returned = observed_write_result(Err(original), &file, &mut allocation).unwrap_err();
+        assert_eq!(returned.code, PortableV2ErrorCode::Cancelled);
+        assert_eq!(operation.totals().unwrap(), (actual, actual));
+        drop(file);
+        allocation.remove(&path);
+        assert_eq!(operation.totals().unwrap(), (0, actual));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn export_operation_tracks_published_routes_and_cancelled_staging() {
+        let (_project, generation) = graph_generation_with_composition(true);
+        let limits = PortableV2ExportLimits::default();
+        let plan = plan_complete_portable_v2(&generation, limits).unwrap();
+        for output in [PortableV2Output::Expanded, PortableV2Output::Bundle] {
+            let root = tempfile::tempdir().unwrap();
+            let retained = root.path().join("retained");
+            fs::write(&retained, vec![1_u8; 8192]).unwrap();
+            let operation =
+                crate::StorageAllocationOperation::from_paths(&[root.path().to_path_buf()])
+                    .unwrap();
+            let baseline = operation.totals().unwrap().0;
+            let destination = root.path().join("package");
+            let cancelled = AtomicBool::new(false);
+            let receipt = export_complete_portable_v2_with_allocation(
+                &plan,
+                &destination,
+                output,
+                limits,
+                &cancelled,
+                |_| {},
+                Some(&operation),
+            )
+            .unwrap();
+            let expected = baseline
+                + receipt
+                    .allocation_identity_allocated_bytes
+                    .values()
+                    .sum::<u64>();
+            assert_eq!(operation.totals().unwrap(), (expected, expected));
+            let actual =
+                crate::StorageAllocationOperation::from_paths(&[root.path().to_path_buf()])
+                    .unwrap();
+            assert_eq!(operation.snapshot().unwrap(), actual.snapshot().unwrap());
+
+            let cancelled_destination = root.path().join("cancelled");
+            let error = export_complete_portable_v2_with_allocation(
+                &plan,
+                &cancelled_destination,
+                output,
+                limits,
+                &cancelled,
+                |_| cancelled.store(true, Ordering::Relaxed),
+                Some(&operation),
+            )
+            .unwrap_err();
+            assert_eq!(error.code, PortableV2ErrorCode::Cancelled);
+            assert!(!cancelled_destination.exists());
+            assert_eq!(operation.totals().unwrap().0, expected);
+            assert!(operation.totals().unwrap().1 > expected);
+            assert_eq!(fs::read_dir(root.path()).unwrap().count(), 2);
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -13,7 +13,6 @@ use graphforge_ontology::{
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::project_generation::open_or_initialize_project_admitted;
 use crate::project_portable::{prepare_import_target, semantically_pristine_generation};
 use crate::project_portable_v2::{
     PortableV2Error, PortableV2ErrorCode, PortableV2Limits, PortableV2PackageClass,
@@ -225,7 +224,35 @@ pub fn import_complete_portable_v2_with_progress(
     supported_capabilities: &[ProjectCapability],
     limits: PortableV2Limits,
     cancelled: Option<&AtomicBool>,
+    progress: impl FnMut(PortableV2ImportProgress),
+) -> Result<PortableV2ImportReceipt, PortableV2Error> {
+    import_complete_portable_v2_with_allocation(
+        source,
+        target,
+        transaction_uuid,
+        generation_uuid,
+        supported_capabilities,
+        limits,
+        cancelled,
+        progress,
+        None,
+    )
+}
+
+// Preserve the existing explicit import arguments; diagnostics stays separate
+// from the public request contract and does not use ambient state.
+#[allow(clippy::too_many_arguments)]
+#[doc(hidden)]
+pub fn import_complete_portable_v2_with_allocation(
+    source: impl AsRef<Path>,
+    target: impl AsRef<Path>,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    supported_capabilities: &[ProjectCapability],
+    limits: PortableV2Limits,
+    cancelled: Option<&AtomicBool>,
     mut progress: impl FnMut(PortableV2ImportProgress),
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<PortableV2ImportReceipt, PortableV2Error> {
     let source = source.as_ref();
     let target = target.as_ref();
@@ -252,6 +279,7 @@ pub fn import_complete_portable_v2_with_progress(
         generation_uuid,
         limits,
         cancelled,
+        allocation,
     )?;
     progress(PortableV2ImportProgress {
         phase: PortableV2ImportPhase::Materialized,
@@ -270,6 +298,7 @@ pub fn import_complete_portable_v2_with_progress(
         cancelled,
         &report,
         owned_retry,
+        allocation,
     )
     .map(|mut receipt| {
         receipt.materialized_identity_allocated_bytes = materialized_identity_allocated_bytes;
@@ -283,6 +312,7 @@ pub fn import_complete_portable_v2_with_progress(
             materialized_stage_identity,
             &mut owned_identities,
             entry_count,
+            allocation,
         ) {
             return cleanup_error.with_allocation_identities(owned_identities);
         }
@@ -302,6 +332,7 @@ pub fn import_complete_portable_v2_with_progress(
             materialized_stage_identity,
             &mut receipt,
             entry_count,
+            allocation,
         )?;
         Ok(receipt)
     });
@@ -322,6 +353,7 @@ fn finalize_import_materialization_cleanup(
     materialized_stage_identity: graphforge_filesystem::FileIdentity,
     receipt: &mut PortableV2ImportReceipt,
     entry_count: usize,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), PortableV2Error> {
     // Finalization can atomically replace authenticated staging files. Preserve
     // the pre-finalization identities as removed ownership while separately
@@ -347,6 +379,7 @@ fn finalize_import_materialization_cleanup(
         owner,
         materialized_stage_identity,
         &receipt.materialized_identity_allocated_bytes,
+        allocation,
     )
     .map_err(|error| {
         error.with_allocation_identities(receipt.materialized_identity_allocated_bytes.clone())
@@ -377,6 +410,7 @@ fn materialize_owned_import(
     generation_uuid: Uuid,
     limits: PortableV2Limits,
     cancelled: Option<&AtomicBool>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<OwnedMaterialization, PortableV2Error> {
     let target_name = target
         .file_name()
@@ -397,16 +431,38 @@ fn materialize_owned_import(
         PortableV2Error::new(PortableV2ErrorCode::Io, "cannot open import ownership")
     })?;
     record_import_file_identity(&owner_file, &mut identities)?;
+    if let Some(allocation) = allocation {
+        allocation
+            .replace_file_at(&owner, &owner_file)
+            .map_err(|error| storage(&error))?;
+    }
     let materialized = match crate::project_portable_v2::materialize_verified_portable_v2_observed(
         source,
         &stage,
         limits,
         cancelled,
-        |file| record_import_file_identity(file, &mut identities),
+        |path, file| {
+            if let Some(file) = file {
+                record_import_file_identity(file, &mut identities)?;
+            }
+            if let Some(allocation) = allocation {
+                match file {
+                    Some(file) => allocation.replace_file_at(path, file),
+                    None => allocation.remove_file_at(path),
+                }
+                .map_err(|error| storage(&error))?;
+            }
+            Ok(())
+        },
+        allocation.is_some(),
     ) {
         Ok(materialized) => materialized,
         Err(error) => {
-            let _ = fs::remove_file(&owner);
+            if fs::remove_file(&owner).is_ok()
+                && let Some(allocation) = allocation
+            {
+                let _ = allocation.remove_file_at(&owner);
+            }
             let _ = sync_parent(&owner);
             return Err(error.with_allocation_identities(identities));
         }
@@ -472,9 +528,17 @@ fn cleanup_failed_import_finalization(
     expected_stage_identity: graphforge_filesystem::FileIdentity,
     identities: &mut std::collections::BTreeMap<String, u64>,
     entry_count: usize,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), PortableV2Error> {
     capture_finalized_import_identities(stage, expected_stage_identity, identities, entry_count)?;
-    cleanup_import_materialization(stage, owner, expected_stage_identity, identities).map(|_| ())
+    cleanup_import_materialization(
+        stage,
+        owner,
+        expected_stage_identity,
+        identities,
+        allocation,
+    )
+    .map(|_| ())
 }
 
 fn cleanup_import_materialization(
@@ -482,6 +546,7 @@ fn cleanup_import_materialization(
     owner: &Path,
     expected_stage_identity: graphforge_filesystem::FileIdentity,
     identities: &std::collections::BTreeMap<String, u64>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<PortableV2ImportCleanupReceipt, PortableV2Error> {
     #[cfg(test)]
     if INJECT_IMPORT_CLEANUP_FAILURE.with(std::cell::Cell::get) {
@@ -522,6 +587,7 @@ fn cleanup_import_materialization(
             identities,
             &mut removed_identities,
             &mut cleanup_budget,
+            allocation,
         )?;
         parent
             .remove_child_directory_if_identity(name, directory.identity())
@@ -535,6 +601,19 @@ fn cleanup_import_materialization(
             PortableV2Error::new(PortableV2ErrorCode::Io, "cannot sync import staging parent")
         })?;
     }
+    cleanup_import_owner(owner, identities, &mut removed_identities, allocation)?;
+    Ok(PortableV2ImportCleanupReceipt {
+        removed_identity_allocated_bytes: removed_identities,
+        parent_sync_confirmed: true,
+    })
+}
+
+fn cleanup_import_owner(
+    owner: &Path,
+    identities: &std::collections::BTreeMap<String, u64>,
+    removed_identities: &mut std::collections::BTreeMap<String, u64>,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), PortableV2Error> {
     if owner.exists() {
         let parent = graphforge_filesystem::StableDirectory::open(
             owner.parent().unwrap_or_else(|| Path::new(".")),
@@ -574,14 +653,16 @@ fn cleanup_import_materialization(
                     "cannot remove authenticated import owner",
                 )
             })?;
+        if let Some(allocation) = allocation {
+            allocation
+                .remove_file_at(owner)
+                .map_err(|error| storage(&error))?;
+        }
         parent.sync().map_err(|_| {
             PortableV2Error::new(PortableV2ErrorCode::Io, "cannot sync import owner parent")
         })?;
     }
-    Ok(PortableV2ImportCleanupReceipt {
-        removed_identity_allocated_bytes: removed_identities,
-        parent_sync_confirmed: true,
-    })
+    Ok(())
 }
 
 fn remove_stable_tree(
@@ -589,6 +670,7 @@ fn remove_stable_tree(
     identities: &std::collections::BTreeMap<String, u64>,
     removed_identities: &mut std::collections::BTreeMap<String, u64>,
     remaining: &mut usize,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), PortableV2Error> {
     let names = directory.child_names_bounded(*remaining).map_err(|_| {
         PortableV2Error::new(
@@ -599,7 +681,13 @@ fn remove_stable_tree(
     *remaining = (*remaining).saturating_sub(names.len());
     for name in names {
         if let Ok(child) = directory.open_child_directory(&name) {
-            remove_stable_tree(&child, identities, removed_identities, remaining)?;
+            remove_stable_tree(
+                &child,
+                identities,
+                removed_identities,
+                remaining,
+                allocation,
+            )?;
             directory
                 .remove_child_directory_if_identity(&name, child.identity())
                 .map_err(|_| {
@@ -641,6 +729,11 @@ fn remove_stable_tree(
                         "cannot remove authenticated import entry",
                     )
                 })?;
+            if let Some(allocation) = allocation {
+                allocation
+                    .remove_file_at(&directory.path().join(&name))
+                    .map_err(|error| storage(&error))?;
+            }
         }
     }
     directory.sync().map_err(|_| {
@@ -760,6 +853,7 @@ fn import_materialized(
     cancelled: Option<&AtomicBool>,
     report: &PortableV2Report,
     owned_retry: bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<PortableV2ImportReceipt, PortableV2Error> {
     if report.package_class != PortableV2PackageClass::Complete {
         return Err(PortableV2Error::new(
@@ -937,10 +1031,13 @@ fn import_materialized(
     };
     let parent = match existing {
         Some(parent) => parent,
-        None => open_or_initialize_project_admitted(admission.root())
-            .map_err(|error| storage(&error))?,
+        None => crate::project_generation::open_or_initialize_project_admitted_with_allocation(
+            admission.root(),
+            allocation,
+        )
+        .map_err(|error| storage(&error))?,
     };
-    let graph_object_lease = prepare_compact_import_graph(
+    let graph_object_lease = prepare_compact_import_graph_with_allocation(
         admission.root(),
         package_graph_tree.as_deref(),
         &mut participants,
@@ -950,6 +1047,7 @@ fn import_materialized(
                 "import entry count exceeds platform capacity",
             )
         })?,
+        allocation,
     )?;
     let request = ProjectGenerationRequest {
         transaction_uuid,
@@ -972,6 +1070,7 @@ fn import_materialized(
         generation_graph_tree.as_deref(),
         cancelled,
         limits.copy_buffer_bytes,
+        allocation,
     )
     .map_err(|error| storage_or_cancel(&error, cancelled))?
     {
@@ -1156,11 +1255,28 @@ fn validate_import_delta_identities(
     Ok(())
 }
 
+#[cfg(test)]
 fn prepare_compact_import_graph(
     target: &Path,
     package_graph_tree: Option<&Path>,
     participants: &mut [ProjectFileParticipant],
     entry_count: usize,
+) -> Result<Option<crate::GraphObjectPublicationLease>, PortableV2Error> {
+    prepare_compact_import_graph_with_allocation(
+        target,
+        package_graph_tree,
+        participants,
+        entry_count,
+        None,
+    )
+}
+
+fn prepare_compact_import_graph_with_allocation(
+    target: &Path,
+    package_graph_tree: Option<&Path>,
+    participants: &mut [ProjectFileParticipant],
+    entry_count: usize,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<Option<crate::GraphObjectPublicationLease>, PortableV2Error> {
     let Some(graph_tree) = package_graph_tree else {
         return Ok(None);
@@ -1177,7 +1293,9 @@ fn prepare_compact_import_graph(
     if participant.participant.record_version != crate::GRAPH_FILES_V2_RECORD_VERSION {
         return Ok(None);
     }
-    let lease = crate::begin_graph_object_publication(target).map_err(|error| storage(&error))?;
+    let mut lease =
+        crate::begin_graph_object_publication(target).map_err(|error| storage(&error))?;
+    lease.set_allocation_operation(allocation.cloned());
     let directory = graphforge_filesystem::StableDirectory::open(graph_tree).map_err(|_| {
         PortableV2Error::new(
             PortableV2ErrorCode::Io,

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -164,6 +164,7 @@ pub enum ProjectStageOutcome {
 
 /// A staged generation that still requires domain and composite validation.
 pub struct StagedProjectGeneration {
+    allocation: Option<crate::StorageAllocationOperation>,
     root: PathBuf,
     publication_lock: PublicationLock,
     admission: StagedAdmission,
@@ -403,6 +404,7 @@ pub(crate) fn stage_project_generation_from_admitted_parent(
     parent: ResolvedProjectGeneration,
     request: &ProjectGenerationRequest,
     graph_tree: Option<&Path>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<ProjectStageOutcome, GfError> {
     let result = (|| {
         validate_request(request)?;
@@ -443,11 +445,13 @@ pub(crate) fn stage_project_generation_from_admitted_parent(
             None,
             graph_tree,
             ParticipantPayloads::Memory,
+            allocation,
         )
     })();
     result.map_err(|error| map_stage_error(request, error))
 }
 
+#[allow(clippy::too_many_arguments)] // Ordinary staging inputs plus explicit diagnostic context.
 pub(crate) fn stage_project_generation_from_files_admitted(
     admission: crate::filesystem_admission::ProjectLifecycleAdmission,
     parent: ResolvedProjectGeneration,
@@ -456,6 +460,7 @@ pub(crate) fn stage_project_generation_from_files_admitted(
     graph_tree: Option<&Path>,
     cancelled: Option<&AtomicBool>,
     copy_buffer_bytes: usize,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<ProjectStageOutcome, GfError> {
     let result = (|| {
         validate_request(request)?;
@@ -489,6 +494,7 @@ pub(crate) fn stage_project_generation_from_files_admitted(
             None,
             graph_tree,
             ParticipantPayloads::Files(files, cancelled, copy_buffer_bytes),
+            allocation,
         )
     })();
     result.map_err(|error| map_stage_error(request, error))
@@ -537,6 +543,7 @@ fn stage_project_generation_inner(
         None,
         graph_tree,
         ParticipantPayloads::Memory,
+        None,
     )
 }
 
@@ -568,6 +575,7 @@ fn stage_project_generation_optimistic_inner(
         Some(operation_fingerprint),
         graph_tree,
         ParticipantPayloads::Memory,
+        None,
     )
 }
 
@@ -596,6 +604,17 @@ pub(crate) fn stage_project_generation_with_lock(
         None,
         graph_tree,
         ParticipantPayloads::Memory,
+        None,
+    )
+}
+
+fn after_preparing_journal(request: &ProjectGenerationRequest) -> Result<(), GfError> {
+    project_failpoint::hit(
+        "project.after_journal_preparing",
+        Some(request.transaction_uuid),
+        Some(request.generation_uuid),
+        "PREPARING",
+        false,
     )
 }
 
@@ -613,6 +632,7 @@ fn stage_project_generation_inner_with_locks(
     operation_fingerprint: Option<[u8; 32]>,
     graph_tree: Option<&Path>,
     payloads: ParticipantPayloads<'_>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<ProjectStageOutcome, GfError> {
     validate_request(request)?;
     let (capabilities, participants, request_fingerprint) =
@@ -631,6 +651,7 @@ fn stage_project_generation_inner_with_locks(
             &operation_fingerprint,
             revert.as_ref(),
             &journal_path,
+            allocation,
         )?
     {
         return Ok(outcome);
@@ -639,7 +660,7 @@ fn stage_project_generation_inner_with_locks(
     let requires_promotion = matches!(publication_lock, PublicationLock::Optimistic(_));
     let generation_root =
         prepare_generation_directory(&root, request, &request_fingerprint, requires_promotion)?;
-    write_journal(
+    write_journal_with_allocation(
         &journal_path,
         &JournalRecord::new(
             request,
@@ -650,18 +671,25 @@ fn stage_project_generation_inner_with_locks(
             None,
             revert.clone(),
         ),
+        allocation,
     )?;
-    project_failpoint::hit(
-        "project.after_journal_preparing",
-        Some(request.transaction_uuid),
-        Some(request.generation_uuid),
-        "PREPARING",
-        false,
-    )?;
+    after_preparing_journal(request)?;
 
-    stage_participant_files(request, &generation_root, &participants, payloads)?;
+    stage_participant_files(
+        request,
+        &generation_root,
+        &participants,
+        payloads,
+        allocation,
+    )?;
     sync_participant_directories(&generation_root.join(PARTICIPANTS_DIR), &participants)?;
-    stage_optional_graph_tree(&participants, &parent, &generation_root, graph_tree)?;
+    stage_optional_graph_tree(
+        &participants,
+        &parent,
+        &generation_root,
+        graph_tree,
+        allocation,
+    )?;
     project_failpoint::hit(
         "project.after_participant_dir_fsync",
         Some(request.transaction_uuid),
@@ -669,7 +697,7 @@ fn stage_project_generation_inner_with_locks(
         "STAGED",
         false,
     )?;
-    write_journal(
+    write_journal_with_allocation(
         &journal_path,
         &JournalRecord::new(
             request,
@@ -680,6 +708,7 @@ fn stage_project_generation_inner_with_locks(
             None,
             revert.clone(),
         ),
+        allocation,
     )?;
     project_failpoint::hit(
         "project.after_journal_staged",
@@ -691,6 +720,7 @@ fn stage_project_generation_inner_with_locks(
 
     Ok(ProjectStageOutcome::Staged(Box::new(
         StagedProjectGeneration {
+            allocation: allocation.cloned(),
             admission,
             root,
             publication_lock,
@@ -772,6 +802,7 @@ fn handle_existing_journal(
     operation_fingerprint: &str,
     expected_revert: Option<&RevertJournalExtension>,
     journal_path: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<Option<ProjectStageOutcome>, GfError> {
     let journal = read_journal(journal_path)?;
     if journal.operation_fingerprint() != operation_fingerprint
@@ -792,7 +823,7 @@ fn handle_existing_journal(
                 "aborted transaction cleanup is incomplete; run recovery again",
             ));
         }
-        cleanup_aborted_attempts(root, request.transaction_uuid)?;
+        cleanup_aborted_attempts(root, request.transaction_uuid, allocation)?;
         return Ok(None);
     }
     if journal.request_fingerprint != request_fingerprint
@@ -840,7 +871,11 @@ fn handle_existing_journal(
     )))
 }
 
-fn cleanup_aborted_attempts(root: &Path, transaction_uuid: Uuid) -> Result<(), GfError> {
+fn cleanup_aborted_attempts(
+    root: &Path,
+    transaction_uuid: Uuid,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), GfError> {
     let attempts_root = root.join(ATTEMPTS_DIR);
     let transaction_root = attempts_root.join(transaction_uuid.hyphenated().to_string());
     let metadata = match std::fs::symlink_metadata(&transaction_root) {
@@ -854,7 +889,7 @@ fn cleanup_aborted_attempts(root: &Path, transaction_uuid: Uuid) -> Result<(), G
             "aborted transaction attempt path is linked or not a directory",
         ));
     }
-    std::fs::remove_dir_all(&transaction_root).map_err(publication_io)?;
+    crate::project_recovery::remove_recovery_tree_with_allocation(&transaction_root, allocation)?;
     sync_directory(&attempts_root)
 }
 
@@ -997,6 +1032,7 @@ fn stage_optional_graph_tree(
     parent: &ResolvedProjectGeneration,
     generation_root: &Path,
     graph_tree: Option<&Path>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), GfError> {
     let files_participant = participants.iter().find(|participant| {
         participant.capability_id == crate::GRAPH_CAPABILITY_ID
@@ -1068,7 +1104,12 @@ fn stage_optional_graph_tree(
             ));
         }
     };
-    crate::stage_graph_tree(source, generation_root, &inventory)?;
+    crate::graph_files::stage_graph_tree_with_allocation(
+        source,
+        generation_root,
+        &inventory,
+        allocation,
+    )?;
     sync_directory(generation_root)?;
     Ok(())
 }
@@ -1169,6 +1210,7 @@ fn stage_participant_files(
     generation_root: &Path,
     participants: &[StagedParticipant],
     payloads: ParticipantPayloads<'_>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), GfError> {
     for metadata in participants {
         let (index, input) = request
@@ -1195,39 +1237,49 @@ fn stage_participant_files(
             .create_new(true)
             .open(&destination)
             .map_err(publication_io)?;
-        match payloads {
-            ParticipantPayloads::Memory => file.write_all(&input.bytes).map_err(publication_io)?,
-            ParticipantPayloads::Files(files, cancelled, copy_buffer_bytes) => {
-                let source = &files[index];
-                let mut input = crate::project_portable::open_regular_nofollow(&source.source)
-                    .map_err(publication_io)?;
-                let mut hash = Sha256::new();
-                let mut copied = 0;
-                let mut buffer = vec![0; copy_buffer_bytes];
-                loop {
-                    if cancelled.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+        let write_result = (|| -> Result<(), GfError> {
+            match payloads {
+                ParticipantPayloads::Memory => {
+                    file.write_all(&input.bytes).map_err(publication_io)?;
+                }
+                ParticipantPayloads::Files(files, cancelled, copy_buffer_bytes) => {
+                    let source = &files[index];
+                    let mut input = crate::project_portable::open_regular_nofollow(&source.source)
+                        .map_err(publication_io)?;
+                    let mut hash = Sha256::new();
+                    let mut copied = 0;
+                    let mut buffer = vec![0; copy_buffer_bytes];
+                    loop {
+                        if cancelled.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+                            return Err(project_error(
+                                ProjectErrorCode::PublicationFailed,
+                                "portable import cancelled during staging",
+                            ));
+                        }
+                        let count = input.read(&mut buffer).map_err(publication_io)?;
+                        if count == 0 {
+                            break;
+                        }
+                        file.write_all(&buffer[..count]).map_err(publication_io)?;
+                        hash.update(&buffer[..count]);
+                        copied += count as u64;
+                    }
+                    let digest: [u8; 32] = hash.finalize().into();
+                    if copied != source.byte_length || digest != source.content_sha256 {
                         return Err(project_error(
                             ProjectErrorCode::PublicationFailed,
-                            "portable import cancelled during staging",
+                            "portable participant changed during staging",
                         ));
                     }
-                    let count = input.read(&mut buffer).map_err(publication_io)?;
-                    if count == 0 {
-                        break;
-                    }
-                    file.write_all(&buffer[..count]).map_err(publication_io)?;
-                    hash.update(&buffer[..count]);
-                    copied += count as u64;
-                }
-                let digest: [u8; 32] = hash.finalize().into();
-                if copied != source.byte_length || digest != source.content_sha256 {
-                    return Err(project_error(
-                        ProjectErrorCode::PublicationFailed,
-                        "portable participant changed during staging",
-                    ));
                 }
             }
-        }
+            Ok(())
+        })();
+        let observed = allocation.map_or(Ok(()), |allocation| {
+            allocation.replace_file_at(&destination, &file)
+        });
+        write_result?;
+        observed?;
         project_failpoint::hit(
             "project.after_participant_write",
             Some(request.transaction_uuid),
@@ -1236,6 +1288,9 @@ fn stage_participant_files(
             false,
         )?;
         file.sync_all().map_err(publication_io)?;
+        if let Some(allocation) = allocation {
+            allocation.replace_file_at(&destination, &file)?;
+        }
         project_failpoint::hit(
             "project.after_participant_fsync",
             Some(request.transaction_uuid),
@@ -1306,9 +1361,10 @@ impl StagedProjectGeneration {
             "VALIDATED",
             false,
         )?;
-        write_journal(
+        write_journal_with_allocation(
             &self.journal_path(),
             &self.journal(JournalPhase::Validated, None),
+            self.allocation.as_ref(),
         )?;
         project_failpoint::hit(
             "project.after_journal_validated",
@@ -1550,12 +1606,16 @@ fn has_compact_graph_participant(staged: &StagedProjectGeneration) -> Result<boo
 }
 
 fn abort_stale_generation(staged: &StagedProjectGeneration) -> Result<(), GfError> {
-    write_journal(
+    write_journal_with_allocation(
         &staged.journal_path(),
         &staged.journal(JournalPhase::Aborted, None),
+        staged.allocation.as_ref(),
     )?;
     if staged.generation_root.exists() {
-        std::fs::remove_dir_all(&staged.generation_root).map_err(publication_io)?;
+        crate::project_recovery::remove_recovery_tree_with_allocation(
+            &staged.generation_root,
+            staged.allocation.as_ref(),
+        )?;
         sync_directory(
             staged
                 .generation_root
@@ -1574,6 +1634,9 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
         .open(&lease_path)
         .map_err(publication_io)?;
     lease.sync_all().map_err(publication_io)?;
+    if let Some(allocation) = &staged.allocation {
+        allocation.replace_file_at(&lease_path, &lease)?;
+    }
     // Windows rejects a parent-directory rename while a descendant file handle
     // is still live. The transaction lock, not this newly created lease file,
     // owns the staged attempt, so release the handle after its durability sync.
@@ -1597,7 +1660,7 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
     };
     let manifest_bytes = canonical_line(&manifest)?;
     let manifest_path = staged.generation_root.join(MANIFEST_FILE);
-    let manifest_file = write_new(&manifest_path, &manifest_bytes)?;
+    let manifest_file = write_new(&manifest_path, &manifest_bytes, staged.allocation.as_ref())?;
     project_failpoint::hit(
         "project.after_manifest_write",
         Some(staged.transaction_uuid),
@@ -1606,6 +1669,9 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
         false,
     )?;
     manifest_file.sync_all().map_err(publication_io)?;
+    if let Some(allocation) = &staged.allocation {
+        allocation.replace_file_at(&manifest_path, &manifest_file)?;
+    }
     // Optimistic publication promotes the complete staging directory below.
     // Close the manifest handle before that rename for Windows parity.
     drop(manifest_file);
@@ -1645,9 +1711,10 @@ fn make_generation_durable(staged: &StagedProjectGeneration) -> Result<[u8; 32],
     } else {
         sync_directory(&staged.root.join(GENERATIONS_DIR))?;
     }
-    write_journal(
+    write_journal_with_allocation(
         &staged.journal_path(),
         &staged.journal(JournalPhase::Durable, Some(hex_digest(manifest_sha256))),
+        staged.allocation.as_ref(),
     )?;
     project_failpoint::hit(
         "project.after_journal_durable",
@@ -1761,6 +1828,7 @@ fn replace_current(
             }
             Ok(())
         },
+        staged.allocation.as_ref(),
     );
     if let Err(error) = replace_result {
         reconcile_current_replacement_error(
@@ -1849,9 +1917,10 @@ fn finish_published_generation(
         "PUBLISHED",
         true,
     )?;
-    write_journal(
+    write_journal_with_allocation(
         &staged.journal_path(),
         &staged.journal(JournalPhase::Published, Some(hex_digest(manifest_sha256))),
+        staged.allocation.as_ref(),
     )
     .map_err(|error| {
         publication_error_from_parts(
@@ -2279,13 +2348,20 @@ fn sync_participant_directories(
     sync_directory(participants_root)
 }
 
-fn write_new(path: &Path, bytes: &[u8]) -> Result<File, GfError> {
+fn write_new(
+    path: &Path,
+    bytes: &[u8],
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<File, GfError> {
     let mut file = OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
         .map_err(publication_io)?;
-    file.write_all(bytes).map_err(publication_io)?;
+    let written = file.write_all(bytes).map_err(publication_io);
+    let observed = allocation.map_or(Ok(()), |allocation| allocation.replace_file_at(path, &file));
+    written?;
+    observed?;
     Ok(file)
 }
 
@@ -2402,9 +2478,19 @@ fn verify_exact_file(path: &Path, expected: &[u8]) -> Result<(), GfError> {
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn write_journal(path: &Path, journal: &JournalRecord) -> Result<(), GfError> {
+    write_journal_with_allocation(path, journal, None)
+}
+
+pub(crate) fn write_journal_with_allocation(
+    path: &Path,
+    journal: &JournalRecord,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), GfError> {
     let bytes = canonical_line(journal)?;
-    publish_atomic_bytes(path, &bytes, || Ok(()), || Ok(()), || Ok(())).map_err(publication_io)?;
+    publish_atomic_bytes_with_allocation(path, &bytes, || Ok(()), || Ok(()), || Ok(()), allocation)
+        .map_err(publication_io)?;
     sync_directory(
         path.parent()
             .expect("transaction journal always has a parent"),
@@ -2460,6 +2546,17 @@ pub(crate) fn publish_atomic_bytes(
     after_sync: impl FnOnce() -> std::io::Result<()>,
     before_replace: impl FnOnce() -> std::io::Result<()>,
 ) -> Result<(), AtomicPublishError> {
+    publish_atomic_bytes_with_allocation(path, bytes, after_write, after_sync, before_replace, None)
+}
+
+pub(crate) fn publish_atomic_bytes_with_allocation(
+    path: &Path,
+    bytes: &[u8],
+    after_write: impl FnOnce() -> std::io::Result<()>,
+    after_sync: impl FnOnce() -> std::io::Result<()>,
+    before_replace: impl FnOnce() -> std::io::Result<()>,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), AtomicPublishError> {
     let parent = path
         .parent()
         .ok_or_else(|| std::io::Error::other("atomic publication target has no parent"))?;
@@ -2487,9 +2584,19 @@ pub(crate) fn publish_atomic_bytes(
         // not an authority across those environments, so the temporary file
         // itself carries a kernel-visible lease until replacement completes.
         crate::file_lock::lock_exclusive(&temp)?;
-        temp.write_all(bytes)?;
+        let written = temp.write_all(bytes);
+        let observed = allocation.map_or(Ok(()), |allocation| {
+            allocation.replace_file_at(&temp_path, &temp)
+        });
+        written?;
+        observed.map_err(std::io::Error::other)?;
         after_write()?;
         temp.sync_all()?;
+        if let Some(allocation) = allocation {
+            allocation
+                .replace_file_at(&temp_path, &temp)
+                .map_err(std::io::Error::other)?;
+        }
         after_sync()?;
         before_replace()?;
 
@@ -2522,17 +2629,49 @@ pub(crate) fn publish_atomic_bytes(
             }
             Err(error) => Err(AtomicPublishError::Io(error)),
         };
+        if result.is_ok() {
+            record_atomic_replacement(allocation, path, &temp_path, &temp)?;
+        }
         let unlock = crate::file_lock::unlock(&temp);
         drop(temp);
         result.and_then(|()| unlock.map_err(AtomicPublishError::Io))
     };
     let result = publish();
-    if result.is_err() {
-        let _ = std::fs::remove_file(&temp_path);
+    if result.is_err()
+        && std::fs::remove_file(&temp_path).is_ok()
+        && let Some(allocation) = allocation
+    {
+        // Preserve the original publication error, especially StateUnknown.
+        // This path cannot turn a failed publication into accepted evidence.
+        let _ = allocation.remove_file_at(&temp_path);
     }
     result
 }
 
+fn record_atomic_replacement(
+    allocation: Option<&crate::StorageAllocationOperation>,
+    destination: &Path,
+    temporary_path: &Path,
+    file: &File,
+) -> Result<(), AtomicPublishError> {
+    let Some(allocation) = allocation else {
+        return Ok(());
+    };
+    let recorded = (|| {
+        allocation.remove_file_at(destination)?;
+        allocation.replace_file_at(destination, file)?;
+        allocation.remove_file_at(temporary_path)
+    })();
+    // Namespace replacement has already occurred. An evidence failure must
+    // preserve the publisher's post-replacement reconciliation semantics.
+    recorded.map_err(|error| {
+        AtomicPublishError::Replacement(graphforge_filesystem::ReplaceFileError::StateUnknown(
+            std::io::Error::other(error),
+        ))
+    })
+}
+
+#[allow(clippy::too_many_arguments)] // Existing atomic interface plus optional diagnostic context.
 fn publish_atomic_bytes_in(
     directory: &graphforge_filesystem::StableDirectory,
     diagnostic_path: &Path,
@@ -2541,18 +2680,30 @@ fn publish_atomic_bytes_in(
     after_write: impl FnOnce() -> std::io::Result<()>,
     after_sync: impl FnOnce() -> std::io::Result<()>,
     before_replace: impl FnOnce() -> std::io::Result<()>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), AtomicPublishError> {
     let target_text = target_name
         .to_str()
         .ok_or_else(|| std::io::Error::other("atomic publication target is not UTF-8"))?;
     let temp_name = std::ffi::OsString::from(unique_atomic_temp_name(target_text));
     let mut temp = directory.create_replaceable_child_file(&temp_name)?;
+    let temp_path = diagnostic_path.with_file_name(&temp_name);
     let temp_identity = graphforge_filesystem::file_identity(&temp)?;
     let publish = || -> Result<(), AtomicPublishError> {
         crate::file_lock::lock_exclusive(&temp)?;
-        temp.write_all(bytes)?;
+        let written = temp.write_all(bytes);
+        let observed = allocation.map_or(Ok(()), |allocation| {
+            allocation.replace_file_at(&temp_path, &temp)
+        });
+        written?;
+        observed.map_err(std::io::Error::other)?;
         after_write()?;
         temp.sync_all()?;
+        if let Some(allocation) = allocation {
+            allocation
+                .replace_file_at(&temp_path, &temp)
+                .map_err(std::io::Error::other)?;
+        }
         after_sync()?;
         before_replace()?;
         let namespace_lock = lock_atomic_publish_target(diagnostic_path);
@@ -2560,12 +2711,18 @@ fn publish_atomic_bytes_in(
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         directory.replace_child(&temp_name, temp_identity, target_name)?;
+        record_atomic_replacement(allocation, diagnostic_path, &temp_path, &temp)?;
         crate::file_lock::unlock(&temp)?;
         Ok(())
     };
     let result = publish();
-    if result.is_err() {
-        let _ = directory.unlink_child_if_identity(&temp_name, temp_identity);
+    if result.is_err()
+        && directory
+            .unlink_child_if_identity(&temp_name, temp_identity)
+            .is_ok()
+        && let Some(allocation) = allocation
+    {
+        let _ = allocation.remove_file_at(&temp_path);
     }
     result
 }
@@ -2629,6 +2786,13 @@ pub(crate) fn read_journal(path: &Path) -> Result<JournalRecord, GfError> {
 }
 
 pub(crate) fn cleanup_atomicwrite_temp(path: &Path) -> Result<bool, GfError> {
+    cleanup_atomicwrite_temp_with_allocation(path, None)
+}
+
+pub(crate) fn cleanup_atomicwrite_temp_with_allocation(
+    path: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<bool, GfError> {
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
         return Ok(false);
     };
@@ -2661,7 +2825,13 @@ pub(crate) fn cleanup_atomicwrite_temp(path: &Path) -> Result<bool, GfError> {
             let _ = crate::file_lock::unlock(&file);
             return Ok(false);
         }
+        if let Some(allocation) = allocation {
+            allocation.replace_file_at(path, &file)?;
+        }
         std::fs::remove_file(path).map_err(publication_io)?;
+        if let Some(allocation) = allocation {
+            allocation.remove_file_at(path)?;
+        }
         crate::file_lock::unlock(&file).map_err(publication_io)?;
         drop(file);
         sync_directory(
@@ -2702,7 +2872,15 @@ pub(crate) fn cleanup_atomicwrite_temp(path: &Path) -> Result<bool, GfError> {
                 return Ok(false);
             }
         }
+        if let Some(allocation) = allocation {
+            let file = crate::project_portable::open_regular_nofollow(&entry.path())
+                .map_err(publication_io)?;
+            allocation.replace_file_at(&entry.path(), &file)?;
+        }
         std::fs::remove_file(entry.path()).map_err(publication_io)?;
+        if let Some(allocation) = allocation {
+            allocation.remove_file_at(&entry.path())?;
+        }
     }
     std::fs::remove_dir(path).map_err(publication_io)?;
     sync_directory(
@@ -2850,10 +3028,150 @@ fn safe_cause(cause: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::fs;
 
     use super::*;
     use crate::open_or_initialize_project;
+
+    fn allocation_fixture_files(root: &Path) -> Vec<PathBuf> {
+        let mut pending = vec![root.to_path_buf()];
+        let mut files = Vec::new();
+        while let Some(path) = pending.pop() {
+            for entry in fs::read_dir(path).unwrap() {
+                let entry = entry.unwrap();
+                if entry.file_type().unwrap().is_dir() {
+                    pending.push(entry.path());
+                } else {
+                    files.push(entry.path());
+                }
+            }
+        }
+        files
+    }
+
+    #[test]
+    fn allocation_observed_admitted_publication_matches_reopened_file_union() {
+        let root = project();
+        let operation = crate::StorageAllocationOperation::default();
+        for path in allocation_fixture_files(root.path()) {
+            operation
+                .replace_file_at(&path, &File::open(&path).unwrap())
+                .unwrap();
+        }
+        let admission = crate::filesystem_admission::admit_project_lifecycle(
+            root.path(),
+            crate::filesystem_admission::ProjectLifecycleMode::Durable,
+            crate::filesystem_admission::ProjectRootRequirement::Existing,
+        )
+        .unwrap();
+        let parent = resolve_project_generation(root.path()).unwrap();
+        let request = request(vec![participant("graph", "nodes", &vec![3_u8; 16384])]);
+        let ProjectStageOutcome::Staged(staged) = stage_project_generation_from_admitted_parent(
+            admission,
+            parent,
+            &request,
+            None,
+            Some(&operation),
+        )
+        .unwrap() else {
+            panic!("unexpected replay")
+        };
+        let receipt = staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            receipt.generation_uuid
+        );
+        let mut identities = BTreeMap::new();
+        for path in allocation_fixture_files(root.path()) {
+            let file = File::open(path).unwrap();
+            let identity = graphforge_filesystem::file_identity(&file).unwrap();
+            identities.insert(
+                (identity.volume_serial, identity.file_id),
+                graphforge_filesystem::file_space_usage(&file)
+                    .unwrap()
+                    .allocated_bytes,
+            );
+        }
+        let actual: u64 = identities.values().sum();
+        let (current, peak) = operation.totals().unwrap();
+        assert_eq!(current, actual);
+        assert!(peak >= current);
+    }
+
+    #[test]
+    fn allocation_observed_atomic_replacement_preserves_coexistence_and_cleanup() {
+        for stable in [false, true] {
+            for fail in [false, true] {
+                let root = tempfile::tempdir().unwrap();
+                let path = root.path().join("CURRENT");
+                std::fs::write(&path, vec![1_u8; 8192]).unwrap();
+                let old = File::open(&path).unwrap();
+                let old_bytes = graphforge_filesystem::file_space_usage(&old)
+                    .unwrap()
+                    .allocated_bytes;
+                let operation = crate::StorageAllocationOperation::default();
+                operation.replace_file_at(&path, &old).unwrap();
+                drop(old);
+                let coexistence = std::cell::Cell::new(0);
+                let after_write = || {
+                    let (current, peak) = operation.totals().unwrap();
+                    assert!(current > old_bytes);
+                    assert_eq!(current, peak);
+                    coexistence.set(current);
+                    if fail {
+                        Err(std::io::Error::other("before replacement"))
+                    } else {
+                        Ok(())
+                    }
+                };
+                let payload = vec![2_u8; 16384];
+                let result = if stable {
+                    let directory =
+                        graphforge_filesystem::StableDirectory::open(root.path()).unwrap();
+                    publish_atomic_bytes_in(
+                        &directory,
+                        &path,
+                        std::ffi::OsStr::new("CURRENT"),
+                        &payload,
+                        after_write,
+                        || Ok(()),
+                        || Ok(()),
+                        Some(&operation),
+                    )
+                } else {
+                    publish_atomic_bytes_with_allocation(
+                        &path,
+                        &payload,
+                        after_write,
+                        || Ok(()),
+                        || Ok(()),
+                        Some(&operation),
+                    )
+                };
+                assert_eq!(result.is_err(), fail);
+                let actual = File::open(&path).unwrap();
+                let actual_bytes = graphforge_filesystem::file_space_usage(&actual)
+                    .unwrap()
+                    .allocated_bytes;
+                assert_eq!(
+                    operation.totals().unwrap(),
+                    (actual_bytes, coexistence.get())
+                );
+                assert_eq!(
+                    std::fs::read(&path).unwrap(),
+                    if fail { vec![1_u8; 8192] } else { payload }
+                );
+                assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 1);
+            }
+        }
+    }
 
     #[cfg(windows)]
     #[test]
@@ -3491,10 +3809,15 @@ mod tests {
         let other_parent = resolve_project_generation(other_root.path()).unwrap();
         let request = request(vec![participant("graph", "nodes", b"wrong-root")]);
 
-        let error =
-            stage_project_generation_from_admitted_parent(admission, other_parent, &request, None)
-                .err()
-                .expect("a prepared parent from another root must fail");
+        let error = stage_project_generation_from_admitted_parent(
+            admission,
+            other_parent,
+            &request,
+            None,
+            None,
+        )
+        .err()
+        .expect("a prepared parent from another root must fail");
 
         assert_eq!(error.code(), "GF_PUBLICATION_FAILED");
         assert!(

--- a/crates/graphforge-storage/src/project_recovery.rs
+++ b/crates/graphforge-storage/src/project_recovery.rs
@@ -15,13 +15,15 @@ use uuid::Uuid;
 use crate::project_checkpoints::checkpoint_retention_roots_after_writer_lock;
 use crate::project_failpoint;
 use crate::project_generation::{
-    CURRENT_FILE, ResolvedProjectGeneration, open_or_initialize_project_admitted,
-    resolve_project_generation, validated_generation_manifest_sha256, validated_generation_parent,
+    CURRENT_FILE, ResolvedProjectGeneration, resolve_project_generation,
+    validated_generation_manifest_sha256, validated_generation_parent,
 };
+#[cfg(test)]
+use crate::project_publication::write_journal;
 use crate::project_publication::{
     ATTEMPTS_DIR, GENERATIONS_DIR, JournalPhase, LOCKS_DIR, TRANSACTIONS_DIR, WRITER_LOCK_FILE,
     ensure_machine_directory, open_regular_lock, open_transaction_lock, read_journal,
-    sync_directory, write_journal,
+    sync_directory, write_journal_with_allocation,
 };
 
 pub(crate) const TRASH_DIR: &str = "trash";
@@ -191,6 +193,7 @@ pub fn open_or_initialize_project_with_recovery(
     open_or_initialize_project_with_recovery_for_mode(
         container_root.as_ref(),
         crate::filesystem_admission::ProjectLifecycleMode::Durable,
+        None,
     )
 }
 
@@ -206,12 +209,27 @@ pub fn open_or_initialize_ephemeral_project_with_recovery(
     open_or_initialize_project_with_recovery_for_mode(
         container_root.as_ref(),
         crate::filesystem_admission::ProjectLifecycleMode::Ephemeral,
+        None,
+    )
+}
+
+/// First-party diagnostic open with explicit operation allocation ownership.
+#[doc(hidden)]
+pub fn open_or_initialize_project_with_allocation(
+    root: &Path,
+    allocation: &crate::StorageAllocationOperation,
+) -> Result<(ResolvedProjectGeneration, ProjectOpenRecoveryEvidence), GfError> {
+    open_or_initialize_project_with_recovery_for_mode(
+        root,
+        crate::filesystem_admission::ProjectLifecycleMode::Durable,
+        Some(allocation),
     )
 }
 
 fn open_or_initialize_project_with_recovery_for_mode(
     root: &Path,
     mode: crate::filesystem_admission::ProjectLifecycleMode,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(ResolvedProjectGeneration, ProjectOpenRecoveryEvidence), GfError> {
     let admission = crate::filesystem_admission::admit_project_lifecycle(
         root,
@@ -221,9 +239,11 @@ fn open_or_initialize_project_with_recovery_for_mode(
     admission.revalidate_identity()?;
     let root = admission.root();
     if root.join(CURRENT_FILE).exists() {
-        return recover_project_on_open_admitted(root);
+        return recover_project_on_open_admitted_with_allocation(root, allocation);
     }
-    let resolved = open_or_initialize_project_admitted(root)?;
+    let resolved = crate::project_generation::open_or_initialize_project_admitted_with_allocation(
+        root, allocation,
+    )?;
     Ok((
         resolved.clone(),
         ProjectOpenRecoveryEvidence::initialization(resolved.generation_uuid()),
@@ -255,6 +275,13 @@ pub fn recover_project_on_open(
 fn recover_project_on_open_admitted(
     root: &Path,
 ) -> Result<(ResolvedProjectGeneration, ProjectOpenRecoveryEvidence), GfError> {
+    recover_project_on_open_admitted_with_allocation(root, None)
+}
+
+fn recover_project_on_open_admitted_with_allocation(
+    root: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(ResolvedProjectGeneration, ProjectOpenRecoveryEvidence), GfError> {
     let started = Instant::now();
     let selected = resolve_project_generation(root).map_err(map_recovery_resolution)?;
     let work_detected = project_needs_recovery_pass(root)?;
@@ -276,7 +303,7 @@ fn recover_project_on_open_admitted(
         ));
     }
 
-    match recover_project_transactions_admitted(root) {
+    match recover_project_transactions_admitted_with_allocation(root, allocation) {
         Ok(report) => {
             let selected = resolve_project_generation(root).map_err(map_recovery_resolution)?;
             Ok((
@@ -459,9 +486,19 @@ pub fn remove_durable_project_root(container_root: impl AsRef<Path>) -> Result<(
 }
 
 fn recover_project_transactions_admitted(root: &Path) -> Result<ProjectRecoveryReport, GfError> {
+    recover_project_transactions_admitted_with_allocation(root, None)
+}
+
+fn recover_project_transactions_admitted_with_allocation(
+    root: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<ProjectRecoveryReport, GfError> {
     let selected = resolve_project_generation(root).map_err(map_recovery_resolution)?;
     let root = selected.container_root().to_owned();
     let writer_lock = acquire_recovery_lock(&root)?;
+    if let Some(allocation) = allocation {
+        allocation.replace_file_at(&root.join(LOCKS_DIR).join(WRITER_LOCK_FILE), &writer_lock)?;
+    }
 
     // A writer may have published between the read-side resolution and lock
     // acquisition. Only the post-lock resolution is authoritative here.
@@ -484,7 +521,14 @@ fn recover_project_transactions_admitted(root: &Path) -> Result<ProjectRecoveryR
 
     let transactions_root = root.join(TRANSACTIONS_DIR);
     if transactions_root.exists() {
-        recover_journals(&root, &transactions_root, &selected, &retained, &mut report)?;
+        recover_journals(
+            &root,
+            &transactions_root,
+            &selected,
+            &retained,
+            &mut report,
+            allocation,
+        )?;
     }
     report.preserved_unknown_entries += count_unknown_generation_entries(&root, &retained)?;
     // Release checkpoints.lock before writer.lock so concurrent mutators never
@@ -515,11 +559,15 @@ fn recover_journals(
     selected: &crate::ResolvedProjectGeneration,
     retained: &BTreeSet<Uuid>,
     report: &mut ProjectRecoveryReport,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), GfError> {
     let mut journal_paths = bounded_directory_entries(transactions_root)?;
     journal_paths.sort();
     for journal_path in journal_paths {
-        if crate::project_publication::cleanup_atomicwrite_temp(&journal_path)? {
+        if crate::project_publication::cleanup_atomicwrite_temp_with_allocation(
+            &journal_path,
+            allocation,
+        )? {
             continue;
         }
         let Some(transaction_uuid) = journal_file_uuid(&journal_path) else {
@@ -550,6 +598,7 @@ fn recover_journals(
                 &mut journal,
                 selected.manifest_sha256(),
                 report,
+                allocation,
             )?;
         } else if retained.contains(&generation_uuid) {
             repair_reachable_journal(
@@ -557,11 +606,12 @@ fn recover_journals(
                 &mut journal,
                 validated_generation_manifest_sha256(root, generation_uuid)?,
                 report,
+                allocation,
             )?;
         } else {
             if journal.phase != JournalPhase::Published && journal.phase != JournalPhase::Aborted {
                 journal.phase = JournalPhase::Aborted;
-                write_journal(&journal_path, &journal)?;
+                write_journal_with_allocation(&journal_path, &journal, allocation)?;
                 report.aborted_journals += 1;
             }
             report.removed_generations += cleanup_abandoned_generation(
@@ -570,6 +620,7 @@ fn recover_journals(
                 generation_uuid,
                 &journal.request_fingerprint,
                 retained,
+                allocation,
             )?;
         }
     }
@@ -581,6 +632,7 @@ fn repair_reachable_journal(
     journal: &mut crate::project_publication::JournalRecord,
     manifest_sha256: [u8; 32],
     report: &mut ProjectRecoveryReport,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), GfError> {
     let expected_digest = digest_hex(manifest_sha256);
     if journal.generation_manifest_sha256.as_deref() != Some(expected_digest.as_str()) {
@@ -590,7 +642,7 @@ fn repair_reachable_journal(
     }
     if journal.phase != JournalPhase::Published {
         journal.phase = JournalPhase::Published;
-        write_journal(path, journal)?;
+        write_journal_with_allocation(path, journal, allocation)?;
         report.repaired_journals += 1;
     }
     Ok(())
@@ -744,6 +796,7 @@ fn cleanup_abandoned_generation(
     generation_uuid: Uuid,
     request_fingerprint: &str,
     retained: &BTreeSet<Uuid>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<u64, GfError> {
     if retained.contains(&generation_uuid) {
         return Ok(0);
@@ -757,7 +810,7 @@ fn cleanup_abandoned_generation(
     let mut removed = 0;
     if attempt_path.exists() {
         reject_real_directory(&attempt_path)?;
-        std::fs::remove_dir_all(&attempt_path).map_err(storage_io)?;
+        remove_recovery_tree_with_allocation(&attempt_path, allocation)?;
         sync_directory(
             attempt_path
                 .parent()
@@ -777,12 +830,13 @@ fn cleanup_abandoned_generation(
     let trash_path = trash_root.join(&generation_name);
 
     if trash_path.exists() {
-        remove_trash_entry(
+        remove_trash_entry_with_allocation(
             root,
             &trash_root,
             &trash_path,
             transaction_uuid,
             generation_uuid,
+            allocation,
         )?;
         return Ok(1);
     }
@@ -810,12 +864,13 @@ fn cleanup_abandoned_generation(
         "GC",
         true,
     )?;
-    remove_trash_entry(
+    remove_trash_entry_with_allocation(
         root,
         &trash_root,
         &trash_path,
         transaction_uuid,
         generation_uuid,
+        allocation,
     )?;
     Ok(1)
 }
@@ -827,6 +882,24 @@ fn remove_trash_entry(
     transaction_uuid: Uuid,
     generation_uuid: Uuid,
 ) -> Result<(), GfError> {
+    remove_trash_entry_with_allocation(
+        root,
+        trash_root,
+        trash_path,
+        transaction_uuid,
+        generation_uuid,
+        None,
+    )
+}
+
+fn remove_trash_entry_with_allocation(
+    root: &Path,
+    trash_root: &Path,
+    trash_path: &Path,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), GfError> {
     reject_real_directory(trash_path)?;
     if resolve_project_generation(root)
         .map_err(map_recovery_resolution)?
@@ -837,7 +910,26 @@ fn remove_trash_entry(
             "trash entry is reachable from the committed pointer",
         ));
     }
-    std::fs::remove_dir_all(trash_path).map_err(storage_io)?;
+    // A returned failure after generation -> trash may leave this same
+    // operation holding the original route keys. Reconstruct those exact
+    // relative routes only when the original generation no longer exists.
+    // Never release keys belonging to a still-live generation with this UUID.
+    let generation_path = root
+        .join(GENERATIONS_DIR)
+        .join(generation_uuid.hyphenated().to_string());
+    let previous_root = if allocation.is_some() {
+        match std::fs::symlink_metadata(&generation_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Some(generation_path.as_path())
+            }
+            Ok(_) => None,
+            Err(error) => return Err(storage_io(error)),
+        }
+    } else {
+        None
+    };
+    let owners = recovery_removal_owners(trash_path, allocation, previous_root)?;
+    remove_recovery_tree_owners(trash_path, owners, allocation)?;
     sync_directory(trash_root)?;
     project_failpoint::hit(
         "project.after_gc_delete",
@@ -846,6 +938,78 @@ fn remove_trash_entry(
         "GC",
         true,
     )
+}
+
+// Only the caller's already authorized, idle cleanup subtree is inspected.
+// Retained directory handles refuse links; no graph payload bytes are read.
+fn recovery_removal_owners(
+    root: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
+    previous_root: Option<&Path>,
+) -> Result<Vec<String>, GfError> {
+    if allocation.is_none() {
+        return Ok(Vec::new());
+    }
+    let directory = graphforge_filesystem::StableDirectory::open(root).map_err(storage_io)?;
+    let mut pending = vec![directory];
+    let mut remaining = 1_000_000_usize;
+    let mut owners = Vec::new();
+    while let Some(directory) = pending.pop() {
+        let names = directory
+            .child_names_bounded(remaining)
+            .map_err(storage_io)?;
+        remaining = remaining
+            .checked_sub(names.len())
+            .ok_or_else(|| storage_io("recovery allocation inventory exceeds bound"))?;
+        for name in names {
+            if let Ok(child) = directory.open_child_directory(&name) {
+                pending.push(child);
+            } else {
+                // Opening the retained child rejects symlinks and special files.
+                let _file = directory.open_child_file(&name).map_err(storage_io)?;
+                let path = directory.path().join(name);
+                owners.push(crate::StorageAllocationOperation::file_owner(&path)?);
+                if let Some(previous_root) = previous_root {
+                    let relative = path.strip_prefix(root).map_err(storage_io)?;
+                    owners.push(crate::StorageAllocationOperation::file_owner(
+                        &previous_root.join(relative),
+                    )?);
+                }
+            }
+        }
+    }
+    Ok(owners)
+}
+
+fn forget_recovery_owners(
+    owners: Vec<String>,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), GfError> {
+    if let Some(allocation) = allocation {
+        for owner in owners {
+            allocation.remove_owner(&owner)?;
+        }
+    }
+    Ok(())
+}
+
+/// Delete an authorized idle subtree and release its actual per-file owners.
+/// Callers retain the existing transaction/lease and reachability checks.
+pub(crate) fn remove_recovery_tree_with_allocation(
+    root: &Path,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), GfError> {
+    let owners = recovery_removal_owners(root, allocation, None)?;
+    remove_recovery_tree_owners(root, owners, allocation)
+}
+
+fn remove_recovery_tree_owners(
+    root: &Path,
+    owners: Vec<String>,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), GfError> {
+    std::fs::remove_dir_all(root).map_err(storage_io)?;
+    forget_recovery_owners(owners, allocation)
 }
 
 /// Delete a trash entry that is not the committed generation.
@@ -1019,6 +1183,206 @@ mod tests {
         "project.after_root_fsync",
         "project.after_journal_published",
     ];
+
+    #[cfg(unix)]
+    fn recovery_allocation_inventory(
+        root: &Path,
+        seed: Option<&crate::StorageAllocationOperation>,
+    ) -> u64 {
+        use std::os::unix::fs::MetadataExt as _;
+        let mut pending = vec![root.to_owned()];
+        let mut identities = std::collections::BTreeMap::new();
+        while let Some(directory) = pending.pop() {
+            for entry in std::fs::read_dir(directory).unwrap() {
+                let entry = entry.unwrap();
+                let metadata = entry.path().symlink_metadata().unwrap();
+                if metadata.is_dir() {
+                    pending.push(entry.path());
+                } else {
+                    assert!(metadata.is_file());
+                    identities.insert((metadata.dev(), metadata.ino()), metadata.blocks() * 512);
+                    if let Some(seed) = seed {
+                        seed.replace_file_at(&entry.path(), &File::open(entry.path()).unwrap())
+                            .unwrap();
+                    }
+                }
+            }
+        }
+        identities.values().sum()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn recovery_allocation_tracks_repair_and_abandoned_generation_cleanup() {
+        use std::os::unix::fs::MetadataExt as _;
+        for publish in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            open_or_initialize_project(root.path()).unwrap();
+            let request = ProjectGenerationRequest {
+                transaction_uuid: Uuid::now_v7(),
+                generation_uuid: Uuid::now_v7(),
+                capabilities: capabilities("graph"),
+                participants: participants("graph"),
+            };
+            let ProjectStageOutcome::Staged(staged) =
+                stage_project_generation(root.path(), &request).unwrap()
+            else {
+                panic!("fresh recovery allocation fixture replayed");
+            };
+            let journal_path = root
+                .path()
+                .join(TRANSACTIONS_DIR)
+                .join(format!("{}.json", request.transaction_uuid.hyphenated()));
+            if publish {
+                staged
+                    .validate(|_| Ok(()), |_, _| Ok(()))
+                    .unwrap()
+                    .publish()
+                    .unwrap();
+                let mut journal = read_journal(&journal_path).unwrap();
+                journal.phase = JournalPhase::Durable;
+                write_journal(&journal_path, &journal).unwrap();
+            } else {
+                drop(staged);
+            }
+            let allocation = crate::StorageAllocationOperation::default();
+            let before = recovery_allocation_inventory(root.path(), Some(&allocation));
+            assert_eq!(allocation.totals().unwrap(), (before, before));
+            let (_, report) =
+                open_or_initialize_project_with_allocation(root.path(), &allocation).unwrap();
+            let after = recovery_allocation_inventory(root.path(), None);
+            let journal_bytes = journal_path.metadata().unwrap().blocks() * 512;
+            assert_eq!(
+                allocation.totals().unwrap(),
+                (after, before + journal_bytes)
+            );
+            if publish {
+                assert_eq!(report.repaired_journals, 1);
+                assert_eq!(report.removed_generations, 0);
+            } else {
+                assert_eq!(report.aborted_journals, 1);
+                assert!(report.removed_generations > 0);
+                assert!(after < before);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn recovery_allocation_cleanup_preserves_aliases_and_refuses_links_before_delete() {
+        let root = tempfile::tempdir().unwrap();
+        let abandoned = root.path().join("abandoned");
+        std::fs::create_dir(&abandoned).unwrap();
+        let payload = abandoned.join("payload");
+        std::fs::write(&payload, vec![1_u8; 8192]).unwrap();
+        std::fs::hard_link(&payload, root.path().join("retained-alias")).unwrap();
+        let allocation = crate::StorageAllocationOperation::default();
+        let before = recovery_allocation_inventory(root.path(), Some(&allocation));
+        std::os::unix::fs::symlink(root.path().join("retained-alias"), abandoned.join("unsafe"))
+            .unwrap();
+        let unchanged = allocation.snapshot().unwrap();
+        assert!(remove_recovery_tree_with_allocation(&abandoned, Some(&allocation)).is_err());
+        assert!(payload.exists());
+        assert_eq!(allocation.snapshot().unwrap(), unchanged);
+        std::fs::remove_file(abandoned.join("unsafe")).unwrap();
+        remove_recovery_tree_with_allocation(&abandoned, Some(&allocation)).unwrap();
+        assert!(!abandoned.exists());
+        assert_eq!(allocation.totals().unwrap(), (before, before));
+        assert_eq!(recovery_allocation_inventory(root.path(), None), before);
+        allocation
+            .snapshot()
+            .unwrap()
+            .validate_continuation()
+            .unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn recovery_allocation_returned_errors_allow_same_context_retry() {
+        const CHILD: &str = "GRAPHFORGE_RECOVERY_ALLOCATION_CHILD";
+        if std::env::var(CHILD).as_deref() != Ok("1") {
+            for boundary in [
+                "project.after_gc_move.error",
+                "project.after_gc_delete.error",
+            ] {
+                let status = Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        "--exact",
+                        "project_recovery::tests::recovery_allocation_returned_errors_allow_same_context_retry",
+                        "--nocapture",
+                    ])
+                    .env(CHILD, "1")
+                    .env("GRAPHFORGE_PROJECT_FAILPOINTS", ENABLE_COOKIE)
+                    .env("GRAPHFORGE_PROJECT_FAILPOINT", boundary)
+                    .status().unwrap();
+                assert!(
+                    status.success(),
+                    "same-context recovery failed at {boundary}"
+                );
+            }
+            return;
+        }
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let request = ProjectGenerationRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            capabilities: capabilities("graph"),
+            participants: participants("graph"),
+        };
+        let staged = stage_project_generation(root.path(), &request).unwrap();
+        drop(staged);
+        let allocation = crate::StorageAllocationOperation::default();
+        recovery_allocation_inventory(root.path(), Some(&allocation));
+        let error = open_or_initialize_project_with_allocation(root.path(), &allocation)
+            .err()
+            .expect("selected recovery boundary must fail");
+        assert!(error.to_string().contains("injected_failpoint"));
+        assert_eq!(
+            allocation.totals().unwrap().0,
+            recovery_allocation_inventory(root.path(), None),
+            "a returned error must preserve the actual surviving union",
+        );
+        open_or_initialize_project_with_allocation(root.path(), &allocation).unwrap();
+        assert_eq!(
+            allocation.totals().unwrap().0,
+            recovery_allocation_inventory(root.path(), None),
+            "same-context retry must release original route owners",
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn recovery_allocation_trash_cleanup_preserves_existing_generation_routes() {
+        let root = tempfile::tempdir().unwrap();
+        open_or_initialize_project(root.path()).unwrap();
+        let generation = Uuid::now_v7();
+        let name = generation.hyphenated().to_string();
+        let generation_path = root.path().join(GENERATIONS_DIR).join(&name);
+        let trash_root = root.path().join(TRASH_DIR);
+        let trash_path = trash_root.join(&name);
+        std::fs::create_dir_all(&generation_path).unwrap();
+        std::fs::create_dir_all(&trash_path).unwrap();
+        std::fs::write(generation_path.join("payload"), vec![1_u8; 8192]).unwrap();
+        std::fs::write(trash_path.join("payload"), vec![2_u8; 8192]).unwrap();
+        let allocation = crate::StorageAllocationOperation::default();
+        recovery_allocation_inventory(root.path(), Some(&allocation));
+        remove_trash_entry_with_allocation(
+            root.path(),
+            &trash_root,
+            &trash_path,
+            Uuid::now_v7(),
+            generation,
+            Some(&allocation),
+        )
+        .unwrap();
+        assert!(generation_path.join("payload").exists());
+        assert!(!trash_path.exists());
+        assert_eq!(
+            allocation.totals().unwrap().0,
+            recovery_allocation_inventory(root.path(), None),
+        );
+    }
 
     #[derive(serde::Serialize)]
     struct NativeOracleObservation {

--- a/crates/graphforge-storage/src/storage_attribution.rs
+++ b/crates/graphforge-storage/src/storage_attribution.rs
@@ -468,41 +468,42 @@ pub struct StorageAllocationLifecycle {
     peak_allocated_bytes: u64,
 }
 
+struct PreparedAllocationChange {
+    active: BTreeMap<String, Option<(u64, u64)>>,
+    current: u64,
+    peak: u64,
+}
+
 impl StorageAllocationLifecycle {
+    /// Check diagnostic raw owner facts against a per-file baseline without exposing identities.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn matches_file_inventory(
+        &self,
+        identities: &BTreeMap<String, u64>,
+        logical_references: u64,
+    ) -> bool {
+        u64::try_from(self.owners.len()).ok() == Some(logical_references)
+            && self.owners.values().all(|owner| owner.len() == 1)
+            && self.active.len() == identities.len()
+            && self
+                .active
+                .iter()
+                .all(|(identity, (allocated, _))| identities.get(identity) == Some(allocated))
+    }
+
     /// Replace an owner's exact authenticated identity inventory.
     pub fn replace_owner(
         &mut self,
         owner: impl Into<String>,
         identities: &BTreeMap<String, u64>,
     ) -> Result<(), GfError> {
-        let mut candidate = self.clone();
-        candidate.replace_owner_inner(owner.into(), identities)?;
-        *self = candidate;
-        Ok(())
-    }
-
-    fn replace_owner_inner(
-        &mut self,
-        owner: String,
-        identities: &BTreeMap<String, u64>,
-    ) -> Result<(), GfError> {
-        self.remove_owner(&owner)?;
-        let mut installed = BTreeSet::new();
-        for (identity, allocated) in identities {
-            if let Some((existing, references)) = self.active.get_mut(identity) {
-                if existing != allocated {
-                    return Err(validation("active identity allocation changed"));
-                }
-                *references = checked_add(*references, 1)?;
-            } else {
-                self.current_allocated_bytes =
-                    checked_add(self.current_allocated_bytes, *allocated)?;
-                self.active.insert(identity.clone(), (*allocated, 1));
-            }
-            installed.insert(identity.clone());
-            self.peak_allocated_bytes = self.peak_allocated_bytes.max(self.current_allocated_bytes);
-        }
-        self.owners.insert(owner, installed);
+        let owner = owner.into();
+        let removed = self.owners.get(&owner).cloned().unwrap_or_default();
+        let prepared = self.prepare_change(&removed, identities)?;
+        self.commit_change(prepared);
+        self.owners
+            .insert(owner, identities.keys().cloned().collect());
         Ok(())
     }
 
@@ -523,90 +524,158 @@ impl StorageAllocationLifecycle {
         owner: impl Into<String>,
         transition: &StorageAllocationTransition,
     ) -> Result<(), GfError> {
-        let mut candidate = self.clone();
-        candidate.apply_owner_transition_inner(owner.into(), transition)?;
-        *self = candidate;
-        Ok(())
-    }
-
-    fn apply_owner_transition_inner(
-        &mut self,
-        owner: String,
-        transition: &StorageAllocationTransition,
-    ) -> Result<(), GfError> {
+        let owner = owner.into();
         if transition
             .installed
             .keys()
-            .any(|identity| transition.removed.contains(identity))
+            .any(|id| transition.removed.contains(id))
         {
             return Err(validation(
                 "allocation transition installs and removes one identity",
             ));
         }
-        let owner_identities = self.owners.entry(owner).or_default();
-        for identity in &transition.removed {
-            if !owner_identities.remove(identity) {
-                return Err(validation(
-                    "allocation transition removes an unowned identity",
-                ));
-            }
-            let (allocated, references) = self
-                .active
-                .get(identity)
-                .copied()
-                .ok_or_else(|| validation("active transition identity is absent"))?;
-            if references == 1 {
-                self.active.remove(identity);
-                self.current_allocated_bytes = self
-                    .current_allocated_bytes
-                    .checked_sub(allocated)
-                    .ok_or_else(|| validation("active allocation underflow"))?;
-            } else {
-                self.active
-                    .insert(identity.clone(), (allocated, references - 1));
-            }
+        let existing = self.owners.get(&owner);
+        if transition
+            .removed
+            .iter()
+            .any(|id| existing.is_none_or(|ids| !ids.contains(id)))
+        {
+            return Err(validation(
+                "allocation transition removes an unowned identity",
+            ));
         }
-        for (identity, allocated) in &transition.installed {
-            if !owner_identities.insert(identity.clone()) {
-                return Err(validation(
-                    "allocation transition installs an owned identity",
-                ));
-            }
-            if let Some((existing, references)) = self.active.get_mut(identity) {
-                if existing != allocated {
-                    return Err(validation("active identity allocation changed"));
-                }
-                *references = checked_add(*references, 1)?;
-            } else {
-                self.current_allocated_bytes =
-                    checked_add(self.current_allocated_bytes, *allocated)?;
-                self.active.insert(identity.clone(), (*allocated, 1));
-            }
-            self.peak_allocated_bytes = self.peak_allocated_bytes.max(self.current_allocated_bytes);
+        if transition
+            .installed
+            .keys()
+            .any(|id| existing.is_some_and(|ids| ids.contains(id)))
+        {
+            return Err(validation(
+                "allocation transition installs an owned identity",
+            ));
         }
+        let prepared = self.prepare_change(&transition.removed, &transition.installed)?;
+        self.commit_change(prepared);
+        let identities = self.owners.entry(owner).or_default();
+        for id in &transition.removed {
+            identities.remove(id);
+        }
+        identities.extend(transition.installed.keys().cloned());
         Ok(())
     }
 
     /// Remove an owner and decrement every exact identity reference.
     pub fn remove_owner(&mut self, owner: &str) -> Result<(), GfError> {
-        let Some(identities) = self.owners.remove(owner) else {
+        let Some(removed) = self.owners.get(owner) else {
             return Ok(());
         };
-        for identity in identities {
+        let prepared = self.prepare_change(removed, &BTreeMap::new())?;
+        self.commit_change(prepared);
+        self.owners.remove(owner);
+        Ok(())
+    }
+
+    // Validate only changed identities. All fallible arithmetic and consistency
+    // checks precede mutation; unrelated owners are neither copied nor visited.
+    fn prepare_change(
+        &self,
+        removed: &BTreeSet<String>,
+        installed: &BTreeMap<String, u64>,
+    ) -> Result<PreparedAllocationChange, GfError> {
+        let mut active = BTreeMap::new();
+        let mut current = self.current_allocated_bytes;
+        for id in removed {
             let (allocated, references) = self
                 .active
-                .get(&identity)
+                .get(id)
                 .copied()
                 .ok_or_else(|| validation("active identity owner is absent"))?;
-            if references == 1 {
-                self.active.remove(&identity);
-                self.current_allocated_bytes = self
-                    .current_allocated_bytes
+            let references = references
+                .checked_sub(1)
+                .ok_or_else(|| validation("active identity has no references"))?;
+            let next = if references == 0 {
+                current = current
                     .checked_sub(allocated)
                     .ok_or_else(|| validation("active allocation underflow"))?;
+                None
             } else {
-                self.active.insert(identity, (allocated, references - 1));
+                Some((allocated, references))
+            };
+            active.insert(id.clone(), next);
+        }
+        for (id, allocated) in installed {
+            let previous = active
+                .get(id)
+                .copied()
+                .unwrap_or_else(|| self.active.get(id).copied());
+            let next = if let Some((previous, references)) = previous {
+                if previous != *allocated || references == 0 {
+                    return Err(validation("active identity allocation changed"));
+                }
+                (*allocated, checked_add(references, 1)?)
+            } else {
+                current = checked_add(current, *allocated)?;
+                (*allocated, 1)
+            };
+            active.insert(id.clone(), Some(next));
+        }
+        Ok(PreparedAllocationChange {
+            active,
+            current,
+            peak: self.peak_allocated_bytes.max(current),
+        })
+    }
+
+    fn commit_change(&mut self, prepared: PreparedAllocationChange) {
+        for (id, value) in prepared.active {
+            if let Some(value) = value {
+                self.active.insert(id, value);
+            } else {
+                self.active.remove(&id);
             }
+        }
+        self.current_allocated_bytes = prepared.current;
+        self.peak_allocated_bytes = prepared.peak;
+    }
+
+    /// Validate private continuation state once before operation admission.
+    /// This checks structure and arithmetic, not the provenance of its peak.
+    /// The transport must separately bound encoded bytes and authenticate the
+    /// producing operation; ordinary writer updates do not repeat this scan.
+    ///
+    /// # Errors
+    /// Rejects excessive inventory, dangling identities, inconsistent reference
+    /// counts or totals, overflow, and a peak below current allocation.
+    pub fn validate_continuation(&self) -> Result<(), GfError> {
+        const MAX_ENTRIES: usize = 1_000_000;
+        if self.owners.len() > MAX_ENTRIES || self.active.len() > MAX_ENTRIES {
+            return Err(validation("allocation continuation exceeds entry bound"));
+        }
+        let mut references = BTreeMap::<&String, u64>::new();
+        let mut entries = 0_usize;
+        for ids in self.owners.values() {
+            entries = entries
+                .checked_add(ids.len())
+                .filter(|count| *count <= MAX_ENTRIES)
+                .ok_or_else(|| validation("allocation continuation exceeds reference bound"))?;
+            for id in ids {
+                let count = references.entry(id).or_default();
+                *count = checked_add(*count, 1)?;
+            }
+        }
+        if references.len() != self.active.len() {
+            return Err(validation("allocation continuation identity set differs"));
+        }
+        let mut current = 0_u64;
+        for (id, (allocated, count)) in &self.active {
+            if *count == 0 || references.get(id) != Some(count) {
+                return Err(validation(
+                    "allocation continuation reference counts differ",
+                ));
+            }
+            current = checked_add(current, *allocated)?;
+        }
+        if current != self.current_allocated_bytes || self.peak_allocated_bytes < current {
+            return Err(validation("allocation continuation totals differ"));
         }
         Ok(())
     }
@@ -1235,7 +1304,7 @@ fn checked_add(left: u64, right: u64) -> Result<u64, GfError> {
         .ok_or_else(|| validation("storage attribution counter overflow"))
 }
 
-fn native_identity_key(volume_serial: u64, file_id: &[u8; 16]) -> String {
+pub(crate) fn native_identity_key(volume_serial: u64, file_id: &[u8; 16]) -> String {
     use std::fmt::Write as _;
     let mut value = format!("{volume_serial:016x}:");
     for byte in file_id {
@@ -1291,6 +1360,129 @@ mod tests {
             .publish()
             .unwrap();
         crate::resolve_project_generation(project).unwrap()
+    }
+
+    #[test]
+    fn lifecycle_rejected_updates_are_atomic() {
+        let mut state = StorageAllocationLifecycle::default();
+        state
+            .replace_owner(
+                "writer",
+                &BTreeMap::from([("a".into(), 4), ("b".into(), 8)]),
+            )
+            .unwrap();
+        state
+            .replace_owner("alias", &BTreeMap::from([("a".into(), 4)]))
+            .unwrap();
+        let before = state.clone();
+        assert!(
+            state
+                .replace_owner("writer", &BTreeMap::from([("a".into(), 5)]))
+                .is_err()
+        );
+        assert_eq!(state, before);
+        for change in [
+            StorageAllocationTransition {
+                installed: BTreeMap::new(),
+                removed: ["a".into(), "missing".into()].into(),
+            },
+            StorageAllocationTransition {
+                installed: BTreeMap::from([("a".into(), 4)]),
+                removed: ["b".into()].into(),
+            },
+            StorageAllocationTransition {
+                installed: BTreeMap::from([("b".into(), 8)]),
+                removed: ["b".into()].into(),
+            },
+            StorageAllocationTransition {
+                installed: BTreeMap::from([("z".into(), u64::MAX)]),
+                removed: ["b".into()].into(),
+            },
+        ] {
+            assert!(state.apply_owner_transition("writer", &change).is_err());
+            assert_eq!(state, before);
+        }
+        let mut malformed = before.clone();
+        malformed.active.remove("b");
+        let unchanged = malformed.clone();
+        assert!(malformed.remove_owner("writer").is_err());
+        assert_eq!(malformed, unchanged);
+        let mut overflow = before.clone();
+        overflow.active.get_mut("a").unwrap().1 = u64::MAX;
+        let unchanged = overflow.clone();
+        assert!(
+            overflow
+                .replace_owner("new-alias", &BTreeMap::from([("a".into(), 4)]))
+                .is_err()
+        );
+        assert_eq!(overflow, unchanged);
+        state.remove_owner("alias").unwrap();
+        state
+            .replace_owner("writer", &BTreeMap::from([("a".into(), 20)]))
+            .unwrap();
+        assert_eq!(
+            (
+                state.current_allocated_bytes(),
+                state.peak_allocated_bytes()
+            ),
+            (20, 20)
+        );
+        state.validate_continuation().unwrap();
+    }
+
+    #[test]
+    fn lifecycle_continuation_rejects_inconsistent_deserialized_state() {
+        let mut valid = StorageAllocationLifecycle::default();
+        valid
+            .replace_owner("one", &BTreeMap::from([("a".into(), 4096)]))
+            .unwrap();
+        valid
+            .replace_owner("two", &BTreeMap::from([("a".into(), 4096)]))
+            .unwrap();
+        valid.validate_continuation().unwrap();
+        let encoded = serde_json::to_value(&valid).unwrap();
+        let mut malformed = Vec::new();
+        let mut value = encoded.clone();
+        value["active"]["a"][1] = serde_json::json!(1);
+        malformed.push(value);
+        let mut value = encoded.clone();
+        value["active"]["a"][1] = serde_json::json!(0);
+        malformed.push(value);
+        let mut value = encoded.clone();
+        value["active"]["extra"] = serde_json::json!([1, 1]);
+        malformed.push(value);
+        let mut value = encoded.clone();
+        value["owners"]["one"] = serde_json::json!(["absent"]);
+        malformed.push(value);
+        let mut value = encoded.clone();
+        value["current_allocated_bytes"] = serde_json::json!(4097);
+        malformed.push(value);
+        let mut value = encoded;
+        value["peak_allocated_bytes"] = serde_json::json!(4095);
+        malformed.push(value);
+        for value in malformed {
+            let state: StorageAllocationLifecycle = serde_json::from_value(value).unwrap();
+            assert!(state.validate_continuation().is_err());
+        }
+    }
+
+    #[test]
+    fn lifecycle_single_file_preflight_does_not_copy_unrelated_inventory() {
+        let mut state = StorageAllocationLifecycle::default();
+        for count in [16, 256, 4096] {
+            let identities = (0..count).map(|n| (format!("file-{n}"), 1)).collect();
+            state.replace_owner("unrelated", &identities).unwrap();
+            let prepared = state
+                .prepare_change(&BTreeSet::new(), &BTreeMap::from([("new".into(), 7)]))
+                .unwrap();
+            assert_eq!(
+                prepared.active.len(),
+                1,
+                "only the affected identity is staged"
+            );
+            assert_eq!(prepared.current, count + 7);
+            state.validate_continuation().unwrap();
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -178,13 +178,178 @@ pub(crate) struct V4OrdinalBuildMetrics {
 pub(crate) struct V4ConstructionArtifactBundle {
     pub(crate) manifest: crate::V4OrdinalIdentityManifest,
     pub(crate) metrics: V4OrdinalBuildMetrics,
-    publications: Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: Vec<(String, V4PublicationGuard)>,
+}
+
+// Publication ownership carries the optional observer through explicit cleanup
+// and ordinary RAII cleanup. Only current file owners and a high-water survive.
+#[derive(Debug)]
+struct V4PublicationGuard {
+    directory: Option<graphforge_filesystem::StableDirectory>,
+    inner: Option<graphforge_filesystem::UnpublishedArtifactGuard>,
+    path: PathBuf,
+    allocation: Option<crate::StorageAllocationOperation>,
+}
+impl V4PublicationGuard {
+    fn create(
+        directory: &graphforge_filesystem::StableDirectory,
+        name: &str,
+        allocation: Option<&crate::StorageAllocationOperation>,
+    ) -> std::io::Result<Self> {
+        Ok(Self {
+            directory: allocation.map(|_| directory.try_clone()).transpose()?,
+            inner: Some(
+                directory.create_unpublished_replaceable_child(std::ffi::OsStr::new(name))?,
+            ),
+            path: directory.path().join(name),
+            allocation: allocation.cloned(),
+        })
+    }
+    fn inner(&self) -> &graphforge_filesystem::UnpublishedArtifactGuard {
+        self.inner.as_ref().expect("live publication")
+    }
+    fn inner_mut(&mut self) -> &mut graphforge_filesystem::UnpublishedArtifactGuard {
+        self.inner.as_mut().expect("live publication")
+    }
+    fn identity(&self) -> std::io::Result<graphforge_filesystem::FileIdentity> {
+        self.inner().identity()
+    }
+    fn verify_identity_with(
+        &mut self,
+        check: impl FnOnce() -> std::io::Result<()>,
+    ) -> std::io::Result<graphforge_filesystem::FileIdentity> {
+        self.inner_mut().verify_identity_with(check)
+    }
+    fn take_file(&mut self) -> std::io::Result<File> {
+        self.inner_mut().take_file()
+    }
+    fn open_sibling(&self, name: &std::ffi::OsStr) -> std::io::Result<File> {
+        self.inner().open_sibling(name)
+    }
+    fn observe(&self, file: &File) -> std::io::Result<()> {
+        if let Some(allocation) = &self.allocation {
+            allocation
+                .replace_file_at(&self.path, file)
+                .map_err(std::io::Error::other)?;
+        }
+        Ok(())
+    }
+    fn observe_named(&self) -> std::io::Result<()> {
+        if let Some(directory) = &self.directory {
+            match directory.open_child_file(self.path.file_name().expect("artifact name")) {
+                Ok(file) => {
+                    if let Ok(expected) = self.identity()
+                        && graphforge_filesystem::file_identity(&file)? != expected
+                    {
+                        return Err(std::io::Error::other("observed artifact identity changed"));
+                    }
+                    self.observe(&file)?;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    }
+    fn reconcile_removed(
+        &self,
+        expected: Option<graphforge_filesystem::FileIdentity>,
+    ) -> std::io::Result<()> {
+        let Some(directory) = &self.directory else {
+            return Ok(());
+        };
+        let removed = match directory.open_child_file(self.path.file_name().expect("artifact name"))
+        {
+            Ok(file) => match expected {
+                Some(expected) => graphforge_filesystem::file_identity(&file)? != expected,
+                None => {
+                    return Err(std::io::Error::other(
+                        "artifact identity unavailable during cleanup",
+                    ));
+                }
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+            Err(error) => return Err(error),
+        };
+        if removed {
+            self.allocation
+                .as_ref()
+                .expect("observed directory")
+                .remove_file_at(&self.path)
+                .map_err(std::io::Error::other)?;
+        }
+        Ok(())
+    }
+    fn install_child(&mut self, target: &std::ffi::OsStr) -> std::io::Result<()> {
+        self.observe_named()?;
+        let installed = self.inner_mut().install_child(target);
+        if installed.is_err() {
+            // Installation can rename successfully before a later validation
+            // fails. Rebind only the actual retained artifact, never a collision.
+            if let Some(directory) = &self.directory
+                && let Ok(file) = directory.open_child_file(target)
+                && matches!(
+                    (graphforge_filesystem::file_identity(&file), self.identity()),
+                    (Ok(actual), Ok(expected)) if actual == expected
+                )
+            {
+                let previous = self.path.clone();
+                self.path.set_file_name(target);
+                let _ = self.observe(&file);
+                if let Some(allocation) = &self.allocation {
+                    let _ = allocation.remove_file_at(&previous);
+                }
+            }
+            return installed;
+        }
+        let previous = self.path.clone();
+        self.path.set_file_name(target);
+        self.observe_named()?;
+        if let Some(allocation) = &self.allocation {
+            allocation
+                .remove_file_at(&previous)
+                .map_err(std::io::Error::other)?;
+        }
+        Ok(())
+    }
+    fn sync_parent(&mut self) -> std::io::Result<()> {
+        self.inner_mut().sync_parent()
+    }
+    fn commit(mut self) -> std::io::Result<()> {
+        let identity = self.identity().ok();
+        let committed = self.inner.take().expect("live publication").commit();
+        if committed.is_err() {
+            let _ = self.reconcile_removed(identity);
+        }
+        committed
+    }
+    fn cleanup_checked(
+        &mut self,
+        check: impl FnOnce() -> std::io::Result<()>,
+    ) -> std::io::Result<()> {
+        let observed = self.observe_named();
+        let identity = self.identity().ok();
+        let cleaned = self.inner_mut().cleanup_checked(check);
+        // Cleanup may unlink successfully then fail its directory barrier or
+        // finalization hook. Release the absent route even on that error.
+        let reconciled = self.reconcile_removed(identity);
+        cleaned?;
+        observed?;
+        reconciled
+    }
+}
+impl Drop for V4PublicationGuard {
+    fn drop(&mut self) {
+        if self.inner.is_some() {
+            let _ = self.cleanup_checked(|| Ok(()));
+        }
+    }
 }
 
 struct V4AuthorityTransactionProof;
 
 fn commit_v4_publications(
-    publications: Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: Vec<(String, V4PublicationGuard)>,
     _proof: V4AuthorityTransactionProof,
 ) -> Result<(), GfError> {
     for (_, publication) in publications {
@@ -194,18 +359,16 @@ fn commit_v4_publications(
 }
 
 fn retain_v4_publication(
-    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: &mut Vec<(String, V4PublicationGuard)>,
     name: String,
-    publication: Option<graphforge_filesystem::UnpublishedArtifactGuard>,
+    publication: Option<V4PublicationGuard>,
 ) {
     if let Some(publication) = publication {
         publications.push((name, publication));
     }
 }
 
-fn cleanup_v4_publication(
-    publication: &mut graphforge_filesystem::UnpublishedArtifactGuard,
-) -> Result<(), GfError> {
+fn cleanup_v4_publication(publication: &mut V4PublicationGuard) -> Result<(), GfError> {
     publication
         .cleanup_checked(|| {
             take_v4_output_cleanup_failure()
@@ -423,12 +586,13 @@ where
 /// Incremental v4 encoder used to tee the already-assigned fresh-construction
 /// node stream without retaining it or reading it a second time.
 pub(crate) struct V4OrdinalConstructionWriter<'a> {
+    allocation: Option<crate::StorageAllocationOperation>,
     generation: u64,
     index: &'a graphforge_filesystem::StableDirectory,
     cache_window: std::num::NonZeroU64,
     forward: StreamingV4Artifact,
     ranges: Vec<crate::V4OrdinalRange>,
-    publications: Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: Vec<(String, V4PublicationGuard)>,
     current: Option<V4OrdinalRangeWriter>,
     previous_forward_uuid: Option<[u8; 16]>,
     previous_ordinal_node_id: u64,
@@ -448,18 +612,30 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
     ) -> Result<Self, GfError> {
         let cache_window =
             graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage_err)?;
-        Self::start_with_cache_window(generation, index, cache_window)
+        Self::start_with_cache_window(generation, index, cache_window, None)
+    }
+
+    pub(crate) fn start_with_allocation(
+        generation: u64,
+        index: &'a graphforge_filesystem::StableDirectory,
+        allocation: Option<&crate::StorageAllocationOperation>,
+    ) -> Result<Self, GfError> {
+        let cache_window =
+            graphforge_filesystem::cache_release_window_for_streams(2).map_err(storage_err)?;
+        Self::start_with_cache_window(generation, index, cache_window, allocation)
     }
 
     pub(crate) fn start_with_cache_window(
         generation: u64,
         index: &'a graphforge_filesystem::StableDirectory,
         cache_window: std::num::NonZeroU64,
+        allocation: Option<&crate::StorageAllocationOperation>,
     ) -> Result<Self, GfError> {
         if generation == 0 {
             return Err(storage_err("v4 ordinal generation is zero"));
         }
-        let forward = StreamingV4Artifact::create_with_window(index, "forward", cache_window)?;
+        let forward =
+            StreamingV4Artifact::create_with_window(index, "forward", cache_window, allocation)?;
         let validated = graphforge_filesystem::validate_cache_release_operation_windows(&[forward
             .writer
             .get_ref()
@@ -473,6 +649,7 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
         Ok(Self {
             generation,
             index,
+            allocation: allocation.cloned(),
             cache_window,
             forward,
             ranges: Vec::new(),
@@ -593,6 +770,7 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
                 self.ranges.len(),
                 node_id,
                 self.cache_window,
+                self.allocation.as_ref(),
             )?);
         }
         self.current
@@ -653,7 +831,12 @@ impl<'a> V4OrdinalConstructionWriter<'a> {
         // Construction has no deletions, but an explicit authenticated empty run
         // commits that fact instead of leaving tombstone authority implicit.
         let tombstone = finish_streamed_v4_artifact(
-            StreamingV4Artifact::create_with_window(self.index, "tombstones", self.cache_window)?,
+            StreamingV4Artifact::create_with_window(
+                self.index,
+                "tombstones",
+                self.cache_window,
+                self.allocation.as_ref(),
+            )?,
             "tombstones-v4",
             self.generation,
             crate::V4OrdinalArtifactKind::NodeTombstones,
@@ -720,7 +903,7 @@ fn add_v4_mapping_commitment(commitment: &mut [u8; 32], domain: u8, uuid: [u8; 1
 
 struct StreamingV4Artifact {
     writer: BufWriter<graphforge_filesystem::DurableFileCacheWriter>,
-    publication: graphforge_filesystem::UnpublishedArtifactGuard,
+    publication: V4PublicationGuard,
     digest: Sha256,
     bytes: u64,
 }
@@ -730,11 +913,11 @@ impl StreamingV4Artifact {
         index: &graphforge_filesystem::StableDirectory,
         role: &str,
         cache_window: std::num::NonZeroU64,
+        allocation: Option<&crate::StorageAllocationOperation>,
     ) -> Result<Self, GfError> {
         let temporary_name = format!(".v4-{role}-{}.tmp", Uuid::new_v4().simple());
-        let mut publication = index
-            .create_unpublished_replaceable_child(std::ffi::OsStr::new(&temporary_name))
-            .map_err(storage_err)?;
+        let mut publication =
+            V4PublicationGuard::create(index, &temporary_name, allocation).map_err(storage_err)?;
         if let Err(primary) = publication
             .verify_identity_with(|| v4_publication_io_failure("initial_file_identity"))
             .map_err(storage_err)
@@ -763,7 +946,18 @@ impl StreamingV4Artifact {
     }
 
     fn push(&mut self, bytes: &[u8]) -> Result<(), GfError> {
-        self.writer.write_all(bytes).map_err(storage_err)?;
+        let flushes =
+            self.writer.buffer().len().saturating_add(bytes.len()) > self.writer.capacity();
+        let written = self.writer.write_all(bytes).map_err(storage_err);
+        let observed = if flushes || written.is_err() {
+            self.publication
+                .observe(self.writer.get_ref().file())
+                .map_err(storage_err)
+        } else {
+            Ok(())
+        };
+        written?;
+        observed?;
         self.digest.update(bytes);
         self.bytes = self
             .bytes
@@ -784,7 +978,12 @@ impl StreamingV4Artifact {
             .get_mut()
             .sync_all_and_release()
             .map_err(storage_err);
+        let observed = self
+            .publication
+            .observe(self.writer.get_ref().file())
+            .map_err(storage_err);
         let cache_release = self.writer.get_ref().evidence();
+        let synchronized = combine_v4_cleanup(synchronized, observed, "v4 allocation observation");
         let finalized = combine_v4_cleanup(flushed, synchronized, "v4 output synchronization");
         drop(self.writer);
         let removed = cleanup_v4_publication(&mut self.publication);
@@ -798,7 +997,7 @@ impl StreamingV4Artifact {
 #[derive(Debug)]
 struct GuardedV4Artifact {
     artifact: crate::V4OrdinalArtifact,
-    publication: Option<graphforge_filesystem::UnpublishedArtifactGuard>,
+    publication: Option<V4PublicationGuard>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -821,6 +1020,10 @@ fn finish_streamed_v4_artifact(
         merge_cache_release_evidence(&mut metrics.cache_release, cache_release);
         return combine_v4_cleanup(Err(primary), cleanup, "v4 failed output cleanup");
     }
+    writer
+        .publication
+        .observe(writer.writer.get_ref().file())
+        .map_err(storage_err)?;
     let cache_release = writer.writer.get_ref().evidence();
     let prepared = (|| -> Result<(_, _), GfError> {
         v4_publication_failure("fsync_evidence_overflow")?;
@@ -929,12 +1132,14 @@ impl V4OrdinalRangeWriter {
         ordinal: usize,
         first_node_id: u64,
         cache_window: std::num::NonZeroU64,
+        allocation: Option<&crate::StorageAllocationOperation>,
     ) -> Result<Self, GfError> {
         Ok(Self {
             artifact: StreamingV4Artifact::create_with_window(
                 index,
                 &format!("ordinal-{ordinal:08}"),
                 cache_window,
+                allocation,
             )?,
             first_node_id,
             count: 0,
@@ -987,7 +1192,7 @@ fn finish_streamed_v4_range(
     generation: u64,
     mut writer: V4OrdinalRangeWriter,
     ranges: &mut Vec<crate::V4OrdinalRange>,
-    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: &mut Vec<(String, V4PublicationGuard)>,
     metrics: &mut V4OrdinalBuildMetrics,
 ) -> Result<(), GfError> {
     let prepared = if writer.count == 0 {
@@ -1548,6 +1753,7 @@ pub(crate) fn publish_v4_construction_artifacts(
         &crate::V4OrdinalIdentityManifest,
     )>,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<
     (
         Vec<ConstructionIndexOutput>,
@@ -1573,6 +1779,7 @@ pub(crate) fn publish_v4_construction_artifacts(
                 &mut publications,
                 &mut local_names,
                 cancelled,
+                allocation,
             )?,
             None => (0, 0),
         };
@@ -1587,6 +1794,7 @@ pub(crate) fn publish_v4_construction_artifacts(
             generation,
             topology_delta_sha256,
             &local_names,
+            allocation,
         )?;
         publication.read_bytes = read_bytes;
         publication.read_operations = read_operations;
@@ -1632,9 +1840,10 @@ fn merge_construction_v4_delta(
     prior: &crate::V4OrdinalIdentityManifest,
     delta: &mut crate::V4OrdinalIdentityManifest,
     metrics: &mut V4OrdinalBuildMetrics,
-    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: &mut Vec<(String, V4PublicationGuard)>,
     local_names: &mut BTreeSet<String>,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(u64, u64), GfError> {
     if prior.topology_generation.checked_add(1) != Some(delta.topology_generation) {
         return Err(storage_err(
@@ -1727,6 +1936,7 @@ fn merge_construction_v4_delta(
         &mut combined,
         &mut created,
         cancelled,
+        allocation,
     )?;
     metrics.artifact_bytes = metrics
         .artifact_bytes
@@ -1770,7 +1980,7 @@ fn merge_construction_v4_delta(
 }
 
 fn cleanup_v4_publications(
-    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: &mut Vec<(String, V4PublicationGuard)>,
 ) -> Result<(), GfError> {
     let mut cleanup = Ok(());
     for (_, mut publication) in publications.drain(..).rev() {
@@ -1788,10 +1998,11 @@ fn publish_v4_construction_artifacts_inner(
     encoded: &graphforge_filesystem::StableDirectory,
     manifest: &crate::V4OrdinalIdentityManifest,
     metrics: &V4OrdinalBuildMetrics,
-    publications: &mut Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: &mut Vec<(String, V4PublicationGuard)>,
     generation: u64,
     topology_delta_sha256: &str,
     local_names: &BTreeSet<String>,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<
     (
         Vec<ConstructionIndexOutput>,
@@ -1843,18 +2054,28 @@ fn publish_v4_construction_artifacts_inner(
     // The selected project generation is still unpublished. Install the
     // receipt first, then its manifest, and create the lock last so every
     // visible construction inventory is complete and reopenable.
-    let (receipt_output, receipt_publication) =
-        install_construction_bytes(&index, V4_ORDINAL_RECEIPT, &receipt_body, &mut work)?;
+    let (receipt_output, receipt_publication) = install_construction_bytes(
+        &index,
+        V4_ORDINAL_RECEIPT,
+        &receipt_body,
+        &mut work,
+        allocation,
+    )?;
     outputs.push(receipt_output);
     publications.push((V4_ORDINAL_RECEIPT.to_owned(), receipt_publication));
     crate::graph_construction::construction_failpoint("v4_publish.after_receipt_install");
-    let (manifest_output, manifest_publication) =
-        install_construction_bytes(&index, V4_ORDINAL_MANIFEST, &manifest_body, &mut work)?;
+    let (manifest_output, manifest_publication) = install_construction_bytes(
+        &index,
+        V4_ORDINAL_MANIFEST,
+        &manifest_body,
+        &mut work,
+        allocation,
+    )?;
     outputs.push(manifest_output);
     publications.push((V4_ORDINAL_MANIFEST.to_owned(), manifest_publication));
     crate::graph_construction::construction_failpoint("v4_publish.after_manifest_install");
     let (lock_output, lock_publication) =
-        install_construction_bytes(&index, "ordinal-v4.lock", &[], &mut work)?;
+        install_construction_bytes(&index, "ordinal-v4.lock", &[], &mut work, allocation)?;
     outputs.push(lock_output);
     publications.push(("ordinal-v4.lock".to_owned(), lock_publication));
     crate::graph_construction::construction_failpoint("v4_publish.after_lock_install");
@@ -1923,6 +2144,7 @@ struct ConstructionRecoveryIntent {
 }
 
 struct ConstructionIndexCleanupGuard<'a> {
+    allocation: Option<crate::StorageAllocationOperation>,
     encoded: &'a graphforge_filesystem::StableDirectory,
     armed: bool,
 }
@@ -1936,7 +2158,10 @@ impl ConstructionIndexCleanupGuard<'_> {
 impl Drop for ConstructionIndexCleanupGuard<'_> {
     fn drop(&mut self) {
         if self.armed {
-            let _ = cleanup_private_construction_index(self.encoded);
+            let _ = cleanup_private_construction_index_with_allocation(
+                self.encoded,
+                self.allocation.as_ref(),
+            );
         }
     }
 }
@@ -3014,11 +3239,13 @@ pub(crate) fn encode_construction_index(
     live_nodes: u64,
     live_edges: u64,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<ConstructionIndexEncoding, GfError> {
-    cleanup_private_construction_index(encoded)?;
+    cleanup_private_construction_index_with_allocation(encoded, allocation)?;
     let mut cleanup_guard = ConstructionIndexCleanupGuard {
         encoded,
         armed: true,
+        allocation: allocation.cloned(),
     };
     let result = encode_construction_index_inner(
         source,
@@ -3031,6 +3258,7 @@ pub(crate) fn encode_construction_index(
         live_nodes,
         live_edges,
         cancelled,
+        allocation,
     );
     match result {
         Ok(value) => {
@@ -3038,9 +3266,9 @@ pub(crate) fn encode_construction_index(
             Ok(value)
         }
         Err(original) => {
-            cleanup_private_construction_index(encoded).map_err(|cleanup| {
-                storage_err(format!("{original}; exact cleanup also failed: {cleanup}"))
-            })?;
+            cleanup_private_construction_index_with_allocation(encoded, allocation).map_err(
+                |cleanup| storage_err(format!("{original}; exact cleanup also failed: {cleanup}")),
+            )?;
             Err(original)
         }
     }
@@ -3058,7 +3286,11 @@ fn encode_construction_index_inner(
     live_nodes: u64,
     live_edges: u64,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<ConstructionIndexEncoding, GfError> {
+    let encoded =
+        crate::construction_directory::ConstructionDirectory::from_physical(encoded, allocation)
+            .map_err(storage_err)?;
     let graph = encoded
         .create_child_directory(std::ffi::OsStr::new("graph"))
         .map_err(storage_err)?;
@@ -3240,6 +3472,18 @@ fn encode_construction_index_inner(
         }
         Ok(())
     })();
+    let observed = (|| {
+        index
+            .observe_file(std::ffi::OsStr::new(&identity_temp), identity_writer.file())
+            .map_err(storage_err)?;
+        index
+            .observe_file(
+                std::ffi::OsStr::new(&surrogate_temp),
+                surrogate_writer.file(),
+            )
+            .map_err(storage_err)
+    })();
+    let streamed = combine_v4_cleanup(streamed, observed, "construction allocation observation");
     let released = input.finish().map_err(storage_err);
     let input_cache_release = match (streamed, released) {
         (Ok(()), Ok(released)) => released,
@@ -3275,6 +3519,15 @@ fn encode_construction_index_inner(
         .map_err(storage_err)?;
     surrogate_writer
         .sync_all_and_release()
+        .map_err(storage_err)?;
+    index
+        .observe_file(std::ffi::OsStr::new(&identity_temp), identity_writer.file())
+        .map_err(storage_err)?;
+    index
+        .observe_file(
+            std::ffi::OsStr::new(&surrogate_temp),
+            surrogate_writer.file(),
+        )
         .map_err(storage_err)?;
     let identity_cache_release = identity_writer.evidence();
     let surrogate_cache_release = surrogate_writer.evidence();
@@ -3388,7 +3641,7 @@ fn encode_construction_index_inner(
 
     let body = serde_json::to_vec(&manifest).map_err(storage_err)?;
     let (manifest_output, manifest_publication) =
-        install_construction_bytes(&index, MANIFEST, &body, &mut work)?;
+        install_construction_bytes(index.physical(), MANIFEST, &body, &mut work, allocation)?;
     crate::graph_construction::construction_failpoint("uuid_encode.after_manifest");
     artifacts.push(manifest_output);
     let retained_names = manifest_file_names(&manifest);
@@ -3488,9 +3741,20 @@ fn encode_construction_index_inner(
     })
 }
 
+#[cfg(test)]
 fn cleanup_private_construction_index(
     encoded: &graphforge_filesystem::StableDirectory,
 ) -> Result<(), GfError> {
+    cleanup_private_construction_index_with_allocation(encoded, None)
+}
+
+fn cleanup_private_construction_index_with_allocation(
+    encoded: &graphforge_filesystem::StableDirectory,
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(), GfError> {
+    let encoded =
+        crate::construction_directory::ConstructionDirectory::from_physical(encoded, allocation)
+            .map_err(storage_err)?;
     let graph = match encoded.open_child_directory(std::ffi::OsStr::new("graph")) {
         Ok(value) => value,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -3520,8 +3784,19 @@ fn cleanup_private_construction_index(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(storage_err(error)),
     }
-    let names = index.child_names().map_err(storage_err)?;
-    let v4_allowed = authenticate_private_v4_residue(&index, &names)?;
+    let names = if allocation.is_some() {
+        index.child_names_bounded(1_000_000)
+    } else {
+        index.child_names()
+    }
+    .map_err(storage_err)?;
+    let v4_allowed = authenticate_private_v4_residue(index.physical(), &names)?;
+    if allocation.is_some() {
+        for name in &names {
+            let file = index.open_child_file(name).map_err(storage_err)?;
+            index.observe_file(name, &file).map_err(storage_err)?;
+        }
+    }
     for name in names {
         let name_text = name
             .to_str()
@@ -3869,7 +4144,7 @@ fn sha256_reader_streaming(file: File) -> Result<String, GfError> {
 }
 
 fn write_construction_intent(
-    index: &graphforge_filesystem::StableDirectory,
+    index: &crate::construction_directory::ConstructionDirectory,
     intent: &ConstructionRecoveryIntent,
     work: &mut ConstructionIndexWork,
 ) -> Result<(), GfError> {
@@ -3880,10 +4155,18 @@ fn write_construction_intent(
         .create_replaceable_child_file(std::ffi::OsStr::new(&temporary))
         .map_err(storage_err)?;
     let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
-    file.write_all(&body).map_err(storage_err)?;
+    let written = file.write_all(&body).map_err(storage_err);
+    let observed = index
+        .observe_file(std::ffi::OsStr::new(&temporary), &file)
+        .map_err(storage_err);
+    written?;
+    observed?;
     work.write_bytes = work.write_bytes.saturating_add(body.len() as u64);
     work.write_operations = work.write_operations.saturating_add(1);
     file.sync_all().map_err(storage_err)?;
+    index
+        .observe_file(std::ffi::OsStr::new(&temporary), &file)
+        .map_err(storage_err)?;
     work.fsync_operations = work.fsync_operations.saturating_add(1);
     drop(file);
     index
@@ -3900,7 +4183,7 @@ fn write_construction_intent(
 
 #[allow(clippy::too_many_arguments)]
 fn compact_construction_levels(
-    output: &graphforge_filesystem::StableDirectory,
+    output: &crate::construction_directory::ConstructionDirectory,
     parent: Option<&AuthenticatedUuidIndexSnapshot>,
     generation: u64,
     manifest: &mut Manifest,
@@ -3988,7 +4271,7 @@ fn compact_construction_levels(
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)] // Streamed merge keeps both reader cleanups coupled to the primary result.
 fn merge_construction_records(
-    output: &graphforge_filesystem::StableDirectory,
+    output: &crate::construction_directory::ConstructionDirectory,
     parent: Option<&AuthenticatedUuidIndexSnapshot>,
     left: &FileRecord,
     right: &FileRecord,
@@ -4120,8 +4403,15 @@ fn merge_construction_records(
         right_reader.finish_cache(),
         "right construction merge source",
     );
+    let observed = output
+        .observe_file(std::ffi::OsStr::new(&temporary), writer.file())
+        .map_err(storage_err);
+    let merged = combine_v4_cleanup(merged, observed, "construction merge allocation");
     merged?;
     writer.sync_all_and_release().map_err(storage_err)?;
+    output
+        .observe_file(std::ffi::OsStr::new(&temporary), writer.file())
+        .map_err(storage_err)?;
     let write_cache_release = writer.evidence();
     work.fsync_operations = work
         .fsync_operations
@@ -4319,7 +4609,7 @@ fn finish_construction_cursor_pair<T>(
 }
 
 fn open_construction_source(
-    output: &graphforge_filesystem::StableDirectory,
+    output: &crate::construction_directory::ConstructionDirectory,
     parent: Option<&AuthenticatedUuidIndexSnapshot>,
     record: &FileRecord,
     output_names: &BTreeSet<String>,
@@ -4345,7 +4635,7 @@ fn open_construction_source(
 }
 
 fn install_empty_construction_run(
-    output: &graphforge_filesystem::StableDirectory,
+    output: &crate::construction_directory::ConstructionDirectory,
     prefix: &str,
     generation: u64,
     width: usize,
@@ -4367,7 +4657,7 @@ fn install_empty_construction_run(
 
 #[allow(clippy::too_many_arguments)]
 fn describe_and_install_construction_run(
-    output: &graphforge_filesystem::StableDirectory,
+    output: &crate::construction_directory::ConstructionDirectory,
     temporary: &str,
     identity: graphforge_filesystem::FileIdentity,
     prefix: &str,
@@ -4470,25 +4760,23 @@ fn install_construction_bytes(
     name: &str,
     bytes: &[u8],
     work: &mut ConstructionIndexWork,
-) -> Result<
-    (
-        ConstructionIndexOutput,
-        graphforge_filesystem::UnpublishedArtifactGuard,
-    ),
-    GfError,
-> {
+    allocation: Option<&crate::StorageAllocationOperation>,
+) -> Result<(ConstructionIndexOutput, V4PublicationGuard), GfError> {
     let temporary = format!(".{name}-{}.tmp", Uuid::new_v4().simple());
-    let mut publication = output
-        .create_unpublished_replaceable_child(std::ffi::OsStr::new(&temporary))
-        .map_err(storage_err)?;
+    let mut publication =
+        V4PublicationGuard::create(output, &temporary, allocation).map_err(storage_err)?;
     let mut file = publication.take_file().map_err(storage_err)?;
-    file.write_all(bytes).map_err(storage_err)?;
+    let written = file.write_all(bytes).map_err(storage_err);
+    let observed = publication.observe(&file).map_err(storage_err);
+    written?;
+    observed?;
     work.write_bytes = work.write_bytes.saturating_add(bytes.len() as u64);
     work.write_operations = work.write_operations.saturating_add(1);
     work.peak_temporary_bytes = work
         .peak_temporary_bytes
         .max(u64::try_from(bytes.len()).map_err(storage_err)?);
     file.sync_all().map_err(storage_err)?;
+    publication.observe(&file).map_err(storage_err)?;
     work.fsync_operations = work.fsync_operations.saturating_add(1);
     let failpoint = match name {
         V4_ORDINAL_RECEIPT => Some("v4_publish.after_receipt_temp_fsync"),
@@ -7606,7 +7894,7 @@ fn write_v4_tombstone_artifact(
 
 struct GuardedV4Tombstones {
     run: crate::V4OrdinalTombstones,
-    publication: Option<graphforge_filesystem::UnpublishedArtifactGuard>,
+    publication: Option<V4PublicationGuard>,
 }
 
 struct V4TombstoneStreamWriter {
@@ -7625,13 +7913,14 @@ impl V4TombstoneStreamWriter {
     ) -> Result<Self, GfError> {
         let cache_window =
             graphforge_filesystem::cache_release_window_for_streams(1).map_err(storage_err)?;
-        Self::new_with_cache_window(index, generation, cache_window)
+        Self::new_with_cache_window(index, generation, cache_window, None)
     }
 
     fn new_with_cache_window(
         index: &graphforge_filesystem::StableDirectory,
         generation: u64,
         cache_window: std::num::NonZeroU64,
+        allocation: Option<&crate::StorageAllocationOperation>,
     ) -> Result<Self, GfError> {
         Ok(Self {
             generation,
@@ -7639,6 +7928,7 @@ impl V4TombstoneStreamWriter {
                 index,
                 "tombstones-delta",
                 cache_window,
+                allocation,
             )?,
             blocks: Vec::new(),
             block: Vec::with_capacity(V4_ORDINAL_BLOCK_BYTES),
@@ -7788,7 +8078,7 @@ struct V4CompactionWork {
     fsync_operations: u64,
     cache_release: graphforge_filesystem::FileCacheReleaseEvidence,
     peak_configured_cache_window_bytes: u64,
-    publications: Vec<(String, graphforge_filesystem::UnpublishedArtifactGuard)>,
+    publications: Vec<(String, V4PublicationGuard)>,
 }
 
 fn compact_v4_binary_carry(
@@ -7805,6 +8095,7 @@ fn compact_v4_binary_carry(
         manifest,
         created,
         &mut || false,
+        None,
     )
 }
 
@@ -7815,6 +8106,7 @@ fn compact_v4_binary_carry_with_cancellation(
     manifest: &mut crate::V4OrdinalIdentityManifest,
     created: &mut HashMap<String, PathBuf>,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<V4CompactionWork, GfError> {
     let prior_manifest = manifest.clone();
     let prior_created = created.clone();
@@ -7825,6 +8117,7 @@ fn compact_v4_binary_carry_with_cancellation(
         manifest,
         created,
         cancelled,
+        allocation,
     ) {
         Ok(work) => Ok(work),
         Err(error) => {
@@ -7842,6 +8135,7 @@ fn compact_v4_binary_carry_inner(
     manifest: &mut crate::V4OrdinalIdentityManifest,
     created: &mut HashMap<String, PathBuf>,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<V4CompactionWork, GfError> {
     let mut work = V4CompactionWork::default();
     loop {
@@ -7866,6 +8160,7 @@ fn compact_v4_binary_carry_inner(
             right.1,
             &mut work,
             cancelled,
+            allocation,
         )?;
         created.insert(
             merged_forward.artifact.name.clone(),
@@ -7891,6 +8186,7 @@ fn compact_v4_binary_carry_inner(
             right.1,
             &mut work,
             cancelled,
+            allocation,
         )?;
         compact_v4_tombstone_interval(
             pinned,
@@ -7902,6 +8198,7 @@ fn compact_v4_binary_carry_inner(
             right.1,
             &mut work,
             cancelled,
+            allocation,
         )?;
         work.compactions = work.compactions.saturating_add(1);
     }
@@ -8125,6 +8422,7 @@ fn merge_v4_forward_artifacts(
     generation: u64,
     work: &mut V4CompactionWork,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<GuardedV4Artifact, GfError> {
     let cache_window =
         graphforge_filesystem::cache_release_window_for_streams(3).map_err(storage_err)?;
@@ -8148,8 +8446,12 @@ fn merge_v4_forward_artifacts(
             .map_err(storage_err)?,
         ),
     ];
-    let mut writer =
-        StreamingV4Artifact::create_with_window(index, "forward-compact", cache_window)?;
+    let mut writer = StreamingV4Artifact::create_with_window(
+        index,
+        "forward-compact",
+        cache_window,
+        allocation,
+    )?;
     let configured = record_v4_compaction_windows(
         work,
         &[
@@ -8288,6 +8590,7 @@ fn compact_v4_ordinal_interval(
     last_generation: u64,
     work: &mut V4CompactionWork,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), GfError> {
     let mut replacement = Vec::new();
     let mut cursor = 0;
@@ -8327,6 +8630,7 @@ fn compact_v4_ordinal_interval(
                 replacement.len(),
                 manifest.ordinal_ranges[start].first_node_id,
                 cache_window,
+                allocation,
             )?;
             let compacted = (|| -> Result<u64, GfError> {
                 let mut reader_peak = 0_u64;
@@ -8439,6 +8743,7 @@ fn compact_v4_tombstone_interval(
     last_generation: u64,
     work: &mut V4CompactionWork,
     cancelled: &mut impl FnMut() -> bool,
+    allocation: Option<&crate::StorageAllocationOperation>,
 ) -> Result<(), GfError> {
     let selected = manifest
         .tombstones
@@ -8467,8 +8772,12 @@ fn compact_v4_tombstone_interval(
             .map_err(storage_err)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let mut merged =
-        V4TombstoneStreamWriter::new_with_cache_window(index, last_generation, cache_window)?;
+    let mut merged = V4TombstoneStreamWriter::new_with_cache_window(
+        index,
+        last_generation,
+        cache_window,
+        allocation,
+    )?;
     let mut windows = readers
         .iter()
         .map(|reader| reader.get_ref().window_bytes())
@@ -10117,7 +10426,8 @@ pub(crate) mod tests {
                 .unwrap(),
             );
         }
-        let writer = V4TombstoneStreamWriter::new_with_cache_window(&index, 9, window).unwrap();
+        let writer =
+            V4TombstoneStreamWriter::new_with_cache_window(&index, 9, window, None).unwrap();
         let mut windows = readers
             .iter()
             .map(graphforge_filesystem::FileCacheReleasingReader::window_bytes)
@@ -10154,6 +10464,7 @@ pub(crate) mod tests {
             2,
             &mut work,
             &mut || false,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -10228,6 +10539,7 @@ pub(crate) mod tests {
             2,
             &mut work,
             &mut || false,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -10256,6 +10568,7 @@ pub(crate) mod tests {
             3,
             &mut release_work,
             &mut || false,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -10361,6 +10674,7 @@ pub(crate) mod tests {
             &hex_sha256(b"delta"),
             None,
             &mut || false,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -10391,6 +10705,7 @@ pub(crate) mod tests {
             &hex_sha256(b"delta"),
             None,
             &mut || false,
+            None,
         )
         .unwrap();
         for (name, identity, bytes) in &originals {
@@ -10496,6 +10811,7 @@ pub(crate) mod tests {
             2,
             &mut work,
             &mut || false,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -10564,6 +10880,7 @@ pub(crate) mod tests {
             2,
             &mut work,
             &mut || false,
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -10996,6 +11313,7 @@ pub(crate) mod tests {
             &hex_sha256(b"delta"),
             None,
             &mut || false,
+            None,
         )
         .unwrap();
 
@@ -11035,6 +11353,7 @@ pub(crate) mod tests {
                 records,
                 0,
                 &mut || false,
+                None,
             )
             .unwrap();
             let identity_blocks = (records * IDENTITY_RECORD_BYTES).div_ceil(BULK_IO_BYTES as u64);
@@ -12238,6 +12557,43 @@ pub(crate) mod tests {
                 .to_string()
                 .contains("invalid node surrogate")
         );
+    }
+
+    #[test]
+    fn v4_observed_guard_tracks_install_and_failed_cleanup() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = graphforge_filesystem::StableDirectory::open(root.path()).unwrap();
+        let operation = crate::StorageAllocationOperation::default();
+        let mut guard =
+            V4PublicationGuard::create(&directory, ".temporary", Some(&operation)).unwrap();
+        let mut file = guard.take_file().unwrap();
+        file.write_all(&vec![7_u8; 32768]).unwrap();
+        file.sync_all().unwrap();
+        guard.observe(&file).unwrap();
+        let actual = graphforge_filesystem::file_space_usage(&file)
+            .unwrap()
+            .allocated_bytes;
+        assert!(actual > 0);
+        assert_eq!(operation.totals().unwrap(), (actual, actual));
+        drop(file);
+        guard
+            .install_child(std::ffi::OsStr::new("installed"))
+            .unwrap();
+        let expected =
+            crate::StorageAllocationOperation::from_paths(&[root.path().to_path_buf()]).unwrap();
+        assert_eq!(operation.snapshot().unwrap(), expected.snapshot().unwrap());
+        let error = guard
+            .cleanup_checked(|| Err(std::io::Error::other("after unlink")))
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("unpublished artifact cleanup finalization failed")
+        );
+        assert!(!root.path().join("installed").exists());
+        assert_eq!(operation.totals().unwrap(), (0, actual));
+        drop(guard);
+        assert_eq!(operation.totals().unwrap(), (0, actual));
     }
 
     #[test]

--- a/docs/development/evidence/g500-ladder-qualification.schema.json
+++ b/docs/development/evidence/g500-ladder-qualification.schema.json
@@ -4,7 +4,7 @@
   "type": "object", "additionalProperties": false,
   "required": ["schema", "rungs", "projection"],
   "properties": {
-    "schema": {"const": "graphforge-g500-ladder-qualification/3"},
+    "schema": {"const": "graphforge-g500-ladder-qualification/4"},
     "rungs": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"$ref": "#/$defs/rung"}},
     "projection": {"$ref": "#/$defs/projection"}
   },
@@ -15,11 +15,11 @@
       "type": "object", "additionalProperties": false,
       "required": ["category", "logical_bytes", "allocated_bytes", "current_retained_bytes", "transient_peak_allocated_bytes", "logical_references", "physical_objects", "source"],
       "properties": {
-        "category": {"enum": ["canonical_node_topology", "canonical_edge_topology", "properties", "uuid_surrogate_indexes", "adjacency_csr", "catalog_manifests", "construction_staging_spill", "portable_package", "clean_imported_project"]},
+        "category": {"enum": ["canonical_node_topology", "canonical_edge_topology", "properties", "uuid_surrogate_indexes", "adjacency_csr", "catalog_manifests", "construction_staging_spill", "portable_package", "clean_imported_project", "source-project-construction", "source-project-import", "source-project-transactions", "source-project-locks", "source-project-admission_lock", "source-project-published", "imported-project-construction", "imported-project-import", "imported-project-transactions", "imported-project-locks", "imported-project-admission_lock", "imported-project-published", "generated-inputs", "query-results", "portable-package"]},
         "logical_bytes": {"$ref": "#/$defs/nonNegative"}, "allocated_bytes": {"$ref": "#/$defs/nonNegative"},
         "current_retained_bytes": {"$ref": "#/$defs/nonNegative"}, "transient_peak_allocated_bytes": {"$ref": "#/$defs/nonNegative"},
         "logical_references": {"$ref": "#/$defs/nonNegative"}, "physical_objects": {"$ref": "#/$defs/nonNegative"},
-        "source": {"enum": ["storage_owned_snapshot", "construction_receipts", "exact_descriptor", "clean_import_snapshot"]}
+        "source": {"enum": ["storage_owned_snapshot", "construction_receipts", "exact_descriptor", "clean_import_snapshot", "lifecycle_owner_snapshot"]}
       }
     },
     "phase": {
@@ -47,7 +47,7 @@
       "properties": {
         "id": {"enum": ["S20", "S22", "S24", "S26"]}, "scale": {"enum": [20, 22, 24, 26]}, "live_nodes": {"$ref": "#/$defs/positive"}, "live_edges": {"$ref": "#/$defs/positive"},
         "source_project_current_allocated_bytes": {"$ref": "#/$defs/nonNegative"}, "workspace_current_allocated_bytes": {"$ref": "#/$defs/nonNegative"},
-        "artifacts": {"type": "array", "minItems": 9, "maxItems": 9, "items": {"$ref": "#/$defs/artifact"}}, "phases": {"type": "array", "minItems": 9, "maxItems": 9, "items": {"$ref": "#/$defs/phase"}},
+        "artifacts": {"type": "array", "minItems": 24, "maxItems": 24, "items": {"$ref": "#/$defs/artifact"}}, "phases": {"type": "array", "minItems": 9, "maxItems": 9, "items": {"$ref": "#/$defs/phase"}},
         "totals": {"$ref": "#/$defs/totals"},
         "ratios": {"type": "object", "additionalProperties": false, "required": ["canonical_node_bytes_per_live_node", "canonical_edge_bytes_per_live_edge", "authoritative_project_bytes_per_live_edge", "full_lifecycle_peak_bytes_per_live_edge"], "properties": {
           "canonical_node_bytes_per_live_node": {"$ref": "#/$defs/ratio"}, "canonical_edge_bytes_per_live_edge": {"$ref": "#/$defs/ratio"}, "authoritative_project_bytes_per_live_edge": {"$ref": "#/$defs/ratio"}, "full_lifecycle_peak_bytes_per_live_edge": {"$ref": "#/$defs/ratio"}

--- a/docs/development/perf-g500-ladder.md
+++ b/docs/development/perf-g500-ladder.md
@@ -238,13 +238,20 @@ rejected as certification evidence.
 
 ### Disk attribution and S26 admission
 
-The versioned `graphforge-g500-ladder-qualification/3` companion document is
+The versioned `graphforge-g500-ladder-qualification/4` companion document is
 produced and validated by
 `graphforge_bench.progressive_storage_qualification`. Every observed
 rung has exactly one row for canonical node topology, canonical edge topology,
 properties, UUID/surrogate indexes, adjacency/CSR, catalogs/manifests,
-construction staging/spill, portable package, and clean import. Native file
-identity deduplicates content-addressed/shared objects. Logical bytes,
+construction staging/spill, portable package, and clean import. Fifteen additional
+closed owner views cover the published and private construction/import/transaction/lock
+files of both projects, generated inputs, query results, and the portable package.
+These raw facts come from the version-2 lifecycle receipt. Its fifteen views
+partition retained file references; physical identities can be shared across
+views. Before emitting the receipt, the certifier requires their deduplicated
+identity/allocation map and reference count to match the current per-file
+inventory, including zero-byte files and aliases. Native file identity
+deduplicates content-addressed/shared objects. Logical bytes,
 filesystem allocation, current retained allocation, and full-lifecycle
 transient peak remain separate quantities.
 

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 380)
+        self.assertEqual(len(GATE.public_methods()), 384)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "2e9d24ea3fc8ae0300399f986a947c72a7b5df7cf77e592f54d24237c226c8b2",
+  "public_method_digest": "c07b80a5bb8c6d907d1c02d0862702965c94730e21bd71302e0288ba2c7af4b1",
   "method_policy": {
     "receiver_defaults": {
       "PortableV2ImportResult": "release-tested",
@@ -20,6 +20,7 @@
       "ProviderEmbeddingExecution": "internal-helper",
       "ProviderFindExecution": "internal-helper",
       "ProviderRerankExecution": "internal-helper",
+      "StorageAllocationDiagnostics": "internal-helper",
       "RuntimeGuard": "internal-helper",
       "CancellationToken": "introspection",
       "FindExecutionResult": "introspection",


### PR DESCRIPTION
The lifecycle certifier omitted live construction/import files and transaction controls, so storage qualification rejected otherwise correct scale runs. This change tracks actual writer allocation through an explicit per-command diagnostic context and reports raw facts for all 15 retained owner views. Every command's reported current allocation must match a fresh physical inventory; the peak comes from observed writes and removals.

The new `/2` lifecycle receipt and current profiles move together, with historical `/1` evidence still readable. Normal facade options stay unchanged. Failure, cancellation, and retry cleanup preserve real allocation evidence and the original error.

Validation on the actual public SCALE1 lifecycle passed all ten phases, including clean import and reopen/query proof. Reported retained allocation of 983,040 bytes exactly matched an independent device/inode-deduplicated filesystem measurement; observed peak was 1,040,384 bytes. The regression checks all five raw facts for live construction, import, and transaction owners. The native consumer also accepted the actual lifecycle receipt, both storage snapshots, and committed application I/O.

Targeted tests cover aliases, atomic replacement, recovery errors and retries, export and materializer cleanup, dropped async result exports, bounded private input, and closed receipt validation. Workspace Clippy with warnings denied, repository fast checks, and both workspace formatting checks passed.

Canonical S20/S22 ladder qualification remains tracked in #951.

Closes #1165

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791537589&installation_model_id=20486&pr_number=1167&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1167&signature=610d867cae8fd6ba82ac01d858238e335fad08f6a84961b0779efe566d0fd3c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->