### PR TITLE
fix(storage): preserve valid runtime catalogs in graph subsets

### DIFF
--- a/crates/graphforge-api/src/portable.rs
+++ b/crates/graphforge-api/src/portable.rs
@@ -1921,3 +1921,7 @@ mod repack_boundary_tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "portable_subset_catalog_tests.rs"]
+mod subset_catalog_tests;

--- a/crates/graphforge-api/src/portable_subset_catalog_tests.rs
+++ b/crates/graphforge-api/src/portable_subset_catalog_tests.rs
@@ -1,0 +1,139 @@
+//! Sparse runtime catalog subsets export and verify without changing source authority.
+
+use arrow::util::display::array_value_to_string;
+use graphforge_core::portable::{
+    PortableV2GraphSelector, PortableV2Limits, PortableV2Mode, PortableV2Output,
+    PortableV2PropertyProjection, PortableV2SelectionProfile, PortableV2SubsetClosure,
+    PortableV2SubsetRequest,
+};
+use uuid::Uuid;
+
+use crate::{
+    GraphForge, OperationId, PortableSelection, PortableV2ExportRequest, PortableV2ImportRequest,
+    PortableVerifyRequest, verify_portable_v2,
+};
+
+fn rows(graph: &GraphForge, query: &str) -> Vec<Vec<String>> {
+    let mut rows = Vec::new();
+    for batch in graph.execute(query).unwrap().batches {
+        for row in 0..batch.num_rows() {
+            rows.push(
+                batch
+                    .columns()
+                    .iter()
+                    .map(|column| array_value_to_string(column.as_ref(), row).unwrap())
+                    .collect(),
+            );
+        }
+    }
+    rows.sort();
+    rows
+}
+
+#[test]
+fn sparse_catalog_expanded_export_verify() {
+    round_trip(PortableV2Output::Expanded);
+}
+
+#[test]
+fn sparse_catalog_bundle_export_verify() {
+    round_trip(PortableV2Output::Bundle);
+}
+
+fn round_trip(representation: PortableV2Output) {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    graph.execute("CREATE (a:Alpha {name: 'a', score: 11}), (b:Beta:Extra {name: 'b', score: 22}), (c:Gamma {name: 'c', score: 33}) CREATE (a)-[:FIRST {cost: 101}]->(a), (b)-[:SECOND {cost: 202}]->(c), (c)-[:THIRD {cost: 303}]->(a)").unwrap();
+    let node_query = "MATCH (n) RETURN n.node_uuid, labels(n), n.name, n.score";
+    let edge_query =
+        "MATCH (a)-[r]->(b) RETURN r.edge_uuid, type(r), a.node_uuid, b.node_uuid, r.cost";
+    let original_nodes = rows(&graph, node_query);
+    let original_edges = rows(&graph, edge_query);
+    assert_eq!(original_nodes.len(), 3);
+    assert_eq!(original_edges.len(), 3);
+    let selected = original_edges
+        .iter()
+        .find(|row| row[1] == "SECOND")
+        .unwrap();
+    assert_eq!(selected[4], "202");
+    let expected_nodes = original_nodes
+        .iter()
+        .filter(|row| row[0] == selected[2] || row[0] == selected[3])
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(expected_nodes.len(), 2);
+    let edge_batch = graph
+        .execute("MATCH ()-[r:SECOND]->() RETURN r.edge_uuid")
+        .unwrap();
+    let ids = edge_batch.batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+        .unwrap();
+    let selected_uuid = Uuid::from_slice(ids.value(0)).unwrap();
+    let generation = graph.generation_for_read().unwrap().generation_uuid();
+    let limits = PortableV2Limits::default();
+    let package = root.path().join("package");
+    let exported = graph
+        .export_portable_v2(
+            &PortableV2ExportRequest {
+                selection: PortableSelection::Current,
+                output_path: package.clone(),
+                representation,
+                profile: PortableV2SelectionProfile::Complete,
+                subset: Some(PortableV2SubsetRequest {
+                    selector: PortableV2GraphSelector {
+                        node_uuids: vec![],
+                        edge_uuids: vec![selected_uuid.to_string()],
+                    },
+                    closure: PortableV2SubsetClosure::Referential,
+                    projection: PortableV2PropertyProjection { exclude: vec![] },
+                }),
+                limits,
+            },
+            None,
+            |_| {},
+        )
+        .unwrap();
+    let verified = verify_portable_v2(
+        &PortableVerifyRequest {
+            input: package.clone(),
+            mode: PortableV2Mode::Full,
+            limits,
+        },
+        None,
+    )
+    .unwrap();
+    assert_eq!(verified.package_digest, exported.package_digest);
+    let target = root.path().join("imported");
+    let error = GraphForge::import_portable_v2(
+        &target,
+        &PortableV2ImportRequest {
+            input: package,
+            operation_id: OperationId(Uuid::new_v4()),
+            limits,
+        },
+        None,
+    )
+    .unwrap_err();
+    assert_eq!(
+        error.code,
+        graphforge_core::portable::PortableV2ErrorCode::Incompatible
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("selective package requires an explicit class-specific consumer")
+    );
+    assert!(!target.exists());
+    assert_eq!(rows(&graph, node_query), original_nodes);
+    assert_eq!(rows(&graph, edge_query), original_edges);
+    assert_eq!(
+        GraphForge::new(source.to_str())
+            .unwrap()
+            .resolved_generation
+            .generation_uuid(),
+        generation
+    );
+}

--- a/crates/graphforge-storage/src/graph_projection.rs
+++ b/crates/graphforge-storage/src/graph_projection.rs
@@ -25,6 +25,8 @@ use graphforge_core::canonical::{
 };
 use parquet::arrow::ArrowWriter;
 
+mod runtime_remap;
+
 type GraphUuid = [u8; 16];
 type EdgeEndpoints = BTreeMap<GraphUuid, (GraphUuid, GraphUuid)>;
 
@@ -427,6 +429,7 @@ fn copy_runtime_catalog(source: &Path, target: &Path) -> Result<(), GfError> {
         .map(|column| take(column.as_ref(), &indices, None).map_err(storage))
         .collect::<Result<Vec<_>, _>>()?;
     let canonical = RecordBatch::try_new(canonical.schema(), columns).map_err(storage)?;
+    let canonical = runtime_remap::compact(&canonical, target)?;
     write_parquet(&target.join("topology/runtime_catalog.parquet"), &canonical)
 }
 
@@ -1909,14 +1912,14 @@ mod tests {
         let (alice, bob, excluded) = (uuid(31), uuid(32), uuid(33));
         let (knows, ignores) = (uuid(41), uuid(42));
         let mut catalog = RuntimeCatalog::new();
-        let person = catalog.intern_label("Person").unwrap();
         let company = catalog.intern_label("Company").unwrap();
-        catalog.intern_relation_type("KNOWS").unwrap();
         catalog.intern_relation_type("IGNORES").unwrap();
+        catalog.intern_property("noise", Some("Company")).unwrap();
+        let person = catalog.intern_label("Person").unwrap();
+        catalog.intern_relation_type("KNOWS").unwrap();
         catalog.intern_property("name", Some("Person")).unwrap();
         catalog.intern_property("global", None).unwrap();
         catalog.intern_property("since", Some("KNOWS")).unwrap();
-        catalog.intern_property("noise", Some("Company")).unwrap();
 
         let mut writer = GraphWriter::open_at(source.path(), OntologyMode::Strict, TS).unwrap();
         writer
@@ -2004,7 +2007,67 @@ mod tests {
             ])
         );
 
+        let reopened_catalog = RuntimeCatalog::from_record_batch(&projected).unwrap();
+        let (projected_person, name) = reopened_catalog
+            .entity_type_names_with_ids()
+            .next()
+            .unwrap();
+        assert_eq!(name, "Person");
+        assert_ne!(projected_person, person);
         let reopened_nodes = read_nodes(target.path()).unwrap();
+        let mut actual_nodes = Vec::new();
+        for batch in &reopened_nodes {
+            let ids = batch
+                .column_by_name("node_uuid")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
+            let primary = batch
+                .column_by_name("type_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap();
+            for row in 0..batch.num_rows() {
+                assert_eq!(
+                    primary.value(row),
+                    EntityTypeId::runtime(projected_person).encode()
+                );
+                actual_nodes.push(ids.value(row).to_vec());
+            }
+        }
+        actual_nodes.sort();
+        assert_eq!(
+            actual_nodes,
+            vec![alice.as_bytes().to_vec(), bob.as_bytes().to_vec()]
+        );
+        let edge = read_parquet(&target.path().join("topology/edges/KNOWS.parquet"))
+            .unwrap()
+            .remove(0);
+        for (column, expected) in [("edge_uuid", knows), ("src_uuid", alice), ("dst_uuid", bob)] {
+            let ids = edge
+                .column_by_name(column)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
+            assert_eq!(ids.len(), 1);
+            assert_eq!(ids.value(0), expected.as_bytes());
+        }
+        let properties = crate::read_node_property_rows(target.path(), "Person").unwrap();
+        assert_eq!(
+            properties[alice.as_bytes()]["name"],
+            IrLiteral::Str("Alice".into())
+        );
+        let edge_properties = read_edge_properties(target.path(), "KNOWS").unwrap();
+        let since = edge_properties[0]
+            .column_by_name("since")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(since.value(0), 2020);
         assert_eq!(
             reopened_nodes
                 .iter()

--- a/crates/graphforge-storage/src/graph_projection/runtime_remap.rs
+++ b/crates/graphforge-storage/src/graph_projection/runtime_remap.rs
@@ -1,0 +1,262 @@
+//! Compact only the selected runtime namespace in an unpublished projection.
+//! Ontology IDs, UUIDs, semantic routes and source files remain unchanged.
+
+use super::{read_parquet, storage, string_column, validation, write_parquet};
+use arrow::array::{Array, ArrayRef, ListArray, UInt32Array};
+use arrow::datatypes::DataType;
+use arrow::record_batch::RecordBatch;
+use graphforge_core::GfError;
+use graphforge_value::{EntityTypeId, PrimaryEntityTypeId, RuntimeEntityId};
+use std::{collections::HashMap, path::Path, sync::Arc};
+
+type EntityRemap = HashMap<RuntimeEntityId, RuntimeEntityId>;
+
+pub(super) fn compact(catalog: &RecordBatch, target: &Path) -> Result<RecordBatch, GfError> {
+    let kinds = string_column(catalog, "entry_kind")?;
+    let ids = catalog
+        .column_by_name("runtime_id")
+        .and_then(|column| column.as_any().downcast_ref::<UInt32Array>())
+        .ok_or_else(|| validation("runtime catalog runtime_id is not UInt32"))?;
+    let mut next_type = 0_u32;
+    let mut next_property = 0_u32;
+    let mut entities = EntityRemap::new();
+    let mut mapped = Vec::with_capacity(catalog.num_rows());
+    for row in 0..catalog.num_rows() {
+        let counter = match kinds.value(row) {
+            "entity_type" | "relation_type" => &mut next_type,
+            "property" => &mut next_property,
+            _ => return Err(validation("unknown runtime catalog entry kind")),
+        };
+        let id = *counter;
+        *counter = counter
+            .checked_add(1)
+            .ok_or_else(|| validation("projected runtime catalog ID overflow"))?;
+        if kinds.value(row) == "entity_type" {
+            entities.insert(
+                RuntimeEntityId::new(ids.value(row)).map_err(|e| validation(e.to_string()))?,
+                RuntimeEntityId::new(id).map_err(|e| validation(e.to_string()))?,
+            );
+        }
+        mapped.push(id);
+    }
+    let mut columns = catalog.columns().to_vec();
+    let id_column = catalog.schema().index_of("runtime_id").map_err(storage)?;
+    columns[id_column] = Arc::new(UInt32Array::from(mapped));
+    let compact = RecordBatch::try_new(catalog.schema(), columns).map_err(storage)?;
+    // Keep the normal persisted-catalog admission as the final namespace oracle.
+    graphforge_ir::RuntimeCatalog::from_record_batch(&compact)?;
+    for path in crate::mutator::node_parquet_files(target).map_err(storage)? {
+        let batches = read_parquet(&path)?;
+        let schema = batches
+            .first()
+            .map(RecordBatch::schema)
+            .ok_or_else(|| validation("projected node table lacks schema"))?;
+        let rewritten = batches
+            .iter()
+            .map(|batch| remap_nodes(batch, &entities))
+            .collect::<Result<Vec<_>, _>>()?;
+        let batch = arrow::compute::concat_batches(&schema, &rewritten).map_err(storage)?;
+        write_parquet(&path, &batch)?;
+    }
+    Ok(compact)
+}
+
+fn entity(id: EntityTypeId, mapping: &EntityRemap) -> Result<EntityTypeId, GfError> {
+    match id.tagged().runtime_entity_id() {
+        None => Ok(id),
+        Some(old) => mapping
+            .get(&old)
+            .copied()
+            .map(EntityTypeId::runtime)
+            .ok_or_else(|| validation("projected runtime node type has no selected catalog entry")),
+    }
+}
+
+fn remap_nodes(batch: &RecordBatch, mapping: &EntityRemap) -> Result<RecordBatch, GfError> {
+    let mut columns = batch.columns().to_vec();
+    let schema = batch.schema();
+    for (index, field) in schema.fields().iter().enumerate() {
+        columns[index] = match field.name().as_str() {
+            "type_id" => {
+                let values = columns[index]
+                    .as_any()
+                    .downcast_ref::<UInt32Array>()
+                    .ok_or_else(|| validation("node type_id is not UInt32"))?;
+                let mapped = values
+                    .iter()
+                    .map(|value| {
+                        let raw = value.ok_or_else(|| validation("node primary type is null"))?;
+                        let primary = PrimaryEntityTypeId::decode(raw)
+                            .map_err(|e| validation(e.to_string()))?;
+                        Ok(match primary.label() {
+                            None => primary.encode(),
+                            Some(id) => PrimaryEntityTypeId::known(entity(id, mapping)?).encode(),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, GfError>>()?;
+                Arc::new(UInt32Array::from(mapped)) as ArrayRef
+            }
+            "type_ids" => {
+                let lists = columns[index]
+                    .as_any()
+                    .downcast_ref::<ListArray>()
+                    .ok_or_else(|| validation("node type_ids is not List"))?;
+                let values = lists
+                    .values()
+                    .as_any()
+                    .downcast_ref::<UInt32Array>()
+                    .ok_or_else(|| validation("node type_ids values are not UInt32"))?;
+                let mapped = values
+                    .iter()
+                    .map(|value| {
+                        let raw = value.ok_or_else(|| validation("node label is null"))?;
+                        let id =
+                            EntityTypeId::decode(raw).map_err(|e| validation(e.to_string()))?;
+                        Ok(entity(id, mapping)?.encode())
+                    })
+                    .collect::<Result<Vec<_>, GfError>>()?;
+                let DataType::List(item) = lists.data_type() else {
+                    unreachable!()
+                };
+                Arc::new(
+                    ListArray::try_new(
+                        Arc::clone(item),
+                        lists.offsets().clone(),
+                        Arc::new(UInt32Array::from(mapped)),
+                        lists.nulls().cloned(),
+                    )
+                    .map_err(storage)?,
+                )
+            }
+            _ => Arc::clone(&columns[index]),
+        };
+    }
+    RecordBatch::try_new(schema, columns).map_err(storage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ListBuilder, UInt32Builder};
+    use arrow::datatypes::{Field, Schema};
+
+    #[test]
+    fn remap_preserves_ontology_absent_primary_and_all_runtime_labels() {
+        let old = RuntimeEntityId::new(9).unwrap();
+        let new = RuntimeEntityId::new(1).unwrap();
+        let old_second = RuntimeEntityId::new(12).unwrap();
+        let new_second = RuntimeEntityId::new(2).unwrap();
+        let ontology = EntityTypeId::ontology(graphforge_core::TypeId(9)).unwrap();
+        let mut labels = ListBuilder::new(UInt32Builder::new());
+        for values in [
+            vec![
+                ontology.encode(),
+                EntityTypeId::runtime(old).encode(),
+                EntityTypeId::runtime(old_second).encode(),
+            ],
+            vec![EntityTypeId::runtime(old).encode()],
+            vec![EntityTypeId::runtime(old_second).encode()],
+        ] {
+            labels.values().append_slice(&values);
+            labels.append(true);
+        }
+        let labels = labels.finish();
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("type_id", DataType::UInt32, false),
+                Field::new("type_ids", labels.data_type().clone(), false),
+            ])),
+            vec![
+                Arc::new(UInt32Array::from(vec![
+                    ontology.encode(),
+                    PrimaryEntityTypeId::absent().encode(),
+                    EntityTypeId::runtime(old_second).encode(),
+                ])),
+                Arc::new(labels),
+            ],
+        )
+        .unwrap();
+        let mapping = HashMap::from([(old, new), (old_second, new_second)]);
+        let result = remap_nodes(&batch, &mapping).unwrap();
+        assert_eq!(
+            result
+                .column(0)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap()
+                .values()
+                .as_ref(),
+            &[
+                ontology.encode(),
+                PrimaryEntityTypeId::absent().encode(),
+                EntityTypeId::runtime(new_second).encode()
+            ]
+        );
+        let lists = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        let first = lists.value(0);
+        assert_eq!(
+            first
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap()
+                .values()
+                .as_ref(),
+            &[
+                ontology.encode(),
+                EntityTypeId::runtime(new).encode(),
+                EntityTypeId::runtime(new_second).encode()
+            ]
+        );
+        assert_eq!(
+            entity(EntityTypeId::runtime(old), &mapping).unwrap(),
+            EntityTypeId::runtime(new)
+        );
+        assert!(remap_nodes(&batch, &HashMap::from([(old, new)])).is_err());
+    }
+    #[test]
+    fn compact_catalog_closes_type_and_property_gaps_without_changing_other_fields() {
+        let mut source = graphforge_ir::RuntimeCatalog::new();
+        source.intern_label("Unused").unwrap();
+        source.intern_property("unused", Some("Unused")).unwrap();
+        source.intern_label("Selected").unwrap();
+        source.intern_relation_type("LINK").unwrap();
+        source.intern_property("value", Some("Selected")).unwrap();
+        source.intern_property("weight", Some("LINK")).unwrap();
+        let original = source.to_record_batch();
+        let indices = UInt32Array::from(vec![2, 3, 4, 5]);
+        let columns = original
+            .columns()
+            .iter()
+            .map(|array| arrow::compute::take(array.as_ref(), &indices, None).unwrap())
+            .collect();
+        let selected = RecordBatch::try_new(original.schema(), columns).unwrap();
+        assert!(graphforge_ir::RuntimeCatalog::from_record_batch(&selected).is_err());
+        let target = tempfile::tempdir().unwrap();
+        let result = compact(&selected, target.path()).unwrap();
+        graphforge_ir::RuntimeCatalog::from_record_batch(&result).unwrap();
+        let id_index = result.schema().index_of("runtime_id").unwrap();
+        assert_eq!(
+            result
+                .column(id_index)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap()
+                .values()
+                .as_ref(),
+            &[0, 1, 0, 1]
+        );
+        for index in 0..result.num_columns() {
+            if index != id_index {
+                assert_eq!(
+                    result.column(index).as_ref(),
+                    selected.column(index).as_ref()
+                );
+            }
+        }
+        assert_eq!(source.to_record_batch(), original);
+    }
+}


### PR DESCRIPTION
Selecting graph rows that omit earlier runtime catalog entries currently produces a sparse catalog and makes subset export fail during fingerprinting. Compact the selected runtime namespace and remap projected node primary and additional labels consistently, preserving ontology IDs, UUIDs, semantic names, properties, and source authority.

Tests cover sparse type/property IDs, mixed ontology/runtime labels, exact projected rows and values, and expanded/bundled export with full verification. The complete-project importer retains its existing typed refusal for subset packages.

Validation: storage projection suite (28 passed), expanded/bundled public API tests (2 passed), targeted strict Clippy, final formatting, `make pre-push-fast`, and `make gate-registry-check` passed. Independent LOW review found no remaining actionable findings.

Closes #1186.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791565042&installation_model_id=20486&pr_number=1187&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1187&signature=cdedb250a01201cc047baac50cae9440f0cf15b79e1da7b39a6a32cb2da731fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->