### PR TITLE
fix(storage): encode semantic routes into portable components

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -85,7 +85,10 @@ only when the platform supports them.
   same Rust classification also runs native filesystem publication/admission
   tests on `blacksmith-4vcpu-windows-2025` and
   `blacksmith-12vcpu-macos-15`; Windows retains the existing project-root lock
-  tests. Linux Bazel CI cannot execute those host-specific contracts.
+  tests. Both native lanes also exercise mapped semantic routes, legacy CAS
+  translation, reserved-route adjacency/deletion, lazy stream isolation, and full
+  and projected portable export/import/reopen through the Rust facade. Linux
+  Bazel CI cannot execute those host-specific contracts.
 - Python, Gherkin, public binding, Pulumi static-validation, and Terraform
   static-validation gates run only when their owned surfaces change. Shared
   GraphForge configuration and infrastructure contract fixtures run both IaC

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1002,6 +1002,7 @@ jobs:
           route_status=0
           cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib graph_files::tests::graph_file_copy_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1
@@ -1109,6 +1110,7 @@ jobs:
           route_status=0
           cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib graph_files::tests::graph_file_copy_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1003,6 +1003,7 @@ jobs:
           cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib graph_files::tests::graph_file_copy_ -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib project_portable_v2_export::tests::canonical_source_path_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1
@@ -1111,6 +1112,7 @@ jobs:
           cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib graph_files::tests::graph_file_copy_ -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib project_portable_v2_export::tests::canonical_source_path_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1001,6 +1001,7 @@ jobs:
         run: |
           route_status=0
           cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1
@@ -1107,6 +1108,7 @@ jobs:
         run: |
           route_status=0
           cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -996,6 +996,18 @@ jobs:
             graph_object_store::tests::publication_and_gc_lifecycles_are_mutually_exclusive \
             -- --exact --nocapture
 
+      - name: Verify mapped routes and portable lifecycle on Windows
+        shell: bash
+        run: |
+          route_status=0
+          cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1
+          cargo test -p graphforge-api --lib mapped_portable_tests:: -- --nocapture || route_status=1
+          cargo test -p graphforge-api --lib mapped_stream_tests:: -- --nocapture || route_status=1
+          exit "$route_status"
+
       - name: Cross-check Windows publication-kill results against the fault oracle
         shell: bash
         env:
@@ -1089,6 +1101,18 @@ jobs:
       - name: Run macOS exact filesystem primitive tests
         run: >-
           cargo test -p graphforge-filesystem --lib --no-fail-fast
+
+      - name: Verify mapped routes and portable lifecycle on macOS
+        shell: bash
+        run: |
+          route_status=0
+          cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1
+          cargo test -p graphforge-api --lib mapped_portable_tests:: -- --nocapture || route_status=1
+          cargo test -p graphforge-api --lib mapped_stream_tests:: -- --nocapture || route_status=1
+          exit "$route_status"
 
       - name: Cross-check macOS publication-kill results against the fault oracle
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1004,6 +1004,7 @@ jobs:
           cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib graph_files::tests::graph_file_copy_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib project_portable_v2_export::tests::canonical_source_path_ -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib project_portable_v2_import::tests::authenticated_cleanup_releases_handles_before_removal -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1
@@ -1113,6 +1114,7 @@ jobs:
           cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib graph_files::tests::graph_file_copy_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib project_portable_v2_export::tests::canonical_source_path_ -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib project_portable_v2_import::tests::authenticated_cleanup_releases_handles_before_removal -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib route_component::owned::tests::legacy_cas_materialization_translates_routes_before_creating_paths -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib adjacency::builder::tests::admitted_reserved_relations_build_portable_distinct_indexes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -1913,6 +1913,7 @@ dependencies = [
  "graphforge-value",
  "rayon",
  "sha2",
+ "tempfile",
  "thiserror 2.0.20",
 ]
 

--- a/benchmarks/scripts/test-tiny-lifecycle-certification.py
+++ b/benchmarks/scripts/test-tiny-lifecycle-certification.py
@@ -183,9 +183,13 @@ def positive_slopes(name: str, values: list[int], work: list[int]) -> None:
         raise ValueError(f"{name}: adjacent normalized slopes differ by more than factor2")
 
 
-def normalized_ceiling(name: str, values: list[int], work: list[int]) -> None:
-    if values[0] <= 0 or any(b < a for a, b in itertools.pairwise(values)):
-        raise ValueError(f"{name}: positive nondecreasing evidence required")
+def normalized_ceiling(
+    name: str, values: list[int], work: list[int], *, nondecreasing: bool = True
+) -> None:
+    if any(value <= 0 for value in values):
+        raise ValueError(f"{name}: positive evidence required")
+    if nondecreasing and any(b < a for a, b in itertools.pairwise(values)):
+        raise ValueError(f"{name}: nondecreasing evidence required")
     if any(values[i] * work[0] > 2 * values[0] * work[i] for i in (1, 2)):
         raise ValueError(f"{name}: exceeds existing factor2 normalized ceiling")
 
@@ -251,7 +255,17 @@ def validate_growth(observations: list[dict[str, object]]) -> None:
                 if len(set(values)) != 1:
                     raise ValueError(f"{owner}: fixed lock inventory changed")
             elif owner in DATA_OWNERS:
-                normalized_ceiling(f"{owner}.{field}", values, work)
+                # Published inventories include content-addressed radix nodes. Their
+                # count depends on hashed path prefixes, not graph row count; a
+                # larger graph can need fewer nodes. Each run still reconciles
+                # every physical file independently before this growth check.
+                published_count = owner in {
+                    "source-project-published",
+                    "imported-project-published",
+                } and field in {"logical_references", "physical_objects"}
+                normalized_ceiling(
+                    f"{owner}.{field}", values, work, nondecreasing=not published_count
+                )
                 if field in ("logical_bytes", "physical_logical_bytes"):
                     positive_slopes(f"{owner}.{field}", values, work)
             # Transaction journals have fixed protocol shape and fixed-width

--- a/benchmarks/tests/test_lifecycle_growth.py
+++ b/benchmarks/tests/test_lifecycle_growth.py
@@ -73,6 +73,23 @@ class LifecycleGrowthTests(unittest.TestCase):
     def test_declared_linear_and_fixed_policies(self):
         GROWTH.validate_growth(observations())
 
+    def test_published_radix_object_counts_keep_positive_linear_ceiling(self):
+        for owner in ("source-project-published", "imported-project-published"):
+            changed = observations()
+            # Real SCALE6/7/8 inventories: radix nodes 47/48/46 plus
+            # 25 fixed objects. Every graph inventory has 18 logical files.
+            for observation, count in zip(changed, (72, 73, 71), strict=True):
+                totals = observation["receipt"]["retained_owners"][owner]["totals"]
+                totals["logical_references"] = totals["physical_objects"] = count
+            GROWTH.validate_growth(changed)
+            for invalid in (0, -1, 577):
+                with self.subTest(owner=owner, invalid=invalid):
+                    refused = copy.deepcopy(changed)
+                    totals = refused[2]["receipt"]["retained_owners"][owner]["totals"]
+                    totals["logical_references"] = totals["physical_objects"] = invalid
+                    with self.assertRaises(ValueError):
+                        GROWTH.validate_growth(refused)
+
     def test_each_data_owner_rejects_flat_underreported_and_inflated_eof(self):
         for owner in GROWTH.DATA_OWNERS:
             for field in ("logical_bytes", "physical_logical_bytes"):

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7a4bf6809a93be5676332ba45a2e8d4de029ae879e07c4198b5c9034771daebe",
+  "checksum": "30f5fd15462196c741cda03c05604373758ae8a21e39b725b483719429012b26",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -13208,6 +13208,10 @@
               "target": "sha2"
             },
             {
+              "id": "tempfile 3.27.0",
+              "target": "tempfile"
+            },
+            {
               "id": "thiserror 2.0.20",
               "target": "thiserror"
             }
@@ -13223,10 +13227,6 @@
             {
               "id": "parquet 58.4.0",
               "target": "parquet"
-            },
-            {
-              "id": "tempfile 3.27.0",
-              "target": "tempfile"
             },
             {
               "id": "tokio 1.53.1",

--- a/crates/graphforge-api/src/algorithm_writeback.rs
+++ b/crates/graphforge-api/src/algorithm_writeback.rs
@@ -50,7 +50,13 @@ impl GraphForge {
                 "algorithm result {value_name:?} must be non-null {expected:?}"
             )));
         }
-        reject_property_collision(&self.dir, stem, property, &expected)?;
+        reject_property_collision(
+            &self.dir,
+            &self.property_inventory_for_session(),
+            stem,
+            property,
+            &expected,
+        )?;
 
         let known = persisted_node_uuids(&self.dir)?;
         let updates = algorithm_property_updates(
@@ -87,7 +93,7 @@ impl GraphForge {
                 self.ontology.clone(),
                 self.dir.clone(),
                 self.ontology_mode,
-                std::sync::Arc::clone(&self.adjacency_provider),
+                self.adjacency_provider_for_session(),
                 Some(std::sync::Arc::clone(&self.ordinal_identities)),
                 &self.session_resource_config(),
             )?;
@@ -229,11 +235,12 @@ fn persisted_node_uuids(dir: &std::path::Path) -> Result<HashSet<[u8; 16]>, GfEr
 
 fn reject_property_collision(
     dir: &std::path::Path,
+    inventory: &graphforge_storage::AuthenticatedPropertyInventory,
     stem: &str,
     property: &str,
     expected: &DataType,
 ) -> Result<(), GfError> {
-    let batches = graphforge_storage::read_properties(dir, stem)
+    let batches = graphforge_storage::read_properties_from_inventory(dir, inventory, stem)
         .map_err(|error| GfError::Storage(error.to_string()))?;
     for batch in batches {
         if let Ok(field) = batch.schema().field_with_name(property)

--- a/crates/graphforge-api/src/analyst.rs
+++ b/crates/graphforge-api/src/analyst.rs
@@ -31,9 +31,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let projection = graphforge_exec::rank_projection_fingerprint(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -110,9 +114,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let projection = graphforge_exec::cluster_projection_fingerprint(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -197,9 +205,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let projection = graphforge_exec::similar_projection_fingerprint(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -296,9 +308,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let prepared = graphforge_exec::prepare_embedding_invocation_descriptor_with_compute(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -610,9 +626,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let projection = graphforge_exec::analyze_projection_fingerprint(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -739,9 +759,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let projection = graphforge_exec::paths_projection_fingerprint(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             source,
@@ -939,9 +963,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let batch = graphforge_exec::rank_algorithm_with_compute(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -997,9 +1025,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let batch = graphforge_exec::cluster_algorithm_with_compute(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -1055,9 +1087,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         graphforge_exec::paths_algorithm_with_compute(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             source.map(|uuid| *uuid.as_bytes()),
@@ -1091,9 +1127,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         graphforge_exec::analyze_algorithm_with_compute(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -1126,9 +1166,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         graphforge_exec::embedding_algorithm_execution_with_compute(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,
@@ -1159,9 +1203,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        self.adjacency_provider.revalidate();
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         graphforge_exec::similar_algorithm_with_compute(
-            self.adjacency_provider.as_ref(),
+            &graphforge_exec::AdmittedAdjacencyProvider::new(
+                adjacency_provider.as_ref(),
+                self.property_inventory_for_session(),
+            ),
             &self.dir,
             self.ontology_mode,
             label_id,

--- a/crates/graphforge-api/src/belief_projection.rs
+++ b/crates/graphforge-api/src/belief_projection.rs
@@ -434,10 +434,15 @@ impl GraphForge {
                 .expect("runtime catalog poisoned")
                 .clone(),
         ));
-        projected.adjacency_provider = Arc::new(crate::adjacency_provider_for_graph(
-            &projected.dir,
-            projected.ontology_mode,
-        )?);
+        *projected
+            .adjacency_provider
+            .write()
+            .expect("adjacency provider lock poisoned") =
+            Arc::new(crate::adjacency_provider_for_graph(
+                &projected.dir,
+                projected.ontology_mode,
+                projected.property_inventory_for_session(),
+            )?);
         let current = self.generation_for_read()?;
         if current.generation_uuid() != source_generation_uuid {
             return Err(transaction_conflict(

--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -666,7 +666,7 @@ impl GraphForge {
                     .runtime_catalog
                     .lock()
                     .expect("runtime catalog poisoned") = next_catalog;
-                self.adjacency_provider.invalidate();
+                self.adjacency_provider_for_session().invalidate();
             }
             return Err(error.into());
         }
@@ -674,7 +674,7 @@ impl GraphForge {
             .runtime_catalog
             .lock()
             .expect("runtime catalog poisoned") = next_catalog;
-        self.adjacency_provider.invalidate();
+        self.adjacency_provider_for_session().invalidate();
         Ok(node_receipt(
             &normalized.rows,
             operation_uuid,
@@ -1031,7 +1031,7 @@ impl GraphForge {
                     .runtime_catalog
                     .lock()
                     .expect("runtime catalog poisoned") = next_catalog;
-                self.adjacency_provider.invalidate();
+                self.adjacency_provider_for_session().invalidate();
             }
             return Err(error.into());
         }
@@ -1039,7 +1039,7 @@ impl GraphForge {
             .runtime_catalog
             .lock()
             .expect("runtime catalog poisoned") = next_catalog;
-        self.adjacency_provider.invalidate();
+        self.adjacency_provider_for_session().invalidate();
         Ok(edge_receipt(
             &normalized.rows,
             operation_uuid,

--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -395,7 +395,7 @@ impl GraphForge {
                     .runtime_catalog
                     .lock()
                     .expect("runtime catalog poisoned") = next_catalog;
-                self.adjacency_provider.invalidate();
+                self.adjacency_provider_for_session().invalidate();
                 debug_assert_eq!(batch.schema().as_ref(), composite_receipt_schema().as_ref());
                 Ok(batch)
             }
@@ -669,7 +669,7 @@ fn reconcile_workspace_to(
         .lock()
         .expect("runtime catalog poisoned") = crate::load_runtime_catalog(&graph.dir)?;
     graph.install_property_generation(generation)?;
-    graph.adjacency_provider.invalidate();
+    graph.adjacency_provider_for_session().invalidate();
     Ok(())
 }
 
@@ -780,8 +780,12 @@ fn build_validation_snapshot(
             }
         }
     }
-    for batch in graphforge_storage::read_edges(&graph.dir, "*", graph.ontology_mode)
-        .map_err(|error| GfError::Storage(format!("failed to read edge topology: {error}")))?
+    for batch in graphforge_storage::read_edges_from_inventory(
+        &graph.property_inventory_for_session(),
+        "*",
+        graph.ontology_mode,
+    )
+    .map_err(|error| GfError::Storage(format!("failed to read edge topology: {error}")))?
     {
         let Some(column) = batch.column_by_name("edge_uuid") else {
             continue;
@@ -2343,6 +2347,19 @@ mod tests {
             })
             .unwrap();
 
+        let retained_sources = graph
+            .property_inventory_for_session()
+            .edge_files(None)
+            .into_iter()
+            .map(|(_, path)| {
+                let file = std::fs::File::open(&path).unwrap();
+                let identity = graphforge_filesystem::file_identity(&file).unwrap();
+                let bytes = std::fs::read(&path).unwrap();
+                (path, identity, bytes)
+            })
+            .collect::<Vec<_>>();
+        assert!(!retained_sources.is_empty());
+
         let created_node = uuid7(205);
         let created_edge = uuid7(206);
         graph
@@ -2401,6 +2418,18 @@ mod tests {
                 knowledge: CompositeKnowledgeParticipants::default(),
             })
             .unwrap();
+
+        for (path, identity, bytes) in retained_sources {
+            assert_eq!(
+                graphforge_filesystem::file_identity(&std::fs::File::open(&path).unwrap()).unwrap(),
+                identity
+            );
+            assert_eq!(
+                std::fs::read(path).unwrap(),
+                bytes,
+                "deletion must preserve published input objects"
+            );
+        }
 
         let rows = graph
             .execute("MATCH (n:Person) RETURN n.node_uuid AS id")

--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -358,12 +358,16 @@ fn facade_migrates_legacy_routes_with_atomic_participants_and_plain_reopen() {
     forge
         .execute("CREATE (n:`research:Person`)")
         .expect_err("stale legacy publication must fail");
-    assert!(forge.dir.join("topology/edges/KNOWS.parquet").exists());
+    let retained_edges = forge.property_inventory_for_session().edge_files(None);
+    assert!(
+        retained_edges
+            .iter()
+            .any(|(route, path)| route == "KNOWS" && path.exists())
+    );
     assert_eq!(
-        std::fs::read_dir(forge.dir.join("topology/edges"))
-            .unwrap()
-            .filter_map(Result::ok)
-            .filter(|entry| entry.file_name().to_string_lossy().starts_with("s-"))
+        retained_edges
+            .iter()
+            .filter(|(route, _)| route.starts_with("s-"))
             .count(),
         0
     );
@@ -717,10 +721,11 @@ fn facade_reopens_relation_edge_property_through_default_context() {
         })
         .unwrap();
     assert_ne!(relation.route, genealogy_relation.route);
-    let edge_path = forge
-        .dir
-        .join("topology/edges")
-        .join(format!("{}.parquet", relation.route));
+    let paths = forge
+        .property_inventory_for_session()
+        .edge_files(Some(&relation.route));
+    assert_eq!(paths.len(), 1);
+    let edge_path = &paths[0].1;
     assert!(
         edge_path.exists(),
         "missing opaque edge route {}",

--- a/crates/graphforge-api/src/construction.rs
+++ b/crates/graphforge-api/src/construction.rs
@@ -180,11 +180,11 @@ impl GraphForge {
                 == expected_generation;
             if still_prior {
                 crate::graph_snapshot::restore(&prior.bytes, &self.dir)?;
-                self.adjacency_provider.invalidate();
+                self.adjacency_provider_for_session().invalidate();
             }
             return Err(error);
         }
-        self.adjacency_provider.invalidate();
+        self.adjacency_provider_for_session().invalidate();
         Ok(EdgeHandle::new(edge_uuid, rel_type))
     }
 }

--- a/crates/graphforge-api/src/explanation.rs
+++ b/crates/graphforge-api/src/explanation.rs
@@ -115,11 +115,12 @@ impl GraphForge {
             String::new()
         };
         let adjacency_provider = if execution_mode == self.ontology_mode {
-            Arc::clone(&self.adjacency_provider)
+            self.adjacency_provider_for_session()
         } else {
             Arc::new(crate::adjacency_provider_for_graph(
                 &self.dir,
                 execution_mode,
+                self.property_inventory_for_session(),
             )?)
         };
         let session =

--- a/crates/graphforge-api/src/knowledge.rs
+++ b/crates/graphforge-api/src/knowledge.rs
@@ -2876,8 +2876,12 @@ fn match_requested_edge_uuids(
     if pending.is_empty() {
         return Ok(());
     }
-    let batches = graphforge_storage::read_edges(&graph.dir, "*", graph.ontology_mode)
-        .map_err(|error| GfError::Storage(error.to_string()))?;
+    let batches = graphforge_storage::read_edges_from_inventory(
+        &graph.property_inventory_for_session(),
+        "*",
+        graph.ontology_mode,
+    )
+    .map_err(|error| GfError::Storage(error.to_string()))?;
     match_requested_uuids(batches, "edge_uuid", pending)
 }
 

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -2763,7 +2763,9 @@ fn property_inventory_for_hydrated_generation(
         .is_empty(),
         None => false,
     };
-    let admitted = if has_deltas {
+    // Snapshot-only generations have no graph-files inventory; hydration has
+    // authenticated their snapshot payload into this private workspace.
+    let admitted = if has_deltas || inventory.is_none() {
         let (materialized, _) = graphforge_storage::capture_graph_files(hydrated_root)?;
         graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
             generation,

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -102,6 +102,10 @@ mod import_session;
 mod invocation_descriptor;
 mod knowledge;
 mod maintenance;
+#[cfg(test)]
+mod mapped_portable_tests;
+#[cfg(test)]
+mod mapped_stream_tests;
 mod multi_ontology;
 mod mutation_transaction;
 #[cfg(test)]
@@ -477,7 +481,7 @@ pub struct GraphForge {
     /// Long-lived adjacency provider (#832): one per instance so loaded CSR
     /// views amortize across queries. Each session revalidates it (one
     /// generation read) at construction, and write paths invalidate it.
-    adjacency_provider: Arc<graphforge_exec::PersistentAdjacencyProvider>,
+    adjacency_provider: Arc<std::sync::RwLock<Arc<graphforge_exec::PersistentAdjacencyProvider>>>,
     /// Prevent adjacency readers from observing a staged directory swap.
     adjacency_visibility: Arc<std::sync::RwLock<()>>,
     /// Bounded worker state owned only by this exact embedded process.
@@ -668,14 +672,16 @@ impl GraphForge {
             resolved_generation,
             property_authority: Arc::new(Mutex::new(GenerationPropertyAuthority {
                 generation_uuid,
-                inventory: property_inventory,
+                inventory: Arc::clone(&property_inventory),
             })),
             read_only: false,
             current_generation_uuid: Arc::new(Mutex::new(generation_uuid)),
             uuid_membership_index: Mutex::new(None),
             ordinal_identities,
             clock: Mutex::new(Arc::new(system_time_micros)),
-            adjacency_provider: Arc::new(adjacency_provider_for_graph(&dir, ontology_mode)?),
+            adjacency_provider: Arc::new(std::sync::RwLock::new(Arc::new(
+                adjacency_provider_for_graph(&dir, ontology_mode, Arc::clone(&property_inventory))?,
+            ))),
             adjacency_visibility: Arc::new(std::sync::RwLock::new(())),
             embedding_refresh_scheduler: Arc::new(Mutex::new(
                 embedding_refresh::initialize_embedding_refresh_scheduler(&dir)?,
@@ -870,7 +876,8 @@ impl GraphForge {
         )?);
         let runtime = build_runtime(&resource_policy)?;
 
-        let adjacency_provider = adjacency_provider_for_graph(&dir, ontology_mode)?;
+        let adjacency_provider =
+            adjacency_provider_for_graph(&dir, ontology_mode, Arc::clone(&property_inventory))?;
         let graph = Self {
             identity: GraphIdentity::new(),
             path: Some(container_dir),
@@ -878,14 +885,14 @@ impl GraphForge {
             resolved_generation,
             property_authority: Arc::new(Mutex::new(GenerationPropertyAuthority {
                 generation_uuid,
-                inventory: property_inventory,
+                inventory: Arc::clone(&property_inventory),
             })),
             read_only,
             current_generation_uuid: Arc::new(Mutex::new(generation_uuid)),
             uuid_membership_index: Mutex::new(None),
             ordinal_identities,
             clock: Mutex::new(Arc::new(system_time_micros)),
-            adjacency_provider: Arc::new(adjacency_provider),
+            adjacency_provider: Arc::new(std::sync::RwLock::new(Arc::new(adjacency_provider))),
             adjacency_visibility: Arc::new(std::sync::RwLock::new(())),
             embedding_refresh_scheduler: Arc::new(Mutex::new(
                 embedding_refresh::initialize_embedding_refresh_scheduler(&dir)?,
@@ -980,6 +987,15 @@ impl GraphForge {
         }
     }
 
+    fn adjacency_provider_for_session(&self) -> Arc<graphforge_exec::PersistentAdjacencyProvider> {
+        Arc::clone(
+            &self
+                .adjacency_provider
+                .read()
+                .expect("adjacency provider lock poisoned"),
+        )
+    }
+
     fn property_inventory_for_session(
         &self,
     ) -> Arc<graphforge_storage::AuthenticatedPropertyInventory> {
@@ -1004,17 +1020,26 @@ impl GraphForge {
             )?,
         );
         let ordinal_replacement = ordinal_identity_handle(generation, &self.dir)?;
+        let adjacency_replacement = Arc::new(adjacency_provider_for_graph(
+            &self.dir,
+            self.ontology_mode,
+            Arc::clone(&replacement),
+        )?);
         *self
             .property_authority
             .lock()
             .expect("property authority lock poisoned") = GenerationPropertyAuthority {
             generation_uuid: generation.generation_uuid(),
-            inventory: replacement,
+            inventory: Arc::clone(&replacement),
         };
         *self
             .current_generation_uuid
             .lock()
             .expect("generation UUID lock poisoned") = generation.generation_uuid();
+        *self
+            .adjacency_provider
+            .write()
+            .expect("adjacency provider lock poisoned") = adjacency_replacement;
         self.ordinal_identities.replace(ordinal_replacement);
         Ok(())
     }
@@ -1494,9 +1519,13 @@ impl GraphForge {
         // must never fall back to `_untyped` host routing.
         let execution_mode = composition_mode.unwrap_or(self.ontology_mode);
         let adjacency_provider = if execution_mode == self.ontology_mode {
-            Arc::clone(&self.adjacency_provider)
+            self.adjacency_provider_for_session()
         } else {
-            Arc::new(adjacency_provider_for_graph(&self.dir, execution_mode)?)
+            Arc::new(adjacency_provider_for_graph(
+                &self.dir,
+                execution_mode,
+                self.property_inventory_for_session(),
+            )?)
         };
         let session = ExecutionSession::new_with_target_provider_resources_and_identity(
             catalog,
@@ -1924,9 +1953,13 @@ impl GraphForge {
                 Self::composition_execution_mode(context)
             });
         let adjacency_provider = if execution_mode == self.ontology_mode {
-            Arc::clone(&self.adjacency_provider)
+            self.adjacency_provider_for_session()
         } else {
-            Arc::new(adjacency_provider_for_graph(&self.dir, execution_mode)?)
+            Arc::new(adjacency_provider_for_graph(
+                &self.dir,
+                execution_mode,
+                self.property_inventory_for_session(),
+            )?)
         };
         let session = ExecutionSession::new_with_target_provider_resources_and_identity(
             catalog,
@@ -2040,56 +2073,56 @@ impl GraphForge {
             ));
         }
 
-        let cleanup_result = self
-            .adjacency_provider
-            .reset_graph(|| -> Result<(), GfError> {
-                let entries = std::fs::read_dir(&self.dir).map_err(|e| {
-                    GfError::Storage(format!("failed to read in-memory project: {e}"))
-                })?;
-                let mut first_error = None;
+        let cleanup_result =
+            self.adjacency_provider_for_session()
+                .reset_graph(|| -> Result<(), GfError> {
+                    let entries = std::fs::read_dir(&self.dir).map_err(|e| {
+                        GfError::Storage(format!("failed to read in-memory project: {e}"))
+                    })?;
+                    let mut first_error = None;
 
-                for entry in entries {
-                    let entry = match entry {
-                        Ok(entry) => entry,
-                        Err(error) => {
+                    for entry in entries {
+                        let entry = match entry {
+                            Ok(entry) => entry,
+                            Err(error) => {
+                                first_error.get_or_insert_with(|| {
+                                    GfError::Storage(format!(
+                                        "failed to inspect in-memory project entry: {error}"
+                                    ))
+                                });
+                                continue;
+                            }
+                        };
+                        let path = entry.path();
+                        let file_type = match entry.file_type() {
+                            Ok(file_type) => file_type,
+                            Err(error) => {
+                                first_error.get_or_insert_with(|| {
+                                    GfError::Storage(format!(
+                                        "failed to inspect in-memory project entry {}: {error}",
+                                        path.display()
+                                    ))
+                                });
+                                continue;
+                            }
+                        };
+                        let result = if file_type.is_dir() && !file_type.is_symlink() {
+                            std::fs::remove_dir_all(&path)
+                        } else {
+                            std::fs::remove_file(&path)
+                        };
+                        if let Err(error) = result {
                             first_error.get_or_insert_with(|| {
                                 GfError::Storage(format!(
-                                    "failed to inspect in-memory project entry: {error}"
-                                ))
-                            });
-                            continue;
-                        }
-                    };
-                    let path = entry.path();
-                    let file_type = match entry.file_type() {
-                        Ok(file_type) => file_type,
-                        Err(error) => {
-                            first_error.get_or_insert_with(|| {
-                                GfError::Storage(format!(
-                                    "failed to inspect in-memory project entry {}: {error}",
+                                    "failed to remove in-memory project entry {}: {error}",
                                     path.display()
                                 ))
                             });
-                            continue;
                         }
-                    };
-                    let result = if file_type.is_dir() && !file_type.is_symlink() {
-                        std::fs::remove_dir_all(&path)
-                    } else {
-                        std::fs::remove_file(&path)
-                    };
-                    if let Err(error) = result {
-                        first_error.get_or_insert_with(|| {
-                            GfError::Storage(format!(
-                                "failed to remove in-memory project entry {}: {error}",
-                                path.display()
-                            ))
-                        });
                     }
-                }
 
-                first_error.map_or(Ok(()), Err)
-            });
+                    first_error.map_or(Ok(()), Err)
+                });
 
         // These registries describe the fixture, not only its remaining files.
         // Reset them even when filesystem cleanup is partial so callers never
@@ -2099,7 +2132,7 @@ impl GraphForge {
             .lock()
             .expect("procedure registry lock")
             .clear();
-        self.adjacency_provider.invalidate();
+        self.adjacency_provider_for_session().invalidate();
         cleanup_result
     }
 
@@ -2229,8 +2262,15 @@ impl GraphForge {
             // reads by it (exploratory `_exploratory.parquet` vs typed
             // `topology/edges/<REL>.parquet`); rebuild it so the adjacency path
             // matches the new mode.
-            self.adjacency_provider =
-                Arc::new(adjacency_provider_for_graph(&self.dir, self.ontology_mode)?);
+            *self
+                .adjacency_provider
+                .write()
+                .expect("adjacency provider lock poisoned") =
+                Arc::new(adjacency_provider_for_graph(
+                    &self.dir,
+                    self.ontology_mode,
+                    self.property_inventory_for_session(),
+                )?);
         }
         Ok(())
     }
@@ -2725,10 +2765,10 @@ fn property_inventory_for_hydrated_generation(
     };
     let admitted = if has_deltas {
         let (materialized, _) = graphforge_storage::capture_graph_files(hydrated_root)?;
-        graphforge_storage::AuthenticatedPropertyInventory::from_materialized_generation(
+        graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
             generation,
             hydrated_root,
-            materialized.files,
+            materialized,
         )?
     } else {
         graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(generation)?
@@ -2771,8 +2811,10 @@ fn ordinal_identity_resolver(
 fn adjacency_provider_for_graph(
     dir: &Path,
     mode: OntologyMode,
+    inventory: Arc<graphforge_storage::AuthenticatedPropertyInventory>,
 ) -> Result<graphforge_exec::PersistentAdjacencyProvider, GfError> {
-    let provider = graphforge_exec::PersistentAdjacencyProvider::new(dir.to_path_buf(), mode);
+    let provider = graphforge_exec::PersistentAdjacencyProvider::new(dir.to_path_buf(), mode)
+        .with_inventory(inventory);
     // A pinned view must not mutate its generation. Writable workspaces also
     // have concurrent readers that enumerate graph files, so lazy build temps
     // must stay outside those trees. Each provider owns a unique cache root.
@@ -2781,6 +2823,14 @@ fn adjacency_provider_for_graph(
         .tempdir()
         .map_err(|error| GfError::Storage(format!("cannot create adjacency cache: {error}")))?;
     Ok(provider.with_rebuild_root(artifacts))
+}
+
+fn create_graph_workspace() -> Result<Arc<tempfile::TempDir>, GfError> {
+    tempfile::Builder::new()
+        .prefix("graphforge-graph-workspace-")
+        .tempdir()
+        .map(Arc::new)
+        .map_err(|error| GfError::Storage(format!("failed to create graph workspace: {error}")))
 }
 
 fn hydrate_graph_workspace(
@@ -2807,7 +2857,11 @@ fn hydrate_graph_workspace(
 
     if let Some(files) = files {
         validate_graph_files_snapshot(&files)?;
-        if files.record_version == graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION {
+        if matches!(
+            files.record_version,
+            graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION
+                | graphforge_storage::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
+        ) {
             let inventory = generation
                 .graph_files_inventory()?
                 .ok_or_else(|| GfError::Validation("compact graph root disappeared".into()))?;
@@ -2855,27 +2909,13 @@ fn hydrate_graph_workspace(
                 graphforge_storage::pinned_open_evidence(&inventory),
             ));
         }
-        let workspace = Arc::new(
-            tempfile::Builder::new()
-                .prefix("graphforge-graph-workspace-")
-                .tempdir()
-                .map_err(|error| {
-                    GfError::Storage(format!("failed to create graph workspace: {error}"))
-                })?,
-        );
+        let workspace = create_graph_workspace()?;
         let evidence =
             graphforge_storage::materialize_graph_tree(&tree, &inventory, workspace.path())?;
         return Ok((workspace.path().to_path_buf(), workspace, evidence));
     }
 
-    let workspace = Arc::new(
-        tempfile::Builder::new()
-            .prefix("graphforge-graph-workspace-")
-            .tempdir()
-            .map_err(|error| {
-                GfError::Storage(format!("failed to create graph workspace: {error}"))
-            })?,
-    );
+    let workspace = create_graph_workspace()?;
     let mut evidence = graphforge_storage::GraphFilesOpenEvidence {
         strategy: graphforge_storage::GraphFilesOpenStrategy::Empty,
         ..graphforge_storage::GraphFilesOpenEvidence::default()
@@ -2905,6 +2945,8 @@ fn validate_graph_files_snapshot(
             files.record_version,
             graphforge_storage::GRAPH_FILES_RECORD_VERSION
                 | graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION
+                | graphforge_storage::GRAPH_FILES_MAPPED_RECORD_VERSION
+                | graphforge_storage::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
         )
         || files.encoding != "json"
     {
@@ -3058,7 +3100,11 @@ pub(crate) fn rematerialize_graph_workspace(
         graphforge_storage::GRAPH_FILES_FAMILY,
     )? {
         validate_graph_files_snapshot(&files)?;
-        if files.record_version == graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION {
+        if matches!(
+            files.record_version,
+            graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION
+                | graphforge_storage::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
+        ) {
             let inventory = generation
                 .graph_files_inventory()?
                 .ok_or_else(|| GfError::Validation("compact graph root disappeared".into()))?;
@@ -3543,24 +3589,29 @@ mod tests {
         let lease = graphforge_storage::begin_graph_object_publication(project).unwrap();
         let mut state = graphforge_storage::GraphManifestState::empty();
         let (inventory, _) = graphforge_storage::capture_graph_files(workspace).unwrap();
+        let mapped =
+            inventory.format_version == graphforge_storage::GRAPH_FILES_MAPPED_RECORD_VERSION;
         let paths = inventory
             .files
             .into_iter()
             .map(|entry| PathBuf::from(entry.relative_path))
             .collect::<Vec<_>>();
-        let (root, _) =
+        let (mut root, _) =
             graphforge_storage::append_graph_files_v2(&lease, workspace, &mut state, &paths, &[])
                 .unwrap();
+        if mapped {
+            root.format_version = graphforge_storage::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION;
+        }
         let participant = ProjectParticipant {
             capability_id: graphforge_storage::GRAPH_CAPABILITY_ID.into(),
             capability_version: graphforge_storage::GRAPH_CAPABILITY_VERSION,
             record_family_id: graphforge_storage::GRAPH_FILES_FAMILY.into(),
-            record_version: graphforge_storage::GRAPH_FILES_V2_RECORD_VERSION,
+            record_version: root.format_version,
             encoding: ProjectParticipantEncoding::Json,
             schema_fingerprint: fingerprint(
                 CanonicalDomain::Schema,
                 CANONICAL_CONTRACT_VERSION,
-                b"graphforge-graph-files-root/2|root_node_sha256|logical_file_count|logical_byte_length",
+                if mapped { b"graphforge-graph-files-root/4|root_node_sha256|logical_file_count|logical_byte_length|semantic-routes/1" } else { b"graphforge-graph-files-root/2|root_node_sha256|logical_file_count|logical_byte_length" },
             )
             .unwrap(),
             row_count: root.logical_file_count,
@@ -3845,7 +3896,14 @@ mod tests {
             .execute("MATCH (n:Person) RETURN n.name AS name")
             .expect("ordinary query over compact-root generation");
         assert_eq!(result.stats.rows_produced, 1);
-        assert_eq!(reopened.graph_open_evidence().files_copied, 0);
+        // Mutable route authority owns a private copy; immutable payloads stay shared.
+        assert_eq!(reopened.graph_open_evidence().files_copied, 1);
+        assert_eq!(
+            reopened.graph_open_evidence().bytes_copied,
+            std::fs::metadata(reopened.dir.join("semantic-routes.json"))
+                .unwrap()
+                .len()
+        );
         assert!(reopened.graph_open_evidence().files_reused > 0);
         assert!(!reopened.dir.join("files").exists());
         assert!(reopened.dir.join("topology").is_dir());
@@ -4259,7 +4317,7 @@ mod tests {
             .execute("CREATE (:Person)-[:KNOWS]->(:Person)")
             .unwrap();
         let retained = graph
-            .adjacency_provider
+            .adjacency_provider_for_session()
             .adjacency("KNOWS", graphforge_ir::Direction::Out)
             .unwrap();
         let generation =

--- a/crates/graphforge-api/src/mapped_portable_tests.rs
+++ b/crates/graphforge-api/src/mapped_portable_tests.rs
@@ -1,0 +1,255 @@
+//! Public portable round trips preserve reserved and case-distinct semantic names.
+
+use arrow::array::{Array, FixedSizeBinaryArray, Int64Array, ListArray, StringArray, StructArray};
+use graphforge_core::portable::{
+    PortableV2GraphSelector, PortableV2Limits, PortableV2Mode, PortableV2Output,
+    PortableV2PropertyProjection, PortableV2SelectionProfile, PortableV2SubsetClosure,
+    PortableV2SubsetRequest,
+};
+use uuid::Uuid;
+
+use crate::{
+    GraphForge, OperationId, PortableSelection, PortableV2ExportRequest, PortableV2ImportRequest,
+    PortableVerifyRequest, verify_portable_v2,
+};
+
+type NodeRow = (Uuid, Vec<String>, String, i64);
+type EdgeRow = (Uuid, String, Uuid, Uuid, i64);
+
+fn uuid_at(batch: &arrow::record_batch::RecordBatch, column: usize, row: usize) -> Uuid {
+    let array = batch
+        .column(column)
+        .as_any()
+        .downcast_ref::<FixedSizeBinaryArray>()
+        .unwrap();
+    assert!(!array.is_null(row));
+    Uuid::from_slice(array.value(row)).unwrap()
+}
+
+fn rows(graph: &GraphForge) -> (Vec<NodeRow>, Vec<EdgeRow>) {
+    let mut nodes = Vec::new();
+    for batch in graph
+        .execute("MATCH (n) RETURN n.node_uuid, labels(n), n.name, n.score")
+        .unwrap()
+        .batches
+    {
+        let labels = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        let names = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let scores = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            let values = labels.value(row);
+            let values = values.as_any().downcast_ref::<StringArray>().unwrap();
+            let mut labels = values
+                .iter()
+                .map(|value| value.unwrap().to_owned())
+                .collect::<Vec<_>>();
+            labels.sort();
+            assert!(!names.is_null(row) && !scores.is_null(row));
+            nodes.push((
+                uuid_at(&batch, 0, row),
+                labels,
+                names.value(row).to_owned(),
+                scores.value(row),
+            ));
+        }
+    }
+    let mut edges = Vec::new();
+    for batch in graph
+        .execute("MATCH (a)-[r]->(b) RETURN r.edge_uuid, type(r), a.node_uuid, b.node_uuid, r.cost")
+        .unwrap()
+        .batches
+    {
+        let routes = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let costs = batch.column(4);
+        for row in 0..batch.num_rows() {
+            assert!(!routes.is_null(row) && !costs.is_null(row));
+            edges.push((
+                uuid_at(&batch, 0, row),
+                routes.value(row).to_owned(),
+                uuid_at(&batch, 2, row),
+                uuid_at(&batch, 3, row),
+                match costs.as_any().downcast_ref::<Int64Array>() {
+                    Some(values) => values.value(row),
+                    None => {
+                        let values =
+                            costs
+                                .as_any()
+                                .downcast_ref::<StructArray>()
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "edge cost type {:?}, schema {:?}, values {:?}",
+                                        costs.data_type(),
+                                        batch.schema(),
+                                        costs
+                                    )
+                                });
+                        let value = graphforge_value::heterogeneous::decode_scalar(values, row)
+                            .expect("valid canonical scalar property");
+                        let graphforge_value::Literal::Int(value) = value else {
+                            panic!("cost must retain its integer value: {value:?}");
+                        };
+                        value
+                    }
+                },
+            ));
+        }
+    }
+    nodes.sort();
+    edges.sort();
+    (nodes, edges)
+}
+
+#[test]
+fn reserved_routes_full_expanded_verify_import_reopen() {
+    round_trip(false, PortableV2Output::Expanded);
+}
+#[test]
+fn reserved_routes_full_bundle_verify_import_reopen() {
+    round_trip(false, PortableV2Output::Bundle);
+}
+#[test]
+fn reserved_routes_projected_expanded_export_verify() {
+    round_trip(true, PortableV2Output::Expanded);
+}
+#[test]
+fn reserved_routes_projected_bundle_export_verify() {
+    round_trip(true, PortableV2Output::Bundle);
+}
+
+fn round_trip(projected: bool, representation: PortableV2Output) {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    graph.execute("CREATE (a:AUX {name: 'a', score: 11, secret: 'redact'}), (b:aux {name: 'b', score: 22, secret: 'redact'}), (c:COM1 {name: 'c', score: 33, secret: 'redact'}) CREATE (a)-[:CON {cost: 101}]->(a), (a)-[:con {cost: 202}]->(b), (b)-[:NUL {cost: 303}]->(c)").unwrap();
+    let original = rows(&graph);
+    assert_eq!(original.0.len(), 3);
+    assert_eq!(original.1.len(), 3);
+    let mut labels = original
+        .0
+        .iter()
+        .map(|row| row.1[0].as_str())
+        .collect::<Vec<_>>();
+    labels.sort();
+    assert_eq!(labels, vec!["AUX", "COM1", "aux"]);
+    let mut relations = original
+        .1
+        .iter()
+        .map(|row| row.1.as_str())
+        .collect::<Vec<_>>();
+    relations.sort();
+    assert_eq!(relations, vec!["CON", "NUL", "con"]);
+    let selected_edge = original.1.iter().find(|row| row.1 == "con").unwrap();
+    let source_generation = graph
+        .property_inventory_for_session()
+        .generation_uuid()
+        .unwrap();
+    let limits = PortableV2Limits::default();
+    let package = root.path().join("package");
+    let subset = projected.then(|| PortableV2SubsetRequest {
+        selector: PortableV2GraphSelector {
+            node_uuids: Vec::new(),
+            edge_uuids: vec![selected_edge.0.to_string()],
+        },
+        closure: PortableV2SubsetClosure::Referential,
+        projection: PortableV2PropertyProjection {
+            exclude: vec!["secret".to_owned()],
+        },
+    });
+    let exported = graph
+        .export_portable_v2(
+            &PortableV2ExportRequest {
+                selection: PortableSelection::Current,
+                output_path: package.clone(),
+                representation,
+                profile: PortableV2SelectionProfile::Complete,
+                subset,
+                limits,
+            },
+            None,
+            |_| {},
+        )
+        .unwrap();
+    let verified = verify_portable_v2(
+        &PortableVerifyRequest {
+            input: package.clone(),
+            mode: PortableV2Mode::Full,
+            limits,
+        },
+        None,
+    )
+    .unwrap();
+    assert_eq!(verified.package_digest, exported.package_digest);
+    let target = root.path().join("imported");
+    assert!(!target.exists());
+    let import = GraphForge::import_portable_v2(
+        &target,
+        &PortableV2ImportRequest {
+            input: package,
+            operation_id: OperationId(Uuid::new_v4()),
+            limits,
+        },
+        None,
+    );
+    if projected {
+        let error = import.unwrap_err();
+        assert_eq!(
+            error.code,
+            graphforge_core::portable::PortableV2ErrorCode::Incompatible
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("selective package requires an explicit class-specific consumer")
+        );
+        assert!(!target.exists());
+    } else {
+        let imported = import.unwrap();
+        assert_eq!(imported.package_digest, exported.package_digest);
+        assert!(!imported.idempotent_replay);
+        let reopened = GraphForge::new(target.to_str()).unwrap();
+        assert_eq!(
+            reopened.resolved_generation.generation_uuid(),
+            imported.generation_uuid
+        );
+        assert_eq!(rows(&reopened), original);
+        let secrets = reopened
+            .execute("MATCH (n) RETURN n.secret AS secret")
+            .unwrap();
+        for batch in secrets.batches {
+            let strings = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            assert!(strings.iter().all(|value| value == Some("redact")));
+        }
+    }
+    assert_eq!(
+        graph.property_inventory_for_session().generation_uuid(),
+        Some(source_generation)
+    );
+    assert_eq!(rows(&graph), original);
+    drop(graph);
+    let reopened_source = GraphForge::new(source.to_str()).unwrap();
+    assert_eq!(
+        reopened_source.resolved_generation.generation_uuid(),
+        source_generation
+    );
+    assert_eq!(rows(&reopened_source), original);
+}

--- a/crates/graphforge-api/src/mapped_stream_tests.rs
+++ b/crates/graphforge-api/src/mapped_stream_tests.rs
@@ -1,0 +1,113 @@
+//! A lazy traversal retains the generation that admitted its route readers.
+
+use arrow::array::{Array, FixedSizeBinaryArray, Int64Array};
+use arrow::record_batch::RecordBatch;
+use futures::TryStreamExt;
+
+use crate::{ExecutionResourcePolicy, GfError, GraphForge, GraphForgeOptions};
+
+type EdgeRow = ([u8; 16], [u8; 16], [u8; 16], i64);
+
+fn edge_rows(batches: &[RecordBatch]) -> Vec<EdgeRow> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let identities = ["source", "edge", "target"].map(|name| {
+            batch
+                .column_by_name(name)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap()
+        });
+        let cost = batch
+            .column_by_name("cost")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            assert!(!cost.is_null(row));
+            let [source, edge, target] = identities.map(|values| {
+                assert!(!values.is_null(row));
+                <[u8; 16]>::try_from(values.value(row)).unwrap()
+            });
+            rows.push((source, edge, target, cost.value(row)));
+        }
+    }
+    rows.sort_unstable();
+    rows
+}
+
+#[test]
+fn mapped_warm_lazy_traversal_keeps_old_rows_after_same_owner_publication() {
+    assert_retained_traversal(false);
+}
+
+#[test]
+fn mapped_cold_lazy_traversal_keeps_old_rows_after_same_owner_publication() {
+    assert_retained_traversal(true);
+}
+
+fn assert_retained_traversal(cold: bool) {
+    let project = tempfile::tempdir().unwrap();
+    let graph = GraphForge::new_with_options(
+        project.path().to_str(),
+        GraphForgeOptions {
+            resource: ExecutionResourcePolicy {
+                target_partitions: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    graph
+        .execute("CREATE (a:AUX {name: 'a'}), (b:AUX {name: 'b'}) CREATE (a)-[:CON {cost: 1}]->(b)")
+        .unwrap();
+    const QUERY: &str = "MATCH (a:AUX)-[r:CON]->(b:AUX) RETURN a.node_uuid AS source, r.edge_uuid AS edge, b.node_uuid AS target, r.cost AS cost";
+    let original = edge_rows(&graph.execute(QUERY).unwrap().batches);
+    assert_eq!(original.len(), 1);
+    assert_eq!(original[0].3, 1);
+    let old_inventory = graph.property_inventory_for_session();
+    if cold {
+        // Remove the eager oracle query's cached adjacency before creating the
+        // lazy traversal, so its first build must read the retained inventory.
+        graph.adjacency_provider_for_session().invalidate();
+    }
+    let stream = graph.execute_stream(QUERY).unwrap();
+    // No consumer polling occurs before both later publications. One partition
+    // also avoids a repartition worker eagerly draining the traversal input.
+    graph
+        .execute("MATCH ()-[r:CON]->() SET r.cost = 2")
+        .unwrap();
+    graph
+        .execute("MATCH (a:AUX {name: 'a'}), (b:AUX {name: 'b'}) CREATE (a)-[:CON {cost: 3}]->(b)")
+        .unwrap();
+    assert_ne!(
+        old_inventory.generation_uuid(),
+        graph.property_inventory_for_session().generation_uuid()
+    );
+    let retained: Vec<RecordBatch> = graph
+        .block_on(async {
+            stream
+                .try_collect()
+                .await
+                .map_err(|error| GfError::Execution(error.to_string()))
+        })
+        .unwrap();
+    assert_eq!(edge_rows(&retained), original);
+    let current = edge_rows(&graph.execute(QUERY).unwrap().batches);
+    assert_eq!(current.len(), 2);
+    assert!(current.contains(&(original[0].0, original[0].1, original[0].2, 2)));
+    let added = current.iter().find(|row| row.1 != original[0].1).unwrap();
+    assert_eq!(
+        (added.0, added.2, added.3),
+        (original[0].0, original[0].2, 3)
+    );
+    drop(graph);
+    let reopened = GraphForge::new(project.path().to_str()).unwrap();
+    assert_eq!(
+        edge_rows(&reopened.execute(QUERY).unwrap().batches),
+        current
+    );
+}

--- a/crates/graphforge-api/src/multi_ontology.rs
+++ b/crates/graphforge-api/src/multi_ontology.rs
@@ -525,7 +525,7 @@ impl GraphForge {
             .lock()
             .expect("runtime catalog poisoned") =
             crate::load_runtime_catalog(&self.dir).map_err(MultiOntologyError::from)?;
-        self.adjacency_provider.invalidate();
+        self.adjacency_provider_for_session().invalidate();
         Ok(ModuleMigrationReceipt {
             project_generation_uuid: expected_generation,
             composition_fingerprint: preview.plan.to_composition_fingerprint.clone(),

--- a/crates/graphforge-api/src/mutation_transaction.rs
+++ b/crates/graphforge-api/src/mutation_transaction.rs
@@ -52,20 +52,30 @@ impl<'a> FacadeMutationLifecycle<'a> {
     fn refresh_unpublished(&self) -> Result<(), GfError> {
         let (inventory, _) = graphforge_storage::capture_graph_files(&self.graph.dir)?;
         let inventory = Arc::new(
-            graphforge_storage::AuthenticatedPropertyInventory::from_materialized_generation(
+            graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
                 &self.parent,
                 &self.graph.dir,
-                inventory.files,
+                inventory,
             )?,
         );
+        let adjacency = Arc::new(crate::adjacency_provider_for_graph(
+            &self.graph.dir,
+            self.graph.ontology_mode,
+            Arc::clone(&inventory),
+        )?);
         *self
             .graph
             .property_authority
             .lock()
             .expect("property authority lock poisoned") = crate::GenerationPropertyAuthority {
             generation_uuid: self.parent.generation_uuid(),
-            inventory,
+            inventory: Arc::clone(&inventory),
         };
+        *self
+            .graph
+            .adjacency_provider
+            .write()
+            .expect("adjacency provider lock poisoned") = adjacency;
         Ok(())
     }
 }
@@ -100,7 +110,7 @@ impl MutationLifecycle for FacadeMutationLifecycle<'_> {
         if !self.publish {
             self.refresh_unpublished()?;
         }
-        self.graph.adjacency_provider.invalidate();
+        self.graph.adjacency_provider_for_session().invalidate();
         Ok(())
     }
 
@@ -153,7 +163,7 @@ impl FacadeMutationLifecycle<'_> {
             .uuid_membership_index
             .lock()
             .expect("UUID membership index lock poisoned") = None;
-        self.graph.adjacency_provider.invalidate();
+        self.graph.adjacency_provider_for_session().invalidate();
         Ok(())
     }
 }

--- a/crates/graphforge-api/src/node_selector.rs
+++ b/crates/graphforge-api/src/node_selector.rs
@@ -59,10 +59,11 @@ impl GraphForge {
         let mut observed = HashMap::new();
         let mut matches = HashSet::new();
         let mut scanned = 0usize;
-        for stem in graphforge_storage::list_property_stems(&self.dir) {
-            for (bytes, properties) in
-                graphforge_storage::read_node_property_rows(&self.dir, &stem)?
-            {
+        let inventory = self.property_inventory_for_session();
+        for stem in inventory.routes(graphforge_storage::PropertyRouteKind::Node) {
+            for (bytes, properties) in graphforge_storage::read_node_property_rows_from_inventory(
+                &self.dir, &inventory, stem,
+            )? {
                 scanned += 1;
                 if scanned > MAX_SELECTOR_ROWS {
                     return Err(validation("node selector property scan exceeds row limit"));
@@ -204,8 +205,13 @@ mod tests {
         Uuid::from_slice(column.value(0)).unwrap()
     }
 
+    #[track_caller]
     fn assert_validation<T>(result: Result<T, GfError>) {
-        assert!(matches!(result, Err(GfError::Validation(_))));
+        assert!(
+            matches!(&result, Err(GfError::Validation(_))),
+            "expected validation refusal; error={:?}",
+            result.as_ref().err()
+        );
     }
 
     #[test]
@@ -232,6 +238,29 @@ mod tests {
             uuid
         );
         assert_eq!(graph.resolve_node_selector(&property).unwrap(), uuid);
+    }
+
+    #[test]
+    fn reserved_label_property_selector_preserves_exact_match() {
+        let graph = GraphForge::new(None).unwrap();
+        graph
+            .execute("CREATE (:CON {name: 'Alice'}), (:con {name: 'Alice'})")
+            .unwrap();
+        let upper = graph
+            .resolve_node_selector(&NodeSelector::Match {
+                label: "CON".into(),
+                property: "name".into(),
+                value: PropValue::Str("Alice".into()),
+            })
+            .unwrap();
+        let lower = graph
+            .resolve_node_selector(&NodeSelector::Match {
+                label: "con".into(),
+                property: "name".into(),
+                value: PropValue::Str("Alice".into()),
+            })
+            .unwrap();
+        assert_ne!(upper, lower);
     }
 
     #[test]
@@ -270,6 +299,23 @@ mod tests {
             property: "name".into(),
             value: PropValue::Str("unique".into()),
         };
+        // Direct storage edits do not replace an already admitted facade view.
+        assert_eq!(other.resolve_node_selector(&duplicate).unwrap(), uuid);
+        // Explicitly admit the malformed workspace to test cross-route duplicate rejection.
+        let generation = other.generation_for_read().unwrap();
+        let (captured, _) = graphforge_storage::capture_graph_files(&other.dir).unwrap();
+        let inventory =
+            graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
+                &generation,
+                &other.dir,
+                captured,
+            )
+            .unwrap();
+        {
+            let mut authority = other.property_authority.lock().unwrap();
+            assert_eq!(Some(authority.generation_uuid), inventory.generation_uuid());
+            authority.inventory = std::sync::Arc::new(inventory);
+        }
         assert_validation(other.resolve_node_selector(&duplicate));
     }
 

--- a/crates/graphforge-api/src/ontology_composition_lifecycle.rs
+++ b/crates/graphforge-api/src/ontology_composition_lifecycle.rs
@@ -485,10 +485,15 @@ impl GraphForge {
             .expect("composition binding lock poisoned") =
             Some(std::sync::Arc::new(published_binding));
         self.ontology_mode = configuration.ontology_mode.execution_mode();
-        self.adjacency_provider = std::sync::Arc::new(crate::adjacency_provider_for_graph(
-            &self.dir,
-            self.ontology_mode,
-        )?);
+        *self
+            .adjacency_provider
+            .write()
+            .expect("adjacency provider lock poisoned") =
+            std::sync::Arc::new(crate::adjacency_provider_for_graph(
+                &self.dir,
+                self.ontology_mode,
+                self.property_inventory_for_session(),
+            )?);
         Ok(CompositionChangeReceipt {
             project_generation_uuid: *self
                 .current_generation_uuid

--- a/crates/graphforge-api/src/provider_rerank.rs
+++ b/crates/graphforge-api/src/provider_rerank.rs
@@ -418,7 +418,12 @@ impl GraphForge {
         let (mut hits, status) = application.into_parts();
         hits.truncate(request.limit);
         let label_id = self.search_label_id(&request.label)?;
-        let batch = shape_search_output(&self.dir, label_id, &hits)?;
+        let batch = shape_search_output(
+            &self.dir,
+            &self.property_inventory_for_session(),
+            label_id,
+            &hits,
+        )?;
         Ok(ProviderRerankedFindResult { batch, status })
     }
 }

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -344,7 +344,7 @@ impl GraphConstructionSession<'_> {
             .uuid_membership_index
             .lock()
             .expect("UUID membership lock poisoned") = None;
-        self.graph.adjacency_provider.invalidate();
+        self.graph.adjacency_provider_for_session().invalidate();
         Ok(GraphConstructionPublicationReceipt {
             generation_uuid: published.generation_uuid,
             idempotent_replay: published.idempotent_replay,

--- a/crates/graphforge-api/src/resumable_construction/codec_tests.rs
+++ b/crates/graphforge-api/src/resumable_construction/codec_tests.rs
@@ -216,8 +216,8 @@ fn compact_public_construction_reopens_and_round_trips_exact_graph() {
     let control: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&checkpoint).unwrap()).unwrap();
     assert_eq!(
-        control["format_version"], 7,
-        "public new sessions use compact details"
+        control["format_version"], 8,
+        "public new sessions use compact details with mapped output"
     );
     let mut session = graph
         .resume_graph_construction(session_id, budgets)

--- a/crates/graphforge-api/src/search_find.rs
+++ b/crates/graphforge-api/src/search_find.rs
@@ -79,7 +79,12 @@ impl GraphForge {
                 force_stale,
                 limit,
             )?;
-            let batch = shape_search_output(&self.dir, label_id, &hits)?;
+            let batch = shape_search_output(
+                &self.dir,
+                &self.property_inventory_for_session(),
+                label_id,
+                &hits,
+            )?;
             if before == read_search_generation(&self.dir)? {
                 return Ok(batch);
             }

--- a/crates/graphforge-api/src/search_index.rs
+++ b/crates/graphforge-api/src/search_index.rs
@@ -254,16 +254,18 @@ impl GraphForge {
         // not enable an absolute spill directory so cancel/failure cleanup is
         // scoped to the unpublished artifact (#336).
         let build_options = self.adjacency_build_options(staged.path());
-        graphforge_storage::adjacency::build_adjacency_index_into_with_options(
+        graphforge_storage::adjacency::build_adjacency_index_from_inventory(
             &self.dir,
             staged.path(),
+            Some(&self.property_inventory_for_session()),
             transaction_time_micros(),
             &build_options,
             &mut || token.checkpoint(),
         )?;
-        let issues = graphforge_storage::adjacency::validate_adjacency_index_against(
+        let issues = graphforge_storage::adjacency::validate_adjacency_index_from_inventory(
             &self.dir,
             staged.path(),
+            Some(&self.property_inventory_for_session()),
         )?;
         if !issues.is_empty() {
             return Err(GfError::Validation(format!(
@@ -295,7 +297,7 @@ impl GraphForge {
         }
         let staged_adjacency = graphforge_storage::adjacency::adjacency_dir(staged.path());
         if let Err(error) = std::fs::rename(&staged_adjacency, &adjacency) {
-            self.adjacency_provider.invalidate();
+            self.adjacency_provider_for_session().invalidate();
             let restore = had_prior
                 .then(|| std::fs::rename(&backup, &adjacency))
                 .transpose()
@@ -303,7 +305,7 @@ impl GraphForge {
                 .map(|restore| restore.to_string());
             return Err(adjacency_swap_error(&error.to_string(), restore.as_deref()));
         }
-        self.adjacency_provider.invalidate();
+        self.adjacency_provider_for_session().invalidate();
         let prior_generation = *self
             .current_generation_uuid
             .lock()
@@ -316,7 +318,7 @@ impl GraphForge {
         if let Err(error) =
             reconcile_adjacency_publication(prior_generation, observed_generation, publication)
         {
-            self.adjacency_provider.invalidate();
+            self.adjacency_provider_for_session().invalidate();
             std::fs::remove_dir_all(&adjacency).map_err(|restore| {
                 GfError::Storage(format!(
                     "adjacency publication failed ({error}); rollback cleanup failed: {restore}"
@@ -329,10 +331,10 @@ impl GraphForge {
                     ))
                 })?;
             }
-            self.adjacency_provider.invalidate();
+            self.adjacency_provider_for_session().invalidate();
             return Err(error);
         }
-        self.adjacency_provider.invalidate();
+        self.adjacency_provider_for_session().invalidate();
         if had_prior {
             // Publication is already authoritative. A best-effort cleanup
             // failure must not turn a committed rebuild into a false failure.
@@ -398,7 +400,10 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        let inspection = graphforge_storage::adjacency::inspect_adjacency_index(&self.dir)?;
+        let inspection = graphforge_storage::adjacency::inspect_adjacency_index_from_inventory(
+            &self.dir,
+            Some(&self.property_inventory_for_session()),
+        )?;
         Ok(AdjacencyInspection {
             project_generation_uuid: *self
                 .current_generation_uuid

--- a/crates/graphforge-api/src/search_output.rs
+++ b/crates/graphforge-api/src/search_output.rs
@@ -10,7 +10,9 @@ use arrow::compute::concat;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use graphforge_search::{FusedSearchHit, VectorLifecycleLimits, project_label_members};
-use graphforge_storage::{list_property_stems, read_properties};
+use graphforge_storage::{
+    AuthenticatedPropertyInventory, PropertyRouteKind, read_properties_from_inventory,
+};
 
 use super::GfError;
 
@@ -44,6 +46,7 @@ type LoadedProperties = (
 /// hit order is preserved exactly; retrieval owns scoring and ordering.
 pub(crate) fn shape_search_output(
     project_dir: &std::path::Path,
+    inventory: &AuthenticatedPropertyInventory,
     label_id: graphforge_value::EntityTypeSelection,
     hits: &[FusedSearchHit],
 ) -> Result<RecordBatch, GfError> {
@@ -61,7 +64,7 @@ pub(crate) fn shape_search_output(
         )));
     }
 
-    let (batches, rows, properties) = load_properties(project_dir, &eligible)?;
+    let (batches, rows, properties) = load_properties(project_dir, inventory, &eligible)?;
     let mut fields = Vec::<Arc<Field>>::with_capacity(properties.len() + 3);
     let mut columns = Vec::<ArrayRef>::with_capacity(properties.len() + 3);
 
@@ -139,17 +142,18 @@ fn validate_hits(hits: &[FusedSearchHit]) -> Result<(), GfError> {
 
 fn load_properties(
     project_dir: &std::path::Path,
+    inventory: &AuthenticatedPropertyInventory,
     eligible: &BTreeSet<[u8; 16]>,
 ) -> Result<LoadedProperties, GfError> {
     let mut batches = Vec::new();
     let mut rows = HashMap::new();
     let mut properties = BTreeMap::<String, PropertySpec>::new();
-    for stem in list_property_stems(project_dir) {
-        let stem_batches = read_properties(project_dir, &stem)
+    for stem in inventory.routes(PropertyRouteKind::Node) {
+        let stem_batches = read_properties_from_inventory(project_dir, inventory, stem)
             .map_err(|error| storage(format!("read property table {stem:?}: {error}")))?;
         for batch in stem_batches {
             let batch_index = batches.len();
-            let uuids = uuid_column(&batch, &stem)?;
+            let uuids = uuid_column(&batch, stem)?;
             let mut contains_member = false;
             for row in 0..batch.num_rows() {
                 if uuids.is_null(row) {
@@ -284,6 +288,22 @@ fn execution(message: impl Into<String>) -> GfError {
 
 #[cfg(test)]
 mod tests {
+    fn shape_test_output(
+        project_dir: &std::path::Path,
+        label_id: graphforge_value::EntityTypeSelection,
+        hits: &[FusedSearchHit],
+    ) -> Result<RecordBatch, GfError> {
+        let catalog = graphforge_storage::GraphCatalog::open(
+            project_dir,
+            None,
+            &graphforge_ir::RuntimeCatalog::new(),
+        )
+        .map_err(|error| storage(error.to_string()))?;
+        let inventory = catalog
+            .admitted_inventory()
+            .expect("admitted fixture inventory");
+        shape_search_output(project_dir, &inventory, label_id, hits)
+    }
     use std::collections::HashMap;
 
     use arrow::array::{Array, BooleanArray, Float64Array, Int64Array, StringArray};
@@ -375,7 +395,7 @@ mod tests {
             hit(1, 0.5, MatchedOn::TextAndVector),
             hit(3, -0.25, MatchedOn::Text),
         ];
-        let batch = shape_search_output(
+        let batch = shape_test_output(
             project.path(),
             graphforge_value::EntityTypeSelection::Known(
                 graphforge_value::EntityTypeId::decode(9).unwrap(),
@@ -451,7 +471,7 @@ mod tests {
             [Some("vector"), Some("text+vector"), Some("text")]
         );
 
-        let empty = shape_search_output(
+        let empty = shape_test_output(
             project.path(),
             graphforge_value::EntityTypeSelection::Known(
                 graphforge_value::EntityTypeId::decode(9).unwrap(),
@@ -473,7 +493,7 @@ mod tests {
         writer.flush().unwrap();
 
         assert!(matches!(
-            shape_search_output(
+            shape_test_output(
                 project.path(),
                 graphforge_value::EntityTypeSelection::Known(
                     graphforge_value::EntityTypeId::decode(9).unwrap()
@@ -483,7 +503,7 @@ mod tests {
             Err(GfError::Validation(_))
         ));
         assert!(matches!(
-            shape_search_output(
+            shape_test_output(
                 project.path(),
                 graphforge_value::EntityTypeSelection::Known(
                     graphforge_value::EntityTypeId::decode(9).unwrap()
@@ -493,7 +513,7 @@ mod tests {
             Err(GfError::Validation(_))
         ));
         assert!(matches!(
-            shape_search_output(
+            shape_test_output(
                 project.path(),
                 graphforge_value::EntityTypeSelection::Known(
                     graphforge_value::EntityTypeId::decode(9).unwrap()

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -192,10 +192,15 @@ impl GraphForge {
                 &catalog,
             )?;
         }
-        self.adjacency_provider = std::sync::Arc::new(crate::adjacency_provider_for_graph(
-            &self.dir,
-            self.ontology_mode,
-        )?);
+        *self
+            .adjacency_provider
+            .write()
+            .expect("adjacency provider lock poisoned") =
+            std::sync::Arc::new(crate::adjacency_provider_for_graph(
+                &self.dir,
+                self.ontology_mode,
+                self.property_inventory_for_session(),
+            )?);
         Ok(())
     }
 
@@ -229,10 +234,15 @@ impl GraphForge {
         self.ontology = None;
         self.ontology_document = None;
         self.ontology_mode = OntologyMode::Exploratory;
-        self.adjacency_provider = std::sync::Arc::new(crate::adjacency_provider_for_graph(
-            &self.dir,
-            self.ontology_mode,
-        )?);
+        *self
+            .adjacency_provider
+            .write()
+            .expect("adjacency provider lock poisoned") =
+            std::sync::Arc::new(crate::adjacency_provider_for_graph(
+                &self.dir,
+                self.ontology_mode,
+                self.property_inventory_for_session(),
+            )?);
         Ok(())
     }
 }

--- a/crates/graphforge-exec/Cargo.toml
+++ b/crates/graphforge-exec/Cargo.toml
@@ -28,11 +28,11 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 sha2 = { workspace = true }
 rayon = "1.10"
+tempfile = "3"
 
 [dev-dependencies]
 graphforge-cypher = { path = "../graphforge-cypher" }
 insta = { workspace = true, features = ["filters"] }
-tempfile = "3"
 tokio = { workspace = true }
 parquet = { workspace = true }
 

--- a/crates/graphforge-exec/src/adjacency.rs
+++ b/crates/graphforge-exec/src/adjacency.rs
@@ -87,6 +87,25 @@ pub enum AdjacencyBacking {
 #[derive(Clone, Debug, Default)]
 pub struct Adjacency {
     inner: AdjacencyInner,
+    // Lazy shard readers must keep private files alive after provider replacement.
+    retained_root: Option<RetainedAdjacencyRoot>,
+}
+
+#[derive(Clone)]
+struct RetainedAdjacencyRoot(Arc<dyn AsRef<std::path::Path> + Send + Sync>);
+
+impl std::fmt::Debug for RetainedAdjacencyRoot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RetainedAdjacencyRoot")
+            .finish_non_exhaustive()
+    }
+}
+
+impl AsRef<std::path::Path> for RetainedAdjacencyRoot {
+    fn as_ref(&self) -> &std::path::Path {
+        self.0.as_ref().as_ref()
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -554,6 +573,14 @@ fn merge_undirected_row<'a>(out: &NeighborRow<'a>, inbound: &NeighborRow<'a>) ->
 /// view is produced (scan-build now; disk-loaded CSR with scan fallback in
 /// #761) — consumers only see [`Adjacency`].
 pub trait AdjacencyProvider: Send + Sync {
+    /// Explicit graph authority for metadata reads accompanying this operation.
+    /// Legacy standalone providers have no admitted inventory.
+    fn admitted_inventory(
+        &self,
+    ) -> Option<Arc<graphforge_storage::AuthenticatedPropertyInventory>> {
+        None
+    }
+
     /// The adjacency view for (`rel_type_name`, `direction`).
     ///
     /// `"*"` means all relation types (#823): the per-row `rel_type_name`
@@ -589,6 +616,56 @@ pub trait AdjacencyProvider: Send + Sync {
     /// manifest count so unconstrained `count(r)` cannot charge O(E) RSS.
     fn edge_cardinality(&self, rel_type_name: &str, direction: Direction) -> Result<u64, GfError> {
         self.adjacency(rel_type_name, direction)?.edge_entry_count()
+    }
+}
+
+/// Operation-scoped adjacency view carrying already-admitted graph metadata.
+/// Adjacency lookup, repair, status and cardinality retain the underlying provider's behavior.
+pub struct AdmittedAdjacencyProvider<'a> {
+    provider: &'a dyn AdjacencyProvider,
+    inventory: Arc<graphforge_storage::AuthenticatedPropertyInventory>,
+}
+
+impl<'a> AdmittedAdjacencyProvider<'a> {
+    /// Bind one operation to its already-authenticated graph inventory.
+    #[must_use]
+    pub fn new(
+        provider: &'a dyn AdjacencyProvider,
+        inventory: Arc<graphforge_storage::AuthenticatedPropertyInventory>,
+    ) -> Self {
+        Self {
+            provider,
+            inventory,
+        }
+    }
+}
+
+impl AdjacencyProvider for AdmittedAdjacencyProvider<'_> {
+    fn admitted_inventory(
+        &self,
+    ) -> Option<Arc<graphforge_storage::AuthenticatedPropertyInventory>> {
+        Some(Arc::clone(&self.inventory))
+    }
+
+    fn adjacency(&self, relation: &str, direction: Direction) -> Result<Arc<Adjacency>, GfError> {
+        self.provider.adjacency(relation, direction)
+    }
+
+    fn repair_adjacency(
+        &self,
+        relation: &str,
+        direction: Direction,
+        error: GfError,
+    ) -> Result<Arc<Adjacency>, GfError> {
+        self.provider.repair_adjacency(relation, direction, error)
+    }
+
+    fn status(&self, relation: &str, direction: Direction) -> AdjacencyStatus {
+        self.provider.status(relation, direction)
+    }
+
+    fn edge_cardinality(&self, relation: &str, direction: Direction) -> Result<u64, GfError> {
+        self.provider.edge_cardinality(relation, direction)
     }
 }
 
@@ -679,17 +756,38 @@ impl<'a> AdjacencyReader<'a> {
 pub struct ScanBuildAdjacencyProvider {
     dir: PathBuf,
     mode: OntologyMode,
+    inventory: Option<Arc<graphforge_storage::AuthenticatedPropertyInventory>>,
 }
 
 impl ScanBuildAdjacencyProvider {
     /// A provider over the project at `dir` in ontology `mode`.
     #[must_use]
     pub fn new(dir: PathBuf, mode: OntologyMode) -> Self {
-        Self { dir, mode }
+        Self {
+            dir,
+            mode,
+            inventory: None,
+        }
+    }
+
+    /// Retain the graph inventory admitted by this provider's owner.
+    #[must_use]
+    pub fn with_inventory(
+        mut self,
+        inventory: Arc<graphforge_storage::AuthenticatedPropertyInventory>,
+    ) -> Self {
+        self.inventory = Some(inventory);
+        self
     }
 }
 
 impl AdjacencyProvider for ScanBuildAdjacencyProvider {
+    fn admitted_inventory(
+        &self,
+    ) -> Option<Arc<graphforge_storage::AuthenticatedPropertyInventory>> {
+        self.inventory.clone()
+    }
+
     fn adjacency(
         &self,
         rel_type_name: &str,
@@ -704,8 +802,14 @@ impl AdjacencyProvider for ScanBuildAdjacencyProvider {
         } else {
             rel_type_name
         };
-        let batches = graphforge_storage::read_edges(&self.dir, read_name, self.mode)
-            .map_err(|e| GfError::Execution(e.to_string()))?;
+        let inventory = self.admitted_inventory();
+        let batches = match &inventory {
+            Some(inventory) => {
+                graphforge_storage::read_edges_from_inventory(inventory, read_name, self.mode)
+            }
+            None => graphforge_storage::read_edges(&self.dir, read_name, self.mode),
+        }
+        .map_err(|e| GfError::Execution(e.to_string()))?;
         build_from_edge_batches(rel_type_name, direction, &batches).map(Arc::new)
     }
 
@@ -714,7 +818,13 @@ impl AdjacencyProvider for ScanBuildAdjacencyProvider {
     }
 
     fn edge_cardinality(&self, rel_type_name: &str, direction: Direction) -> Result<u64, GfError> {
-        footer_edge_cardinality(&self.dir, rel_type_name, self.mode, direction)
+        footer_edge_cardinality(
+            &self.dir,
+            self.admitted_inventory().as_deref(),
+            rel_type_name,
+            self.mode,
+            direction,
+        )
     }
 }
 
@@ -722,11 +832,17 @@ impl AdjacencyProvider for ScanBuildAdjacencyProvider {
 /// each stored edge on both the out and in sides.
 fn footer_edge_cardinality(
     dir: &std::path::Path,
+    inventory: Option<&graphforge_storage::AuthenticatedPropertyInventory>,
     rel_type_name: &str,
     mode: OntologyMode,
     direction: Direction,
 ) -> Result<u64, GfError> {
-    let rows = graphforge_storage::count_edge_rows(dir, rel_type_name, mode)?;
+    let rows = match inventory {
+        Some(inventory) => {
+            graphforge_storage::count_edge_rows_from_inventory(inventory, rel_type_name, mode)
+        }
+        None => graphforge_storage::count_edge_rows(dir, rel_type_name, mode),
+    }?;
     Ok(match direction {
         Direction::Out | Direction::In => rows,
         Direction::Undirected => rows.saturating_mul(2),
@@ -781,6 +897,7 @@ fn build_from_edge_batches(
         }
     }
     Ok(Adjacency {
+        retained_root: None,
         inner: if adj.is_empty() {
             AdjacencyInner::Empty
         } else {
@@ -837,7 +954,7 @@ enum IndexState {
 pub struct PersistentAdjacencyProvider {
     dir: PathBuf,
     /// Owned artifact root; a TempDir owner also removes it on provider drop.
-    rebuild_root: Option<Box<dyn AsRef<std::path::Path> + Send + Sync>>,
+    rebuild_root: Option<RetainedAdjacencyRoot>,
     /// Serialize initial loads/builds; row reads retain their independent views.
     load_lock: Mutex<()>,
     /// A graph reset can reuse generation numbers. Reject pre-reset manifests
@@ -867,6 +984,16 @@ impl PersistentAdjacencyProvider {
         }
     }
 
+    /// Retain the graph inventory admitted by this provider's owner.
+    #[must_use]
+    pub fn with_inventory(
+        mut self,
+        inventory: Arc<graphforge_storage::AuthenticatedPropertyInventory>,
+    ) -> Self {
+        self.scan = self.scan.with_inventory(inventory);
+        self
+    }
+
     /// Keep lazy builds and repairs outside the source graph workspace.
     /// Passing an owned temporary directory retains it for the provider's lifetime.
     /// Existing source indexes remain readable until a private rebuild succeeds.
@@ -875,25 +1002,27 @@ impl PersistentAdjacencyProvider {
         mut self,
         root: impl AsRef<std::path::Path> + Send + Sync + 'static,
     ) -> Self {
-        self.rebuild_root = Some(Box::new(root));
+        self.rebuild_root = Some(RetainedAdjacencyRoot(Arc::new(root)));
         self
     }
 
     fn index_root(&self) -> &std::path::Path {
         self.rebuild_root
-            .as_deref()
+            .as_ref()
             .map(AsRef::as_ref)
             .filter(|root| csr::manifest_path(root).is_file())
             .unwrap_or(&self.dir)
     }
 
     fn rebuild(&self, now: i64) -> Result<Vec<AdjacencyManifestRow>, GfError> {
-        let rows = csr::build_adjacency_index_into(
+        let (rows, _) = csr::build_adjacency_index_from_inventory(
             &self.dir,
             self.rebuild_root
-                .as_deref()
+                .as_ref()
                 .map_or(self.dir.as_path(), AsRef::as_ref),
+            self.admitted_inventory().as_deref(),
             now,
+            &csr::AdjacencyBuildOptions::default(),
             || Ok(()),
         )?;
         self.reset_pending.store(false, Ordering::SeqCst);
@@ -1067,12 +1196,15 @@ impl PersistentAdjacencyProvider {
         };
         match direction {
             Direction::Out => Ok(Adjacency {
+                retained_root: None,
                 inner: directed(csr::Direction::Out)?,
             }),
             Direction::In => Ok(Adjacency {
+                retained_root: None,
                 inner: directed(csr::Direction::In)?,
             }),
             Direction::Undirected => Ok(Adjacency {
+                retained_root: None,
                 inner: AdjacencyInner::Undirected {
                     out: Arc::new(directed(csr::Direction::Out)?),
                     inbound: Arc::new(directed(csr::Direction::In)?),
@@ -1190,7 +1322,8 @@ impl PersistentAdjacencyProvider {
         view
     }
 
-    fn cache_view(&self, stem: &str, direction: Direction, view: Adjacency) -> Arc<Adjacency> {
+    fn cache_view(&self, stem: &str, direction: Direction, mut view: Adjacency) -> Arc<Adjacency> {
+        view.retained_root.clone_from(&self.rebuild_root);
         self.cache_shared_view(stem, direction, Arc::new(view))
     }
 }
@@ -1234,6 +1367,12 @@ fn sharded_overlay_rows(
 }
 
 impl AdjacencyProvider for PersistentAdjacencyProvider {
+    fn admitted_inventory(
+        &self,
+    ) -> Option<Arc<graphforge_storage::AuthenticatedPropertyInventory>> {
+        self.scan.admitted_inventory()
+    }
+
     fn repair_adjacency(
         &self,
         rel_type_name: &str,
@@ -1380,6 +1519,7 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
                     }) {
                         return footer_edge_cardinality(
                             &self.dir,
+                            self.scan.admitted_inventory().as_deref(),
                             rel_type_name,
                             self.scan.mode,
                             direction,
@@ -1400,7 +1540,13 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
                     }
                 })
             }
-            _ => footer_edge_cardinality(&self.dir, rel_type_name, self.scan.mode, direction),
+            _ => footer_edge_cardinality(
+                &self.dir,
+                self.scan.admitted_inventory().as_deref(),
+                rel_type_name,
+                self.scan.mode,
+                direction,
+            ),
         }
     }
 }
@@ -1409,6 +1555,7 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
 #[cfg(test)]
 fn merge_undirected(out: CsrIndex, inbound: CsrIndex) -> Adjacency {
     Adjacency {
+        retained_root: None,
         inner: AdjacencyInner::Undirected {
             out: Arc::new(AdjacencyInner::Csr(Arc::new(out))),
             inbound: Arc::new(AdjacencyInner::Csr(Arc::new(inbound))),
@@ -1432,6 +1579,23 @@ mod tests {
     use graphforge_storage::GraphWriter;
 
     use super::*;
+
+    fn admitted_inventory(dir: &Path) -> Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+        graphforge_storage::GraphCatalog::open(dir, None, &graphforge_ir::RuntimeCatalog::new())
+            .unwrap()
+            .admitted_inventory()
+            .unwrap()
+    }
+
+    fn scan_provider(dir: PathBuf, mode: OntologyMode) -> ScanBuildAdjacencyProvider {
+        let inventory = admitted_inventory(&dir);
+        ScanBuildAdjacencyProvider::new(dir, mode).with_inventory(inventory)
+    }
+
+    fn persistent_provider(dir: PathBuf, mode: OntologyMode) -> PersistentAdjacencyProvider {
+        let inventory = admitted_inventory(&dir);
+        PersistentAdjacencyProvider::new(dir, mode).with_inventory(inventory)
+    }
 
     /// Fixed timestamp so written Parquet is deterministic.
     const TS: i64 = 1_700_000_000_000_000;
@@ -1457,8 +1621,7 @@ mod tests {
     fn out_in_undirected_strict() {
         let dir = TempDir::new().unwrap();
         let [a, b, _c, d] = write_diamond(dir.path());
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         let out = provider.adjacency("KNOWS", Direction::Out).unwrap();
         // a has three outgoing entries: a→b, a→c, then the parallel a→b.
         assert_eq!(out.neighbors(a).unwrap().len(), 3);
@@ -1488,8 +1651,7 @@ mod tests {
         w.create_edge(new_v7(), "OWNS", &a, &c).unwrap();
         w.flush().unwrap();
 
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Exploratory);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Exploratory);
         let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
         assert_eq!(
             view.neighbors(ids[0]).unwrap().to_vec(),
@@ -1511,8 +1673,7 @@ mod tests {
         w.create_edge(new_v7(), "OWNS", &a, &c).unwrap();
         w.flush().unwrap();
 
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Exploratory);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Exploratory);
         let view = provider.adjacency("*", Direction::Out).unwrap();
         assert_eq!(
             view.neighbors(ids[0]).unwrap().to_vec(),
@@ -1539,8 +1700,7 @@ mod tests {
         w.create_edge(new_v7(), "OWNS", &a, &c).unwrap();
         w.flush().unwrap();
 
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         let view = provider.adjacency("*", Direction::Out).unwrap();
         // Both relations' edges appear (KNOWS a→b, OWNS a→c), unioned across the
         // two per-relation files — no longer the pre-#823 empty view.
@@ -1578,8 +1738,7 @@ mod tests {
         let edge_set: std::collections::HashSet<[u8; 16]> = incident.into_iter().collect();
         graphforge_storage::delete_nodes_and_edges(dir.path(), &node_set, &edge_set).unwrap();
 
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
         assert!(
             view.neighbors(ids[1]).unwrap().is_empty(),
@@ -1595,8 +1754,7 @@ mod tests {
     #[test]
     fn absent_edges_dir_yields_empty_adjacency() {
         let dir = TempDir::new().unwrap();
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
         assert!(view.is_empty());
         assert!(view.neighbors(1).unwrap().is_empty());
@@ -1622,8 +1780,7 @@ mod tests {
         }
         w.flush().unwrap();
 
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         let view = provider.adjacency("KNOWS", Direction::Out).unwrap();
         assert_eq!(
             view.neighbors(hub_id).unwrap().to_vec(),
@@ -1637,8 +1794,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let _ids = write_diamond(dir.path());
         graphforge_storage::adjacency::build_adjacency_index(dir.path(), TS).unwrap();
-        let provider =
-            PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = persistent_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         assert_eq!(
             provider.status("KNOWS", Direction::Out),
             AdjacencyStatus::Hit
@@ -1652,10 +1808,9 @@ mod tests {
         assert_eq!(undirected.backing(), AdjacencyBacking::CsrUndirected);
         assert_eq!(undirected.base_csr_entries_expanded(), 0);
 
-        let scanned =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict)
-                .adjacency("KNOWS", Direction::Out)
-                .unwrap();
+        let scanned = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict)
+            .adjacency("KNOWS", Direction::Out)
+            .unwrap();
         assert_eq!(
             out.as_ref(),
             scanned.as_ref(),
@@ -1685,8 +1840,7 @@ mod tests {
     #[test]
     fn scan_build_status_is_building() {
         let dir = TempDir::new().unwrap();
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         for direction in [Direction::Out, Direction::In, Direction::Undirected] {
             assert_eq!(
                 provider.status("KNOWS", direction),
@@ -1730,8 +1884,7 @@ mod tests {
             !csr::adjacency_dir(dir.path()).exists(),
             "diamond fixture must start without an adjacency index"
         );
-        let provider =
-            PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = persistent_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         assert_eq!(
             provider.edge_cardinality("KNOWS", Direction::Out).unwrap(),
             6
@@ -1759,8 +1912,7 @@ mod tests {
             "fixture must publish sharded CSR payloads"
         );
 
-        let provider =
-            PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = persistent_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         assert_eq!(
             provider.edge_cardinality("KNOWS", Direction::Out).unwrap(),
             expected
@@ -1799,8 +1951,7 @@ mod tests {
             let [src, ..] = write_diamond(dir.path());
             build_adjacency_index(dir.path(), TS).unwrap();
             assert!(overwrite_sharded_csr_payloads(dir.path()) > 0);
-            let provider =
-                PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+            let provider = persistent_provider(dir.path().to_path_buf(), OntologyMode::Strict);
             let corrupt = provider.adjacency("KNOWS", Direction::Out).unwrap();
             assert!(corrupt.neighbors(src).is_err());
             assert_ne!(
@@ -1844,7 +1995,7 @@ mod tests {
         let artifacts = TempDir::new().unwrap();
         let artifact_path = artifacts.path().to_path_buf();
         let provider = Arc::new(
-            PersistentAdjacencyProvider::new(source.path().to_path_buf(), OntologyMode::Strict)
+            persistent_provider(source.path().to_path_buf(), OntologyMode::Strict)
                 .with_rebuild_root(artifacts),
         );
         let barrier = Arc::new(std::sync::Barrier::new(4));
@@ -1889,9 +2040,8 @@ mod tests {
             let before = graphforge_storage::capture_graph_files(source.path())
                 .unwrap()
                 .0;
-            let provider =
-                PersistentAdjacencyProvider::new(source.path().to_path_buf(), OntologyMode::Strict)
-                    .with_rebuild_root(artifacts.path().to_path_buf());
+            let provider = persistent_provider(source.path().to_path_buf(), OntologyMode::Strict)
+                .with_rebuild_root(artifacts.path().to_path_buf());
             let mut reader = AdjacencyReader::new(&provider, "KNOWS", Direction::Out).unwrap();
             assert_eq!(reader.with_neighbors(src, |row| row.len()).unwrap(), 3);
             assert_eq!(reader.view.backing(), AdjacencyBacking::CsrNative);
@@ -1929,20 +2079,20 @@ mod tests {
         let source = TempDir::new().unwrap();
         let [src, ..] = write_diamond(source.path());
         let artifacts = TempDir::new().unwrap();
-        let provider =
-            PersistentAdjacencyProvider::new(source.path().to_path_buf(), OntologyMode::Strict)
-                .with_rebuild_root(artifacts);
+        let provider = persistent_provider(source.path().to_path_buf(), OntologyMode::Strict)
+            .with_rebuild_root(artifacts);
         let retained = provider.adjacency("KNOWS", Direction::Out).unwrap();
-        let corrupted_path = source.path().join("topology/edges/KNOWS.parquet");
+        let corrupted_path = provider
+            .admitted_inventory()
+            .unwrap()
+            .edge_files(Some("KNOWS"))[0]
+            .1
+            .clone();
         let original = std::fs::read(&corrupted_path).ok();
         assert!(
             provider
                 .reset_graph(|| {
-                    std::fs::write(
-                        source.path().join("topology/edges/KNOWS.parquet"),
-                        b"partial cleanup",
-                    )
-                    .unwrap();
+                    std::fs::write(&corrupted_path, b"partial cleanup").unwrap();
                     Err(GfError::Storage("cleanup failed".into()))
                 })
                 .is_err()
@@ -1987,13 +2137,16 @@ mod tests {
         let [src, ..] = write_diamond(dir.path());
         build_adjacency_index(dir.path(), TS).unwrap();
         assert!(overwrite_sharded_csr_payloads(dir.path()) > 0);
-        let provider =
-            PersistentAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = persistent_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         let mut reader = AdjacencyReader::new(&provider, "KNOWS", Direction::Out).unwrap();
         // Topology corruption makes the actual rebuild fail; it cannot be
         // hidden as a successful empty row or a successful scan fallback.
         std::fs::write(
-            dir.path().join("topology/edges/KNOWS.parquet"),
+            &provider
+                .admitted_inventory()
+                .unwrap()
+                .edge_files(Some("KNOWS"))[0]
+                .1,
             b"corrupt topology",
         )
         .unwrap();
@@ -2010,12 +2163,12 @@ mod tests {
     #[test]
     fn row_callback_borrows_high_degree_map_without_copying() {
         let dir = TempDir::new().unwrap();
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         let entries: Vec<_> = (0..65_536).map(|id| (id, id + 1)).collect();
         let original = entries.as_ptr();
         let mut reader = AdjacencyReader::new(&provider, "KNOWS", Direction::Out).unwrap();
         reader.view = Arc::new(Adjacency {
+            retained_root: None,
             inner: AdjacencyInner::Map(HashMap::from([(1, entries)])),
         });
         let mut visits = 0;

--- a/crates/graphforge-exec/src/algorithm_analyze.rs
+++ b/crates/graphforge-exec/src/algorithm_analyze.rs
@@ -2518,8 +2518,9 @@ fn load_hashgnn_node_types(
     let selected = graph.node_uuids().collect::<HashSet<_>>();
     let mut values = BTreeMap::new();
     let mut kind = None;
-    for stem in graphforge_storage::list_property_stems(dir) {
-        for (uuid, row) in graphforge_storage::read_node_property_rows(dir, &stem)
+    for stem in graph.property_routes(dir, false) {
+        for (uuid, row) in graph
+            .node_property_rows(dir, &stem)
             .map_err(|error| GfError::Storage(error.to_string()))?
         {
             if !selected.contains(&uuid) {
@@ -2573,8 +2574,9 @@ fn load_hashgnn_relationship_types(
         .collect::<HashSet<_>>();
     let mut values = BTreeMap::new();
     let mut kind = None;
-    for stem in graphforge_storage::list_edge_property_stems(dir) {
-        for batch in graphforge_storage::read_edge_properties(dir, &stem)
+    for stem in graph.property_routes(dir, true) {
+        for batch in graph
+            .edge_property_batches(dir, &stem)
             .map_err(|error| GfError::Storage(error.to_string()))?
         {
             let Some(uuids) = batch

--- a/crates/graphforge-exec/src/algorithm_graph.rs
+++ b/crates/graphforge-exec/src/algorithm_graph.rs
@@ -112,6 +112,7 @@ pub(crate) struct AdjacencyGraph {
     /// Flat adjacency entries in CSR order.
     neighbor_edges: Vec<AlgorithmEdge>,
     node_vectors: HashMap<u64, Vec<f64>>,
+    inventory: Option<std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory>>,
 }
 
 /// Build CSR neighbor arrays from `(node_id, edge)` pairs already sorted by
@@ -156,6 +157,55 @@ fn neighbor_csr_from_map(
 }
 
 impl AdjacencyGraph {
+    pub(crate) fn retain_inventory(
+        &mut self,
+        inventory: Option<std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory>>,
+    ) {
+        self.inventory = inventory;
+    }
+
+    pub(crate) fn property_routes(&self, dir: &Path, edge: bool) -> Vec<String> {
+        match &self.inventory {
+            Some(inventory) => inventory
+                .routes(if edge {
+                    graphforge_storage::PropertyRouteKind::Edge
+                } else {
+                    graphforge_storage::PropertyRouteKind::Node
+                })
+                .map(str::to_owned)
+                .collect(),
+            None if edge => graphforge_storage::list_edge_property_stems(dir),
+            None => graphforge_storage::list_property_stems(dir),
+        }
+    }
+
+    pub(crate) fn node_property_rows(
+        &self,
+        dir: &Path,
+        route: &str,
+    ) -> Result<HashMap<[u8; 16], HashMap<String, IrLiteral>>, GfError> {
+        match &self.inventory {
+            Some(inventory) => {
+                graphforge_storage::read_node_property_rows_from_inventory(dir, inventory, route)
+            }
+            None => graphforge_storage::read_node_property_rows(dir, route),
+        }
+    }
+
+    pub(crate) fn edge_property_batches(
+        &self,
+        dir: &Path,
+        route: &str,
+    ) -> Result<Vec<arrow::record_batch::RecordBatch>, GfError> {
+        match &self.inventory {
+            Some(inventory) => {
+                graphforge_storage::read_edge_properties_from_inventory(dir, inventory, route)
+            }
+            None => graphforge_storage::read_edge_properties(dir, route),
+        }
+        .map_err(storage_error)
+    }
+
     #[cfg(test)]
     pub(crate) fn malformed_for_defensive_tests(
         directed: bool,
@@ -177,6 +227,7 @@ impl AdjacencyGraph {
             neighbor_offsets,
             neighbor_edges,
             node_vectors: HashMap::new(),
+            inventory: None,
         }
     }
 
@@ -410,6 +461,7 @@ impl AdjacencyGraph {
             neighbor_offsets,
             neighbor_edges,
             node_vectors: HashMap::new(),
+            inventory: None,
         })
     }
 
@@ -533,6 +585,7 @@ impl AdjacencyGraph {
             neighbor_offsets,
             neighbor_edges,
             node_vectors: HashMap::new(),
+            inventory: None,
         }
     }
 
@@ -567,6 +620,7 @@ impl AdjacencyGraph {
             neighbor_offsets,
             neighbor_edges,
             node_vectors: HashMap::new(),
+            inventory: None,
         }
     }
 
@@ -632,6 +686,7 @@ impl AdjacencyGraph {
             neighbor_offsets,
             neighbor_edges,
             node_vectors: HashMap::new(),
+            inventory: None,
         }
     }
 
@@ -666,6 +721,7 @@ pub(crate) fn export_node_selection(
         neighbor_offsets: vec![0],
         neighbor_edges: Vec::new(),
         node_vectors: HashMap::new(),
+        inventory: None,
     })
 }
 
@@ -706,9 +762,17 @@ pub(crate) fn export_adjacency(
     }
     raw.sort_unstable();
 
-    let edge_uuids = selected_edge_uuids(dir, mode, selection.via, &edge_ids)?;
+    let inventory = provider.admitted_inventory();
+    let edge_uuids =
+        selected_edge_uuids(dir, mode, selection.via, &edge_ids, inventory.as_deref())?;
     let weights = match selection.weight {
-        Some(property) => selected_weights(dir, selection.via, property, &edge_uuids)?,
+        Some(property) => selected_weights(
+            dir,
+            selection.via,
+            property,
+            &edge_uuids,
+            inventory.as_deref(),
+        )?,
         None => HashMap::new(),
     };
 
@@ -751,6 +815,7 @@ pub(crate) fn export_adjacency(
         neighbor_offsets,
         neighbor_edges,
         node_vectors: HashMap::new(),
+        inventory,
     })
 }
 
@@ -767,9 +832,7 @@ pub(crate) fn load_node_vectors(
     validate_vector_shape(graph.node_ids.len(), 1)?;
     let mut values = HashMap::new();
     for stem in property_stems {
-        for (uuid, row) in
-            graphforge_storage::read_node_property_rows(dir, stem).map_err(storage_error)?
-        {
+        for (uuid, row) in graph.node_property_rows(dir, stem).map_err(storage_error)? {
             if !graph.node_id_by_uuid.contains_key(&uuid) {
                 continue;
             }
@@ -820,9 +883,10 @@ pub(crate) fn load_node_numeric_property(
     property: &str,
 ) -> Result<HashMap<u64, f64>, GfError> {
     let mut values = HashMap::new();
-    for stem in graphforge_storage::list_property_stems(dir) {
-        for (uuid, row) in
-            graphforge_storage::read_node_property_rows(dir, &stem).map_err(storage_error)?
+    for stem in graph.property_routes(dir, false) {
+        for (uuid, row) in graph
+            .node_property_rows(dir, &stem)
+            .map_err(storage_error)?
         {
             let Some(&node_id) = graph.node_id_by_uuid.get(&uuid) else {
                 continue;
@@ -908,9 +972,10 @@ pub(crate) fn load_node_feature_properties(
         .collect::<HashMap<_, _>>();
     for property in properties {
         let mut values = HashMap::new();
-        for stem in graphforge_storage::list_property_stems(dir) {
-            for (uuid, row) in
-                graphforge_storage::read_node_property_rows(dir, &stem).map_err(storage_error)?
+        for stem in graph.property_routes(dir, false) {
+            for (uuid, row) in graph
+                .node_property_rows(dir, &stem)
+                .map_err(storage_error)?
             {
                 if !graph.node_id_by_uuid.contains_key(&uuid) {
                     continue;
@@ -984,9 +1049,11 @@ pub(crate) fn load_node_partition_property(
     property: &str,
 ) -> Result<ResolvedPartitionMap, GfError> {
     let mut rows = Vec::new();
-    for stem in graphforge_storage::list_property_stems(dir) {
+    for stem in graph.property_routes(dir, false) {
         rows.extend(
-            graphforge_storage::read_node_property_rows(dir, &stem).map_err(storage_error)?,
+            graph
+                .node_property_rows(dir, &stem)
+                .map_err(storage_error)?,
         );
     }
     resolve_partition_rows(graph, property, rows)
@@ -1117,6 +1184,7 @@ fn selected_edge_uuids(
     mode: OntologyMode,
     via: &str,
     edge_ids: &HashSet<u64>,
+    inventory: Option<&graphforge_storage::AuthenticatedPropertyInventory>,
 ) -> Result<HashMap<u64, [u8; 16]>, GfError> {
     let mut out = HashMap::new();
     // An advisory ontology can be adopted after exploratory writes. Resolve a
@@ -1127,9 +1195,14 @@ fn selected_edge_uuids(
     } else {
         via
     };
-    for batch in graphforge_storage::read_edges_filtered(dir, read_name, mode, edge_ids)
-        .map_err(storage_error)?
-    {
+    let batches = match inventory {
+        Some(inventory) => graphforge_storage::read_edges_filtered_from_inventory(
+            inventory, read_name, mode, edge_ids,
+        ),
+        None => graphforge_storage::read_edges_filtered(dir, read_name, mode, edge_ids),
+    }
+    .map_err(storage_error)?;
+    for batch in batches {
         let ids = uint64(&batch, "edge_id")?;
         let uuids = fixed_binary(&batch, "edge_uuid")?;
         let relation_names = batch
@@ -1152,19 +1225,33 @@ fn selected_weights(
     via: &str,
     property: &str,
     edge_uuids: &HashMap<u64, [u8; 16]>,
+    inventory: Option<&graphforge_storage::AuthenticatedPropertyInventory>,
 ) -> Result<HashMap<[u8; 16], f64>, GfError> {
     let wanted: HashSet<[u8; 16]> = edge_uuids.values().copied().collect();
     if wanted.is_empty() {
         return Ok(HashMap::new());
     }
     let stems = if via == "*" {
-        graphforge_storage::list_edge_property_stems(dir)
+        match inventory {
+            Some(inventory) => inventory
+                .routes(graphforge_storage::PropertyRouteKind::Edge)
+                .map(str::to_owned)
+                .collect(),
+            None => graphforge_storage::list_edge_property_stems(dir),
+        }
     } else {
         vec![via.to_owned()]
     };
     let mut out = HashMap::new();
     for stem in stems {
-        for batch in graphforge_storage::read_edge_properties(dir, &stem).map_err(storage_error)? {
+        let batches = match inventory {
+            Some(inventory) => {
+                graphforge_storage::read_edge_properties_from_inventory(dir, inventory, &stem)
+            }
+            None => graphforge_storage::read_edge_properties(dir, &stem),
+        }
+        .map_err(storage_error)?;
+        for batch in batches {
             let uuids = fixed_binary(&batch, "edge_uuid")?;
             let values = batch.column_by_name(property).ok_or_else(|| {
                 GfError::Validation(format!("edge weight property {property:?} does not exist"))
@@ -1330,6 +1417,28 @@ mod tests {
         assert_eq!(exact_u64_as_f64(1_u64 << 53), Some((1_u64 << 53) as f64));
         assert_eq!(exact_u64_as_f64((1_u64 << 53) + 1), None);
         assert!(storage_error("sentinel").to_string().contains("sentinel"));
+    }
+
+    fn admitted_inventory(
+        dir: &std::path::Path,
+    ) -> std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+        graphforge_storage::GraphCatalog::open(dir, None, &graphforge_ir::RuntimeCatalog::new())
+            .unwrap()
+            .admitted_inventory()
+            .unwrap()
+    }
+
+    fn scan_provider(dir: std::path::PathBuf, mode: OntologyMode) -> ScanBuildAdjacencyProvider {
+        let inventory = admitted_inventory(&dir);
+        ScanBuildAdjacencyProvider::new(dir, mode).with_inventory(inventory)
+    }
+
+    fn persistent_provider(
+        dir: std::path::PathBuf,
+        mode: OntologyMode,
+    ) -> PersistentAdjacencyProvider {
+        let inventory = admitted_inventory(&dir);
+        PersistentAdjacencyProvider::new(dir, mode).with_inventory(inventory)
     }
 
     struct Fixture {
@@ -1526,8 +1635,7 @@ mod tests {
     #[test]
     fn node2vec_native_and_equivalent_resolved_projection_are_exactly_equal() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let native = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -1652,8 +1760,7 @@ mod tests {
     #[test]
     fn direction_parallel_self_loop_and_uuid_round_trip() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
 
         let out = export_adjacency(
             &provider,
@@ -1704,8 +1811,7 @@ mod tests {
     #[test]
     fn label_filter_excludes_nonmatching_endpoints() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -1725,10 +1831,86 @@ mod tests {
     }
 
     #[test]
+    fn mapped_algorithm_metadata_preserves_reserved_relation_and_weight() {
+        let dir = TempDir::new().unwrap();
+        let mut writer = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS).unwrap();
+        let source = new_v7();
+        let target = new_v7();
+        let edge = new_v7();
+        let label = EntityTypeId::decode(1).unwrap();
+        writer.create_node_with_labels(source, &[label]).unwrap();
+        writer.create_node_with_labels(target, &[label]).unwrap();
+        let edge_id = writer.create_edge(edge, "CON", &source, &target).unwrap();
+        writer
+            .set_edge_properties(
+                &edge,
+                Some("CON"),
+                HashMap::from([("cost".to_owned(), IrLiteral::Float(-2.5))]),
+            )
+            .unwrap();
+        for node in [&source, &target] {
+            writer
+                .set_properties(
+                    node,
+                    Some("AUX"),
+                    HashMap::from([
+                        ("score".to_owned(), IrLiteral::Float(7.0)),
+                        (
+                            "features".to_owned(),
+                            IrLiteral::List(vec![IrLiteral::Float(2.0), IrLiteral::Float(3.0)]),
+                        ),
+                    ]),
+                )
+                .unwrap();
+        }
+        writer.flush().unwrap();
+        drop(writer);
+        let catalog = graphforge_storage::GraphCatalog::open(
+            dir.path(),
+            None,
+            &graphforge_ir::RuntimeCatalog::new(),
+        )
+        .unwrap();
+        let inventory = catalog.admitted_inventory().unwrap();
+        assert_eq!(
+            inventory
+                .routes(graphforge_storage::PropertyRouteKind::Edge)
+                .collect::<Vec<_>>(),
+            vec!["CON"]
+        );
+        let mut graph = export_node_selection(dir.path(), EntityTypeSelection::All).unwrap();
+        graph.retain_inventory(Some(std::sync::Arc::clone(&inventory)));
+        let routes = graph.property_routes(dir.path(), false);
+        assert_eq!(routes, vec!["AUX"]);
+        load_node_vectors(&mut graph, dir.path(), &routes, "features").unwrap();
+        assert_eq!(graph.node_ids().len(), 2);
+        for &node in graph.node_ids() {
+            assert_eq!(graph.node_vector(node), Some([2.0, 3.0].as_slice()));
+        }
+        let scores = load_node_numeric_property(&graph, dir.path(), "score").unwrap();
+        assert_eq!(scores.len(), 2);
+        assert!(scores.values().all(|value| *value == 7.0));
+        for relation in ["CON", "*"] {
+            let identities = selected_edge_uuids(
+                dir.path(),
+                OntologyMode::Strict,
+                relation,
+                &HashSet::from([edge_id]),
+                Some(&inventory),
+            )
+            .unwrap();
+            assert_eq!(identities, HashMap::from([(edge_id, to_bytes(&edge))]));
+            let weights =
+                selected_weights(dir.path(), relation, "cost", &identities, Some(&inventory))
+                    .unwrap();
+            assert_eq!(weights, HashMap::from([(to_bytes(&edge), -2.5)]));
+        }
+    }
+
+    #[test]
     fn selected_weights_preserve_negative_values() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -1752,8 +1934,7 @@ mod tests {
     #[test]
     fn missing_weight_is_a_validation_error() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let error = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -1770,8 +1951,7 @@ mod tests {
     #[test]
     fn empty_graph_keeps_a_valid_empty_mapping() {
         let dir = TempDir::new().unwrap();
-        let provider =
-            ScanBuildAdjacencyProvider::new(dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(dir.path().to_path_buf(), OntologyMode::Strict);
         let mut graph = export_adjacency(
             &provider,
             dir.path(),
@@ -1788,8 +1968,7 @@ mod tests {
     #[test]
     fn graph_native_vectors_load_by_uuid_in_topology_order() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let mut graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -1818,8 +1997,7 @@ mod tests {
     #[test]
     fn graphsage_feature_loader_preserves_property_order_and_is_atomic() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let mut graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -1857,8 +2035,7 @@ mod tests {
     #[test]
     fn graph_native_loaders_reject_conflicting_stems_and_ragged_features() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let mut graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -1882,6 +2059,8 @@ mod tests {
         )
         .unwrap();
 
+        // The mutation creates a new fixture snapshot; existing views stay pinned.
+        graph.retain_inventory(Some(admitted_inventory(fixture.dir.path())));
         for error in [
             load_node_vectors(
                 &mut graph,
@@ -1898,8 +2077,7 @@ mod tests {
         }
 
         let ragged = self::fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(ragged.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(ragged.dir.path().to_path_buf(), OntologyMode::Strict);
         let mut ragged_graph = export_adjacency(
             &provider,
             ragged.dir.path(),
@@ -1919,6 +2097,7 @@ mod tests {
             )]),
         )
         .unwrap();
+        ragged_graph.retain_inventory(Some(admitted_inventory(ragged.dir.path())));
         let error = load_node_feature_properties(
             &mut ragged_graph,
             ragged.dir.path(),
@@ -1931,8 +2110,7 @@ mod tests {
     #[test]
     fn vector_loader_ignores_property_rows_for_unselected_nodes() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let mut graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -1965,8 +2143,7 @@ mod tests {
     #[test]
     fn scalar_feature_loader_is_ordered_and_rejects_invalid_or_missing_values() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let mut graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -2001,7 +2178,9 @@ mod tests {
     #[test]
     fn graph_native_partition_property_loads_without_knowledge_storage() {
         let fixture = fixture();
-        let graph = export_node_selection(fixture.dir.path(), EntityTypeSelection::All).unwrap();
+        let mut graph =
+            export_node_selection(fixture.dir.path(), EntityTypeSelection::All).unwrap();
+        graph.retain_inventory(Some(admitted_inventory(fixture.dir.path())));
         let mapping = load_node_partition_property(&graph, fixture.dir.path(), "side").unwrap();
         assert_eq!(mapping.iter().count(), fixture.uuids.len());
         assert_eq!(
@@ -2159,8 +2338,7 @@ mod tests {
     #[test]
     fn missing_and_ragged_vectors_fail_without_partial_attachment() {
         let fixture = fixture();
-        let provider =
-            ScanBuildAdjacencyProvider::new(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
+        let provider = scan_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let mut graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -2196,6 +2374,7 @@ mod tests {
             )]),
         )
         .unwrap();
+        graph.retain_inventory(Some(admitted_inventory(fixture.dir.path())));
         assert!(matches!(
             load_node_vectors(
                 &mut graph,
@@ -2229,10 +2408,7 @@ mod tests {
             .unwrap();
         writer.flush().unwrap();
 
-        let provider = PersistentAdjacencyProvider::new(
-            fixture.dir.path().to_path_buf(),
-            OntologyMode::Strict,
-        );
+        let provider = persistent_provider(fixture.dir.path().to_path_buf(), OntologyMode::Strict);
         let graph = export_adjacency(
             &provider,
             fixture.dir.path(),
@@ -2268,6 +2444,7 @@ mod tests {
                 neighbor_offsets,
                 neighbor_edges,
                 node_vectors: HashMap::new(),
+                inventory: None,
             }
         };
 

--- a/crates/graphforge-exec/src/algorithm_similar.rs
+++ b/crates/graphforge-exec/src/algorithm_similar.rs
@@ -478,7 +478,9 @@ fn similar_projection(
         SimilarAlgorithm::Knn | SimilarAlgorithm::FilteredKnn | SimilarAlgorithm::Cosine
     );
     let mut graph = if matches!(by, SimilarAlgorithm::Knn | SimilarAlgorithm::Cosine) {
-        export_node_selection(dir, label)?
+        let mut selected = export_node_selection(dir, label)?;
+        selected.retain_inventory(provider.admitted_inventory());
+        selected
     } else {
         export_adjacency(
             provider,

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -106,8 +106,8 @@ mod edge_count;
 mod ordered_one_hop;
 mod ordered_two_hop;
 pub use adjacency::{
-    Adjacency, AdjacencyBacking, AdjacencyProvider, AdjacencyStatus, PersistentAdjacencyProvider,
-    ScanBuildAdjacencyProvider,
+    Adjacency, AdjacencyBacking, AdjacencyProvider, AdjacencyStatus, AdmittedAdjacencyProvider,
+    PersistentAdjacencyProvider, ScanBuildAdjacencyProvider,
 };
 pub use algorithm_analyze::{
     analyze_algorithm, analyze_algorithm_with_compute, analyze_projection_fingerprint,
@@ -2645,9 +2645,21 @@ fn expand_bfs(cfg: &ExpandConfig, input_batches: &[RecordBatch]) -> Result<Recor
     // the per-path relationship list (#709) — read lazily for the traversed
     // ids only (row-group pruning + row filter; an empty traversal never
     // opens the file).
-    let edge_batches =
-        graphforge_storage::read_edges_filtered(&cfg.dir, &cfg.rel_type_name, cfg.mode, &traversed)
-            .map_err(|e| exec_err(e.to_string()))?;
+    let edge_batches = match cfg.provider.admitted_inventory() {
+        Some(inventory) => graphforge_storage::read_edges_filtered_from_inventory(
+            &inventory,
+            &cfg.rel_type_name,
+            cfg.mode,
+            &traversed,
+        ),
+        None => graphforge_storage::read_edges_filtered(
+            &cfg.dir,
+            &cfg.rel_type_name,
+            cfg.mode,
+            &traversed,
+        ),
+    }
+    .map_err(|e| exec_err(e.to_string()))?;
     let edge_records = build_edge_records(cfg, &edge_batches)?;
 
     // --- Read nodes; map node_id -> row index for destination columns. ---
@@ -2949,6 +2961,7 @@ fn build_edge_list_column(
     // then one array per property field (#755).
     let mut children: Vec<ArrayRef> = vec![edge_arr, src_arr, dst_arr, rel_arr];
     children.extend(build_edge_prop_children(
+        cfg.provider.admitted_inventory().as_deref(),
         &cfg.rel_type_name,
         &cfg.dir,
         &prop_fields,
@@ -2978,6 +2991,7 @@ fn build_edge_list_column(
 /// to exactly one relation), coalesced per field — NULL where the owning
 /// relation lacks the column, matching the lowering's nullable union schema.
 fn build_edge_prop_children(
+    inventory: Option<&graphforge_storage::AuthenticatedPropertyInventory>,
     rel_type_name: &str,
     dir: &Path,
     prop_fields: &[arrow::datatypes::FieldRef],
@@ -2998,7 +3012,13 @@ fn build_edge_prop_children(
     // (absent files contribute nothing). Typed traversals read one file; a
     // wildcard reads all of them, in the lowering's sorted-stem order.
     let stems: Vec<String> = if rel_type_name == "*" {
-        graphforge_storage::list_edge_property_stems(dir)
+        match inventory {
+            Some(inventory) => inventory
+                .routes(graphforge_storage::PropertyRouteKind::Edge)
+                .map(str::to_owned)
+                .collect(),
+            None => graphforge_storage::list_edge_property_stems(dir),
+        }
     } else {
         vec![rel_type_name.to_owned()]
     };
@@ -3008,9 +3028,16 @@ fn build_edge_prop_children(
         .map(|field| field.name().clone())
         .collect::<Vec<_>>();
     for stem in &stems {
-        let batches =
-            graphforge_storage::read_edge_properties_projected(dir, stem, &property_names)
-                .map_err(|e| exec_err(e.to_string()))?;
+        let batches = match inventory {
+            Some(inventory) => graphforge_storage::read_edge_properties_projected_from_inventory(
+                dir,
+                inventory,
+                stem,
+                &property_names,
+            ),
+            None => graphforge_storage::read_edge_properties_projected(dir, stem, &property_names),
+        }
+        .map_err(|e| exec_err(e.to_string()))?;
         if let Some(first) = batches.first() {
             prop_batches_by_rel.push(
                 concat_batches(&first.schema(), &batches).map_err(|e| exec_err(e.to_string()))?,
@@ -3985,25 +4012,44 @@ fn expand_single_hop_chunk(
     if relationship_properties_required {
         edge_projection.push(0);
     }
-    let edge_batches = if required.is_some() {
-        graphforge_storage::read_edges_filtered_projected_observed(
-            &cfg.dir,
-            &cfg.rel_type_name,
-            cfg.mode,
-            &traversed,
-            &edge_projection,
-            edge_observer.as_ref(),
-        )
-    } else {
-        graphforge_storage::read_edges_filtered_observed(
-            &cfg.dir,
-            &cfg.rel_type_name,
-            cfg.mode,
-            &traversed,
-            edge_observer.as_ref(),
-        )
-    }
-    .map_err(|e| exec_err(e.to_string()))?;
+    let admitted_inventory = cfg.provider.admitted_inventory();
+    let edge_batches =
+        if let Some(inventory) = admitted_inventory.as_deref().filter(|_| required.is_some()) {
+            graphforge_storage::read_edges_filtered_projected_from_inventory(
+                inventory,
+                &cfg.rel_type_name,
+                cfg.mode,
+                &traversed,
+                &edge_projection,
+                edge_observer.as_ref(),
+            )
+        } else if required.is_some() {
+            graphforge_storage::read_edges_filtered_projected_observed(
+                &cfg.dir,
+                &cfg.rel_type_name,
+                cfg.mode,
+                &traversed,
+                &edge_projection,
+                edge_observer.as_ref(),
+            )
+        } else if let Some(inventory) = admitted_inventory.as_deref() {
+            graphforge_storage::read_edges_filtered_observed_from_inventory(
+                inventory,
+                &cfg.rel_type_name,
+                cfg.mode,
+                &traversed,
+                edge_observer.as_ref(),
+            )
+        } else {
+            graphforge_storage::read_edges_filtered_observed(
+                &cfg.dir,
+                &cfg.rel_type_name,
+                cfg.mode,
+                &traversed,
+                edge_observer.as_ref(),
+            )
+        }
+        .map_err(|e| exec_err(e.to_string()))?;
     drop(edge_permit);
     let edge_schema = edge_batches
         .first()
@@ -4184,6 +4230,7 @@ fn expand_single_hop_chunk(
         .map(|(_, field)| Arc::clone(field))
         .collect::<Vec<_>>();
     let demanded_property_columns = build_edge_prop_children(
+        cfg.provider.admitted_inventory().as_deref(),
         &cfg.rel_type_name,
         &cfg.dir,
         &demanded_property_fields,
@@ -4746,6 +4793,9 @@ fn unwind_explode(
 /// [`GraphForgeExtensionPlanner`].
 pub struct AdjacencyProviderExt(pub Arc<dyn AdjacencyProvider>);
 
+/// Mutable session ownership ends at planning: plans retain only a selected immutable provider.
+struct OwnedSessionAdjacency(RwLock<Arc<PersistentAdjacencyProvider>>);
+
 /// `SessionConfig` extension carrying the facade's exact generation-pinned
 /// ordinal identity authority.
 struct OrdinalIdentityResolverExt(pub Option<Arc<V4OrdinalIdentitySession>>);
@@ -4902,6 +4952,22 @@ impl QueryPlanner for GraphForgeQueryPlanner {
         logical_plan: &LogicalPlan,
         session_state: &SessionState,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let mut pinned_state = session_state.clone();
+        if let Some(owner) = session_state
+            .config()
+            .get_extension::<OwnedSessionAdjacency>()
+        {
+            let provider: Arc<dyn AdjacencyProvider> = {
+                let current = owner.0.read().map_err(|_| {
+                    DataFusionError::Execution("session adjacency lock poisoned".into())
+                })?;
+                Arc::clone(&*current) as _
+            };
+            pinned_state
+                .config_mut()
+                .set_extension(Arc::new(AdjacencyProviderExt(provider)));
+        }
+        let session_state = &pinned_state;
         let (logical_plan, hydration) = read_resource::bind(logical_plan, session_state)?;
         let planner = DefaultPhysicalPlanner::with_extension_planners(vec![Arc::new(
             GraphForgeExtensionPlanner,
@@ -5037,6 +5103,7 @@ pub struct ExecutionSession {
     /// invalidate its memoized state and loaded views — a same-session
     /// read → write → read must observe post-write adjacency.
     adjacency_provider: Arc<PersistentAdjacencyProvider>,
+    owned_adjacency: Option<Arc<OwnedSessionAdjacency>>,
     /// Differential-test strategy, absent from ordinary builds.
     #[cfg(feature = "differential-testing")]
     relational_fixed_hop_reference: bool,
@@ -5211,13 +5278,25 @@ impl ExecutionSession {
         // A facade-shared provider (#832) is revalidated here — once per
         // session — so its memoized state is as fresh as a per-query
         // provider's, while loaded views amortize across queries.
+        let owns_provider = shared_provider.is_none();
         let adjacency_provider = shared_provider.map_or_else(
-            || Arc::new(PersistentAdjacencyProvider::new(dir.clone(), mode)),
+            || {
+                let provider = PersistentAdjacencyProvider::new(dir.clone(), mode);
+                Arc::new(match catalog.admitted_inventory() {
+                    Some(inventory) => provider.with_inventory(inventory),
+                    None => provider,
+                })
+            },
             |p| {
                 p.revalidate();
                 p
             },
         );
+        let owned_adjacency = owns_provider.then(|| {
+            Arc::new(OwnedSessionAdjacency(RwLock::new(Arc::clone(
+                &adjacency_provider,
+            ))))
+        });
         let provider: Arc<dyn AdjacencyProvider> = Arc::clone(&adjacency_provider) as _;
         let catalog = Arc::new(catalog);
         let mutation_health = mutation::MutationHealth::default();
@@ -5236,6 +5315,9 @@ impl ExecutionSession {
             )))
             .with_target_partitions(resources.target_partitions)
             .with_batch_size(resources.batch_size);
+        if let Some(owner) = &owned_adjacency {
+            config.set_extension(Arc::clone(owner));
+        }
         if !dir.as_os_str().is_empty() {
             config.set_extension(Arc::new(write_resource::GraphWriteContext {
                 resource: read_resource,
@@ -5295,9 +5377,34 @@ impl ExecutionSession {
             mode,
             semantic_composition_fingerprint,
             adjacency_provider,
+            owned_adjacency,
             #[cfg(feature = "differential-testing")]
             relational_fixed_hop_reference: false,
         }
+    }
+
+    fn refresh_adjacency_after_mutation(&self) -> Result<(), GfError> {
+        let Some(owner) = &self.owned_adjacency else {
+            self.adjacency_provider.invalidate();
+            return Ok(());
+        };
+        let inventory = self.catalog.admitted_inventory().ok_or_else(|| {
+            GfError::Storage("refreshed session lacks admitted graph inventory".into())
+        })?;
+        let private = tempfile::Builder::new()
+            .prefix("graphforge-session-adjacency-")
+            .tempdir()
+            .map_err(|error| GfError::Storage(error.to_string()))?;
+        let provider = Arc::new(
+            PersistentAdjacencyProvider::new(self.dir.clone(), self.mode)
+                .with_inventory(inventory)
+                .with_rebuild_root(private),
+        );
+        *owner
+            .0
+            .write()
+            .map_err(|_| GfError::Storage("session adjacency lock poisoned".into()))? = provider;
+        Ok(())
     }
 
     /// Use the relational fixed-hop implementation as an independent test
@@ -5386,7 +5493,10 @@ impl ExecutionSession {
                 ..SideEffects::default()
             },
         ));
-        self.adjacency_provider.invalidate();
+        self.catalog
+            .refresh_property_inventory(&self.dir)
+            .map_err(GfError::from_execution_error)?;
+        self.refresh_adjacency_after_mutation()?;
         Ok(ExecutionResult {
             schema,
             batches,
@@ -5557,6 +5667,7 @@ impl ExecutionSession {
 
         // Phase loop: buffer every effect, then one staged commit.
         let env = write_driver::PhaseEnv {
+            inventory: self.catalog.admitted_inventory(),
             lowerer: &lowerer,
             exprs: &plan.exprs,
             dir: &resource.dir,

--- a/crates/graphforge-exec/src/mutation.rs
+++ b/crates/graphforge-exec/src/mutation.rs
@@ -465,8 +465,7 @@ impl MutationLifecycle for LocalMutationLifecycle<'_> {
             .catalog
             .refresh_property_inventory(self.resource.directory())
             .map_err(graphforge_core::GfError::from_execution_error)?;
-        self.session.adjacency_provider.invalidate();
-        Ok(())
+        self.session.refresh_adjacency_after_mutation()
     }
     fn abort(&mut self) -> Result<(), graphforge_core::GfError> {
         let health = self.session.mutation_health.clone();

--- a/crates/graphforge-exec/src/read_resource.rs
+++ b/crates/graphforge-exec/src/read_resource.rs
@@ -60,11 +60,9 @@ impl GraphReadContext {
             GraphReadTable::Edges(stem)
                 if stem == "_exploratory" && self.mode != OntologyMode::Exploratory =>
             {
-                Arc::new(graphforge_storage::UnionEdgeTable::open(&self.dir))
+                Arc::new(self.catalog.union_edge_table(&self.dir))
             }
-            GraphReadTable::Edges(stem) => {
-                Arc::new(graphforge_storage::TypedEdgeTable::open(&self.dir, stem))
-            }
+            GraphReadTable::Edges(stem) => Arc::new(self.catalog.edge_table(&self.dir, stem)),
             GraphReadTable::SemanticEdges(id) => {
                 self.catalog.semantic_edge_table(*id).ok_or_else(|| {
                     DataFusionError::Plan("GF_READ_RESOURCE_INCOMPATIBLE: semantic relation".into())

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -1307,6 +1307,7 @@ impl CreateRecorder {
 
 /// Everything the phases borrow from the session.
 pub(crate) struct PhaseEnv<'a> {
+    pub inventory: Option<std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory>>,
     pub lowerer: &'a GraphPlanLowerer,
     pub exprs: &'a ExprArena,
     pub dir: &'a Path,
@@ -1990,8 +1991,13 @@ fn run_relationship_merge_phase(
             "node_id",
         )
         .ok_or_else(|| GfError::Plan("MERGE destination node has no node_id".into()))?;
-    let edge_batches = graphforge_storage::read_edges(env.dir, rel_name, env.mode)
-        .map_err(|e| GfError::Storage(e.to_string()))?;
+    let edge_batches = match &env.inventory {
+        Some(inventory) => {
+            graphforge_storage::read_edges_from_inventory(inventory, rel_name, env.mode)
+        }
+        None => graphforge_storage::read_edges(env.dir, rel_name, env.mode),
+    }
+    .map_err(|e| GfError::Storage(e.to_string()))?;
     let mut edge_rows = Vec::with_capacity(frontier.num_rows());
     let mut created = Vec::with_capacity(frontier.num_rows());
     let mut input_rows = Vec::with_capacity(frontier.num_rows());
@@ -2486,6 +2492,19 @@ fn scalar_struct_uuid(values: &StructArray, field: &str) -> Result<Option<[u8; 1
     Ok(Some(uuid))
 }
 
+fn count_deleted_properties(
+    env: &PhaseEnv<'_>,
+    targets: &HashSet<[u8; 16]>,
+    edge: bool,
+) -> Result<u64, GfError> {
+    match &env.inventory {
+        Some(inventory) => graphforge_storage::count_entity_properties_from_inventory(
+            env.dir, inventory, targets, edge,
+        ),
+        None => graphforge_storage::count_entity_properties(env.dir, targets, edge),
+    }
+}
+
 /// DELETE phase: collect targets from the frontier, enforce the openCypher
 /// incident-edge rule against committed **and** pending edges, cancel
 /// pending-created targets in the buffer, and queue committed targets for the
@@ -2586,7 +2605,7 @@ fn run_delete_phase(
     let committed_edges: HashSet<[u8; 16]> =
         edge_targets.difference(&pending_edges).copied().collect();
     ctx.mutation.counters.properties_removed +=
-        graphforge_storage::count_entity_properties(env.dir, &committed_edges, true)?;
+        count_deleted_properties(env, &committed_edges, true)?;
     ctx.mutation.counters.edges_deleted += edge_targets.len() as u64;
     ctx.writer.cancel_edges(&pending_edges);
     ctx.pending_edge_deletes.extend(&committed_edges);
@@ -2594,7 +2613,7 @@ fn run_delete_phase(
 
     // Nodes, likewise.
     ctx.mutation.counters.properties_removed +=
-        graphforge_storage::count_entity_properties(env.dir, &committed_nodes, false)?;
+        count_deleted_properties(env, &committed_nodes, false)?;
     ctx.mutation.counters.nodes_deleted += node_targets.len() as u64;
     ctx.writer.cancel_nodes(&pending_nodes);
     ctx.pending_node_deletes.extend(committed_nodes);
@@ -4141,6 +4160,7 @@ mod tests {
         params: &'a HashMap<String, IrLiteral>,
     ) -> PhaseEnv<'a> {
         PhaseEnv {
+            inventory: None,
             lowerer,
             exprs,
             dir,

--- a/crates/graphforge-exec/tests/bench_traversal_scaling.rs
+++ b/crates/graphforge-exec/tests/bench_traversal_scaling.rs
@@ -217,18 +217,27 @@ async fn run_measured(
     (reached, snap)
 }
 
+fn admitted_inventory(
+    dir: &std::path::Path,
+) -> Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    graphforge_storage::GraphCatalog::open(dir, None, &graphforge_ir::RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
 fn persistent(dir: &Path) -> Arc<dyn AdjacencyProvider> {
-    Arc::new(PersistentAdjacencyProvider::new(
-        dir.to_path_buf(),
-        OntologyMode::Strict,
-    )) as Arc<dyn AdjacencyProvider>
+    Arc::new(
+        PersistentAdjacencyProvider::new(dir.to_path_buf(), OntologyMode::Strict)
+            .with_inventory(admitted_inventory(dir)),
+    ) as Arc<dyn AdjacencyProvider>
 }
 
 fn scan_build(dir: &Path) -> Arc<dyn AdjacencyProvider> {
-    Arc::new(ScanBuildAdjacencyProvider::new(
-        dir.to_path_buf(),
-        OntologyMode::Strict,
-    )) as Arc<dyn AdjacencyProvider>
+    Arc::new(
+        ScanBuildAdjacencyProvider::new(dir.to_path_buf(), OntologyMode::Strict)
+            .with_inventory(admitted_inventory(dir)),
+    ) as Arc<dyn AdjacencyProvider>
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/graphforge-exec/tests/create_execution.rs
+++ b/crates/graphforge-exec/tests/create_execution.rs
@@ -19,7 +19,7 @@ use graphforge_ir::{Binder, GraphPlan, IrLiteral, OntologyMode, RuntimeCatalog};
 use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
 use graphforge_storage::{
     EdgePropertyTable, GraphCatalog, PropertyOverlayLimits, PropertyRouteKind, PropertyTable,
-    enumerate_property_fragments, visit_authenticated_property_snapshots,
+    visit_authenticated_property_snapshots,
 };
 
 fn hr_handle() -> OntologyHandle {
@@ -65,6 +65,13 @@ fn parquet_row_count(path: &Path) -> usize {
     reader.next().unwrap().unwrap().num_rows()
 }
 
+fn admitted_inventory(dir: &Path) -> Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    GraphCatalog::open(dir, None, &RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
 fn property_rows(
     dir: &Path,
     kind: PropertyRouteKind,
@@ -89,7 +96,7 @@ fn property_rows(
 }
 
 fn assert_canonical_fragment(dir: &Path, kind: PropertyRouteKind, route: &str) {
-    let fragments = enumerate_property_fragments(dir, kind, route).unwrap();
+    let fragments = admitted_inventory(dir).property_fragments(kind, route);
     assert!(!fragments.is_empty(), "missing immutable property fragment");
     for fragment in fragments {
         assert_ne!(fragment.id.generation, 0, "new writes are not legacy files");
@@ -163,9 +170,12 @@ async fn create_edge_between_two_nodes_strict() {
         parquet_row_count(&dir.path().join("topology/nodes.parquet")),
         2
     );
-    let edges = dir.path().join("topology/edges/IS_FRIEND_OF.parquet");
+    let inventory = admitted_inventory(dir.path());
+    let paths = inventory.edge_files(Some("IS_FRIEND_OF"));
+    assert_eq!(paths.len(), 1);
+    let edges = &paths[0].1;
     assert!(edges.exists(), "typed edge file should exist");
-    assert_eq!(parquet_row_count(&edges), 1);
+    assert_eq!(parquet_row_count(edges), 1);
 }
 
 #[tokio::test]

--- a/crates/graphforge-exec/tests/persistent_adjacency.rs
+++ b/crates/graphforge-exec/tests/persistent_adjacency.rs
@@ -55,12 +55,22 @@ fn write_diamond(dir: &Path) -> [u64; 4] {
     [ids[0], ids[1], ids[2], ids[3]]
 }
 
+fn admitted_inventory(
+    dir: &std::path::Path,
+) -> Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    graphforge_storage::GraphCatalog::open(dir, None, &graphforge_ir::RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
 fn persistent(dir: &Path, mode: OntologyMode) -> PersistentAdjacencyProvider {
     PersistentAdjacencyProvider::new(dir.to_path_buf(), mode)
+        .with_inventory(admitted_inventory(dir))
 }
 
 fn scan(dir: &Path, mode: OntologyMode) -> ScanBuildAdjacencyProvider {
-    ScanBuildAdjacencyProvider::new(dir.to_path_buf(), mode)
+    ScanBuildAdjacencyProvider::new(dir.to_path_buf(), mode).with_inventory(admitted_inventory(dir))
 }
 
 /// Seed a 3-node KNOWS chain `a→b→c`, build the index, then DELETE the `a→b`
@@ -291,6 +301,7 @@ fn absent_capability_dir_rebuilds_on_first_access() {
     write_diamond(dir.path());
 
     let provider = persistent(dir.path(), OntologyMode::Strict);
+
     assert_eq!(
         provider.status("KNOWS", Direction::Out),
         AdjacencyStatus::Building
@@ -444,11 +455,13 @@ fn hit_serves_without_reading_edge_files() {
         .adjacency("KNOWS", Direction::Out)
         .unwrap();
 
+    let provider = persistent(dir.path(), OntologyMode::Strict);
+    let scanned = scan(dir.path(), OntologyMode::Strict);
+
     // Remove the edge files WITHOUT bumping the generation: the index still
     // reads as fresh, and only a provider that never scans can serve it.
     std::fs::remove_dir_all(dir.path().join("topology").join("edges")).unwrap();
 
-    let provider = persistent(dir.path(), OntologyMode::Strict);
     assert_eq!(
         provider.status("KNOWS", Direction::Out),
         AdjacencyStatus::Hit
@@ -457,13 +470,8 @@ fn hit_serves_without_reading_edge_files() {
         provider.adjacency("KNOWS", Direction::Out).unwrap(),
         expected
     );
-    // The scan-build provider on the same project sees nothing.
-    assert!(
-        scan(dir.path(), OntologyMode::Strict)
-            .adjacency("KNOWS", Direction::Out)
-            .unwrap()
-            .is_empty()
-    );
+    // The admitted scan requires its payload; the index retains the rows.
+    assert!(scanned.adjacency("KNOWS", Direction::Out).is_err());
 }
 
 // ---------------------------------------------------------------------------
@@ -728,6 +736,10 @@ mod session_wiring {
 
         let before = session.execute_plan(&plan).await.unwrap();
         assert_eq!(before.stats.rows_produced, 2, "a reaches b and c");
+        let old_stream = session
+            .execute_plan_stream(&plan, &std::collections::HashMap::new())
+            .await
+            .unwrap();
 
         // Extend the chain THROUGH THE SAME SESSION: c -> d.
         let extend = bind(
@@ -735,6 +747,17 @@ mod session_wiring {
             &rc,
         );
         session.execute_write_statement(&extend).await.unwrap();
+        let old_batches = futures::TryStreamExt::try_collect::<Vec<_>>(old_stream)
+            .await
+            .unwrap();
+        assert_eq!(
+            old_batches
+                .iter()
+                .map(|batch| batch.num_rows())
+                .sum::<usize>(),
+            2,
+            "an already planned stream retains its pre-write adjacency"
+        );
 
         let after = session.execute_plan(&plan).await.unwrap();
         assert_eq!(
@@ -781,12 +804,14 @@ async fn zero_hop_traversal_on_hit_never_opens_edge_files() {
     session().execute_write_statement(&edge).await.unwrap();
     build_adjacency_index(dir.path(), TS).unwrap();
 
+    let admitted_session = session();
+
     // Delete the edge files WITHOUT bumping the generation: only a traversal
     // that truly reads zero edge bytes can succeed now.
     std::fs::remove_dir_all(dir.path().join("topology").join("edges")).unwrap();
 
     let zero_hop = bind("MATCH (a:Person {name: 'Alice'})-[r:KNOWS*0..0]->(b) RETURN 1 AS one");
-    let result = session().execute_plan(&zero_hop).await.unwrap();
+    let result = admitted_session.execute_plan(&zero_hop).await.unwrap();
     assert_eq!(result.stats.rows_produced, 1, "the 0-hop self path");
 }
 

--- a/crates/graphforge-exec/tests/var_len_expand.rs
+++ b/crates/graphforge-exec/tests/var_len_expand.rs
@@ -28,6 +28,15 @@ use graphforge_storage::{GraphWriter, TOPOLOGY_NODES_SCHEMA};
 
 use graphforge_exec::{AdjacencyProvider, ScanBuildAdjacencyProvider, VarLenExpandExec};
 
+fn admitted_inventory(
+    dir: &std::path::Path,
+) -> Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    graphforge_storage::GraphCatalog::open(dir, None, &graphforge_ir::RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
 /// Construct the exec node with a fresh scan-build provider over the node's
 /// project dir — the pre-index behavior these tests pin (the session-injected
 /// persistent provider is exercised by `tests/persistent_adjacency.rs`).
@@ -37,8 +46,10 @@ fn make_exec(
     node: &VarLenExpandNode,
     input: Arc<dyn ExecutionPlan>,
 ) -> Arc<VarLenExpandExec> {
-    let provider: Arc<dyn AdjacencyProvider> =
-        Arc::new(ScanBuildAdjacencyProvider::new(dir.to_path_buf(), mode));
+    let provider: Arc<dyn AdjacencyProvider> = Arc::new(
+        ScanBuildAdjacencyProvider::new(dir.to_path_buf(), mode)
+            .with_inventory(admitted_inventory(dir)),
+    );
     Arc::new(VarLenExpandExec::new(
         node,
         input,

--- a/crates/graphforge-exec/tests/write_statement.rs
+++ b/crates/graphforge-exec/tests/write_statement.rs
@@ -13,8 +13,7 @@ use graphforge_core::GfError;
 use graphforge_exec::{ExecutionResult, ExecutionSession, MutationKind, MutationSubjectKind};
 use graphforge_ir::{Binder, GraphPlan, IrLiteral, OntologyMode, RuntimeCatalog};
 use graphforge_storage::{
-    GraphCatalog, PropertyOverlayLimits, PropertyRouteKind, enumerate_property_fragments,
-    visit_authenticated_property_snapshots,
+    GraphCatalog, PropertyOverlayLimits, PropertyRouteKind, visit_authenticated_property_snapshots,
 };
 
 /// Bind `query` in Exploratory mode against the shared runtime catalog.
@@ -79,6 +78,13 @@ fn rows(path: &Path) -> usize {
         .unwrap()
         .map(|b| b.unwrap().num_rows())
         .sum()
+}
+
+fn admitted_inventory(dir: &Path) -> Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    GraphCatalog::open(dir, None, &RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
 }
 
 fn logical_property_rows(dir: &Path, route: &str) -> Vec<graphforge_storage::PropertySnapshotRow> {
@@ -156,7 +162,11 @@ async fn create_edge_then_plain_delete_errors_with_nothing_persisted() {
     // Nothing persisted: no T node, no edge file, a intact.
     assert_eq!(rows(&dir.path().join("topology/nodes.parquet")), 1);
     assert_eq!(
-        rows(&dir.path().join("topology/edges/_exploratory.parquet")),
+        admitted_inventory(dir.path())
+            .edge_files(Some("_exploratory"))
+            .iter()
+            .map(|(_, path)| rows(path))
+            .sum::<usize>(),
         0
     );
 }
@@ -187,7 +197,11 @@ async fn create_edge_then_detach_delete_drops_pending_edge() {
         1
     );
     assert_eq!(
-        rows(&dir.path().join("topology/edges/_exploratory.parquet")),
+        admitted_inventory(dir.path())
+            .edge_files(Some("_exploratory"))
+            .iter()
+            .map(|(_, path)| rows(path))
+            .sum::<usize>(),
         0
     );
 }
@@ -205,7 +219,7 @@ async fn set_on_created_node_lands_in_buffer() {
     // The property merged into the buffered row and became authenticated
     // immutable logical authority.
     let fragments =
-        enumerate_property_fragments(dir.path(), PropertyRouteKind::Node, "_untyped").unwrap();
+        admitted_inventory(dir.path()).property_fragments(PropertyRouteKind::Node, "_untyped");
     assert_eq!(fragments.len(), 1);
     assert_ne!(fragments[0].id.generation, 0);
     assert_eq!(
@@ -292,7 +306,11 @@ async fn second_create_references_first_with_distinct_surrogates() {
     assert_eq!(counters(&r), [2, 1, 0, 0, 0, 0]);
     assert_eq!(rows(&dir.path().join("topology/nodes.parquet")), 2);
     assert_eq!(
-        rows(&dir.path().join("topology/edges/_exploratory.parquet")),
+        admitted_inventory(dir.path())
+            .edge_files(Some("_exploratory"))
+            .iter()
+            .map(|(_, path)| rows(path))
+            .sum::<usize>(),
         1
     );
 

--- a/crates/graphforge-search/src/lifecycle.rs
+++ b/crates/graphforge-search/src/lifecycle.rs
@@ -1456,7 +1456,18 @@ mod tests {
             )
             .unwrap();
         second.flush().unwrap();
-        let paths = graphforge_storage::node_property_files(dir.path(), LABEL).unwrap();
+        let paths = graphforge_storage::GraphCatalog::open(
+            dir.path(),
+            None,
+            &graphforge_ir::RuntimeCatalog::new(),
+        )
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+        .property_fragments(graphforge_storage::PropertyRouteKind::Node, LABEL)
+        .into_iter()
+        .map(|fragment| fragment.path)
+        .collect::<Vec<_>>();
         assert_eq!(paths.len(), 2);
         let before =
             capture_text_snapshot(dir.path(), TextSearchLimits::default(), || Ok(())).unwrap();

--- a/crates/graphforge-search/src/source.rs
+++ b/crates/graphforge-search/src/source.rs
@@ -706,7 +706,18 @@ mod tests {
             .into_iter()
             .map(|path| std::fs::metadata(path).unwrap().len())
             .sum::<u64>();
-        let properties = graphforge_storage::node_property_files(dir.path(), "Person").unwrap();
+        let properties = graphforge_storage::GraphCatalog::open(
+            dir.path(),
+            None,
+            &graphforge_ir::RuntimeCatalog::new(),
+        )
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+        .property_fragments(graphforge_storage::PropertyRouteKind::Node, "Person")
+        .into_iter()
+        .map(|fragment| fragment.path)
+        .collect::<Vec<_>>();
         assert_eq!(properties.len(), 2);
         let mut limits = TextSearchLimits::default();
         limits.source_bytes = node_bytes + std::fs::metadata(&properties[0]).unwrap().len();
@@ -752,7 +763,18 @@ mod tests {
             1
         );
 
-        let property_files = graphforge_storage::node_property_files(dir.path(), "Person").unwrap();
+        let property_files = graphforge_storage::GraphCatalog::open(
+            dir.path(),
+            None,
+            &graphforge_ir::RuntimeCatalog::new(),
+        )
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+        .property_fragments(graphforge_storage::PropertyRouteKind::Node, "Person")
+        .into_iter()
+        .map(|fragment| fragment.path)
+        .collect::<Vec<_>>();
         assert_eq!(property_files.len(), 2);
         let expected_bytes = graphforge_storage::topology_node_files(dir.path())
             .unwrap()

--- a/crates/graphforge-storage/src/adjacency.rs
+++ b/crates/graphforge-storage/src/adjacency.rs
@@ -39,8 +39,9 @@ mod builder;
 pub use builder::{
     ADJACENCY_SPILL_DIR_NAME, AdjacencyBuildMetrics, AdjacencyBuildOptions,
     DEFAULT_ADJACENCY_CHUNK_ROWS, DEFAULT_ADJACENCY_MERGE_FAN_IN, build_adjacency_index,
-    build_adjacency_index_into, build_adjacency_index_into_with_metrics,
-    build_adjacency_index_into_with_options, build_adjacency_index_with_checkpoint,
+    build_adjacency_index_from_inventory, build_adjacency_index_into,
+    build_adjacency_index_into_with_metrics, build_adjacency_index_into_with_options,
+    build_adjacency_index_with_checkpoint,
 };
 
 use std::fs::File;
@@ -832,10 +833,15 @@ pub fn adjacency_dir(project_dir: &Path) -> PathBuf {
 }
 
 /// Path of the CSR file for (`relation_type`, `direction`):
-/// `indexes/adjacency/<REL_TYPE>.<dir>.csr`.
+/// `indexes/adjacency/<route-component>.<dir>.csr`.
+/// The manifest retains the exact semantic relation name.
 #[must_use]
 pub fn csr_path(project_dir: &Path, relation_type: &str, direction: Direction) -> PathBuf {
-    adjacency_dir(project_dir).join(format!("{relation_type}.{}.csr", direction.as_str()))
+    adjacency_dir(project_dir).join(format!(
+        "{}.{}.csr",
+        crate::route_component::component(relation_type),
+        direction.as_str()
+    ))
 }
 
 /// Path of `index_manifest.parquet` within `project_dir`.
@@ -1138,12 +1144,24 @@ pub const DEFAULT_ADJACENCY_BATCH_SIZE: usize = 8_192;
 ///
 /// Shared by the builder, validator, and inspector so none of them concatenate
 /// a full edge file into one Arrow record batch (#336).
+fn capture_adjacency_inventory(
+    root: &Path,
+) -> Result<crate::AuthenticatedPropertyInventory, GfError> {
+    let (inventory, _) = crate::capture_graph_files(root)?;
+    crate::AuthenticatedPropertyInventory::from_inventory_at_root(root, inventory, None)
+}
+
 fn for_each_adjacency_edge_file(
     project_dir: &Path,
+    inventory: Option<&crate::AuthenticatedPropertyInventory>,
     batch_size: usize,
     on_batch: &mut dyn FnMut(&str, bool, &RecordBatch) -> Result<(), GfError>,
 ) -> Result<(), GfError> {
-    for (stem, path) in crate::mutator::edge_parquet_files(project_dir, None)? {
+    let paths = match inventory {
+        Some(inventory) => inventory.edge_files(None),
+        None => crate::mutator::edge_parquet_files(project_dir, None)?,
+    };
+    for (stem, path) in paths {
         // An unreadable edge file must FAIL the build, not be skipped: a
         // manifest written without it would stamp the current generation and
         // make an index missing a relation's edges look fresh.
@@ -1221,6 +1239,7 @@ pub(crate) fn stream_projected_parquet_batches(
 #[allow(clippy::type_complexity)]
 fn collect_adjacency_groups(
     project_dir: &Path,
+    inventory: Option<&crate::AuthenticatedPropertyInventory>,
 ) -> Result<
     (
         std::collections::BTreeMap<String, Vec<BuildEntry>>,
@@ -1228,12 +1247,13 @@ fn collect_adjacency_groups(
     ),
     GfError,
 > {
-    collect_adjacency_groups_with_batch_size(project_dir, DEFAULT_ADJACENCY_BATCH_SIZE)
+    collect_adjacency_groups_with_batch_size(project_dir, inventory, DEFAULT_ADJACENCY_BATCH_SIZE)
 }
 
 #[allow(clippy::type_complexity)]
 fn collect_adjacency_groups_with_batch_size(
     project_dir: &Path,
+    inventory: Option<&crate::AuthenticatedPropertyInventory>,
     batch_size: usize,
 ) -> Result<
     (
@@ -1246,28 +1266,33 @@ fn collect_adjacency_groups_with_batch_size(
 
     let mut groups: BTreeMap<String, Vec<BuildEntry>> = BTreeMap::new();
     let mut union_out: Vec<BuildEntry> = Vec::new();
-    for_each_adjacency_edge_file(project_dir, batch_size, &mut |stem, exploratory, batch| {
-        let edge_ids = uint64_column(named_column(batch, "edge_id")?, "edge_id")?;
-        let src_ids = uint64_column(named_column(batch, "src_id")?, "src_id")?;
-        let dst_ids = uint64_column(named_column(batch, "dst_id")?, "dst_id")?;
-        let rel_names = if exploratory {
-            Some(string_column(
-                named_column(batch, "rel_type_name")?,
-                "rel_type_name",
-            )?)
-        } else {
-            None
-        };
-        for i in 0..batch.num_rows() {
-            let entry = (src_ids.value(i), edge_ids.value(i), dst_ids.value(i));
-            union_out.push(entry);
-            let rel = rel_names.map_or(stem, |names| names.value(i));
-            if usable_stem(rel) {
-                groups.entry(rel.to_owned()).or_default().push(entry);
+    for_each_adjacency_edge_file(
+        project_dir,
+        inventory,
+        batch_size,
+        &mut |stem, exploratory, batch| {
+            let edge_ids = uint64_column(named_column(batch, "edge_id")?, "edge_id")?;
+            let src_ids = uint64_column(named_column(batch, "src_id")?, "src_id")?;
+            let dst_ids = uint64_column(named_column(batch, "dst_id")?, "dst_id")?;
+            let rel_names = if exploratory {
+                Some(string_column(
+                    named_column(batch, "rel_type_name")?,
+                    "rel_type_name",
+                )?)
+            } else {
+                None
+            };
+            for i in 0..batch.num_rows() {
+                let entry = (src_ids.value(i), edge_ids.value(i), dst_ids.value(i));
+                union_out.push(entry);
+                let rel = rel_names.map_or(stem, |names| names.value(i));
+                if usable_stem(rel) {
+                    groups.entry(rel.to_owned()).or_default().push(entry);
+                }
             }
-        }
-        Ok(())
-    })?;
+            Ok(())
+        },
+    )?;
     Ok((groups, union_out))
 }
 // ---------------------------------------------------------------------------
@@ -1338,6 +1363,20 @@ pub fn validate_adjacency_index_against(
     source_project_dir: &Path,
     artifact_project_dir: &Path,
 ) -> Result<Vec<AdjacencyValidationIssue>, GfError> {
+    let inventory = capture_adjacency_inventory(source_project_dir)?;
+    validate_adjacency_index_from_inventory(
+        source_project_dir,
+        artifact_project_dir,
+        Some(&inventory),
+    )
+}
+
+/// Validate derived adjacency against explicitly admitted semantic routes.
+pub fn validate_adjacency_index_from_inventory(
+    source_project_dir: &Path,
+    artifact_project_dir: &Path,
+    inventory: Option<&crate::AuthenticatedPropertyInventory>,
+) -> Result<Vec<AdjacencyValidationIssue>, GfError> {
     let manifest = read_manifest(artifact_project_dir)?;
     if manifest.is_empty() {
         return Ok(Vec::new()); // no index ⇒ nothing to validate
@@ -1375,7 +1414,7 @@ pub fn validate_adjacency_index_against(
         });
     }
 
-    let (groups, union_out) = collect_adjacency_groups(source_project_dir)?;
+    let (groups, union_out) = collect_adjacency_groups(source_project_dir, inventory)?;
     for row in &manifest {
         let expected_entries: &[BuildEntry] = if row.relation_type == ALL_RELATIONS_STEM {
             &union_out
@@ -1430,8 +1469,17 @@ pub fn validate_adjacency_index_against(
 /// # Errors
 /// Returns a storage error only when canonical topology itself cannot be read.
 pub fn inspect_adjacency_index(project_dir: &Path) -> Result<AdjacencyInspection, GfError> {
+    let inventory = capture_adjacency_inventory(project_dir)?;
+    inspect_adjacency_index_from_inventory(project_dir, Some(&inventory))
+}
+
+/// Inspect derived adjacency against explicitly admitted semantic routes.
+pub fn inspect_adjacency_index_from_inventory(
+    project_dir: &Path,
+    inventory: Option<&crate::AuthenticatedPropertyInventory>,
+) -> Result<AdjacencyInspection, GfError> {
     let source_generation = crate::generation::read_topology_generation(project_dir)?;
-    let (_, mut source_entries) = collect_adjacency_groups(project_dir)?;
+    let (_, mut source_entries) = collect_adjacency_groups(project_dir, inventory)?;
     let source_fingerprint = entries_fingerprint(&mut source_entries);
     let Ok(manifest) = read_manifest(project_dir) else {
         return Ok(inspection_without_artifact(
@@ -1684,8 +1732,7 @@ pub(crate) fn usable_stem(rel: &str) -> bool {
     if rel == ALL_RELATIONS_STEM {
         return false;
     }
-    let mut comps = Path::new(rel).components();
-    matches!(comps.next(), Some(std::path::Component::Normal(_))) && comps.next().is_none()
+    !rel.is_empty() && rel != "." && rel != ".." && !rel.contains('/')
 }
 
 /// Borrow a column by name, erroring on absence.
@@ -2314,7 +2361,13 @@ mod tests {
     #[test]
     fn csr_path_layout() {
         let p = csr_path(Path::new("/proj"), "WORKS_AT", Direction::In);
-        assert_eq!(p, Path::new("/proj/indexes/adjacency/WORKS_AT.in.csr"));
+        assert_eq!(
+            p,
+            Path::new("/proj/indexes/adjacency").join(format!(
+                "{}.in.csr",
+                crate::route_component::component("WORKS_AT")
+            ))
+        );
         assert_eq!(
             manifest_path(Path::new("/proj")),
             Path::new("/proj/indexes/adjacency/index_manifest.parquet")
@@ -2745,7 +2798,7 @@ mod tests {
     // Streaming / spill build (#336)
     // -----------------------------------------------------------------------
 
-    pub(super) fn write_multi_row_group_knows(dir: &Path, edges: &[(u64, u64, u64)]) {
+    pub(super) fn write_multi_row_group_knows(dir: &Path, edges: &[(u64, u64, u64)]) -> PathBuf {
         use parquet::arrow::ArrowWriter;
         use parquet::file::properties::WriterProperties;
 
@@ -2773,7 +2826,11 @@ mod tests {
         .unwrap();
         w.flush().unwrap();
 
-        let edges_path = dir.join("topology/edges/KNOWS.parquet");
+        drop(w);
+        let inventory = capture_adjacency_inventory(dir).unwrap();
+        let paths = inventory.edge_files(Some("KNOWS"));
+        assert_eq!(paths.len(), 1);
+        let edges_path = paths[0].1.clone();
         let schema = crate::schemas::TYPED_EDGE_SCHEMA.clone();
         let n = edges.len();
         let edge_uuid = arrow::array::FixedSizeBinaryArray::try_from_iter((0..n).map(|i| {
@@ -2810,6 +2867,7 @@ mod tests {
         let mut writer = ArrowWriter::try_new(file, schema, Some(props)).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
+        edges_path
     }
 
     #[test]
@@ -2817,8 +2875,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         // 5 edges → 5 row groups with max_row_group_row_count=1.
         let edges = [(0, 1, 1), (0, 2, 2), (1, 3, 2), (2, 4, 3), (3, 5, 0)];
-        write_multi_row_group_knows(dir.path(), &edges);
-        let path = dir.path().join("topology/edges/KNOWS.parquet");
+        let path = write_multi_row_group_knows(dir.path(), &edges);
 
         let mut batches = 0usize;
         let mut rows = 0usize;
@@ -2858,8 +2915,7 @@ mod tests {
     fn arrow_uuid_concat_boundary_is_avoided_by_projection() {
         let dir = TempDir::new().unwrap();
         let edges: Vec<(u64, u64, u64)> = (0..64).map(|i| (i % 8, i + 1, (i + 1) % 8)).collect();
-        write_multi_row_group_knows(dir.path(), &edges);
-        let path = dir.path().join("topology/edges/KNOWS.parquet");
+        let path = write_multi_row_group_knows(dir.path(), &edges);
 
         // Full-schema eager path (what the old builder did) would concat UUID
         // columns to `edges.len()` values. The streaming path must not.

--- a/crates/graphforge-storage/src/adjacency/builder.rs
+++ b/crates/graphforge-storage/src/adjacency/builder.rs
@@ -215,6 +215,27 @@ pub fn build_adjacency_index_into_with_metrics(
     options: &AdjacencyBuildOptions,
     mut checkpoint: impl FnMut() -> Result<(), GfError>,
 ) -> Result<(Vec<AdjacencyManifestRow>, AdjacencyBuildMetrics), GfError> {
+    let inventory = super::capture_adjacency_inventory(source_project_dir)?;
+    build_adjacency_index_from_inventory(
+        source_project_dir,
+        artifact_project_dir,
+        Some(&inventory),
+        built_at_micros,
+        options,
+        &mut checkpoint,
+    )
+}
+
+/// Build derived adjacency using already-admitted route authority, without rehashing the graph.
+/// `None` retains the explicit legacy raw-layout contract.
+pub fn build_adjacency_index_from_inventory(
+    source_project_dir: &Path,
+    artifact_project_dir: &Path,
+    inventory: Option<&crate::AuthenticatedPropertyInventory>,
+    built_at_micros: i64,
+    options: &AdjacencyBuildOptions,
+    mut checkpoint: impl FnMut() -> Result<(), GfError>,
+) -> Result<(Vec<AdjacencyManifestRow>, AdjacencyBuildMetrics), GfError> {
     checkpoint()?;
     // Generation BEFORE the scan — see the race note in the doc comment.
     let generation = crate::generation::read_topology_generation(source_project_dir)?;
@@ -238,6 +259,7 @@ pub fn build_adjacency_index_into_with_metrics(
     let build_result = (|| {
         let mut groups = stream_build_groups(
             source_project_dir,
+            inventory,
             &options,
             &mut spill,
             &mut metrics,
@@ -345,8 +367,11 @@ impl SpillSession {
     fn next_run_path(&mut self, label: &str, direction: Direction) -> PathBuf {
         let id = self.run_counter;
         self.run_counter += 1;
-        self.root
-            .join(format!("{label}.{}.{id}.run", direction.as_str()))
+        self.root.join(format!(
+            "{}.{}.{id}.run",
+            crate::route_component::component(label),
+            direction.as_str()
+        ))
     }
 
     fn account_write(&mut self, bytes: u64) -> Result<(), GfError> {
@@ -749,6 +774,7 @@ fn merge_keyed_runs(
 
 fn stream_build_groups(
     project_dir: &Path,
+    inventory: Option<&crate::AuthenticatedPropertyInventory>,
     options: &AdjacencyBuildOptions,
     spill: &mut SpillSession,
     metrics: &mut AdjacencyBuildMetrics,
@@ -764,6 +790,7 @@ fn stream_build_groups(
 
     for_each_adjacency_edge_file(
         project_dir,
+        inventory,
         options.batch_size,
         &mut |stem, exploratory, batch| {
             checkpoint()?;

--- a/crates/graphforge-storage/src/adjacency/builder/tests.rs
+++ b/crates/graphforge-storage/src/adjacency/builder/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::GraphWriter;
-use crate::adjacency::tests::{BUILD_TS, write_diamond, write_multi_row_group_knows};
+use crate::adjacency::tests::{BUILD_TS, write_diamond};
 use crate::adjacency::{
     AdjacencyFreshnessState, collect_adjacency_groups, csr_from_entries, inspect_adjacency_index,
     manifest_path, read_csr, read_manifest, sharded_csr_exists, validate_adjacency_index,
@@ -240,7 +240,11 @@ fn empty_project_builds_union_pair_and_manifest() {
 fn tiny_chunk_rows_spill_build_matches_csr_from_entries() {
     let dir = TempDir::new().unwrap();
     write_diamond(dir.path());
-    let (groups, union) = collect_adjacency_groups(dir.path()).unwrap();
+    let (groups, union) = collect_adjacency_groups(
+        dir.path(),
+        Some(&crate::adjacency::capture_adjacency_inventory(dir.path()).unwrap()),
+    )
+    .unwrap();
     let expected_knows_out = csr_from_entries(groups.get("KNOWS").unwrap(), Direction::Out);
     let expected_knows_in = csr_from_entries(groups.get("KNOWS").unwrap(), Direction::In);
     let expected_all_out = csr_from_entries(&union, Direction::Out);
@@ -393,5 +397,69 @@ fn spill_max_bytes_fails_closed_without_publishing_manifest() {
         !adjacency_dir(stage.path())
             .join(ADJACENCY_SPILL_DIR_NAME)
             .exists()
+    );
+}
+
+#[test]
+fn admitted_reserved_relations_build_portable_distinct_indexes() {
+    let source = TempDir::new().unwrap();
+    let artifacts = TempDir::new().unwrap();
+    let mut writer = GraphWriter::open_at(source.path(), OntologyMode::Strict, BUILD_TS).unwrap();
+    let a = new_v7();
+    let b = new_v7();
+    for node in [a, b] {
+        writer
+            .create_node(
+                node,
+                graphforge_value::EntityTypeId::ontology(TypeId(1)).unwrap(),
+            )
+            .unwrap();
+    }
+    let relations = ["CON", "con", r"AUX\edge"];
+    for relation in relations {
+        writer.create_edge(new_v7(), relation, &a, &b).unwrap();
+    }
+    writer.flush().unwrap();
+    drop(writer);
+    let inventory = crate::adjacency::capture_adjacency_inventory(source.path()).unwrap();
+    let options = AdjacencyBuildOptions {
+        chunk_rows: 1,
+        ..Default::default()
+    };
+    let (rows, metrics) = build_adjacency_index_from_inventory(
+        source.path(),
+        artifacts.path(),
+        Some(&inventory),
+        BUILD_TS,
+        &options,
+        || Ok(()),
+    )
+    .unwrap();
+    assert_eq!(metrics.source_rows, 3);
+    assert_eq!(rows.len(), 8);
+    let mut names = std::collections::BTreeSet::new();
+    for relation in relations {
+        for direction in [Direction::Out, Direction::In] {
+            let row = rows
+                .iter()
+                .find(|row| row.relation_type == relation && row.direction == direction)
+                .unwrap();
+            assert_eq!(row.edge_count, 1);
+            let path = csr_path(artifacts.path(), relation, direction);
+            let name = path.file_name().unwrap().to_str().unwrap();
+            assert!(name.is_ascii());
+            assert!(!name.contains('\\'));
+            assert!(names.insert(name.to_ascii_lowercase()));
+            assert_eq!(read_csr(&path).unwrap().edge_ids.len(), 1);
+        }
+    }
+    assert!(
+        crate::adjacency::validate_adjacency_index_from_inventory(
+            source.path(),
+            artifacts.path(),
+            Some(&inventory)
+        )
+        .unwrap()
+        .is_empty()
     );
 }

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -82,6 +82,10 @@ pub(crate) fn read_parquet_or_empty(
     if !path.exists() {
         return Ok(vec![RecordBatch::new_empty(schema)]);
     }
+    read_parquet_required(path)
+}
+
+fn read_parquet_required(path: &Path) -> Result<Vec<RecordBatch>, DataFusionError> {
     let builder = admitted_parquet(path)?;
     let file_schema = builder.schema().clone();
     let reader = builder.build().map_err(parquet_err)?;
@@ -244,6 +248,30 @@ pub fn read_edges(
     Ok(batches)
 }
 
+/// Read edge rows using the caller's explicit semantic route authority.
+pub fn read_edges_from_inventory(
+    inventory: &crate::AuthenticatedPropertyInventory,
+    rel_name: &str,
+    mode: OntologyMode,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    if rel_name == "*" && matches!(mode, OntologyMode::Advisory | OntologyMode::Strict) {
+        return read_edges_union_paths(inventory.edge_files(None), None, None, true);
+    }
+    let (route, schema) = match mode {
+        OntologyMode::Exploratory => ("_exploratory", EXPLORATORY_EDGE_SCHEMA.clone()),
+        OntologyMode::Advisory | OntologyMode::Strict => (rel_name, TYPED_EDGE_SCHEMA.clone()),
+    };
+    let mut batches = Vec::new();
+    for (_, path) in inventory.edge_files(Some(route)) {
+        batches.extend(read_parquet_required(&path)?);
+    }
+    if batches.is_empty() {
+        batches.push(RecordBatch::new_empty(schema));
+    }
+    crate::io_stats::record_edge_full_read(total_rows(&batches));
+    Ok(batches)
+}
+
 /// Count topology edge rows without materializing adjacency or the full graph.
 ///
 /// Used by unconstrained `count(r)` so a missing CSR index cannot charge O(E)
@@ -275,8 +303,34 @@ pub fn count_edge_rows(
             (mode == OntologyMode::Strict).then_some(rel_name)
         }
     };
+    count_edge_paths(
+        crate::mutator::edge_parquet_files(dir, relation)?,
+        rel_name,
+        mode,
+    )
+}
+
+/// Count admitted edge payload rows without decoding graph or adjacency data.
+pub fn count_edge_rows_from_inventory(
+    inventory: &crate::AuthenticatedPropertyInventory,
+    rel_name: &str,
+    mode: OntologyMode,
+) -> Result<u64, crate::GfError> {
+    let relation = match mode {
+        OntologyMode::Exploratory => Some("_exploratory"),
+        OntologyMode::Strict if rel_name != "*" => Some(rel_name),
+        _ => None,
+    };
+    count_edge_paths(inventory.edge_files(relation), rel_name, mode)
+}
+
+fn count_edge_paths(
+    paths: Vec<(String, PathBuf)>,
+    rel_name: &str,
+    mode: OntologyMode,
+) -> Result<u64, crate::GfError> {
     let mut total = 0_u64;
-    for (stem, path) in crate::mutator::edge_parquet_files(dir, relation)? {
+    for (stem, path) in paths {
         if mode == OntologyMode::Advisory
             && rel_name != "*"
             && stem != rel_name
@@ -378,6 +432,50 @@ pub fn read_edges_filtered(
     edge_ids: &std::collections::HashSet<u64>,
 ) -> Result<Vec<RecordBatch>, DataFusionError> {
     read_edges_filtered_observed(dir, rel_name, mode, edge_ids, None)
+}
+
+/// Filter edge rows using an explicitly admitted semantic route inventory.
+#[allow(clippy::implicit_hasher)]
+pub fn read_edges_filtered_from_inventory(
+    inventory: &crate::AuthenticatedPropertyInventory,
+    rel_name: &str,
+    mode: OntologyMode,
+    edge_ids: &std::collections::HashSet<u64>,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    read_edges_filtered_observed_from_inventory(inventory, rel_name, mode, edge_ids, None)
+}
+
+/// Filter admitted edge rows with aggregate-only operator attribution.
+#[allow(clippy::implicit_hasher)]
+#[doc(hidden)]
+pub fn read_edges_filtered_observed_from_inventory(
+    inventory: &crate::AuthenticatedPropertyInventory,
+    rel_name: &str,
+    mode: OntologyMode,
+    edge_ids: &std::collections::HashSet<u64>,
+    observer: Option<&Arc<dyn crate::io_stats::FilteredReadObserver>>,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    if rel_name == "*" && matches!(mode, OntologyMode::Advisory | OntologyMode::Strict) {
+        return read_edges_union_paths(inventory.edge_files(None), Some(edge_ids), observer, true);
+    }
+    let (route, schema) = match mode {
+        OntologyMode::Exploratory => ("_exploratory", EXPLORATORY_EDGE_SCHEMA.clone()),
+        OntologyMode::Advisory | OntologyMode::Strict => (rel_name, TYPED_EDGE_SCHEMA.clone()),
+    };
+    let mut batches = Vec::new();
+    for (_, path) in inventory.edge_files(Some(route)) {
+        batches.extend(read_required_edge_filtered(
+            &path,
+            Arc::clone(&schema),
+            edge_ids,
+            observer,
+            None,
+        )?);
+    }
+    if batches.is_empty() {
+        batches.push(RecordBatch::new_empty(schema));
+    }
+    Ok(batches)
 }
 
 /// [`read_edges_filtered`] with optional aggregate-only operator attribution.
@@ -487,6 +585,54 @@ pub fn read_edges_filtered_projected_observed(
     Ok(batches)
 }
 
+/// Project and filter admitted edge fragments using their semantic route authority.
+#[allow(clippy::implicit_hasher)]
+pub fn read_edges_filtered_projected_from_inventory(
+    inventory: &crate::AuthenticatedPropertyInventory,
+    rel_name: &str,
+    mode: OntologyMode,
+    edge_ids: &std::collections::HashSet<u64>,
+    projection: &[usize],
+    observer: Option<&std::sync::Arc<dyn crate::io_stats::FilteredReadObserver>>,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    if rel_name == "*" && matches!(mode, OntologyMode::Advisory | OntologyMode::Strict) {
+        // Union normalization synthesizes rel_type_name. Normalize first, then
+        // shape the result; individual typed files still avoid node reads.
+        return read_edges_union_paths(inventory.edge_files(None), Some(edge_ids), observer, true)
+            .and_then(|batches| {
+                project_batches_with_key(batches, &EXPLORATORY_EDGE_SCHEMA, projection, "edge_id")
+            });
+    }
+    let (stem, schema) = match mode {
+        OntologyMode::Exploratory => ("_exploratory", EXPLORATORY_EDGE_SCHEMA.clone()),
+        OntologyMode::Advisory | OntologyMode::Strict => (rel_name, TYPED_EDGE_SCHEMA.clone()),
+    };
+    if edge_ids.is_empty() {
+        return project_batches_with_key(Vec::new(), &schema, projection, "edge_id");
+    }
+    let mut batches = Vec::new();
+    for (_, path) in inventory.edge_files(Some(stem)) {
+        let file_schema = admitted_parquet(&path)?.schema().clone();
+        if file_schema.fields() != schema.fields() {
+            return Err(DataFusionError::Execution(format!(
+                "projected edge read requires canonical schema: {}",
+                path.display()
+            )));
+        }
+        batches.extend(read_required_edge_filtered(
+            &path,
+            schema.clone(),
+            edge_ids,
+            observer,
+            Some(projection),
+        )?);
+    }
+    if batches.is_empty() {
+        return project_batches_with_key(Vec::new(), &schema, projection, "edge_id");
+    }
+    Ok(batches)
+}
+
 /// Read the union of every relation's edges (#823): the "all relation types"
 /// read for an untyped traversal in a typed project. Enumerates every
 /// `topology/edges/*.parquet` (stem order, for deterministic adjacency/BFS),
@@ -500,22 +646,48 @@ fn read_edges_union(
     edge_ids: Option<&std::collections::HashSet<u64>>,
     observer: Option<&std::sync::Arc<dyn crate::io_stats::FilteredReadObserver>>,
 ) -> Result<Vec<RecordBatch>, DataFusionError> {
+    let paths = crate::mutator::edge_parquet_files(dir, None)
+        .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+    read_edges_union_paths(paths, edge_ids, observer, false)
+}
+
+fn read_edges_union_paths(
+    paths: Vec<(String, PathBuf)>,
+    edge_ids: Option<&std::collections::HashSet<u64>>,
+    observer: Option<&std::sync::Arc<dyn crate::io_stats::FilteredReadObserver>>,
+    required: bool,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    if required && edge_ids.is_some_and(std::collections::HashSet::is_empty) {
+        return Ok(vec![RecordBatch::new_empty(
+            EXPLORATORY_EDGE_SCHEMA.clone(),
+        )]);
+    }
     let mut out = Vec::new();
-    for (stem, path) in crate::mutator::edge_parquet_files(dir, None)
-        .map_err(|error| DataFusionError::Execution(error.to_string()))?
-    {
-        let schema = discover_parquet_schema(&path).unwrap_or_else(|| TYPED_EDGE_SCHEMA.clone());
-        let batches = if let Some(ids) = edge_ids {
-            read_parquet_filtered_u64(
-                &path,
-                schema,
-                "edge_id",
-                ids,
-                FilteredReadKind::Edge,
-                observer,
-            )?
+    for (stem, path) in paths {
+        let schema = if required {
+            admitted_parquet(&path)?.schema().clone()
         } else {
-            let b = read_parquet_or_empty(&path, schema)?;
+            discover_parquet_schema(&path).unwrap_or_else(|| TYPED_EDGE_SCHEMA.clone())
+        };
+        let batches = if let Some(ids) = edge_ids {
+            if required {
+                read_required_edge_filtered(&path, schema, ids, observer, None)?
+            } else {
+                read_parquet_filtered_u64(
+                    &path,
+                    schema,
+                    "edge_id",
+                    ids,
+                    FilteredReadKind::Edge,
+                    observer,
+                )?
+            }
+        } else {
+            let b = if required {
+                read_parquet_required(&path)?
+            } else {
+                read_parquet_or_empty(&path, schema)?
+            };
             crate::io_stats::record_edge_full_read(total_rows(&b));
             b
         };
@@ -919,6 +1091,36 @@ fn read_parquet_filtered_u64(
         observer,
         true,
         None,
+        false,
+    )
+}
+
+fn read_required_edge_filtered(
+    path: &Path,
+    schema: SchemaRef,
+    ids: &std::collections::HashSet<u64>,
+    observer: Option<&Arc<dyn crate::io_stats::FilteredReadObserver>>,
+    projection: Option<&[usize]>,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    let projection = projection
+        .map(|indices| canonical_projection_with_key(&schema, indices, "edge_id"))
+        .transpose()?;
+    if ids.is_empty() {
+        return match projection {
+            Some(indices) => project_batches_with_key(Vec::new(), &schema, &indices, "edge_id"),
+            None => Ok(vec![RecordBatch::new_empty(schema)]),
+        };
+    }
+    read_parquet_filtered_u64_attempt(
+        path,
+        schema,
+        "edge_id",
+        ids,
+        FilteredReadKind::Edge,
+        observer,
+        true,
+        projection.as_deref(),
+        true,
     )
 }
 
@@ -988,6 +1190,7 @@ fn read_parquet_filtered_u64_projected(
         observer,
         true,
         Some(&projection),
+        false,
     )
 }
 
@@ -1001,6 +1204,7 @@ fn read_parquet_filtered_u64_attempt(
     observer: Option<&std::sync::Arc<dyn crate::io_stats::FilteredReadObserver>>,
     allow_dense_node_selection: bool,
     projection: Option<&[usize]>,
+    required: bool,
 ) -> Result<Vec<RecordBatch>, DataFusionError> {
     use parquet::arrow::ProjectionMask;
     use parquet::arrow::arrow_reader::{
@@ -1035,7 +1239,11 @@ fn read_parquet_filtered_u64_attempt(
     let builder_row_groups = u64::try_from(builder.metadata().num_row_groups()).unwrap_or(u64::MAX);
     if total >= 0 && ids.len() as u64 * 2 > u64::try_from(total).unwrap_or(u64::MAX) {
         drop(builder);
-        let batches = read_parquet_or_empty(path, fallback_schema.clone())?;
+        let batches = if required {
+            read_parquet_required(path)?
+        } else {
+            read_parquet_or_empty(path, fallback_schema.clone())?
+        };
         // The fallback scanned the whole file before trimming, so record it as
         // a full read (its row count is the full file, not the trimmed result):
         // a fallback must not masquerade as a cheap filtered read.
@@ -1244,6 +1452,7 @@ fn read_parquet_filtered_u64_attempt(
                 observer,
                 false,
                 projection,
+                required,
             );
         }
     }
@@ -2311,6 +2520,48 @@ pub fn read_edge_properties(dir: &Path, stem: &str) -> Result<Vec<RecordBatch>, 
     read_property_overlay(dir, stem, true)
 }
 
+/// Read edge properties using the caller's already admitted generation authority.
+pub fn read_edge_properties_from_inventory(
+    dir: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    route: &str,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    let mut batches = Vec::new();
+    visit_property_overlay_batched_with_inventory(
+        dir,
+        Some(inventory),
+        route,
+        true,
+        8_192,
+        |batch| {
+            batches.push(batch.clone());
+            Ok(true)
+        },
+    )?;
+    Ok(batches)
+}
+
+/// Read node properties using the caller's admitted route inventory.
+pub fn read_properties_from_inventory(
+    dir: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    route: &str,
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    let mut batches = Vec::new();
+    visit_property_overlay_batched_with_inventory(
+        dir,
+        Some(inventory),
+        route,
+        false,
+        8_192,
+        |batch| {
+            batches.push(batch.clone());
+            Ok(true)
+        },
+    )?;
+    Ok(batches)
+}
+
 /// Read an authenticated newest-wins edge-property overlay while decoding
 /// only the requested property names plus the mandatory edge UUID key.
 #[doc(hidden)]
@@ -2321,6 +2572,30 @@ pub fn read_edge_properties_projected(
 ) -> Result<Vec<RecordBatch>, DataFusionError> {
     let selected = property_names.iter().cloned().collect();
     read_property_overlay_projected(dir, stem, true, Some(&selected))
+}
+
+/// Read selected edge properties through the caller's pinned route inventory.
+pub fn read_edge_properties_projected_from_inventory(
+    dir: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    route: &str,
+    property_names: &[String],
+) -> Result<Vec<RecordBatch>, DataFusionError> {
+    let selected = property_names.iter().cloned().collect();
+    let mut batches = Vec::new();
+    visit_property_overlay_batched_projected(
+        dir,
+        Some(inventory),
+        route,
+        true,
+        8_192,
+        Some(&selected),
+        |batch| {
+            batches.push(batch.clone());
+            Ok(true)
+        },
+    )?;
+    Ok(batches)
 }
 
 /// Stems (relation names) of every `edge_properties/<stem>.parquet` under
@@ -2431,6 +2706,7 @@ impl TableProvider for TopologyNodeTable {
 #[derive(Debug, Clone)]
 pub struct TypedEdgeTable {
     dir: PathBuf,
+    inventory: Option<Arc<crate::AuthenticatedPropertyInventory>>,
     rel_type_name: String,
     schema: SchemaRef,
 }
@@ -2450,8 +2726,19 @@ impl TypedEdgeTable {
         Self {
             dir: dir.to_path_buf(),
             rel_type_name: rel_type_name.to_owned(),
+            inventory: None,
             schema,
         }
+    }
+}
+
+impl TypedEdgeTable {
+    fn with_inventory(
+        mut self,
+        inventory: Option<Arc<crate::AuthenticatedPropertyInventory>>,
+    ) -> Self {
+        self.inventory = inventory;
+        self
     }
 }
 
@@ -2472,8 +2759,12 @@ impl TableProvider for TypedEdgeTable {
         _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let fragments = crate::mutator::edge_parquet_files(&self.dir, Some(&self.rel_type_name))
-            .map_err(|error| DataFusionError::Execution(error.to_string()))?
+        let paths = match &self.inventory {
+            Some(inventory) => inventory.edge_files(Some(&self.rel_type_name)),
+            None => crate::mutator::edge_parquet_files(&self.dir, Some(&self.rel_type_name))
+                .map_err(|error| DataFusionError::Execution(error.to_string()))?,
+        };
+        let fragments = paths
             .into_iter()
             .map(|(_, path)| ParquetFragment::for_path(path, false))
             .collect();
@@ -2500,6 +2791,7 @@ impl TableProvider for TypedEdgeTable {
 #[derive(Debug, Clone)]
 pub struct UnionEdgeTable {
     dir: PathBuf,
+    inventory: Option<Arc<crate::AuthenticatedPropertyInventory>>,
 }
 
 impl UnionEdgeTable {
@@ -2508,6 +2800,7 @@ impl UnionEdgeTable {
     pub fn open(dir: &Path) -> Self {
         Self {
             dir: dir.to_path_buf(),
+            inventory: None,
         }
     }
 }
@@ -2529,8 +2822,12 @@ impl TableProvider for UnionEdgeTable {
         _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let fragments: Vec<ParquetFragment> = crate::mutator::edge_parquet_files(&self.dir, None)
-            .map_err(|error| DataFusionError::Execution(error.to_string()))?
+        let paths = match &self.inventory {
+            Some(inventory) => inventory.edge_files(None),
+            None => crate::mutator::edge_parquet_files(&self.dir, None)
+                .map_err(|error| DataFusionError::Execution(error.to_string()))?,
+        };
+        let fragments: Vec<ParquetFragment> = paths
             .into_iter()
             .map(|(stem, path)| ParquetFragment::for_union_edge(path, stem))
             .collect();
@@ -2913,7 +3210,6 @@ pub struct GraphCatalog {
     semantic_label_routes: HashMap<EntityTypeId, String>,
     semantic_label_names: HashMap<EntityTypeId, String>,
     semantic_composition_fingerprint: Option<String>,
-    semantic_edge_tables: HashMap<RelationTypeId, Arc<dyn TableProvider>>,
     semantic_edge_property_tables: HashMap<RelationTypeId, Arc<dyn TableProvider>>,
 }
 
@@ -3006,7 +3302,10 @@ impl GraphCatalog {
                 if binding.route_kind == crate::SemanticRouteKind::Relation {
                     schema.register(
                         format!("edges_{}", binding.route),
-                        Arc::new(TypedEdgeTable::open(dir, &binding.route)),
+                        Arc::new(
+                            TypedEdgeTable::open(dir, &binding.route)
+                                .with_inventory(inventory.clone()),
+                        ),
                     );
                 }
             }
@@ -3014,7 +3313,7 @@ impl GraphCatalog {
             for rel_name in handle.relation_type_names() {
                 schema.register(
                     format!("edges_{rel_name}"),
-                    Arc::new(TypedEdgeTable::open(dir, rel_name)),
+                    Arc::new(TypedEdgeTable::open(dir, rel_name).with_inventory(inventory.clone())),
                 );
             }
         } else {
@@ -3028,17 +3327,20 @@ impl GraphCatalog {
             // scan a non-existent typed file and return 0 rows.
             schema.register(
                 "edges__exploratory",
-                Arc::new(TypedEdgeTable::open(dir, "_exploratory")),
+                Arc::new(
+                    TypedEdgeTable::open(dir, "_exploratory").with_inventory(inventory.clone()),
+                ),
             );
             for rel_name in runtime_catalog.relation_types() {
-                let typed_path = dir
-                    .join("topology")
-                    .join("edges")
-                    .join(format!("{rel_name}.parquet"));
-                if typed_path.exists() {
+                let has_typed = inventory
+                    .as_ref()
+                    .is_some_and(|inventory| !inventory.edge_files(Some(rel_name)).is_empty());
+                if has_typed {
                     schema.register(
                         format!("edges_{rel_name}"),
-                        Arc::new(TypedEdgeTable::open(dir, rel_name)),
+                        Arc::new(
+                            TypedEdgeTable::open(dir, rel_name).with_inventory(inventory.clone()),
+                        ),
                     );
                 }
             }
@@ -3048,7 +3350,9 @@ impl GraphCatalog {
         if !schema.table_exist("edges__exploratory") {
             schema.register(
                 "edges__exploratory",
-                Arc::new(TypedEdgeTable::open(dir, "_exploratory")),
+                Arc::new(
+                    TypedEdgeTable::open(dir, "_exploratory").with_inventory(inventory.clone()),
+                ),
             );
         }
 
@@ -3103,8 +3407,6 @@ impl GraphCatalog {
         let mut semantic_rel_routes = HashMap::new();
         let mut semantic_label_routes = HashMap::new();
         let mut semantic_label_names = HashMap::new();
-        let mut semantic_edge_tables: HashMap<RelationTypeId, Arc<dyn TableProvider>> =
-            HashMap::new();
         let mut semantic_edge_property_tables: HashMap<RelationTypeId, Arc<dyn TableProvider>> =
             HashMap::new();
         if let Some(bindings) = semantic {
@@ -3120,8 +3422,6 @@ impl GraphCatalog {
                         let id = RelationTypeId::decode(binding.storage_id)
                             .map_err(|e| DataFusionError::Plan(e.to_string()))?;
                         semantic_rel_routes.insert(id, binding.route.clone());
-                        semantic_edge_tables
-                            .insert(id, Arc::new(TypedEdgeTable::open(dir, &binding.route)));
                     }
                     crate::SemanticRouteKind::NodeProperty
                     | crate::SemanticRouteKind::EdgeProperty => {
@@ -3180,9 +3480,29 @@ impl GraphCatalog {
             semantic_label_names,
             semantic_composition_fingerprint: semantic
                 .map(|bindings| bindings.composition_fingerprint.clone()),
-            semantic_edge_tables,
             semantic_edge_property_tables,
         })
+    }
+
+    /// Retain the explicit generation authority for first-party physical readers.
+    #[must_use]
+    pub fn admitted_inventory(&self) -> Option<Arc<crate::AuthenticatedPropertyInventory>> {
+        self.lowering_property_inventory()
+    }
+
+    /// Relation provider pinned to this catalog's admitted route authority.
+    #[must_use]
+    pub fn edge_table(&self, dir: &Path, route: &str) -> TypedEdgeTable {
+        TypedEdgeTable::open(dir, route).with_inventory(self.lowering_property_inventory())
+    }
+
+    /// Union provider preserving semantic relation names from admitted authority.
+    #[must_use]
+    pub fn union_edge_table(&self, dir: &Path) -> UnionEdgeTable {
+        UnionEdgeTable {
+            dir: dir.to_path_buf(),
+            inventory: self.lowering_property_inventory(),
+        }
     }
 
     /// Node-property provider pinned to this catalog's generation authority.
@@ -3293,6 +3613,25 @@ impl GraphCatalog {
             };
             authority.tables.insert(name, table);
         }
+        let mut edge_routes = authority
+            .tables
+            .keys()
+            .filter_map(|name| name.strip_prefix("edges_").map(str::to_owned))
+            .collect::<std::collections::BTreeSet<_>>();
+        edge_routes.extend(
+            inventory
+                .edge_files(None)
+                .into_iter()
+                .map(|(route, _)| route),
+        );
+        for route in edge_routes {
+            authority.tables.insert(
+                format!("edges_{route}"),
+                Arc::new(
+                    TypedEdgeTable::open(dir, &route).with_inventory(Some(Arc::clone(&inventory))),
+                ),
+            );
+        }
         authority.property_inventory = Some(inventory);
         Ok(())
     }
@@ -3348,7 +3687,14 @@ impl GraphCatalog {
     /// Registered authenticated provider for one semantic relation ID.
     #[must_use]
     pub fn semantic_edge_table(&self, id: RelationTypeId) -> Option<Arc<dyn TableProvider>> {
-        self.semantic_edge_tables.get(&id).cloned()
+        let route = self.semantic_rel_routes.get(&id)?;
+        self.schema
+            .authority
+            .read()
+            .expect("graph schema lock poisoned")
+            .tables
+            .get(&format!("edges_{route}"))
+            .cloned()
     }
 
     /// Registered authenticated property provider for one semantic relation ID.
@@ -3478,6 +3824,101 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    fn admitted_topology_requires_payload_except_empty_selection() {
+        let dir = TempDir::new().unwrap();
+        let node = graphforge_core::uuid::new_v7();
+        let mut writer = crate::GraphWriter::open_at(dir.path(), OntologyMode::Strict, 1).unwrap();
+        writer
+            .create_node(node, EntityTypeId::decode(0).unwrap())
+            .unwrap();
+        writer
+            .create_edge(graphforge_core::uuid::new_v7(), "CON", &node, &node)
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        let catalog = GraphCatalog::open(dir.path(), None, &RuntimeCatalog::new()).unwrap();
+        let inventory = catalog.admitted_inventory().unwrap();
+        let path = inventory.edge_files(Some("CON"))[0].1.clone();
+        std::fs::remove_file(&path).unwrap();
+        let ids = std::collections::HashSet::from([0]);
+        let empty = std::collections::HashSet::new();
+        for route in ["CON", "*"] {
+            assert!(read_edges_from_inventory(&inventory, route, OntologyMode::Strict).is_err());
+            assert!(
+                count_edge_rows_from_inventory(&inventory, route, OntologyMode::Strict).is_err()
+            );
+            assert!(
+                read_edges_filtered_from_inventory(&inventory, route, OntologyMode::Strict, &ids)
+                    .is_err()
+            );
+            assert!(
+                read_edges_filtered_projected_from_inventory(
+                    &inventory,
+                    route,
+                    OntologyMode::Strict,
+                    &ids,
+                    &[0],
+                    None
+                )
+                .is_err()
+            );
+            assert_eq!(
+                total_rows(
+                    &read_edges_filtered_from_inventory(
+                        &inventory,
+                        route,
+                        OntologyMode::Strict,
+                        &empty
+                    )
+                    .unwrap()
+                ),
+                0
+            );
+            let observer = Arc::new(Wave12Observer::default());
+            let observed: Arc<dyn crate::io_stats::FilteredReadObserver> = observer.clone();
+            let projected = read_edges_filtered_projected_from_inventory(
+                &inventory,
+                route,
+                OntologyMode::Strict,
+                &empty,
+                &[0],
+                Some(&observed),
+            )
+            .unwrap();
+            let schema = if route == "*" {
+                &EXPLORATORY_EDGE_SCHEMA
+            } else {
+                &TYPED_EDGE_SCHEMA
+            };
+            let expected = project_batches_with_key(Vec::new(), schema, &[0], "edge_id").unwrap();
+            assert_eq!(projected[0].schema(), expected[0].schema());
+            assert_eq!(total_rows(&projected), 0);
+            let filtered = read_edges_filtered_observed_from_inventory(
+                &inventory,
+                route,
+                OntologyMode::Strict,
+                &empty,
+                Some(&observed),
+            )
+            .unwrap();
+            assert_eq!(total_rows(&filtered), 0);
+            for counter in [
+                &observer.started,
+                &observer.scanned,
+                &observer.completed,
+                &observer.failed,
+                &observer.pruning,
+            ] {
+                assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
+            }
+        }
+        assert_eq!(
+            total_rows(&read_parquet_or_empty(&path, TYPED_EDGE_SCHEMA.clone()).unwrap()),
+            0
+        );
+    }
+
+    #[test]
     fn catalog_parquet_admission_rejects_directory_and_bad_leading_magic() {
         let root = TempDir::new().unwrap();
         assert!(admitted_parquet(root.path()).is_err());
@@ -3515,6 +3956,111 @@ mod tests {
                 .success()
         );
         assert!(admitted_parquet(&fifo).is_err());
+    }
+
+    #[tokio::test]
+    async fn mapped_writer_reopen_and_catalog_refresh_preserve_semantic_routes() {
+        let dir = TempDir::new().unwrap();
+        let left = graphforge_core::uuid::new_v7();
+        let right = graphforge_core::uuid::new_v7();
+        let first_edge = graphforge_core::uuid::new_v7();
+        let mut writer = crate::GraphWriter::open_at(dir.path(), OntologyMode::Strict, 1).unwrap();
+        for node in [left, right] {
+            writer
+                .create_node(node, EntityTypeId::decode(0).unwrap())
+                .unwrap();
+        }
+        writer
+            .create_edge(first_edge, "CON", &left, &right)
+            .unwrap();
+        writer
+            .set_properties(
+                &left,
+                Some("con"),
+                HashMap::from([("rank".into(), graphforge_ir::IrLiteral::Int(7))]),
+            )
+            .unwrap();
+        writer
+            .set_edge_properties(
+                &first_edge,
+                Some("CON"),
+                HashMap::from([("weight".into(), graphforge_ir::IrLiteral::Int(11))]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        let mut catalog = GraphCatalog::open(dir.path(), None, &RuntimeCatalog::new()).unwrap();
+        catalog.refresh_property_inventory(dir.path()).unwrap();
+        let semantic_id = RelationTypeId::decode(0).unwrap();
+        catalog
+            .semantic_rel_routes
+            .insert(semantic_id, "CON".into());
+        let old = catalog.semantic_edge_table(semantic_id).unwrap();
+        let inventory = catalog.admitted_inventory().unwrap();
+        assert_eq!(
+            inventory
+                .routes(crate::PropertyRouteKind::Node)
+                .collect::<Vec<_>>(),
+            ["con"]
+        );
+        assert_eq!(
+            inventory
+                .routes(crate::PropertyRouteKind::Edge)
+                .collect::<Vec<_>>(),
+            ["CON"]
+        );
+        let node = read_properties(dir.path(), "con").unwrap();
+        let rank = node[0]
+            .column_by_name("rank")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(rank.null_count(), 0);
+        assert_eq!(rank.values().as_ref(), &[7]);
+        let edge = read_edge_properties_from_inventory(dir.path(), &inventory, "CON").unwrap();
+        let weight = edge[0]
+            .column_by_name("weight")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(weight.null_count(), 0);
+        assert_eq!(weight.values().as_ref(), &[11]);
+        let mut writer = crate::GraphWriter::open_at(dir.path(), OntologyMode::Strict, 2).unwrap();
+        writer.register_existing_node(left, 1).unwrap();
+        writer.register_existing_node(right, 2).unwrap();
+        writer
+            .create_edge(graphforge_core::uuid::new_v7(), "CON", &right, &left)
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        catalog.refresh_property_inventory(dir.path()).unwrap();
+        let ctx = datafusion::prelude::SessionContext::new();
+        let direct = catalog
+            .schema("graph")
+            .unwrap()
+            .table("edges_CON")
+            .await
+            .unwrap()
+            .unwrap();
+        let semantic = catalog.semantic_edge_table(semantic_id).unwrap();
+        for (provider, expected) in [(old, 1), (direct, 2), (semantic, 2)] {
+            let plan = provider.scan(&ctx.state(), None, &[], None).await.unwrap();
+            let batches = datafusion::physical_plan::collect(plan, ctx.task_ctx())
+                .await
+                .unwrap();
+            assert_eq!(total_rows(&batches), expected);
+            for batch in batches {
+                let ids = batch
+                    .column_by_name("edge_uuid")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
+                assert_eq!(ids.null_count(), 0);
+            }
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/construction_detail_codec.rs
+++ b/crates/graphforge-storage/src/construction_detail_codec.rs
@@ -11,7 +11,7 @@ impl DetailCodec {
     pub(crate) fn from_version(version: u32) -> io::Result<Self> {
         match version {
             6 => Ok(Self::Legacy),
-            7 => Ok(Self::Compact),
+            7 | 8 => Ok(Self::Compact),
             _ => Err(invalid("unsupported construction detail version")),
         }
     }
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(DetailCodec::from_version(6).unwrap(), DetailCodec::Legacy);
         assert_eq!(DetailCodec::from_version(7).unwrap(), DetailCodec::Compact);
         assert!(DetailCodec::from_version(5).is_err());
-        assert!(DetailCodec::from_version(8).is_err());
+        assert!(DetailCodec::from_version(9).is_err());
     }
 }
 

--- a/crates/graphforge-storage/src/construction_detail_tests.rs
+++ b/crates/graphforge-storage/src/construction_detail_tests.rs
@@ -61,6 +61,205 @@ mod compact_details {
     }
 
     #[test]
+    fn mapped_encoding_versions_resume_with_explicit_layout_authority() {
+        for version in [6, 7, 8] {
+            let root = TempDir::new().unwrap();
+            crate::open_or_initialize_project(root.path()).unwrap();
+            let operation = Uuid::new_v4();
+            let budgets = GraphConstructionBudgets::default();
+            let mut session = create(&root, operation, version, budgets, None);
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "nodes",
+                    &node_property_batch(1, 3),
+                )
+                .unwrap();
+            session
+                .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 2))
+                .unwrap();
+            session.seal().unwrap();
+            drop(session);
+            let mut resumed =
+                GraphConstructionSession::open(root.path(), operation, 0, budgets).unwrap();
+            assert_eq!(resumed.checkpoint.format_version, version);
+            let encoded = resumed.prepare_canonical_encoding(1).unwrap();
+            assert_eq!(
+                encoded
+                    .artifacts
+                    .iter()
+                    .any(|entry| entry.path == crate::route_component::TABLE_FILE),
+                version == 8
+            );
+            resumed
+                .publish_canonical(&encoded, Uuid::new_v4(), Uuid::new_v4())
+                .unwrap();
+            drop(resumed);
+            let selected = crate::resolve_project_generation(root.path()).unwrap();
+            let crate::GraphFilesParticipant::V2(compact) = selected
+                .declared_graph_files_participant()
+                .unwrap()
+                .unwrap()
+            else {
+                panic!("compact publication required")
+            };
+            assert_eq!(compact.format_version, if version == 8 { 4 } else { 2 });
+            let inventory = selected.graph_files_inventory().unwrap().unwrap();
+            assert_eq!(inventory.format_version, if version == 8 { 3 } else { 1 });
+            let admitted =
+                crate::AuthenticatedPropertyInventory::from_resolved_generation(&selected).unwrap();
+            let edges = crate::read_edges_from_inventory(
+                &admitted,
+                "*",
+                graphforge_core::OntologyMode::Exploratory,
+            )
+            .unwrap();
+            assert_eq!(edges.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+            let lease = crate::begin_graph_object_publication(root.path()).unwrap();
+            let (_, evidence) = crate::GraphManifestState::open(
+                &lease,
+                compact,
+                crate::GraphManifestLimits::default(),
+            )
+            .unwrap();
+            let expected = inventory
+                .files
+                .iter()
+                .find(|entry| entry.relative_path == crate::route_component::TABLE_FILE)
+                .map_or(0, |entry| entry.byte_length);
+            assert_eq!(evidence.authority_read_bytes, expected);
+            assert!(evidence.decoded_bytes > 0);
+        }
+        assert!(DetailCodec::from_version(9).is_err());
+        assert_eq!(
+            DetailCodec::from_version(7).unwrap(),
+            DetailCodec::from_version(8).unwrap()
+        );
+    }
+
+    #[test]
+    fn mapped_encoding_appends_preserve_parent_routes_and_refuse_changed_table() {
+        let root = TempDir::new().unwrap();
+        crate::open_or_initialize_project(root.path()).unwrap();
+        let mut initial = create(
+            &root,
+            Uuid::new_v4(),
+            7,
+            GraphConstructionBudgets::default(),
+            None,
+        );
+        initial
+            .append(
+                ConstructionChunkKind::Node,
+                "nodes",
+                &node_property_batch(1, 3),
+            )
+            .unwrap();
+        initial
+            .append(ConstructionChunkKind::Edge, "edges", &edge_batch(100, 2))
+            .unwrap();
+        initial.seal().unwrap();
+        let encoded = initial.prepare_canonical_encoding(1).unwrap();
+        initial
+            .publish_canonical(&encoded, Uuid::new_v4(), Uuid::new_v4())
+            .unwrap();
+        drop(initial);
+        let mut prior = crate::resolve_project_generation(root.path())
+            .unwrap()
+            .graph_files_inventory()
+            .unwrap()
+            .unwrap();
+        for generation in [2, 3] {
+            let (_source, mut session, shape) =
+                ordinal_append_session(&root, generation, u128::from(generation + 2), 1);
+            assert_eq!(session.checkpoint.format_version, 8);
+            let encoding = session.encode_canonical(&shape, generation).unwrap();
+            let path = session
+                .root
+                .path()
+                .join(&encoding.root)
+                .join("graph")
+                .join(crate::route_component::TABLE_FILE);
+            let bytes = std::fs::read(&path).unwrap();
+            let table =
+                crate::route_component::RouteTable::decode(&bytes, 64 * 1024 * 1024, 100_000)
+                    .unwrap();
+            let before = std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap();
+            let mut corrupted = bytes.clone();
+            corrupted[0] ^= 1;
+            std::fs::write(&path, &corrupted).unwrap();
+            let target = Uuid::new_v4();
+            let transaction = Uuid::new_v4();
+            assert!(
+                session
+                    .publish_canonical(&encoding, target, transaction)
+                    .is_err()
+            );
+            assert_eq!(
+                std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap(),
+                before
+            );
+            std::fs::write(&path, &bytes).unwrap();
+            session
+                .publish_canonical(&encoding, target, transaction)
+                .unwrap();
+            drop(session);
+            let selected = crate::resolve_project_generation(root.path()).unwrap();
+            let current = selected.graph_files_inventory().unwrap().unwrap();
+            assert_eq!(current.format_version, 3);
+            table
+                .validate_paths(
+                    current
+                        .files
+                        .iter()
+                        .map(|entry| entry.relative_path.as_str()),
+                )
+                .unwrap();
+            for old in &prior.files {
+                if crate::route_component::route_position(&old.relative_path)
+                    .unwrap()
+                    .is_none()
+                {
+                    continue;
+                }
+                let path = if prior.format_version == 1 {
+                    crate::route_component::encode_relative_route(
+                        &old.relative_path,
+                        &mut crate::route_component::RouteTable::default(),
+                        64 * 1024 * 1024,
+                        100_000,
+                    )
+                    .unwrap()
+                } else {
+                    old.relative_path.clone()
+                };
+                let retained = current
+                    .files
+                    .iter()
+                    .find(|entry| entry.relative_path == path)
+                    .unwrap();
+                assert_eq!(retained.content_sha256, old.content_sha256);
+                assert_eq!(retained.byte_length, old.byte_length);
+            }
+            let admitted =
+                crate::AuthenticatedPropertyInventory::from_resolved_generation(&selected).unwrap();
+            assert_eq!(
+                crate::read_edges_from_inventory(
+                    &admitted,
+                    "*",
+                    graphforge_core::OntologyMode::Exploratory
+                )
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+                2
+            );
+            prior = current;
+        }
+    }
+
+    #[test]
     fn detail_codec_legacy_and_compact_resume_cross_multiple_merge_levels() {
         let mut measurements = Vec::new();
         for version in [6, 7] {

--- a/crates/graphforge-storage/src/durable_rewrite.rs
+++ b/crates/graphforge-storage/src/durable_rewrite.rs
@@ -313,6 +313,14 @@ impl Drop for RewriteGuard {
     }
 }
 
+#[cfg(test)]
+pub(crate) fn rewrite_lock_is_held() -> bool {
+    matches!(
+        PROCESS_REWRITE_LOCK.try_lock(),
+        Err(std::sync::TryLockError::WouldBlock)
+    )
+}
+
 fn acquire(root: &Path) -> Result<RewriteGuard, GfError> {
     // This mutex owns ordering only; the durable journal owns recovery state.
     // A panicking holder must not disable every later rewrite in the process.
@@ -947,7 +955,7 @@ pub(crate) fn commit(
 
 #[allow(clippy::too_many_lines)] // Linear crash-barrier state machine; splitting obscures order.
 pub(crate) fn commit_with_participant(
-    mut batch: RewriteBatch,
+    batch: RewriteBatch,
     root: &Path,
     bump_topology: bool,
     bump_search: bool,
@@ -955,7 +963,6 @@ pub(crate) fn commit_with_participant(
     auxiliary: Option<AuxiliaryReceipt>,
     participant: Option<RewriteParticipantPreparer<'_>>,
 ) -> Result<GenerationPair, GfError> {
-    let has_participant = participant.is_some();
     // Serialize the pinned-generation precondition with CURRENT replacement.
     // Project publication takes this same lock before it can replace CURRENT.
     let _project_authority_guard = batch
@@ -963,6 +970,62 @@ pub(crate) fn commit_with_participant(
         .map(crate::project_publication::wait_for_writer_lock)
         .transpose()?;
     let guard = acquire(root)?;
+    commit_locked(
+        batch,
+        root,
+        bump_topology,
+        bump_search,
+        bump_property,
+        auxiliary,
+        participant,
+        &guard,
+    )
+}
+
+// Retain the existing journal lock through owned-layout admission, staging and
+// final authentication. The callback cannot introduce published authority.
+pub(crate) fn prepare_owned_layout<T, R>(
+    root: &Path,
+    prepare: impl FnOnce(&StableDirectory) -> Result<(RewriteBatch, T), GfError>,
+    authenticate: impl FnOnce(T) -> Result<R, GfError>,
+) -> Result<R, GfError> {
+    let guard = acquire(root)?;
+    guard.revalidate()?;
+    let current = crate::generation::read_generation_state_raw(root)?;
+    recover_locked(
+        root,
+        &guard.directory,
+        GenerationPair {
+            topology: current.topology,
+            search: current.search,
+            property: current.property,
+        },
+    )?;
+    let (batch, prepared) = prepare(&guard.directory)?;
+    if batch.property_authority_root()?.is_some() {
+        return Err(storage(
+            "owned layout preparation cannot carry project authority",
+        ));
+    }
+    commit_locked(batch, root, false, false, false, None, None, &guard)?;
+    let result = authenticate(prepared)?;
+    guard.revalidate()?;
+    Ok(result)
+}
+
+#[allow(clippy::too_many_arguments)] // Existing commit arguments plus the retained lock; no new public options.
+#[allow(clippy::too_many_lines)] // Preserve the journal's linear crash-barrier ordering.
+fn commit_locked(
+    mut batch: RewriteBatch,
+    root: &Path,
+    bump_topology: bool,
+    bump_search: bool,
+    bump_property: bool,
+    auxiliary: Option<AuxiliaryReceipt>,
+    participant: Option<RewriteParticipantPreparer<'_>>,
+    guard: &RewriteGuard,
+) -> Result<GenerationPair, GfError> {
+    let has_participant = participant.is_some();
     guard.revalidate()?;
     let prior_state = crate::generation::read_generation_state_raw(root)?;
     let prior = GenerationPair {
@@ -1071,6 +1134,7 @@ pub(crate) fn commit_with_participant(
             "UUID rewrite participant must stage its namespace and exact typed receipt",
         ));
     }
+    let route_table_prior = batch.prepare_registered_routes(root, &guard.directory)?;
     let generation_bytes =
         crate::generation::encode_generation_state(next.topology, next.search, next.property)?;
     guard.revalidate()?;
@@ -1159,6 +1223,9 @@ pub(crate) fn commit_with_participant(
     validate_intent(&intent)?;
     for entry in &intent.entries {
         moves::check(root, &guard.directory, entry, false)?;
+    }
+    if let Some(prior) = route_table_prior {
+        prior.verify(&guard.directory)?;
     }
     intent.checksum = checksum(&intent)?;
     if intent.auxiliary.as_ref().is_some_and(is_v4_ordinal_receipt) {

--- a/crates/graphforge-storage/src/durable_rewrite.rs
+++ b/crates/graphforge-storage/src/durable_rewrite.rs
@@ -433,7 +433,7 @@ fn publish_journal(root: &StableDirectory, intent: &Intent) -> Result<(), GfErro
         expected,
         std::ffi::OsStr::new(JOURNAL),
     )
-    .map_err(storage)?;
+    .map_err(|error| storage(format!("rewrite journal publication: {error}")))?;
     root.sync().map_err(storage)
 }
 
@@ -456,9 +456,18 @@ fn install(root_path: &Path, root: &StableDirectory, entry: &Entry) -> Result<()
             authenticate_prior_destination(&parent, &target, entry.prior_destination.as_ref())?;
             let expected = graphforge_filesystem::file_identity(&temp).map_err(storage)?;
             drop(temp);
+            let authority = if entry.destination == crate::route_component::TABLE_FILE {
+                "semantic routes"
+            } else if entry.class == EntryClass::GenerationAuthority {
+                "generation"
+            } else if entry.destination.starts_with("topology/uuid-membership/") {
+                "UUID membership"
+            } else {
+                "graph data"
+            };
             parent
                 .replace_child(&temporary, expected, &target)
-                .map_err(storage)?;
+                .map_err(|error| storage(format!("rewrite {authority} install: {error}")))?;
             parent.sync().map_err(storage)?;
             authenticate_installed_destination(&parent, &target, entry)?;
         }

--- a/crates/graphforge-storage/src/durable_rewrite/moves.rs
+++ b/crates/graphforge-storage/src/durable_rewrite/moves.rs
@@ -137,65 +137,78 @@ pub(crate) fn stage(
     root_path: &Path,
     source_path: &Path,
     destination: &Path,
+    temporary_prefix: &str,
+) -> Result<(tempfile::NamedTempFile, SourceRetirement), GfError> {
+    with_rewrite_lock(root_path, |root| {
+        stage_retained(root_path, root, source_path, destination, temporary_prefix)
+    })
+}
+
+// The owned-layout caller retains the existing rewrite guard for this entire operation.
+pub(crate) fn stage_retained(
+    root_path: &Path,
+    root: &StableDirectory,
+    source_path: &Path,
+    destination: &Path,
+    temporary_prefix: &str,
 ) -> Result<(tempfile::NamedTempFile, SourceRetirement), GfError> {
     let parts = components(root_path, source_path)?;
     let destination_relative = canonical_relative(root_path, destination)?;
     if parts.join("/") == destination_relative {
         return Err(storage("rewrite move source equals destination"));
     }
-    with_rewrite_lock(root_path, |root| {
-        let mut source_parent = root.try_clone().map_err(storage)?;
-        for part in &parts[..parts.len() - 1] {
-            source_parent = source_parent
-                .open_child_directory(std::ffi::OsStr::new(part))
-                .map_err(storage)?;
-        }
-        let source = source_parent
-            .open_child_file(std::ffi::OsStr::new(parts.last().unwrap()))
+    let mut source_parent = root.try_clone().map_err(storage)?;
+    for part in &parts[..parts.len() - 1] {
+        source_parent = source_parent
+            .open_child_directory(std::ffi::OsStr::new(part))
             .map_err(storage)?;
-        let original = authenticated_file(&source)?;
-        authenticate(&source, &original)?;
-        let (destination_parent, name) =
-            retained_parent_at(root_path, root, &destination_relative)?;
-        match destination_parent.open_child_file(&name) {
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(storage(error)),
-            Ok(_) => return Err(storage("rewrite move destination already exists")),
-        }
-        let mut temporary = tempfile::Builder::new()
-            .prefix("move.")
-            .suffix(".tmp")
-            .tempfile_in(
-                destination
-                    .parent()
-                    .ok_or_else(|| storage("move destination has no parent"))?,
-            )
-            .map_err(storage)?;
-        let mut input = source.try_clone().map_err(storage)?;
-        input.rewind().map_err(storage)?;
-        std::io::copy(&mut input, &mut temporary).map_err(storage)?;
-        temporary.as_file().sync_all().map_err(storage)?;
-        authenticate(&source, &original)?;
-        let (bytes, digest) = hash_reader(temporary.as_file().try_clone().map_err(storage)?)?;
-        if bytes != original.bytes || digest != original.sha256 {
-            return Err(storage("rewrite move staged copy differs from source"));
-        }
-        source_parent.revalidate_named().map_err(storage)?;
-        destination_parent.revalidate_named().map_err(storage)?;
-        let root_id = root.identity();
-        let parent_id = source_parent.identity();
-        Ok((
-            temporary,
-            SourceRetirement {
-                components: parts.clone(),
-                root_volume: root_id.volume_serial,
-                root_file: hex(&root_id.file_id),
-                parent_volume: parent_id.volume_serial,
-                parent_file: hex(&parent_id.file_id),
-                original,
-            },
-        ))
-    })
+    }
+    let source = source_parent
+        .open_child_file(std::ffi::OsStr::new(parts.last().unwrap()))
+        .map_err(storage)?;
+    let original = authenticated_file(&source)?;
+    authenticate(&source, &original)?;
+    let (destination_parent, name) = retained_parent_at(root_path, root, &destination_relative)?;
+    match destination_parent.open_child_file(&name) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(storage(error)),
+        Ok(_) => return Err(storage("rewrite move destination already exists")),
+    }
+    // Fixed-size graph-temp spelling remains recognizable to the owned
+    // workspace sweep without expanding a valid near-limit destination.
+    let mut temporary = tempfile::Builder::new()
+        .prefix(temporary_prefix)
+        .suffix(".tmp")
+        .tempfile_in(
+            destination
+                .parent()
+                .ok_or_else(|| storage("move destination has no parent"))?,
+        )
+        .map_err(storage)?;
+    let mut input = source.try_clone().map_err(storage)?;
+    input.rewind().map_err(storage)?;
+    std::io::copy(&mut input, &mut temporary).map_err(storage)?;
+    temporary.as_file().sync_all().map_err(storage)?;
+    authenticate(&source, &original)?;
+    let (bytes, digest) = hash_reader(temporary.as_file().try_clone().map_err(storage)?)?;
+    if bytes != original.bytes || digest != original.sha256 {
+        return Err(storage("rewrite move staged copy differs from source"));
+    }
+    source_parent.revalidate_named().map_err(storage)?;
+    destination_parent.revalidate_named().map_err(storage)?;
+    let root_id = root.identity();
+    let parent_id = source_parent.identity();
+    Ok((
+        temporary,
+        SourceRetirement {
+            components: parts.clone(),
+            root_volume: root_id.volume_serial,
+            root_file: hex(&root_id.file_id),
+            parent_volume: parent_id.volume_serial,
+            parent_file: hex(&parent_id.file_id),
+            original,
+        },
+    ))
 }
 
 pub(super) fn validate(intent: &Intent) -> Result<(), GfError> {
@@ -809,5 +822,22 @@ mod tests {
             b"exact source bytes"
         );
         assert!(!root.path().join("properties/new").exists());
+    }
+    #[test]
+    fn valid_maximum_destination_component_does_not_expand_temporary_name() {
+        let root = fixture();
+        let source = root.path().join("properties/old");
+        let destination = root
+            .path()
+            .join("properties")
+            .join(format!("{}.parquet", "r".repeat(247)));
+        assert_eq!(destination.file_name().unwrap().len(), 255);
+        let mut batch = RewriteBatch::new();
+        batch
+            .stage_move(root.path(), &source, &destination)
+            .unwrap();
+        batch.commit_at(root.path()).unwrap();
+        assert_eq!(std::fs::read(destination).unwrap(), b"exact source bytes");
+        assert!(!source.exists());
     }
 }

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -43,7 +43,7 @@ use crate::UuidIndexKind;
 use crate::construction_detail_codec::{DetailCodec, DetailValidator};
 use crate::uuid_membership::{AuthenticatedUuidIndexSnapshot, UuidConstructionSnapshotWork};
 
-const FORMAT_VERSION: u32 = 7;
+const FORMAT_VERSION: u32 = 8;
 const PRIVATE_ROOT: &str = ".graphforge-construction";
 const SESSION_LOCK: &str = "session.lock";
 const CHECKPOINT: &str = "checkpoint.json";
@@ -280,16 +280,45 @@ fn ordinal_manifest_descriptors(
 
 fn compact_parent_inventory(
     parent: &crate::ResolvedProjectGeneration,
-) -> Result<Option<crate::GraphFilesInventory>, GfError> {
+) -> Result<(Option<crate::GraphFilesInventory>, ReadWork), GfError> {
     let Some(crate::GraphFilesParticipant::V2(root)) = parent.declared_graph_files_participant()?
     else {
-        return Ok(None);
+        return Ok((None, ReadWork::default()));
     };
+    let mut io = crate::GraphObjectIoTotals::default();
     let (entries, _) =
         crate::resolve_graph_manifest(&root, crate::GraphManifestLimits::default(), |digest| {
-            crate::read_graph_object_by_digest(parent.container_root(), digest, 64 * 1024 * 1024)
+            crate::graph_object_store::read_graph_object_counted(
+                parent.container_root(),
+                digest,
+                64 * 1024 * 1024,
+                &mut io,
+            )
         })?;
-    crate::graph_files::inventory_from_entries(entries).map(Some)
+    crate::route_component::authenticate_manifest_routes(root.format_version, &entries, |entry| {
+        crate::graph_object_store::read_graph_object_counted(
+            parent.container_root(),
+            &entry.content_sha256,
+            64 * 1024 * 1024,
+            &mut io,
+        )
+    })?;
+    let inventory = crate::graph_files::inventory_from_entries_with_version(
+        entries,
+        if root.format_version == crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION {
+            crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+        } else {
+            crate::GRAPH_FILES_RECORD_VERSION
+        },
+    )?;
+    Ok((
+        Some(inventory),
+        ReadWork {
+            bytes: io.read_bytes,
+            operations: io.read_calls,
+            ..ReadWork::default()
+        },
+    ))
 }
 
 fn compact_parent_surrogate_tails(
@@ -1409,6 +1438,7 @@ impl GraphConstructionSession {
         }
         let encoded = crate::graph_construction_encoding::encode(
             &self.root,
+            self.checkpoint.format_version >= 8,
             DetailCodec::from_version(self.checkpoint.format_version).map_err(storage)?,
             shape,
             generation,
@@ -1563,7 +1593,10 @@ impl GraphConstructionSession {
                     )?;
                     (
                         state,
-                        evidence.decoded_bytes,
+                        evidence
+                            .decoded_bytes
+                            .checked_add(evidence.authority_read_bytes)
+                            .ok_or_else(|| storage("manifest authority read bytes overflow"))?,
                         evidence.application_read_calls,
                     )
                 }
@@ -1645,14 +1678,57 @@ impl GraphConstructionSession {
             .publication_application_read_operations
             .checked_add(ordinal_io.read_calls)
             .ok_or_else(|| storage("ordinal publication read calls overflow"))?;
-        let (graph_root, cas_evidence) =
+        let (graph_root, cas_evidence) = if self.checkpoint.format_version >= 8 {
+            let artifact = encoding
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.path == crate::route_component::TABLE_FILE)
+                .ok_or_else(|| storage("mapped encoding lacks route authority"))?;
+            let entry = crate::GraphFileEntry {
+                relative_path: artifact.path.clone(),
+                byte_length: artifact.bytes,
+                content_sha256: artifact.sha256.clone(),
+                role: crate::GraphFileRole::Other,
+            };
+            let (bytes, calls) = crate::graph_files::read_route_table_counted(&workspace, &entry)?;
+            if bytes.len() as u64 != artifact.bytes
+                || hex(&Sha256::digest(&bytes)) != artifact.sha256
+            {
+                return Err(storage("mapped encoding route authority changed"));
+            }
+            let routes =
+                crate::route_component::RouteTable::decode(&bytes, 64 * 1024 * 1024, 100_000)?;
+            self.checkpoint.evidence.publication_application_read_bytes = checked_evidence_sum(
+                "route publication read bytes",
+                self.checkpoint.evidence.publication_application_read_bytes,
+                &[bytes.len() as u64],
+            )?;
+            self.checkpoint
+                .evidence
+                .publication_application_read_operations = checked_evidence_sum(
+                "route publication read calls",
+                self.checkpoint
+                    .evidence
+                    .publication_application_read_operations,
+                &[calls],
+            )?;
+            crate::graph_object_store::append_authenticated_mapped_graph_files(
+                &lease,
+                &workspace,
+                &mut manifest_state,
+                &sealed_files,
+                &ordinal_tombstones,
+                &routes,
+            )?
+        } else {
             crate::graph_object_store::append_authenticated_graph_files_v2(
                 &lease,
                 &workspace,
                 &mut manifest_state,
                 &sealed_files,
                 &ordinal_tombstones,
-            )?;
+            )?
+        };
         self.checkpoint.evidence.cas_application_read_bytes = self
             .checkpoint
             .evidence
@@ -2223,12 +2299,13 @@ impl GraphConstructionSession {
                 )
             )
         });
-        let compact_inventory = if publication_replay || project_dir == graph_source_dir {
-            None
-        } else {
-            let parent = crate::resolve_project_generation(project_dir)?;
-            compact_parent_inventory(&parent)?
-        };
+        let (compact_inventory, compact_inventory_work) =
+            if publication_replay || project_dir == graph_source_dir {
+                (None, ReadWork::default())
+            } else {
+                let parent = crate::resolve_project_generation(project_dir)?;
+                compact_parent_inventory(&parent)?
+            };
         let (base_snapshot, base_work) = if publication_replay {
             (
                 None,
@@ -2278,7 +2355,8 @@ impl GraphConstructionSession {
             };
             (Some(snapshot), work)
         };
-        let (parent_catalog, parent_catalog_sha256, parent_catalog_work) = if publication_replay {
+        let (parent_catalog, parent_catalog_sha256, mut parent_catalog_work) = if publication_replay
+        {
             (
                 RuntimeCatalog::new(),
                 recovered_checkpoint
@@ -2299,6 +2377,14 @@ impl GraphConstructionSession {
             let graph_source = StableDirectory::open(graph_source_dir).map_err(storage)?;
             load_parent_runtime_catalog(&graph_source, parent_topology_generation, budgets)?
         };
+        parent_catalog_work.bytes = parent_catalog_work
+            .bytes
+            .checked_add(compact_inventory_work.bytes)
+            .ok_or_else(|| storage("parent inventory read bytes overflow"))?;
+        parent_catalog_work.operations = parent_catalog_work
+            .operations
+            .checked_add(compact_inventory_work.operations)
+            .ok_or_else(|| storage("parent inventory read calls overflow"))?;
         let resumed_parent_work = if recovered_checkpoint.is_some() && !publication_replay {
             ReadWork {
                 bytes: base_work
@@ -10892,8 +10978,12 @@ mod tests {
                 .unwrap();
             assert!(ids.values().iter().all(|id| *id == person_id));
         }
-        let edges = crate::read_edges(
-            &graph,
+        let (files, _) = crate::capture_graph_files(&graph).unwrap();
+        let admitted =
+            crate::AuthenticatedPropertyInventory::from_inventory_at_root(&graph, files, None)
+                .unwrap();
+        let edges = crate::read_edges_from_inventory(
+            &admitted,
             &relation_route,
             graphforge_core::OntologyMode::Strict,
         )
@@ -10918,10 +11008,16 @@ mod tests {
         let index = crate::UuidMembershipIndex::open(&graph).unwrap();
         assert_eq!(index.count(crate::UuidIndexKind::Node), 3);
         assert_eq!(index.count(crate::UuidIndexKind::Edge), 2);
-        let adjacency =
-            crate::adjacency::build_adjacency_index(&graph, shape.runtime_catalog_now_micros)
-                .unwrap();
-        assert!(!adjacency.is_empty());
+        let adjacency = crate::adjacency::build_adjacency_index_from_inventory(
+            &graph,
+            &graph,
+            Some(&admitted),
+            shape.runtime_catalog_now_micros,
+            &crate::adjacency::AdjacencyBuildOptions::default(),
+            || Ok(()),
+        )
+        .unwrap();
+        assert!(!adjacency.0.is_empty());
 
         drop(session);
         let mut resumed_session = GraphConstructionSession::open_with_semantic_authority(
@@ -11681,8 +11777,12 @@ mod tests {
                     .map_or_else(|| fallback.to_owned(), |binding| binding.route.clone())
             };
             let relation_route = route(crate::SemanticRouteKind::Relation, "R", "R");
+            let (files, _) = crate::capture_graph_files(&graph).unwrap();
+            let admitted =
+                crate::AuthenticatedPropertyInventory::from_inventory_at_root(&graph, files, None)
+                    .unwrap();
             assert_eq!(
-                crate::read_edges(&graph, &relation_route, mode)
+                crate::read_edges_from_inventory(&admitted, &relation_route, mode)
                     .unwrap()
                     .iter()
                     .map(RecordBatch::num_rows)
@@ -11690,7 +11790,12 @@ mod tests {
                 1
             );
             let property_stem = if mode == graphforge_core::OntologyMode::Exploratory {
-                assert!(graph.join("topology/edges/_exploratory").is_dir());
+                assert!(
+                    graph
+                        .join("topology/edges")
+                        .join(crate::route_component::component("_exploratory"))
+                        .is_dir()
+                );
                 "_untyped".to_owned()
             } else {
                 assert!(!graph.join("topology/edges/R").exists());
@@ -12567,7 +12672,14 @@ mod tests {
             .join(operation.simple().to_string())
             .join(&encoding.root)
             .join("graph")
-            .join(&encoding.artifacts[0].path);
+            .join(
+                &encoding
+                    .artifacts
+                    .iter()
+                    .find(|artifact| artifact.path.ends_with(".parquet"))
+                    .unwrap()
+                    .path,
+            );
         std::fs::write(victim, b"tampered").unwrap();
 
         let error = session

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -542,6 +542,7 @@ pub(crate) fn inventory_authority_sha256(
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) fn encode(
     source: &StableDirectory,
+    mapped_routes: bool,
     detail_codec: DetailCodec,
     shape: &ConstructionShape,
     generation: u64,
@@ -584,7 +585,12 @@ pub(crate) fn encode(
     cleanup_encoding_temps(&output, budgets)?;
     if let Some(mut existing) = read_inventory(&output)? {
         let authentication = authenticate_inventory(&output, &existing, parent_index)?;
-        if existing.generation != generation
+        if existing
+            .artifacts
+            .iter()
+            .any(|entry| entry.path == crate::route_component::TABLE_FILE)
+            != mapped_routes
+            || existing.generation != generation
             || existing.ontology_mode != shape.ontology_mode
             || existing.semantic_authority_sha256 != shape.semantic_authority_sha256
             || existing.shape_inputs_sha256 != shape.runtime_catalog_inputs_sha256
@@ -639,6 +645,9 @@ pub(crate) fn encode(
         peak_open_writers: 1,
         ..Default::default()
     };
+    let mut routes = mapped_routes
+        .then(|| construction_parent_routes(parent_generation, &mut evidence))
+        .transpose()?;
     let mut artifacts = Vec::new();
     let label_ids = {
         let (catalog_spool, _catalog_guard) = authenticated_source_spool(
@@ -737,6 +746,7 @@ pub(crate) fn encode(
         cancelled,
         &mut artifacts,
         &mut evidence,
+        &mut routes,
     )?;
     if let Some(bundle) = v4 {
         let metrics = &bundle.metrics;
@@ -805,6 +815,7 @@ pub(crate) fn encode(
         cancelled,
         &mut artifacts,
         &mut evidence,
+        &mut routes,
     )?;
     write_surrogate_tails(
         &output,
@@ -823,6 +834,16 @@ pub(crate) fn encode(
         &mut artifacts,
         &mut evidence,
     )?;
+
+    if let Some(routes) = &routes {
+        copy_artifact(
+            std::io::Cursor::new(routes.encode(64 * 1024 * 1024)?),
+            &output,
+            crate::route_component::TABLE_FILE,
+            &mut artifacts,
+            &mut evidence,
+        )?;
+    }
 
     evidence.membership_records = index.input_records;
     evidence.membership_read_bytes = index.read_bytes;
@@ -874,6 +895,84 @@ pub(crate) fn encode(
         evidence: invocation,
     };
     Ok(completed)
+}
+
+fn encoded_route_component(
+    routes: &mut Option<crate::route_component::RouteTable>,
+    route: &str,
+) -> Result<String, GfError> {
+    match routes {
+        Some(table) => table.insert(route, 64 * 1024 * 1024, 100_000),
+        None => Ok(route.to_owned()),
+    }
+}
+
+fn construction_parent_routes(
+    parent: Option<&crate::ResolvedProjectGeneration>,
+    evidence: &mut GraphConstructionEncodingEvidence,
+) -> Result<crate::route_component::RouteTable, GfError> {
+    let mut io = crate::GraphObjectIoTotals::default();
+    let (version, entries) = match parent
+        .map(crate::ResolvedProjectGeneration::declared_graph_files_participant)
+        .transpose()?
+        .flatten()
+    {
+        Some(crate::GraphFilesParticipant::V1(inventory)) => {
+            (inventory.format_version, inventory.files)
+        }
+        Some(crate::GraphFilesParticipant::V2(root)) => {
+            let parent = parent.expect("participant has parent");
+            let (entries, _) = crate::resolve_graph_manifest(
+                &root,
+                crate::GraphManifestLimits::default(),
+                |digest| {
+                    crate::graph_object_store::read_graph_object_counted(
+                        parent.container_root(),
+                        digest,
+                        64 * 1024 * 1024,
+                        &mut io,
+                    )
+                },
+            )?;
+            (root.format_version, entries)
+        }
+        None => return Ok(crate::route_component::RouteTable::default()),
+    };
+    let table = crate::route_component::authenticate_manifest_routes(version, &entries, |entry| {
+        let parent = parent.expect("table authority has parent");
+        let (_, bytes) = parent
+            .authenticated_graph_file_bytes_counted(
+                &entry.relative_path,
+                64 * 1024 * 1024,
+                None,
+                &mut io,
+            )?
+            .ok_or_else(|| storage("parent route authority is absent"))?;
+        Ok(bytes)
+    })?;
+    let mut table = table.unwrap_or_default();
+    if matches!(version, 1 | 2) {
+        for entry in &entries {
+            let logical = crate::graph_files::legacy_inventory_logical_text(&entry.relative_path)?;
+            crate::route_component::encode_relative_route(
+                &logical,
+                &mut table,
+                64 * 1024 * 1024,
+                100_000,
+            )?;
+        }
+    }
+    add_evidence_counter(
+        &mut evidence.input_read_bytes,
+        io.read_bytes,
+        "parent route read bytes",
+    )?;
+    add_evidence_counter(
+        &mut evidence.input_read_operations,
+        io.read_calls,
+        "parent route read calls",
+    )?;
+    Ok(table)
 }
 
 fn retained_artifact(value: ConstructionIndexReference) -> ConstructionRetainedArtifact {
@@ -1023,6 +1122,7 @@ fn encode_nodes(
     cancelled: &mut impl FnMut() -> bool,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
+    route_table: &mut Option<crate::route_component::RouteTable>,
 ) -> Result<Option<crate::uuid_membership::V4ConstructionArtifactBundle>, GfError> {
     if shape.node_rows.is_empty() {
         if !build_v4 {
@@ -1202,6 +1302,7 @@ fn encode_nodes(
         cancelled,
         artifacts,
         evidence,
+        route_table,
     )?;
     v4.map(crate::uuid_membership::V4OrdinalConstructionWriter::finish)
         .transpose()
@@ -1220,6 +1321,7 @@ fn encode_node_properties(
     cancelled: &mut impl FnMut() -> bool,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
+    route_table: &mut Option<crate::route_component::RouteTable>,
 ) -> Result<(), GfError> {
     let mut ordinals = BTreeMap::<String, u64>::new();
     for name in &shape.node_rows {
@@ -1318,7 +1420,8 @@ fn encode_node_properties(
                             property
                         };
                         let path = format!(
-                            "properties/{route}/{:020}-{ordinal:020}.parquet",
+                            "properties/{}/{:020}-{ordinal:020}.parquet",
+                            encoded_route_component(route_table, &route)?,
                             shape.parent_topology_generation + 1
                         );
                         artifacts.push(write_parquet(
@@ -1382,6 +1485,7 @@ fn encode_edges(
     cancelled: &mut impl FnMut() -> bool,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
+    route_table: &mut Option<crate::route_component::RouteTable>,
 ) -> Result<(), GfError> {
     if shape.edge_rows.is_empty() {
         return Ok(());
@@ -1531,8 +1635,10 @@ fn encode_edges(
                     .ok_or_else(|| storage("canonical edge ids are incompatible"))?;
                 let first = ids.value(0);
                 let last = ids.value(ids.len() - 1);
-                let path =
-                    format!("topology/edges/{topology_route}/{first:020}-{last:020}.parquet");
+                let path = format!(
+                    "topology/edges/{}/{first:020}-{last:020}.parquet",
+                    encoded_route_component(route_table, topology_route)?
+                );
                 artifacts.push(write_parquet(
                     output,
                     &path,
@@ -1579,6 +1685,7 @@ fn encode_edges(
         cancelled,
         artifacts,
         evidence,
+        route_table,
     )
 }
 
@@ -1595,6 +1702,7 @@ fn encode_edge_properties(
     cancelled: &mut impl FnMut() -> bool,
     artifacts: &mut Vec<ConstructionEncodedArtifact>,
     evidence: &mut GraphConstructionEncodingEvidence,
+    route_table: &mut Option<crate::route_component::RouteTable>,
 ) -> Result<(), GfError> {
     let mut ordinals = BTreeMap::<String, u64>::new();
     for name in &shape.edge_rows {
@@ -1693,7 +1801,8 @@ fn encode_edge_properties(
                             property
                         };
                         let path = format!(
-                            "edge_properties/{property_route}/{:020}-{ordinal:020}.parquet",
+                            "edge_properties/{}/{:020}-{ordinal:020}.parquet",
+                            encoded_route_component(route_table, &property_route)?,
                             shape.parent_topology_generation + 1
                         );
                         artifacts.push(write_parquet(

--- a/crates/graphforge-storage/src/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/src/graph_delta_compaction.rs
@@ -844,12 +844,14 @@ mod crash_oracle_tests {
             .unwrap();
         second.flush().unwrap();
 
-        assert_eq!(
-            crate::mutator::edge_parquet_files(root.path(), Some("KNOWS"))
-                .unwrap()
-                .len(),
-            2
-        );
+        let (captured, _) = crate::capture_graph_files(root.path()).unwrap();
+        let inventory = crate::AuthenticatedPropertyInventory::from_inventory_at_root(
+            root.path(),
+            captured,
+            None,
+        )
+        .unwrap();
+        assert_eq!(inventory.edge_files(Some("KNOWS")).len(), 2);
         assert_eq!(canonical_topology_rows(root.path(), 1, 1, None).unwrap(), 4);
     }
 

--- a/crates/graphforge-storage/src/graph_delta_journal.rs
+++ b/crates/graphforge-storage/src/graph_delta_journal.rs
@@ -1530,6 +1530,10 @@ pub fn stage_base_graph_workspace(
 }
 
 pub(crate) fn load_base_state(graph_root: &Path) -> Result<ReconstructedGraphState, GfError> {
+    let inventory = crate::property_overlay::authenticated_property_inventory_for_rewrite(
+        graph_root,
+        &crate::RewriteBatch::new(),
+    )?;
     let mut state = ReconstructedGraphState::default();
     let node_batches = crate::catalog::read_nodes(graph_root)
         .map_err(|error| corrupt(format!("canonical node Parquet decode failed: {error}")))?;
@@ -1567,9 +1571,12 @@ pub(crate) fn load_base_state(graph_root: &Path) -> Result<ReconstructedGraphSta
         }
     }
 
-    let edge_batches =
-        crate::catalog::read_edges(graph_root, "*", graphforge_core::OntologyMode::Strict)
-            .map_err(|error| corrupt(format!("canonical edge Parquet decode failed: {error}")))?;
+    let edge_batches = crate::catalog::read_edges_from_inventory(
+        &inventory,
+        "*",
+        graphforge_core::OntologyMode::Strict,
+    )
+    .map_err(|error| corrupt(format!("canonical edge Parquet decode failed: {error}")))?;
     for batch in edge_batches {
         let edge_uuids = required_array::<FixedSizeBinaryArray>(&batch, "edge_uuid")?;
         let src_uuids = required_array::<FixedSizeBinaryArray>(&batch, "src_uuid")?;
@@ -1595,7 +1602,8 @@ pub(crate) fn load_base_state(graph_root: &Path) -> Result<ReconstructedGraphSta
         }
     }
 
-    for (stem, uuid, properties) in crate::writer::read_all_node_properties(graph_root)? {
+    for (stem, uuid, properties) in crate::writer::read_all_node_properties(graph_root, &inventory)?
+    {
         let uuid = Uuid::from_bytes(uuid).hyphenated().to_string();
         for (key, value) in properties {
             state
@@ -1606,7 +1614,8 @@ pub(crate) fn load_base_state(graph_root: &Path) -> Result<ReconstructedGraphSta
                 .insert((uuid.clone(), key), encode_typed_value(&value)?);
         }
     }
-    for (stem, uuid, properties) in crate::writer::read_all_edge_properties(graph_root)? {
+    for (stem, uuid, properties) in crate::writer::read_all_edge_properties(graph_root, &inventory)?
+    {
         let uuid = Uuid::from_bytes(uuid).hyphenated().to_string();
         for (key, value) in properties {
             state

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -1173,6 +1173,17 @@ fn copy_regular_file(source: &Path, destination: &Path) -> Result<CopyIoEvidence
     // bytes remain verified without assembling them into one buffer.
     let copied = fs::copy(source, destination)
         .map_err(|error| storage("copy graph source file", destination, error))?;
+    #[cfg(windows)]
+    {
+        // Copy preserves read-only source attributes. Only the new private
+        // destination needs write access for its durability barrier.
+        let mut permissions = fs::metadata(destination)
+            .map_err(|error| storage("inspect copied graph permissions", destination, error))?
+            .permissions();
+        permissions.set_readonly(false);
+        fs::set_permissions(destination, permissions)
+            .map_err(|error| storage("make copied graph writable", destination, error))?;
+    }
     let (digest, read_bytes, read_calls) = hash_file_io_counted(destination)?;
     sync_file(destination)?;
     Ok(CopyIoEvidence {
@@ -1263,8 +1274,11 @@ fn hash_reader(file: &mut File, path: &Path) -> Result<([u8; 32], u64), GfError>
 }
 
 fn sync_file(path: &Path) -> Result<(), GfError> {
-    let file =
-        File::open(path).map_err(|error| storage("open graph file for fsync", path, error))?;
+    #[cfg(not(windows))]
+    let file = File::open(path);
+    #[cfg(windows)]
+    let file = fs::OpenOptions::new().write(true).open(path);
+    let file = file.map_err(|error| storage("open graph file for fsync", path, error))?;
     file.sync_all()
         .map_err(|error| storage("fsync graph file", path, error))
 }
@@ -1297,9 +1311,7 @@ fn sync_directory_tree(root: &Path) -> Result<u64, GfError> {
 }
 
 fn sync_directory(path: &Path) -> Result<(), GfError> {
-    let file = File::open(path).map_err(|error| storage("open graph directory", path, error))?;
-    file.sync_all()
-        .map_err(|error| storage("fsync graph directory", path, error))
+    crate::project_publication::sync_directory(path)
 }
 
 fn validate_relative_path(path: &Path) -> Result<(), GfError> {
@@ -1610,6 +1622,34 @@ fn storage(action: &str, path: &Path, error: impl std::fmt::Display) -> GfError 
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn graph_file_copy_readonly_source_preserves_authority_and_barriers() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        fs::write(&source, b"authenticated graph payload").unwrap();
+        let mut permissions = fs::metadata(&source).unwrap().permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&source, permissions).unwrap();
+        let output = root.path().join("private");
+        fs::create_dir(&output).unwrap();
+        let nested = output.join("nested");
+        fs::create_dir(&nested).unwrap();
+        let destination = nested.join("payload");
+        let copied = copy_regular_file(&source, &destination).unwrap();
+        assert_eq!(
+            fs::read(&destination).unwrap(),
+            b"authenticated graph payload"
+        );
+        assert_eq!(copied.digest, hash_file(&source).unwrap());
+        assert_eq!(copied.write_bytes, 27);
+        assert_eq!(copied.read_bytes, 27);
+        assert_eq!(copied.fsync_calls, 1);
+        assert!(fs::metadata(&source).unwrap().permissions().readonly());
+        #[cfg(windows)]
+        assert!(!fs::metadata(&destination).unwrap().permissions().readonly());
+        assert_eq!(sync_directory_tree(&output).unwrap(), 2);
+    }
+
     use super::*;
 
     #[test]

--- a/crates/graphforge-storage/src/graph_files.rs
+++ b/crates/graphforge-storage/src/graph_files.rs
@@ -29,6 +29,10 @@ pub const GRAPH_FILES_FAMILY: &str = "files";
 pub const GRAPH_FILES_RECORD_VERSION: u32 = 1;
 /// Record version for compact content-addressed graph roots.
 pub const GRAPH_FILES_V2_RECORD_VERSION: u32 = 2;
+/// Expanded inventory with authenticated semantic route components.
+pub const GRAPH_FILES_MAPPED_RECORD_VERSION: u32 = 3;
+/// Compact root with authenticated semantic route components.
+pub const GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION: u32 = 4;
 /// Generation-owned directory holding graph workspace files.
 pub const GRAPH_TREE_DIR: &str = "graph";
 
@@ -42,6 +46,9 @@ const GRAPH_FILES_SCHEMA_CANONICAL_BYTES: &[u8] =
     b"graphforge-graph-files/1|relative_path|byte_length|content_sha256|role";
 const GRAPH_FILES_V2_SCHEMA_CANONICAL_BYTES: &[u8] =
     b"graphforge-graph-files-root/2|root_node_sha256|logical_file_count|logical_byte_length";
+const MAPPED_FILES_SCHEMA: &[u8] =
+    b"graphforge-graph-files/3|relative_path|byte_length|content_sha256|role|semantic-routes/1";
+const MAPPED_ROOT_SCHEMA: &[u8] = b"graphforge-graph-files-root/4|root_node_sha256|logical_file_count|logical_byte_length|semantic-routes/1";
 
 /// Logical role inferred from a contained relative workspace path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -175,16 +182,21 @@ pub fn inventory_participant(
     bytes: Vec<u8>,
     file_count: u64,
 ) -> Result<ProjectParticipant, GfError> {
+    let version = decode_inventory(&bytes)?.format_version;
     Ok(ProjectParticipant {
         capability_id: GRAPH_CAPABILITY_ID.into(),
         capability_version: GRAPH_CAPABILITY_VERSION,
         record_family_id: GRAPH_FILES_FAMILY.into(),
-        record_version: GRAPH_FILES_RECORD_VERSION,
+        record_version: version,
         encoding: ProjectParticipantEncoding::Json,
         schema_fingerprint: fingerprint(
             CanonicalDomain::Schema,
             CANONICAL_CONTRACT_VERSION,
-            GRAPH_FILES_SCHEMA_CANONICAL_BYTES,
+            if version == GRAPH_FILES_MAPPED_RECORD_VERSION {
+                MAPPED_FILES_SCHEMA
+            } else {
+                GRAPH_FILES_SCHEMA_CANONICAL_BYTES
+            },
         )
         .map_err(|error| GfError::Validation(error.to_string()))?,
         row_count: file_count,
@@ -200,12 +212,16 @@ pub(crate) fn graph_files_root_participant(
         capability_id: GRAPH_CAPABILITY_ID.into(),
         capability_version: GRAPH_CAPABILITY_VERSION,
         record_family_id: GRAPH_FILES_FAMILY.into(),
-        record_version: GRAPH_FILES_V2_RECORD_VERSION,
+        record_version: root.format_version,
         encoding: ProjectParticipantEncoding::Json,
         schema_fingerprint: fingerprint(
             CanonicalDomain::Schema,
             CANONICAL_CONTRACT_VERSION,
-            GRAPH_FILES_V2_SCHEMA_CANONICAL_BYTES,
+            if root.format_version == GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION {
+                MAPPED_ROOT_SCHEMA
+            } else {
+                GRAPH_FILES_V2_SCHEMA_CANONICAL_BYTES
+            },
         )
         .map_err(|error| GfError::Validation(error.to_string()))?,
         row_count: root.logical_file_count,
@@ -255,12 +271,8 @@ pub(crate) fn decode_graph_files_participant(
         .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| validation("graph files participant format_version is missing"))?;
     match (format, version) {
-        (GRAPH_FILES_FORMAT, version) if version == u64::from(GRAPH_FILES_FORMAT_VERSION) => {
-            decode_inventory(bytes).map(GraphFilesParticipant::V1)
-        }
-        (crate::GRAPH_FILES_V2_FORMAT, version)
-            if version == u64::from(crate::GRAPH_FILES_V2_VERSION) =>
-        {
+        (GRAPH_FILES_FORMAT, 1 | 3) => decode_inventory(bytes).map(GraphFilesParticipant::V1),
+        (crate::GRAPH_FILES_V2_FORMAT, 2 | 4) => {
             crate::decode_graph_files_root_v2(bytes).map(GraphFilesParticipant::V2)
         }
         _ => Err(GfError::Project {
@@ -276,11 +288,11 @@ pub(crate) fn decode_versioned_graph_files_participant(
     bytes: &[u8],
 ) -> Result<GraphFilesParticipant, GfError> {
     let participant = decode_graph_files_participant(bytes)?;
-    if !matches!(
-        (record_version, &participant),
-        (GRAPH_FILES_RECORD_VERSION, GraphFilesParticipant::V1(_))
-            | (GRAPH_FILES_V2_RECORD_VERSION, GraphFilesParticipant::V2(_))
-    ) {
+    let payload_version = match &participant {
+        GraphFilesParticipant::V1(inventory) => inventory.format_version,
+        GraphFilesParticipant::V2(root) => root.format_version,
+    };
+    if record_version != payload_version {
         return Err(validation(
             "graph files descriptor version does not match its encoded payload",
         ));
@@ -471,13 +483,20 @@ pub fn verify_graph_tree(
         {
             return Err(corrupt("generation graph file identity changed"));
         }
-        resolved.insert(
+        if !resolved.insert(
             retained
                 .path
                 .strip_prefix(graph_root)
                 .map_err(|_| corrupt("generation graph path escaped tree"))?
                 .to_path_buf(),
-        );
+        ) {
+            return Err(corrupt(
+                "legacy graph entries have ambiguous physical authority",
+            ));
+        }
+    }
+    if inventory.format_version == GRAPH_FILES_MAPPED_RECORD_VERSION {
+        authenticate_route_table(graph_root, inventory)?;
     }
     if observed != resolved {
         return Err(corrupt(
@@ -485,6 +504,89 @@ pub fn verify_graph_tree(
         ));
     }
     Ok(())
+}
+
+/// Authenticate the retained table bytes before exposing any decoded route.
+pub(crate) fn authenticate_route_table(
+    graph_root: &Path,
+    inventory: &GraphFilesInventory,
+) -> Result<crate::route_component::RouteTable, GfError> {
+    use std::io::{Seek, SeekFrom};
+    const MAX_TABLE_BYTES: u64 = 64 * 1024 * 1024;
+    if inventory.format_version != GRAPH_FILES_MAPPED_RECORD_VERSION {
+        return Err(corrupt(
+            "raw graph layout cannot authorize semantic route decoding",
+        ));
+    }
+    let entry = inventory
+        .files
+        .iter()
+        .find(|entry| entry.relative_path == crate::route_component::TABLE_FILE)
+        .ok_or_else(|| corrupt("mapped graph inventory lacks semantic route authority"))?;
+    if entry.byte_length > MAX_TABLE_BYTES {
+        return Err(GfError::Project {
+            code: ProjectErrorCode::ResourceLimit,
+            message: "semantic route table byte budget exceeded".into(),
+        });
+    }
+    let mut retained = resolve_v1_inventory_entry_retained(graph_root, entry)?;
+    retained
+        .file
+        .seek(SeekFrom::Start(0))
+        .map_err(|_| corrupt("semantic route authority seek failed"))?;
+    let mut bytes = Vec::new();
+    (&mut retained.file)
+        .take(entry.byte_length + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| corrupt("semantic route authority read failed"))?;
+    if bytes.len() as u64 != entry.byte_length
+        || hex_digest(Sha256::digest(&bytes).into()) != entry.content_sha256
+        || graphforge_filesystem::file_identity(&retained.file).ok() != Some(retained.identity)
+    {
+        return Err(corrupt("semantic route authority changed during admission"));
+    }
+    let table = crate::route_component::RouteTable::decode(
+        &bytes,
+        MAX_TABLE_BYTES,
+        MAX_GRAPH_FILES as u64,
+    )?;
+    table.validate_paths(
+        inventory
+            .files
+            .iter()
+            .map(|entry| entry.relative_path.as_str()),
+    )?;
+    Ok(table)
+}
+
+pub(crate) fn read_route_table_counted(
+    root: &Path,
+    entry: &GraphFileEntry,
+) -> Result<(Vec<u8>, u64), GfError> {
+    if entry.relative_path != crate::route_component::TABLE_FILE
+        || entry.byte_length > 64 * 1024 * 1024
+    {
+        return Err(corrupt("invalid route authority read request"));
+    }
+    let mut file = open_retained_relative_file(root, Path::new(crate::route_component::TABLE_FILE))
+        .map_err(|error| storage("open retained route table", root, error))?;
+    let mut bytes = Vec::new();
+    let mut calls = 0_u64;
+    let mut buffer = vec![0_u8; HASH_BUFFER_BYTES];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| storage("read retained route table", root, error))?;
+        if read == 0 {
+            break;
+        }
+        if bytes.len() as u64 + read as u64 > entry.byte_length {
+            return Err(corrupt("route authority exceeds authenticated length"));
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+        calls += 1;
+    }
+    Ok((bytes, calls))
 }
 
 /// Materialize `inventory` from `graph_root` into an empty private `target`.
@@ -501,17 +603,25 @@ pub fn materialize_graph_tree(
 ) -> Result<GraphFilesOpenEvidence, GfError> {
     ensure_empty_directory(target)?;
     verify_graph_tree(graph_root, inventory)?;
+    let mut route_reads = (0_u64, 0_u64);
+    let routes =
+        crate::route_component::materialize::MaterializationRoutes::prepare(inventory, |entry| {
+            let (bytes, calls) = read_route_table_counted(graph_root, entry)?;
+            route_reads = (bytes.len() as u64, calls);
+            Ok(bytes)
+        })?;
     let mut evidence = GraphFilesOpenEvidence {
         strategy: GraphFilesOpenStrategy::PrivateMaterialize,
         files_validated: u64::try_from(inventory.files.len())
             .map_err(|_| validation("graph hydration file inventory exceeds u64"))?,
         bytes_validated: inventory.total_byte_length,
+        application_read_bytes: route_reads.0,
+        application_read_calls: route_reads.1,
         ..GraphFilesOpenEvidence::default()
     };
-    for entry in &inventory.files {
+    for (entry, relative) in inventory.files.iter().zip(&routes.destinations) {
         let source = resolve_v1_inventory_entry(graph_root, entry)?;
-        let relative = canonical_inventory_relative_path(&entry.relative_path)?;
-        let destination = target.join(&relative);
+        let destination = target.join(wire_relative_path(relative)?);
         if let Some(parent) = destination.parent() {
             fs::create_dir_all(parent)
                 .map_err(|error| storage("create private graph directory", parent, error))?;
@@ -559,6 +669,7 @@ pub fn materialize_graph_tree(
             .checked_add(entry.byte_length)
             .ok_or_else(|| validation("graph hydration copied-byte count overflows"))?;
     }
+    routes.install_table(target, &mut evidence)?;
     Ok(evidence)
 }
 
@@ -590,7 +701,9 @@ pub fn infer_role(relative: &Path) -> GraphFileRole {
                 "properties" | "edge_properties" => GraphFileRole::Properties,
                 "indexes" | "index" => GraphFileRole::Index,
                 "deltas" => GraphFileRole::Delta,
-                "runtime_catalog.parquet" => GraphFileRole::Catalog,
+                "runtime_catalog.parquet" | crate::route_component::TABLE_FILE => {
+                    GraphFileRole::Catalog
+                }
                 _ if first.starts_with("runtime_catalog") => GraphFileRole::Catalog,
                 _ => GraphFileRole::Other,
             }
@@ -600,19 +713,53 @@ pub fn infer_role(relative: &Path) -> GraphFileRole {
 }
 
 fn build_inventory(source_root: &Path) -> Result<(GraphFilesInventory, u64), GfError> {
+    build_inventory_for_owned_layout(source_root, false, None)
+}
+
+/// Explicit mutable-workspace admission for migration. Published inventory
+/// decoding and portable transport continue to use their versioned contracts.
+pub(crate) fn capture_owned_route_migration_inventory(
+    source_root: &Path,
+) -> Result<GraphFilesInventory, GfError> {
+    build_inventory_for_owned_layout(source_root, true, None).map(|(inventory, _)| inventory)
+}
+
+fn build_inventory_for_owned_layout(
+    source_root: &Path,
+    admit_raw_routes: bool,
+    rewrite: Option<&crate::RewriteBatch>,
+) -> Result<(GraphFilesInventory, u64), GfError> {
     let mut paths = Vec::new();
     collect_source_files(source_root, &mut paths)?;
+    let temporaries = rewrite
+        .map(crate::RewriteBatch::retained_temporary_identities)
+        .transpose()?
+        .unwrap_or_default();
+    let mut retained_paths = Vec::with_capacity(paths.len());
+    for path in paths {
+        if let Some(identity) = temporaries.get(&path) {
+            if graphforge_filesystem::path_identity(&path).ok() != Some(*identity) {
+                return Err(corrupt("rewrite temporary changed during baseline capture"));
+            }
+        } else {
+            retained_paths.push(path);
+        }
+    }
+    let paths = retained_paths;
     if paths.len() > MAX_GRAPH_FILES {
         return Err(resource_limit("graph files count exceeds limit"));
     }
+    let mapped = paths
+        .iter()
+        .any(|path| path == &source_root.join(crate::route_component::TABLE_FILE));
     let mut paths = paths
         .into_iter()
         .map(|path| {
             let relative = path
                 .strip_prefix(source_root)
                 .map_err(|_| validation("graph file path escaped workspace"))?;
-            validate_relative_path(relative)?;
-            Ok((path_text(relative)?, path))
+            let relative_text = owned_inventory_path_text(relative, admit_raw_routes && !mapped)?;
+            Ok((relative_text, path))
         })
         .collect::<Result<Vec<_>, GfError>>()?;
     paths.sort_by(|(left, _), (right, _)| left.cmp(right));
@@ -650,17 +797,67 @@ fn build_inventory(source_root: &Path) -> Result<(GraphFilesInventory, u64), GfE
     }
     let inventory = GraphFilesInventory {
         format: GRAPH_FILES_FORMAT.into(),
-        format_version: GRAPH_FILES_FORMAT_VERSION,
+        format_version: if files
+            .iter()
+            .any(|entry| entry.relative_path == crate::route_component::TABLE_FILE)
+        {
+            GRAPH_FILES_MAPPED_RECORD_VERSION
+        } else {
+            GRAPH_FILES_FORMAT_VERSION
+        },
         file_count: u64::try_from(files.len()).unwrap_or(u64::MAX),
         total_byte_length: total,
         files,
     };
     validate_inventory_contract(&inventory)?;
+    if inventory.format_version == GRAPH_FILES_MAPPED_RECORD_VERSION {
+        authenticate_route_table(source_root, &inventory)?;
+    }
+    for (path, identity) in temporaries {
+        if graphforge_filesystem::path_identity(&path).ok() != Some(identity) {
+            return Err(corrupt("rewrite temporary changed during baseline capture"));
+        }
+    }
     Ok((inventory, read_calls))
 }
 
+fn owned_inventory_path_text(relative: &Path, admit_raw_routes: bool) -> Result<String, GfError> {
+    if admit_raw_routes {
+        let parts = relative
+            .components()
+            .map(|part| match part {
+                Component::Normal(value) => value
+                    .to_str()
+                    .ok_or_else(|| validation("graph route path is not UTF-8")),
+                _ => Err(validation("invalid owned graph route path")),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let text = parts.join("/");
+        legacy_route_destination(&text)?;
+        Ok(text)
+    } else {
+        validate_relative_path(relative)?;
+        path_text(relative)
+    }
+}
+
+pub(crate) fn capture_rewrite_baseline(
+    root: &Path,
+    rewrite: &crate::RewriteBatch,
+) -> Result<(GraphFilesInventory, u64), GfError> {
+    build_inventory_for_owned_layout(root, false, Some(rewrite))
+}
+
+#[cfg(test)]
 pub(crate) fn inventory_from_entries(
     files: Vec<GraphFileEntry>,
+) -> Result<GraphFilesInventory, GfError> {
+    inventory_from_entries_with_version(files, GRAPH_FILES_FORMAT_VERSION)
+}
+
+pub(crate) fn inventory_from_entries_with_version(
+    files: Vec<GraphFileEntry>,
+    version: u32,
 ) -> Result<GraphFilesInventory, GfError> {
     let total_byte_length = files.iter().try_fold(0_u64, |total, entry| {
         total
@@ -669,7 +866,7 @@ pub(crate) fn inventory_from_entries(
     })?;
     let inventory = GraphFilesInventory {
         format: GRAPH_FILES_FORMAT.into(),
-        format_version: GRAPH_FILES_FORMAT_VERSION,
+        format_version: version,
         file_count: u64::try_from(files.len()).unwrap_or(u64::MAX),
         total_byte_length,
         files,
@@ -682,8 +879,31 @@ fn validate_inventory_contract(inventory: &GraphFilesInventory) -> Result<(), Gf
     if inventory.format != GRAPH_FILES_FORMAT {
         return Err(validation("unsupported graph files inventory format"));
     }
-    if inventory.format_version != GRAPH_FILES_FORMAT_VERSION {
+    if !matches!(
+        inventory.format_version,
+        GRAPH_FILES_FORMAT_VERSION | GRAPH_FILES_MAPPED_RECORD_VERSION
+    ) {
         return Err(unsupported_version(inventory.format_version));
+    }
+    if inventory.format_version == GRAPH_FILES_FORMAT_VERSION
+        && inventory
+            .files
+            .iter()
+            .any(|entry| entry.relative_path == crate::route_component::TABLE_FILE)
+    {
+        return Err(corrupt(
+            "raw graph layout contains reserved semantic route authority",
+        ));
+    }
+    if inventory.format_version == GRAPH_FILES_MAPPED_RECORD_VERSION
+        && !inventory
+            .files
+            .iter()
+            .any(|entry| entry.relative_path == crate::route_component::TABLE_FILE)
+    {
+        return Err(corrupt(
+            "mapped graph inventory lacks semantic route authority",
+        ));
     }
     if inventory.files.len() > MAX_GRAPH_FILES {
         return Err(resource_limit("graph files count exceeds limit"));
@@ -706,8 +926,12 @@ fn validate_inventory_contract(inventory: &GraphFilesInventory) -> Result<(), Gf
         if !seen.insert(entry.relative_path.as_str()) {
             return Err(validation("graph files inventory contains duplicate paths"));
         }
-        let _ = inventory_relative_path_candidates(&entry.relative_path)?;
-        let canonical_destination = canonical_inventory_relative_path(&entry.relative_path)?;
+        let canonical_destination = if inventory.format_version == GRAPH_FILES_FORMAT_VERSION {
+            let _ = inventory_relative_path_candidates(&entry.relative_path)?;
+            legacy_route_destination(&entry.relative_path)?
+        } else {
+            wire_relative_path(&entry.relative_path)?
+        };
         if !canonical_destinations.insert(portable_case_collision_key(&canonical_destination)?) {
             return Err(validation(
                 "graph files inventory paths have an ambiguous canonical destination",
@@ -1115,7 +1339,7 @@ fn path_text(path: &Path) -> Result<String, GfError> {
 
 /// Decode the platform-independent inventory spelling without asking the host
 /// path parser to interpret wire separators or aliases.
-fn wire_relative_path(text: &str) -> Result<PathBuf, GfError> {
+pub(crate) fn wire_relative_path(text: &str) -> Result<PathBuf, GfError> {
     if text.is_empty() || text.starts_with('/') || text.ends_with('/') {
         return Err(validation("invalid graph file wire path"));
     }
@@ -1144,7 +1368,48 @@ pub(crate) fn canonical_inventory_relative_text(text: &str) -> Result<String, Gf
         .replace('\\', "/"))
 }
 
+/// Preserve exact legacy semantic route components while canonicalizing only
+/// legacy wire separators outside recognized route positions.
+pub(crate) fn legacy_inventory_logical_text(text: &str) -> Result<String, GfError> {
+    if crate::route_component::route_position(text)?.is_some() {
+        legacy_route_destination(text)?;
+        Ok(text.to_owned())
+    } else {
+        canonical_inventory_relative_text(text)
+    }
+}
+
+/// Legacy route spellings are admitted only at known semantic positions. The
+/// translated destination still passes the unchanged portable wire validator.
+fn legacy_route_destination(text: &str) -> Result<PathBuf, GfError> {
+    let mut table = crate::route_component::RouteTable::default();
+    let encoded =
+        crate::route_component::encode_relative_route(text, &mut table, 64 * 1024 * 1024, 100_000)?;
+    if encoded == text {
+        canonical_inventory_relative_path(text)
+    } else {
+        wire_relative_path(&encoded)
+    }
+}
+
 fn inventory_relative_path_candidates(text: &str) -> Result<Vec<PathBuf>, GfError> {
+    if crate::route_component::route_position(text)?.is_some() {
+        // Validate semantic containment and every non-route component before
+        // opening the raw legacy spelling. No portable-v2 parser is relaxed.
+        legacy_route_destination(text)?;
+        let exact = text.split('/').fold(PathBuf::new(), |mut path, component| {
+            path.push(component);
+            path
+        });
+        let mut candidates = vec![exact];
+        if text.contains('\\')
+            && let Ok(normalized) = canonical_inventory_relative_path(text)
+            && normalized != candidates[0]
+        {
+            candidates.push(normalized);
+        }
+        return Ok(candidates);
+    }
     if !text.contains('\\') {
         return wire_relative_path(text).map(|path| vec![path]);
     }
@@ -1183,6 +1448,8 @@ pub(crate) struct RetainedV1InventoryEntry {
     pub(crate) identity: graphforge_filesystem::FileIdentity,
 }
 
+/// Retains the authenticated file at its post-hash cursor (EOF). Callers that
+/// read the payload must rewind this same handle before reading.
 pub(crate) fn resolve_v1_inventory_entry_retained(
     graph_root: &Path,
     entry: &GraphFileEntry,
@@ -1346,6 +1613,132 @@ mod tests {
     use super::*;
 
     #[test]
+    fn raw_v1_contract_admits_reserved_routes_without_relaxing_mapped_wire() {
+        let mut files = [
+            "CON", "AUX", "COM1", "LPT9", "CON.foo", "tail.", "tail ", "Name", "name",
+        ]
+        .into_iter()
+        .map(|route| GraphFileEntry {
+            relative_path: format!("properties/{route}.parquet"),
+            byte_length: 1,
+            content_sha256: "0".repeat(64),
+            role: GraphFileRole::Properties,
+        })
+        .collect::<Vec<_>>();
+        files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        let inventory = GraphFilesInventory {
+            format: GRAPH_FILES_FORMAT.into(),
+            format_version: 1,
+            file_count: files.len() as u64,
+            total_byte_length: files.len() as u64,
+            files,
+        };
+        let bytes = encode_inventory(&inventory).unwrap();
+        assert_eq!(decode_inventory(&bytes).unwrap(), inventory);
+        for entry in &inventory.files {
+            assert!(legacy_route_destination(&entry.relative_path).is_ok());
+        }
+        assert!(wire_relative_path("properties/CON.parquet").is_err());
+        assert!(inventory_relative_path_candidates("properties/../secret.parquet").is_err());
+        assert!(inventory_relative_path_candidates("properties/x/nested/secret.parquet").is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn authenticated_raw_reserved_v1_files_keep_native_identity_and_digest_checks() {
+        let source = tempfile::tempdir().unwrap();
+        fs::create_dir(source.path().join("properties")).unwrap();
+        let mut files = Vec::new();
+        for route in ["CON", "con", "AUX"] {
+            let relative_path = format!("properties/{route}.parquet");
+            let path = source.path().join(&relative_path);
+            fs::write(&path, route.as_bytes()).unwrap();
+            files.push(GraphFileEntry {
+                relative_path,
+                byte_length: route.len() as u64,
+                content_sha256: hex_digest(hash_file(&path).unwrap()),
+                role: GraphFileRole::Properties,
+            });
+        }
+        files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        let inventory = GraphFilesInventory {
+            format: GRAPH_FILES_FORMAT.into(),
+            format_version: 1,
+            file_count: files.len() as u64,
+            total_byte_length: files.iter().map(|entry| entry.byte_length).sum(),
+            files,
+        };
+        verify_graph_tree(source.path(), &inventory).unwrap();
+        let victim = source.path().join(&inventory.files[0].relative_path);
+        fs::write(&victim, b"bad").unwrap();
+        assert!(verify_graph_tree(source.path(), &inventory).is_err());
+    }
+
+    #[test]
+    fn mapped_inventory_requires_authenticated_exact_route_authority() {
+        let source = tempfile::tempdir().unwrap();
+        let mut table = crate::route_component::RouteTable::default();
+        let component = table.insert("CON", 4096, 10).unwrap();
+        fs::create_dir(source.path().join("properties")).unwrap();
+        fs::write(
+            source
+                .path()
+                .join(format!("properties/{component}.parquet")),
+            b"property",
+        )
+        .unwrap();
+        fs::write(
+            source.path().join(crate::route_component::TABLE_FILE),
+            table.encode(4096).unwrap(),
+        )
+        .unwrap();
+        let (inventory, _) = build_inventory(source.path()).unwrap();
+        assert_eq!(inventory.format_version, GRAPH_FILES_MAPPED_RECORD_VERSION);
+        let mut raw = inventory.clone();
+        raw.format_version = GRAPH_FILES_RECORD_VERSION;
+        assert!(authenticate_route_table(source.path(), &raw).is_err());
+        assert!(encode_inventory(&raw).is_err());
+        verify_graph_tree(source.path(), &inventory).unwrap();
+        let bytes = encode_inventory(&inventory).unwrap();
+        let participant = inventory_participant(bytes.clone(), inventory.file_count).unwrap();
+        assert_eq!(
+            participant.record_version,
+            GRAPH_FILES_MAPPED_RECORD_VERSION
+        );
+        assert!(
+            decode_versioned_graph_files_participant(GRAPH_FILES_MAPPED_RECORD_VERSION, &bytes)
+                .is_ok()
+        );
+        assert!(
+            decode_versioned_graph_files_participant(GRAPH_FILES_RECORD_VERSION, &bytes).is_err()
+        );
+        let mut missing = inventory.clone();
+        missing
+            .files
+            .retain(|entry| entry.relative_path != crate::route_component::TABLE_FILE);
+        missing.file_count = missing.files.len() as u64;
+        missing.total_byte_length = missing.files.iter().map(|entry| entry.byte_length).sum();
+        assert!(encode_inventory(&missing).is_err());
+        let mut hidden = inventory.clone();
+        let property = hidden
+            .files
+            .iter_mut()
+            .find(|entry| entry.relative_path.starts_with("properties/"))
+            .unwrap();
+        property.relative_path = property.relative_path.replace('/', "\\");
+        hidden
+            .files
+            .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        assert!(encode_inventory(&hidden).is_err());
+        fs::write(
+            source.path().join(crate::route_component::TABLE_FILE),
+            b"{}\n",
+        )
+        .unwrap();
+        assert!(authenticate_route_table(source.path(), &inventory).is_err());
+    }
+
+    #[test]
     fn inventory_round_trip_is_canonical_and_path_ordered() {
         let source = tempfile::tempdir().unwrap();
         fs::create_dir_all(source.path().join("topology/edges")).unwrap();
@@ -1472,7 +1865,23 @@ mod tests {
         let private = tempfile::tempdir().unwrap();
         materialize_graph_tree(graph_root.path(), &inventory, private.path()).unwrap();
         let (republished, participant) = capture_graph_files(private.path()).unwrap();
-        assert_eq!(republished.files[0].relative_path, "topology/nodes.parquet");
+        assert_eq!(
+            republished.format_version,
+            GRAPH_FILES_MAPPED_RECORD_VERSION
+        );
+        assert_eq!(
+            republished
+                .files
+                .iter()
+                .map(|entry| entry.relative_path.as_str())
+                .collect::<Vec<_>>(),
+            [crate::route_component::TABLE_FILE, "topology/nodes.parquet"]
+        );
+        assert_eq!(
+            fs::read(private.path().join("topology/nodes.parquet")).unwrap(),
+            b"nodes"
+        );
+        authenticate_route_table(private.path(), &republished).unwrap();
         assert!(!participant.bytes.contains(&b'\\'));
     }
 
@@ -1727,12 +2136,20 @@ mod tests {
         assert_eq!(opened.files_copied, 2);
         assert_eq!(opened.application_read_bytes, inventory.total_byte_length);
         assert_eq!(opened.application_read_calls, 2);
-        assert_eq!(opened.application_write_bytes, inventory.total_byte_length);
-        assert_eq!(opened.application_write_calls, 2);
-        assert_eq!(opened.fsync_calls, 4);
-        assert_eq!(opened.file_fsync_calls, 4);
-        assert_eq!(opened.directory_fsync_calls, 0);
-        let private_copy = private.path().join("properties/Person.parquet");
+        let table_bytes =
+            fs::read(private.path().join(crate::route_component::TABLE_FILE)).unwrap();
+        assert_eq!(
+            opened.application_write_bytes,
+            inventory.total_byte_length + table_bytes.len() as u64
+        );
+        assert_eq!(opened.application_write_calls, 3);
+        assert_eq!(opened.fsync_calls, 6);
+        assert_eq!(opened.file_fsync_calls, 5);
+        assert_eq!(opened.directory_fsync_calls, 1);
+        let private_copy = private.path().join(format!(
+            "properties/{}.parquet",
+            crate::route_component::component("Person")
+        ));
         assert!(
             fs::metadata(&sealed_source)
                 .unwrap()
@@ -1777,6 +2194,27 @@ mod tests {
         )
         .unwrap();
         assert!(verify_graph_tree(&graph_tree_root(generation.path()), &inventory).is_err());
+    }
+
+    #[test]
+    fn checkpoint_restores_exact_legacy_routes_without_layout_upgrade() {
+        let target = tempfile::tempdir().unwrap();
+        fs::create_dir(target.path().join("properties")).unwrap();
+        let path = target.path().join("properties/Person.parquet");
+        fs::write(&path, b"original").unwrap();
+        let before = capture_graph_files(target.path()).unwrap().0;
+        assert_eq!(before.format_version, GRAPH_FILES_FORMAT_VERSION);
+        let mut checkpoint = GraphWorkspaceCheckpoint::capture(target.path()).unwrap();
+        fs::write(&path, b"changed").unwrap();
+        checkpoint.restore(target.path()).unwrap();
+        assert_eq!(capture_graph_files(target.path()).unwrap().0, before);
+        assert_eq!(fs::read(path).unwrap(), b"original");
+        assert!(
+            !target
+                .path()
+                .join(crate::route_component::TABLE_FILE)
+                .exists()
+        );
     }
 
     #[test]
@@ -2127,7 +2565,23 @@ impl GraphWorkspaceCheckpoint {
         let (inventory, source_was_absent) = match fs::symlink_metadata(source) {
             Ok(_) => {
                 let (inventory, _) = capture_graph_files(source)?;
-                materialize_graph_tree(source, &inventory, backup.path())?;
+                // A rollback snapshot preserves the admitted layout exactly;
+                // ordinary hydration may instead upgrade legacy route names.
+                for entry in &inventory.files {
+                    let input = resolve_v1_inventory_entry(source, entry)?;
+                    let relative = input
+                        .strip_prefix(source)
+                        .map_err(|_| validation("rollback source escaped workspace"))?;
+                    let output = backup.path().join(relative);
+                    if let Some(parent) = output.parent() {
+                        fs::create_dir_all(parent).map_err(|error| {
+                            storage("create rollback snapshot directory", parent, error)
+                        })?;
+                    }
+                    copy_regular_file(&input, &output)?;
+                    make_private_copy_owner_writable(&output)?;
+                }
+                verify_graph_tree(backup.path(), &inventory)?;
                 (inventory, false)
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -2200,8 +2654,10 @@ impl GraphWorkspaceCheckpoint {
                 .map_err(|error| storage("remove aborted mutation file", &path, error))?;
         }
         for entry in &self.inventory.files {
-            let relative = canonical_inventory_relative_path(&entry.relative_path)?;
-            let source = backup.path().join(&relative);
+            let source = resolve_v1_inventory_entry(backup.path(), entry)?;
+            let relative = source
+                .strip_prefix(backup.path())
+                .map_err(|_| validation("rollback source escaped backup"))?;
             let destination = target.join(relative);
             if let Some(parent) = destination.parent() {
                 fs::create_dir_all(parent)

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -107,6 +107,8 @@ pub struct GraphManifestResolveEvidence {
     pub entries_examined: u64,
     /// Aggregate encoded bytes admitted for decoding.
     pub decoded_bytes: u64,
+    /// Authenticated route-table bytes read outside radix-node decoding.
+    pub authority_read_bytes: u64,
     /// Nonempty reads performed by a storage-backed resolver; zero for in-memory resolution.
     pub application_read_calls: u64,
     /// Aggregate node, child-reference, and entry work performed.
@@ -457,7 +459,12 @@ fn admit_work(
 }
 
 fn validate_root(root: &GraphFilesRootV2) -> Result<(), GfError> {
-    if root.format != GRAPH_FILES_V2_FORMAT || root.format_version != GRAPH_FILES_V2_VERSION {
+    if root.format != GRAPH_FILES_V2_FORMAT
+        || !matches!(
+            root.format_version,
+            GRAPH_FILES_V2_VERSION | crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
+        )
+    {
         return Err(validation("unsupported graph files v2 root contract"));
     }
     validate_digest(&root.root_node_sha256)

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -810,6 +810,27 @@ impl GraphManifestState {
                 .ok_or_else(|| validation("manifest open read calls overflow"))?;
             Ok(bytes)
         })?;
+        let mut authority_read_bytes = 0_u64;
+        crate::route_component::authenticate_manifest_routes(
+            root.format_version,
+            &entries,
+            |entry| {
+                let (bytes, io) = read_graph_object_by_digest_file_counted(
+                    lease.cas.open_digest(&entry.content_sha256)?,
+                    &entry.content_sha256,
+                    64 * 1024 * 1024,
+                    &lease.cas.diagnostic_root,
+                )?;
+                authority_read_bytes = authority_read_bytes
+                    .checked_add(io.bytes)
+                    .ok_or_else(|| validation("route authority read bytes overflow"))?;
+                read_calls = read_calls
+                    .checked_add(io.calls)
+                    .ok_or_else(|| validation("route authority read count overflow"))?;
+                Ok(bytes)
+            },
+        )?;
+        evidence.authority_read_bytes = authority_read_bytes;
         evidence.application_read_calls = read_calls;
         Ok((
             Self {
@@ -1208,7 +1229,33 @@ pub fn append_graph_files_v2(
     sealed_paths: &[PathBuf],
     tombstones: &[String],
 ) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
-    append_graph_files_v2_inner(lease, workspace, state, sealed_paths, None, tombstones)
+    append_graph_files_v2_inner(
+        lease,
+        workspace,
+        state,
+        sealed_paths,
+        None,
+        tombstones,
+        None,
+    )
+}
+
+/// Seal a verified mapped import into a fresh CAS root, checking exact table closure.
+pub(crate) fn append_mapped_import_graph_files(
+    lease: &GraphObjectPublicationLease,
+    workspace: &Path,
+    paths: &[PathBuf],
+    routes: &crate::route_component::RouteTable,
+) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    append_graph_files_v2_inner(
+        lease,
+        workspace,
+        &mut GraphManifestState::empty(),
+        paths,
+        None,
+        &[],
+        Some(routes),
+    )
 }
 
 /// Publish writer-authenticated files with one copy-and-hash authentication
@@ -1231,7 +1278,106 @@ pub(crate) fn append_authenticated_graph_files_v2(
         &paths,
         Some(sealed_files),
         tombstones,
+        None,
     )
+}
+
+/// Append a checkpoint-authorized mapped encoding, retaining legacy payload objects by digest.
+pub(crate) fn append_authenticated_mapped_graph_files(
+    lease: &GraphObjectPublicationLease,
+    workspace: &Path,
+    state: &mut GraphManifestState,
+    sealed_files: &[AuthenticatedGraphFile],
+    tombstones: &[String],
+    routes: &crate::route_component::RouteTable,
+) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    validate_publication_identity(lease)?;
+    if state
+        .project_identity
+        .is_some_and(|identity| identity != lease.cas.project.identity())
+    {
+        return Err(validation(
+            "graph manifest state belongs to a different project",
+        ));
+    }
+    let mut staged = state.clone();
+    let mut migration_io = GraphPublicationIo::default();
+    let mut changed = 0_u64;
+    if staged
+        .root
+        .as_ref()
+        .is_some_and(|root| root.format_version == GRAPH_FILES_V2_VERSION)
+    {
+        let mut rebuilt = BTreeMap::new();
+        let mut expected = crate::route_component::RouteTable::default();
+        let mut digest = install_manifest_node(lease, &empty_branch(0), &mut migration_io)?;
+        for old in staged.entries.values() {
+            let logical = crate::graph_files::legacy_inventory_logical_text(&old.relative_path)?;
+            let path = crate::route_component::encode_relative_route(
+                &logical,
+                &mut expected,
+                64 * 1024 * 1024,
+                100_000,
+            )?;
+            if let Some(component) = crate::route_component::route_position(&path)?
+                && routes.route(component)? != expected.route(component)?
+            {
+                return Err(validation(
+                    "mapped parent route differs from encoding authority",
+                ));
+            }
+            let mut entry = old.clone();
+            entry.relative_path.clone_from(&path);
+            if rebuilt.insert(path.clone(), entry.clone()).is_some() {
+                return Err(validation("mapped parent paths collide"));
+            }
+            digest = update_manifest_path(
+                lease,
+                Some(&digest),
+                0,
+                &path,
+                Some(entry),
+                &mut migration_io,
+            )?
+            .ok_or_else(|| validation("mapped parent root disappeared"))?;
+            changed = changed
+                .checked_add(1)
+                .ok_or_else(|| validation("mapped parent count overflow"))?;
+        }
+        staged.entries = rebuilt;
+        let root = staged.root.as_mut().expect("legacy parent root exists");
+        root.root_node_sha256 = digest;
+        root.format_version = crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION;
+    }
+    let paths = sealed_files
+        .iter()
+        .map(|file| file.relative_path.clone())
+        .collect::<Vec<_>>();
+    let (root, mut evidence) = append_graph_files_v2_inner(
+        lease,
+        workspace,
+        &mut staged,
+        &paths,
+        Some(sealed_files),
+        tombstones,
+        Some(routes),
+    )?;
+    evidence.publication_io.checked_add_assign(&migration_io)?;
+    let totals = evidence.publication_io.totals()?;
+    evidence.bytes_installed = totals.installed_bytes;
+    evidence.read_calls = totals.read_calls;
+    evidence.write_calls = totals.write_calls;
+    evidence.write_bytes = totals.write_bytes;
+    evidence.fsync_calls = totals
+        .file_fsync_calls
+        .checked_add(totals.directory_fsync_calls)
+        .ok_or_else(|| validation("mapped synchronization count overflow"))?;
+    evidence.changed_entries_examined = evidence
+        .changed_entries_examined
+        .checked_add(changed)
+        .ok_or_else(|| validation("mapped changed entry count overflow"))?;
+    *state = staged;
+    Ok((root, evidence))
 }
 
 #[allow(clippy::too_many_lines)]
@@ -1242,6 +1388,7 @@ fn append_graph_files_v2_inner(
     sealed_paths: &[PathBuf],
     authenticated: Option<&[AuthenticatedGraphFile]>,
     tombstones: &[String],
+    mapped_routes: Option<&crate::route_component::RouteTable>,
 ) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
     validate_publication_identity(lease)?;
     if state
@@ -1336,6 +1483,27 @@ fn append_graph_files_v2_inner(
                 .ok_or_else(|| validation("graph files v2 logical byte total underflows"))?;
         }
     }
+    if let Some(routes) = mapped_routes {
+        let mut final_entries = state.entries.clone();
+        for entry in &additions {
+            final_entries.insert(entry.relative_path.clone(), entry.clone());
+        }
+        for path in &tombstones {
+            final_entries.remove(path);
+        }
+        routes.validate_paths(final_entries.keys().map(String::as_str))?;
+        let table = routes.encode(64 * 1024 * 1024)?;
+        let authority = final_entries
+            .get(crate::route_component::TABLE_FILE)
+            .ok_or_else(|| validation("mapped publication lacks route authority"))?;
+        if authority.byte_length != table.len() as u64
+            || authority.content_sha256 != hex_digest(Sha256::digest(&table).into())
+        {
+            return Err(validation(
+                "mapped publication route authority differs from sealed table",
+            ));
+        }
+    }
     // All payload objects are authenticated before any manifest node can
     // reference them. A returned error here therefore leaves only unreferenced,
     // retry-safe CAS state.
@@ -1398,7 +1566,11 @@ fn append_graph_files_v2_inner(
         .ok_or_else(|| validation("graph files v2 file total overflow"))?;
     let root = GraphFilesRootV2 {
         format: GRAPH_FILES_V2_FORMAT.into(),
-        format_version: GRAPH_FILES_V2_VERSION,
+        format_version: if mapped_routes.is_some() {
+            crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
+        } else {
+            GRAPH_FILES_V2_VERSION
+        },
         root_node_sha256: root_digest,
         logical_file_count: u64::try_from(logical_file_count)
             .map_err(|_| validation("graph files v2 logical file count exceeds u64"))?,
@@ -2051,6 +2223,11 @@ pub fn materialize_graph_objects(
     target: &Path,
 ) -> Result<GraphFilesOpenEvidence, GfError> {
     let lease = begin_graph_object_publication(root)?;
+    let mut route_io = GraphObjectIoTotals::default();
+    let routes =
+        crate::route_component::materialize::MaterializationRoutes::prepare(inventory, |entry| {
+            read_graph_object_counted(root, &entry.content_sha256, 64 * 1024 * 1024, &mut route_io)
+        })?;
     let _target_guard = open_empty_materialization_target(target)?;
     let target_directory = StableDirectory::open(target)
         .map_err(|error| storage("retain stable materialization target", target, error))?;
@@ -2058,10 +2235,17 @@ pub fn materialize_graph_objects(
         strategy: GraphFilesOpenStrategy::PrivateMaterialize,
         files_validated: inventory.file_count,
         bytes_validated: inventory.total_byte_length,
+        application_read_bytes: route_io.read_bytes,
+        application_read_calls: route_io.read_calls,
         ..GraphFilesOpenEvidence::default()
     };
-    for entry in &inventory.files {
-        let materialized = materialize_from_cas(&lease.cas, &target_directory, entry)?;
+    for (entry, destination) in inventory.files.iter().zip(&routes.destinations) {
+        let mut translated = entry.clone();
+        translated.relative_path.clone_from(destination);
+        let copy_route =
+            routes.legacy && crate::route_component::route_position(destination)?.is_some();
+        let materialized =
+            materialize_from_cas(&lease.cas, &target_directory, &translated, copy_route)?;
         evidence.application_read_bytes = evidence
             .application_read_bytes
             .checked_add(materialized.read_bytes)
@@ -2110,6 +2294,7 @@ pub fn materialize_graph_objects(
                 .ok_or_else(|| validation("object hydration reused-byte count overflows"))?;
         }
     }
+    routes.install_table(target, &mut evidence)?;
     lease.revalidate_for_publish()?;
     Ok(evidence)
 }
@@ -2118,6 +2303,7 @@ fn materialize_from_cas(
     cas: &CasRoot,
     target: &StableDirectory,
     entry: &crate::GraphFileEntry,
+    copy_route: bool,
 ) -> Result<MaterializeIoEvidence, GfError> {
     validate_logical_path(Path::new(&entry.relative_path))?;
     let bucket = cas.digest_bucket(&entry.content_sha256, false)?;
@@ -2150,7 +2336,7 @@ fn materialize_from_cas(
             })?);
         } else {
             let parent = parent.as_ref().unwrap_or(target);
-            if requires_single_link_materialization(&entry.relative_path) {
+            if copy_route || requires_single_link_materialization(&entry.relative_path) {
                 return copy_single_link_materialized_object(cas, &source, parent, name, entry);
             }
             let (installed, installed_identity) = bucket
@@ -2199,6 +2385,9 @@ struct MaterializeIoEvidence {
 }
 
 fn requires_single_link_materialization(relative_path: &str) -> bool {
+    if relative_path == crate::route_component::TABLE_FILE {
+        return true;
+    }
     let Some(name) = relative_path.strip_prefix("topology/uuid-membership/") else {
         return false;
     };
@@ -4774,10 +4963,12 @@ mod tests {
     }
 
     #[test]
-    fn materialization_preserves_ordinary_workspace_relative_paths() {
+    fn materialization_translates_legacy_topology_route_and_counts_owned_copy() {
         let root = tempfile::tempdir().unwrap();
         let payload = b"ordinary topology payload";
         let (digest, _) = install_graph_object_bytes(root.path(), payload).unwrap();
+        let source_path = graph_object_path(root.path(), &digest).unwrap();
+        let source_identity = graphforge_filesystem::path_identity(&source_path).unwrap();
         let inventory = crate::graph_files::inventory_from_entries(vec![crate::GraphFileEntry {
             relative_path: "topology/edges/knows.parquet".into(),
             byte_length: payload.len() as u64,
@@ -4791,18 +4982,44 @@ mod tests {
         let evidence = materialize_graph_objects(root.path(), &inventory, &target).unwrap();
 
         assert_eq!(
-            fs::read(target.join("topology/edges/knows.parquet")).unwrap(),
+            fs::read(target.join("topology/edges").join(format!(
+                "{}.parquet",
+                crate::route_component::component("knows")
+            )))
+            .unwrap(),
             payload
         );
+        assert!(!target.join("topology/edges/knows.parquet").exists());
+        let table_bytes = fs::read(target.join(crate::route_component::TABLE_FILE))
+            .unwrap()
+            .len() as u64;
+        assert_eq!(fs::read(&source_path).unwrap(), payload);
+        assert_eq!(
+            graphforge_filesystem::path_identity(&source_path).unwrap(),
+            source_identity
+        );
+        assert_ne!(
+            graphforge_filesystem::path_identity(&target.join("topology/edges").join(format!(
+                "{}.parquet",
+                crate::route_component::component("knows")
+            )))
+            .unwrap(),
+            source_identity
+        );
         assert!(!target.join("files").exists());
-        assert_eq!(evidence.files_reused, 1);
-        assert_eq!(evidence.bytes_reused, payload.len() as u64);
-        assert_eq!(evidence.files_copied, 0);
-        assert_eq!(evidence.application_read_bytes, payload.len() as u64);
-        assert_eq!(evidence.application_read_calls, 1);
-        assert_eq!(evidence.application_write_bytes, 0);
-        assert_eq!(evidence.application_write_calls, 0);
-        assert_eq!(evidence.fsync_calls, 0);
+        assert_eq!(evidence.files_reused, 0);
+        assert_eq!(evidence.bytes_reused, 0);
+        assert_eq!(evidence.files_copied, 1);
+        assert_eq!(evidence.application_read_bytes, payload.len() as u64 * 2);
+        assert_eq!(evidence.application_read_calls, 2);
+        assert_eq!(
+            evidence.application_write_bytes,
+            payload.len() as u64 + table_bytes
+        );
+        assert_eq!(evidence.application_write_calls, 2);
+        assert_eq!(evidence.fsync_calls, 4);
+        assert_eq!(evidence.file_fsync_calls, 2);
+        assert_eq!(evidence.directory_fsync_calls, 2);
     }
 
     #[test]
@@ -4850,11 +5067,17 @@ mod tests {
             .count() as u64;
         assert_eq!(evidence.application_read_bytes, nonempty_bytes * 2);
         assert_eq!(evidence.application_read_calls, nonempty_files * 2);
-        assert_eq!(evidence.application_write_bytes, nonempty_bytes);
-        assert_eq!(evidence.application_write_calls, nonempty_files);
-        assert_eq!(evidence.fsync_calls, inventory.file_count * 2);
-        assert_eq!(evidence.file_fsync_calls, inventory.file_count);
-        assert_eq!(evidence.directory_fsync_calls, inventory.file_count);
+        let table_bytes = fs::read(target.join(crate::route_component::TABLE_FILE))
+            .unwrap()
+            .len() as u64;
+        assert_eq!(
+            evidence.application_write_bytes,
+            nonempty_bytes + table_bytes
+        );
+        assert_eq!(evidence.application_write_calls, nonempty_files + 1);
+        assert_eq!(evidence.fsync_calls, inventory.file_count * 2 + 2);
+        assert_eq!(evidence.file_fsync_calls, inventory.file_count + 1);
+        assert_eq!(evidence.directory_fsync_calls, inventory.file_count + 1);
         for entry in &inventory.files {
             let file = File::open(target.join(&entry.relative_path)).unwrap();
             assert_eq!(graphforge_filesystem::file_link_count(&file).unwrap(), 1);

--- a/crates/graphforge-storage/src/graph_projection.rs
+++ b/crates/graphforge-storage/src/graph_projection.rs
@@ -7,6 +7,7 @@
 use graphforge_value::{EntityTypeId, PrimaryEntityTypeId, RuntimeEntityId};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::{self, File};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -26,6 +27,90 @@ use graphforge_core::canonical::{
 use parquet::arrow::ArrowWriter;
 
 mod runtime_remap;
+
+/// Route authority captured once for a private graph transform. Never migrates the source.
+pub(crate) struct TransformRoutes {
+    table: Option<crate::route_component::RouteTable>,
+    pub(crate) properties: crate::AuthenticatedPropertyInventory,
+}
+
+impl TransformRoutes {
+    pub(crate) fn capture(root: &Path) -> Result<Self, GfError> {
+        let (inventory, _) = crate::capture_graph_files(root)?;
+        Self::from_inventory(root, inventory)
+    }
+
+    pub(crate) fn from_inventory(
+        root: &Path,
+        inventory: crate::GraphFilesInventory,
+    ) -> Result<Self, GfError> {
+        let table = match inventory.format_version {
+            crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION => Some(
+                crate::graph_files::authenticate_route_table(root, &inventory)?,
+            ),
+            crate::graph_files::GRAPH_FILES_RECORD_VERSION => None,
+            _ => {
+                return Err(validation(
+                    "graph transform requires an expanded graph inventory",
+                ));
+            }
+        };
+        let properties =
+            crate::AuthenticatedPropertyInventory::from_inventory_at_root(root, inventory, None)?;
+        Ok(Self { table, properties })
+    }
+
+    pub(crate) fn semantic_path(&self, relative: &str) -> Result<String, GfError> {
+        match &self.table {
+            Some(table) => table.semantic_relative_path(relative),
+            None => crate::graph_files::legacy_inventory_logical_text(relative),
+        }
+    }
+
+    pub(crate) fn property_batches(
+        &self,
+        root: &Path,
+        route: &str,
+        edge: bool,
+    ) -> Result<Vec<RecordBatch>, GfError> {
+        let mut batches = Vec::new();
+        crate::catalog::visit_property_overlay_batched_with_inventory(
+            root,
+            Some(&self.properties),
+            route,
+            edge,
+            8192,
+            |batch| {
+                batches.push(batch.clone());
+                Ok(true)
+            },
+        )
+        .map_err(storage)?;
+        Ok(batches)
+    }
+}
+
+pub(crate) fn encode_transform_path(
+    relative: &str,
+    table: &mut crate::route_component::RouteTable,
+) -> Result<String, GfError> {
+    crate::route_component::encode_relative_route(relative, table, 64 * 1024 * 1024, 100_000)
+}
+
+/// The caller owns this unpublished graph and has finished emitting every route.
+pub(crate) fn install_transform_table(
+    root: &Path,
+    table: &crate::route_component::RouteTable,
+) -> Result<(), GfError> {
+    let bytes = table.encode(64 * 1024 * 1024)?;
+    let mut file = File::options()
+        .write(true)
+        .create_new(true)
+        .open(root.join(crate::route_component::TABLE_FILE))
+        .map_err(storage)?;
+    file.write_all(&bytes).map_err(storage)?;
+    file.sync_all().map_err(storage)
+}
 
 type GraphUuid = [u8; 16];
 type EdgeEndpoints = BTreeMap<GraphUuid, (GraphUuid, GraphUuid)>;
@@ -106,6 +191,8 @@ fn materialize_graph_projection_with_options(
     validate_distinct_paths(source, target)?;
     validate_graph_empty_target(target)?;
 
+    let routes = TransformRoutes::capture(source)?;
+    let mut output_table = crate::route_component::RouteTable::default();
     let node_paths = crate::mutator::node_parquet_files(source).map_err(storage)?;
     let node_ids = uuid_rows_files(&node_paths, "node_uuid")?;
     require_present(&selection.node_uuids, &node_ids, "node")?;
@@ -134,16 +221,28 @@ fn materialize_graph_projection_with_options(
             &selection.exclude_properties,
         )?;
     }
-    project_parquet_directory(
-        &source.join("topology/edges"),
-        &target.join("topology/edges"),
-        "edge_uuid",
-        &selected_edges,
-        &BTreeSet::new(),
-    )?;
+    for path in edge_files {
+        let relative = path
+            .strip_prefix(source)
+            .map_err(storage)?
+            .to_str()
+            .ok_or_else(|| validation("graph path is not UTF-8"))?
+            .replace('\\', "/");
+        let semantic = routes.semantic_path(&relative)?;
+        let destination = encode_transform_path(&semantic, &mut output_table)?;
+        project_parquet_file(
+            &path,
+            &target.join(destination),
+            "edge_uuid",
+            &selected_edges,
+            &BTreeSet::new(),
+        )?;
+    }
     project_property_directory(
         source,
         target,
+        &routes,
+        &mut output_table,
         false,
         "node_uuid",
         &selected_nodes,
@@ -152,11 +251,14 @@ fn materialize_graph_projection_with_options(
     project_property_directory(
         source,
         target,
+        &routes,
+        &mut output_table,
         true,
         "edge_uuid",
         &selected_edges,
         &selection.exclude_properties,
     )?;
+    install_transform_table(target, &output_table)?;
     copy_runtime_catalog(source, target)?;
     if copy_ontology_files {
         for file in [
@@ -263,28 +365,6 @@ fn uuid_rows_files(paths: &[PathBuf], column: &str) -> Result<BTreeSet<GraphUuid
     Ok(rows)
 }
 
-fn project_parquet_directory(
-    source: &Path,
-    target: &Path,
-    key: &str,
-    selected: &BTreeSet<[u8; 16]>,
-    exclude_properties: &BTreeSet<String>,
-) -> Result<(), GfError> {
-    for path in sorted_parquet_files(source)? {
-        let relative = path
-            .strip_prefix(source)
-            .map_err(|_| validation("graph parquet path escaped source directory"))?;
-        project_parquet_file(
-            &path,
-            &target.join(relative),
-            key,
-            selected,
-            exclude_properties,
-        )?;
-    }
-    Ok(())
-}
-
 fn project_parquet_file(
     source: &Path,
     target: &Path,
@@ -309,38 +389,40 @@ fn project_parquet_file(
     project_record_batch(&combined, target, key, selected, exclude_properties)
 }
 
+#[allow(clippy::too_many_arguments)] // explicit input authority and output table belong to one transform
 fn project_property_directory(
     source: &Path,
     target: &Path,
+    authority: &TransformRoutes,
+    table: &mut crate::route_component::RouteTable,
     edge: bool,
     key: &str,
     selected: &BTreeSet<[u8; 16]>,
     exclude_properties: &BTreeSet<String>,
 ) -> Result<(), GfError> {
-    let routes = if edge {
-        crate::catalog::list_edge_property_stems(source)
+    let kind = if edge {
+        crate::PropertyRouteKind::Edge
     } else {
-        crate::catalog::list_property_stems(source)
+        crate::PropertyRouteKind::Node
     };
+    let routes = authority.properties.routes(kind);
     let directory = if edge {
         "edge_properties"
     } else {
         "properties"
     };
     for route in routes {
-        let batches = if edge {
-            crate::catalog::read_edge_properties(source, &route)
-        } else {
-            crate::catalog::read_properties(source, &route)
-        }
-        .map_err(|error| GfError::Storage(error.to_string()))?;
+        let batches = authority.property_batches(source, route, edge)?;
         let Some(schema) = batches.first().map(RecordBatch::schema) else {
             continue;
         };
         let combined = concat_batches(&schema, &batches).map_err(storage)?;
         project_record_batch(
             &combined,
-            &target.join(directory).join(format!("{route}.parquet")),
+            &target.join(encode_transform_path(
+                &format!("{directory}/{route}.parquet"),
+                table,
+            )?),
             key,
             selected,
             exclude_properties,
@@ -438,6 +520,7 @@ fn copy_runtime_catalog(source: &Path, target: &Path) -> Result<(), GfError> {
     reason = "catalog dependency closure remains one auditable selection pass"
 )]
 fn selected_catalog_rows(target: &Path, catalog: &RecordBatch) -> Result<Vec<usize>, GfError> {
+    let authority = TransformRoutes::capture(target)?;
     let mut type_ids = HashSet::new();
     for nodes in crate::mutator::node_parquet_files(target).map_err(storage)? {
         for batch in read_parquet(&nodes)? {
@@ -489,7 +572,22 @@ fn selected_catalog_rows(target: &Path, catalog: &RecordBatch) -> Result<Vec<usi
     let mut relation_names = BTreeSet::new();
     let edge_root = target.join("topology/edges");
     for path in sorted_parquet_files(&edge_root)? {
-        let stem = edge_relation_name(&edge_root, &path)?;
+        let logical = authority.semantic_path(
+            &path
+                .strip_prefix(target)
+                .map_err(storage)?
+                .to_str()
+                .ok_or_else(|| validation("edge path is not UTF-8"))?
+                .replace('\\', "/"),
+        )?;
+        let parts = logical.split('/').collect::<Vec<_>>();
+        let stem = match parts.as_slice() {
+            ["topology", "edges", file] => file
+                .strip_suffix(".parquet")
+                .ok_or_else(|| validation("edge route suffix is invalid"))?,
+            ["topology", "edges", route, _] => route,
+            _ => return Err(validation("edge route shape is invalid")),
+        };
         let batches = read_parquet(&path)?;
         if stem != "_exploratory" && batches.iter().any(|batch| batch.num_rows() != 0) {
             relation_names.insert(stem.to_owned());
@@ -628,6 +726,7 @@ pub(crate) fn projected_graph_fingerprint(root: &Path) -> Result<[u8; 32], GfErr
 /// Portable semantic graph identity excludes runtime catalog IDs while
 /// retaining decoded topology, edges, node properties, and edge properties.
 pub(crate) fn portable_graph_data_fingerprint(root: &Path) -> Result<[u8; 32], GfError> {
+    let authority = TransformRoutes::capture(root)?;
     let runtime_entity_names = portable_runtime_entity_names(root)?;
     let mut tables = Vec::<(String, RecordBatch)>::new();
     let node_paths = crate::mutator::node_parquet_files(root).map_err(storage)?;
@@ -656,23 +755,18 @@ pub(crate) fn portable_graph_data_fingerprint(root: &Path) -> Result<[u8; 32], G
         let batches = read_parquet(&path)?;
         let schema = batches[0].schema();
         tables.push((
-            relative,
+            authority.semantic_path(&relative)?,
             concat_batches(&schema, &batches).map_err(storage)?,
         ));
     }
     for (directory, is_edge) in [("properties", false), ("edge_properties", true)] {
-        let stems = if is_edge {
-            crate::catalog::list_edge_property_stems(root)
+        let kind = if is_edge {
+            crate::PropertyRouteKind::Edge
         } else {
-            crate::catalog::list_property_stems(root)
+            crate::PropertyRouteKind::Node
         };
-        for stem in stems {
-            let batches = if is_edge {
-                crate::catalog::read_edge_properties(root, &stem)
-            } else {
-                crate::catalog::read_properties(root, &stem)
-            }
-            .map_err(storage)?;
+        for stem in authority.properties.routes(kind) {
+            let batches = authority.property_batches(root, stem, is_edge)?;
             if let Some(schema) = batches.first().map(RecordBatch::schema) {
                 tables.push((
                     format!("{directory}/{stem}.parquet"),
@@ -709,20 +803,19 @@ fn fingerprint_graph_paths_with_runtime_names(
     paths: Vec<PathBuf>,
     runtime_entity_names: Option<&HashMap<RuntimeEntityId, String>>,
 ) -> Result<[u8; 32], GfError> {
+    let authority = TransformRoutes::capture(root)?;
     let mut logical_tables = BTreeMap::<String, Vec<PathBuf>>::new();
     for path in paths {
         let relative = path
             .strip_prefix(root)
             .map_err(|_| validation("graph projection path escaped target"))?;
-        let components = relative
-            .components()
-            .map(|component| match component {
-                std::path::Component::Normal(value) => value
-                    .to_str()
-                    .ok_or_else(|| validation("graph projection path is not UTF-8")),
-                _ => Err(validation("graph projection path is not canonical")),
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let semantic = authority.semantic_path(
+            &relative
+                .to_str()
+                .ok_or_else(|| validation("graph path is not UTF-8"))?
+                .replace('\\', "/"),
+        )?;
+        let components = semantic.split('/').collect::<Vec<_>>();
         let logical = match components.as_slice() {
             ["topology", "nodes.parquet"] | ["topology", "nodes", _] => {
                 "topology/nodes.parquet".to_owned()
@@ -1281,27 +1374,6 @@ fn sorted_parquet_files(directory: &Path) -> Result<Vec<PathBuf>, GfError> {
     Ok(paths)
 }
 
-fn edge_relation_name<'a>(root: &Path, path: &'a Path) -> Result<&'a str, GfError> {
-    let relative = path
-        .strip_prefix(root)
-        .map_err(|_| validation("edge topology path escaped root"))?;
-    let mut components = relative.components();
-    let first = components
-        .next()
-        .and_then(|component| match component {
-            std::path::Component::Normal(value) => value.to_str(),
-            _ => None,
-        })
-        .ok_or_else(|| validation("edge topology relation is not canonical UTF-8"))?;
-    if components.next().is_some() {
-        Ok(first)
-    } else {
-        path.file_stem()
-            .and_then(|value| value.to_str())
-            .ok_or_else(|| validation("edge topology stem is not UTF-8"))
-    }
-}
-
 fn uuid_column<'a>(
     batch: &'a RecordBatch,
     name: &str,
@@ -1496,6 +1568,18 @@ fn storage(error: impl std::fmt::Display) -> GfError {
 
 #[cfg(test)]
 mod tests {
+    fn admitted_test_path(root: &std::path::Path, semantic: &str) -> std::path::PathBuf {
+        let (inventory, _) = crate::capture_graph_files(root).unwrap();
+        let authority = super::TransformRoutes::from_inventory(root, inventory.clone()).unwrap();
+        let entries = inventory
+            .files
+            .iter()
+            .filter(|entry| authority.semantic_path(&entry.relative_path).unwrap() == semantic)
+            .collect::<Vec<_>>();
+        assert_eq!(entries.len(), 1, "one exact fixture route {semantic}");
+        crate::graph_files::resolve_v1_inventory_entry(root, entries[0]).unwrap()
+    }
+
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -1521,6 +1605,94 @@ mod tests {
         let mut bytes = [0_u8; 16];
         bytes[15] = marker;
         Uuid::from_bytes(bytes)
+    }
+
+    #[test]
+    fn mapped_projection_keeps_exact_routes_and_source_inventory() {
+        let source = TempDir::new().unwrap();
+        let target = TempDir::new().unwrap();
+        let mut writer = GraphWriter::open_at(source.path(), OntologyMode::Strict, TS).unwrap();
+        let a = uuid(120);
+        let b = uuid(121);
+        let edge = uuid(122);
+        for node in [a, b] {
+            writer
+                .create_node(node, EntityTypeId::ontology(TypeId(1)).unwrap())
+                .unwrap();
+        }
+        writer.create_edge(edge, "CON\\route", &a, &b).unwrap();
+        writer
+            .set_properties(
+                &a,
+                Some("AUX\\label"),
+                HashMap::from([("name".into(), IrLiteral::Str("Ada".into()))]),
+            )
+            .unwrap();
+        writer
+            .set_edge_properties(
+                &edge,
+                Some("CON\\route"),
+                HashMap::from([("cost".into(), IrLiteral::Float(2.5))]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        let before = crate::capture_graph_files(source.path()).unwrap().0;
+        let summary = materialize_portable_graph_tree_projection(
+            source.path(),
+            target.path(),
+            &GraphProjectionSelection {
+                node_uuids: BTreeSet::from([*a.as_bytes()]),
+                edge_uuids: BTreeSet::from([*edge.as_bytes()]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(summary.node_uuids, vec![*a.as_bytes(), *b.as_bytes()]);
+        assert_eq!(summary.edge_uuids, vec![*edge.as_bytes()]);
+        let output = crate::capture_graph_files(target.path()).unwrap().0;
+        let table = crate::graph_files::authenticate_route_table(target.path(), &output).unwrap();
+        table
+            .validate_paths(
+                output
+                    .files
+                    .iter()
+                    .map(|entry| entry.relative_path.as_str()),
+            )
+            .unwrap();
+        let authority = TransformRoutes::from_inventory(target.path(), output).unwrap();
+        assert_eq!(
+            authority
+                .properties
+                .routes(crate::PropertyRouteKind::Node)
+                .collect::<Vec<_>>(),
+            vec!["AUX\\label"]
+        );
+        assert_eq!(
+            authority
+                .properties
+                .routes(crate::PropertyRouteKind::Edge)
+                .collect::<Vec<_>>(),
+            vec!["CON\\route"]
+        );
+        let rows = authority
+            .property_batches(target.path(), "CON\\route", true)
+            .unwrap();
+        assert_eq!(
+            rows[0]
+                .column_by_name("cost")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap()
+                .value(0),
+            2.5
+        );
+        assert_eq!(crate::capture_graph_files(source.path()).unwrap().0, before);
+        assert_eq!(
+            portable_graph_data_fingerprint(source.path()).unwrap(),
+            portable_graph_data_fingerprint(target.path()).unwrap()
+        );
     }
 
     #[test]
@@ -1680,15 +1852,22 @@ mod tests {
             &[7, 9]
         );
 
-        let projected_edges =
-            read_parquet(&target.path().join("topology/edges/_exploratory.parquet")).unwrap();
+        let projected_edges = read_parquet(&admitted_test_path(
+            target.path(),
+            "topology/edges/_exploratory.parquet",
+        ))
+        .unwrap();
         assert_eq!(projected_edges[0].num_rows(), 1);
         assert_eq!(
             uuid_at(uuid_column(&projected_edges[0], "edge_uuid").unwrap(), 0).unwrap(),
             *edges[0].as_bytes()
         );
         let source_edge_ids = id_map(
-            &read_parquet(&source.path().join("topology/edges/_exploratory.parquet")).unwrap()[0],
+            &read_parquet(&admitted_test_path(
+                source.path(),
+                "topology/edges/_exploratory.parquet",
+            ))
+            .unwrap()[0],
             "edge_uuid",
             "edge_id",
         );
@@ -1801,8 +1980,8 @@ mod tests {
             "topology/runtime_catalog.parquet",
         ] {
             assert_eq!(
-                fs::read(first.path().join(relative)).unwrap(),
-                fs::read(second.path().join(relative)).unwrap(),
+                fs::read(admitted_test_path(first.path(), relative)).unwrap(),
+                fs::read(admitted_test_path(second.path(), relative)).unwrap(),
                 "non-deterministic output for {relative}"
             );
         }
@@ -1824,7 +2003,7 @@ mod tests {
 
         let mut paths = vec![
             source.path().join("topology/nodes.parquet"),
-            source.path().join("topology/edges/_exploratory.parquet"),
+            admitted_test_path(source.path(), "topology/edges/_exploratory.parquet"),
             source.path().join("topology/runtime_catalog.parquet"),
         ];
         for (kind, route) in [
@@ -2042,9 +2221,10 @@ mod tests {
             actual_nodes,
             vec![alice.as_bytes().to_vec(), bob.as_bytes().to_vec()]
         );
-        let edge = read_parquet(&target.path().join("topology/edges/KNOWS.parquet"))
-            .unwrap()
-            .remove(0);
+        let admitted = TransformRoutes::capture(target.path()).unwrap();
+        let edge_paths = admitted.properties.edge_files(Some("KNOWS"));
+        assert_eq!(edge_paths.len(), 1);
+        let edge = read_parquet(&edge_paths[0].1).unwrap().remove(0);
         for (column, expected) in [("edge_uuid", knows), ("src_uuid", alice), ("dst_uuid", bob)] {
             let ids = edge
                 .column_by_name(column)

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod durable_rewrite;
 mod file_lock;
+mod route_component;
 pub use durable_rewrite::AuxiliaryReceipt;
 #[doc(hidden)]
 pub mod filesystem_admission;
@@ -72,6 +73,7 @@ pub mod graph_files;
 pub(crate) use graph_files::graph_files_root_participant;
 pub use graph_files::{
     GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, GRAPH_FILES_FAMILY, GRAPH_FILES_IO_BUFFER_BYTES,
+    GRAPH_FILES_MAPPED_RECORD_VERSION, GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION,
     GRAPH_FILES_RECORD_VERSION, GRAPH_FILES_V2_RECORD_VERSION, GRAPH_TREE_DIR, GraphFileEntry,
     GraphFileRole, GraphFilesInventory, GraphFilesOpenEvidence, GraphFilesOpenStrategy,
     GraphWorkspaceCheckpoint, GraphWorkspaceRestoration, capture_graph_files, decode_inventory,
@@ -402,14 +404,18 @@ pub use property_overlay::{
 pub mod catalog;
 pub use catalog::{
     AdmittedSourceFile, EdgePropertyTable, GraphCatalog, PropertyTable, TopologyNodeTable,
-    TypedEdgeTable, UnionEdgeTable, count_edge_rows, list_edge_property_stems, list_property_stems,
-    node_property_files, node_property_source_files, node_property_source_fragments,
-    node_topology_present, read_edge_properties, read_edge_properties_projected, read_edges,
-    read_edges_filtered, read_edges_filtered_observed, read_edges_filtered_projected_observed,
-    read_nodes, read_nodes_filtered, read_nodes_filtered_observed,
-    read_nodes_filtered_projected_observed, read_properties, read_properties_batched,
-    topology_node_files, visit_node_fragments_admitted, visit_node_property_overlay_admitted,
-    visit_nodes_batched, visit_properties_batched, visit_property_fragments_admitted,
+    TypedEdgeTable, UnionEdgeTable, count_edge_rows, count_edge_rows_from_inventory,
+    list_edge_property_stems, list_property_stems, node_property_files, node_property_source_files,
+    node_property_source_fragments, node_topology_present, read_edge_properties,
+    read_edge_properties_from_inventory, read_edge_properties_projected,
+    read_edge_properties_projected_from_inventory, read_edges, read_edges_filtered,
+    read_edges_filtered_from_inventory, read_edges_filtered_observed,
+    read_edges_filtered_observed_from_inventory, read_edges_filtered_projected_from_inventory,
+    read_edges_filtered_projected_observed, read_edges_from_inventory, read_nodes,
+    read_nodes_filtered, read_nodes_filtered_observed, read_nodes_filtered_projected_observed,
+    read_properties, read_properties_batched, read_properties_from_inventory, topology_node_files,
+    visit_node_fragments_admitted, visit_node_property_overlay_admitted, visit_nodes_batched,
+    visit_properties_batched, visit_property_fragments_admitted,
 };
 
 pub mod runtime_entity_labels;
@@ -434,12 +440,13 @@ pub use schemas::{
 pub mod writer;
 pub use writer::{
     GraphWriter, GraphWriterLimits, NodePropertySetCounts, count_entity_properties,
-    decode_spatial_property_value, read_entity_properties, read_entity_property_keys,
-    read_node_property_rows, remove_edge_properties, remove_node_properties,
-    set_edge_properties_rewrite, set_node_properties, stage_property_tombstones_authenticated,
-    stage_remove_edge_properties, stage_remove_edge_properties_authenticated,
-    stage_remove_node_properties, stage_remove_node_properties_authenticated,
-    stage_set_edge_properties, stage_set_edge_properties_authenticated, stage_set_node_properties,
+    count_entity_properties_from_inventory, decode_spatial_property_value, read_entity_properties,
+    read_entity_property_keys, read_node_property_rows, read_node_property_rows_from_inventory,
+    remove_edge_properties, remove_node_properties, set_edge_properties_rewrite,
+    set_node_properties, stage_property_tombstones_authenticated, stage_remove_edge_properties,
+    stage_remove_edge_properties_authenticated, stage_remove_node_properties,
+    stage_remove_node_properties_authenticated, stage_set_edge_properties,
+    stage_set_edge_properties_authenticated, stage_set_node_properties,
     stage_set_node_properties_authenticated, stage_set_node_properties_authenticated_with_counts,
 };
 

--- a/crates/graphforge-storage/src/lowering_snapshot.rs
+++ b/crates/graphforge-storage/src/lowering_snapshot.rs
@@ -54,8 +54,14 @@ impl GraphCatalog {
                     .map_err(GfError::from_plan_error)?
                     .schema(),
             );
-            snapshot.node_property_stems = crate::list_property_stems(dir);
-            snapshot.edge_property_stems = crate::list_edge_property_stems(dir);
+            snapshot.node_property_stems = inventory.discovered_routes(
+                crate::PropertyRouteKind::Node,
+                &crate::list_property_stems(dir),
+            );
+            snapshot.edge_property_stems = inventory.discovered_routes(
+                crate::PropertyRouteKind::Edge,
+                &crate::list_edge_property_stems(dir),
+            );
             let mut nodes: std::collections::BTreeSet<String> =
                 snapshot.node_property_stems.iter().cloned().collect();
             nodes.extend(snapshot.semantic_labels.values().cloned());

--- a/crates/graphforge-storage/src/mutator.rs
+++ b/crates/graphforge-storage/src/mutator.rs
@@ -202,14 +202,15 @@ fn keep_mask<S: BuildHasher>(
 fn stage_rewrite_dropping<S: BuildHasher>(
     staged: &mut RewriteBatch,
     path: &Path,
+    source: &Path,
     schema: SchemaRef,
     key_col: &str,
     targets: &HashSet<[u8; 16], S>,
 ) -> Result<u64, GfError> {
     let read_path = match staged.staged_temp(path) {
         Some(tmp) => tmp.to_path_buf(),
-        None if !path.exists() => return Ok(0),
-        None => path.to_path_buf(),
+        None if !source.exists() => return Ok(0),
+        None => source.to_path_buf(),
     };
     let batches = read_parquet_or_empty(&read_path, schema.clone()).map_err(pq_err)?;
     let mut removed = 0u64;
@@ -482,22 +483,9 @@ pub fn stage_delete_nodes<S: BuildHasher>(
     if node_uuids.is_empty() {
         return Ok(0);
     }
-    // Immutable property history is never rewritten; whole-row tombstones
-    // suppress deleted entities before topology authority commits.
-    for route in crate::catalog::list_property_stems(dir) {
-        crate::writer::stage_property_tombstones(
-            staged,
-            dir,
-            crate::property_overlay::PropertyRouteKind::Node,
-            &route,
-            node_uuids,
-        )?;
-    }
-    let mut removed = 0_u64;
-    for path in node_parquet_files(dir)? {
-        removed = removed.saturating_add(stage_rewrite_nodes_dropping(staged, &path, node_uuids)?);
-    }
-    Ok(removed)
+    let inventory =
+        crate::property_overlay::authenticated_property_inventory_for_rewrite(dir, staged)?;
+    stage_delete_nodes_authenticated(staged, dir, &inventory, node_uuids)
 }
 
 /// Stage node deletion while binding every property tombstone to `inventory`.
@@ -547,21 +535,9 @@ pub fn stage_delete_edges<S: BuildHasher>(
     if edge_uuids.is_empty() {
         return Ok(0);
     }
-    let mut removed = 0u64;
-    for (_, path) in edge_parquet_files(dir, None)? {
-        let schema = discover_parquet_schema_detailed(&path).map_err(pq_err)?;
-        removed += stage_rewrite_dropping(staged, &path, schema, "edge_uuid", edge_uuids)?;
-    }
-    for route in crate::catalog::list_edge_property_stems(dir) {
-        crate::writer::stage_property_tombstones(
-            staged,
-            dir,
-            crate::property_overlay::PropertyRouteKind::Edge,
-            &route,
-            edge_uuids,
-        )?;
-    }
-    Ok(removed)
+    let inventory =
+        crate::property_overlay::authenticated_property_inventory_for_rewrite(dir, staged)?;
+    stage_delete_edges_authenticated(staged, dir, &inventory, edge_uuids)
 }
 
 /// Stage edge deletion while binding every property tombstone to `inventory`.
@@ -575,10 +551,41 @@ pub fn stage_delete_edges_authenticated<S: BuildHasher>(
     if edge_uuids.is_empty() {
         return Ok(0);
     }
+    let directory =
+        graphforge_filesystem::StableDirectory::open(dir).map_err(|error| io_err(&error))?;
+    let table = crate::route_component::owned::read_owned_layout_table(&directory)?;
     let mut removed = 0u64;
-    for (_, path) in edge_parquet_files(dir, None)? {
-        let schema = discover_parquet_schema_detailed(&path).map_err(pq_err)?;
-        removed += stage_rewrite_dropping(staged, &path, schema, "edge_uuid", edge_uuids)?;
+    for (route, source, relative) in inventory.edge_rewrite_files() {
+        let component = match &table {
+            Some(table) => {
+                let component = crate::route_component::component(route);
+                if table.route(&component)? != route {
+                    return Err(GfError::Storage(
+                        "owned edge route differs from admitted source".into(),
+                    ));
+                }
+                component
+            }
+            None => route.to_owned(),
+        };
+        let route_tail = relative.strip_prefix("topology/edges/").ok_or_else(|| {
+            GfError::Storage("admitted edge path has no topology namespace".into())
+        })?;
+        let destination = match route_tail.split_once('/') {
+            Some((_, fragment)) => dir.join("topology/edges").join(component).join(fragment),
+            None => dir
+                .join("topology/edges")
+                .join(format!("{component}.parquet")),
+        };
+        let schema = discover_parquet_schema_detailed(source).map_err(pq_err)?;
+        removed += stage_rewrite_dropping(
+            staged,
+            &destination,
+            source,
+            schema,
+            "edge_uuid",
+            edge_uuids,
+        )?;
     }
     let routes = inventory
         .routes(crate::PropertyRouteKind::Edge)
@@ -842,7 +849,26 @@ mod tests {
 
     /// Total rows across the batches of a (possibly absent) parquet file.
     fn row_count(dir: &Path, rel: &str) -> usize {
-        let path = dir.join(rel);
+        let physical = if let Some(route) = rel
+            .strip_prefix("topology/edges/")
+            .and_then(|value| value.strip_suffix(".parquet"))
+        {
+            let physical = format!(
+                "topology/edges/{}.parquet",
+                crate::route_component::component(route)
+            );
+            let table = crate::route_component::RouteTable::decode(
+                &std::fs::read(dir.join(crate::route_component::TABLE_FILE)).unwrap(),
+                64 * 1024 * 1024,
+                100_000,
+            )
+            .unwrap();
+            assert_eq!(table.semantic_relative_path(&physical).unwrap(), rel);
+            physical
+        } else {
+            rel.to_owned()
+        };
+        let path = dir.join(physical);
         let Some(schema) = discover_parquet_schema(&path) else {
             return 0;
         };
@@ -1135,6 +1161,49 @@ mod tests {
     }
 
     #[test]
+    fn mapped_reserved_delete_preserves_other_routes_and_reopens() {
+        let dir = TempDir::new().unwrap();
+        let (a, b, edge, retained) = (new_v7(), new_v7(), new_v7(), new_v7());
+        let mut writer = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS).unwrap();
+        for (node, route) in [(a, "CON"), (b, "con")] {
+            writer
+                .create_node(node, EntityTypeId::ontology(TypeId(1)).unwrap())
+                .unwrap();
+            writer
+                .set_properties(
+                    &node,
+                    Some(route),
+                    HashMap::from([("name".into(), IrLiteral::Str(route.into()))]),
+                )
+                .unwrap();
+        }
+        for (id, route, source) in [(edge, "AUX", a), (retained, "aux", b)] {
+            writer.create_edge(id, route, &source, &b).unwrap();
+            writer
+                .set_edge_properties(
+                    &id,
+                    Some(route),
+                    HashMap::from([("cost".into(), IrLiteral::Int(7))]),
+                )
+                .unwrap();
+        }
+        writer.flush().unwrap();
+        drop(writer);
+        assert_eq!(
+            delete_nodes_and_edges(dir.path(), &set(&[a]), &set(&[edge])).unwrap(),
+            (1, 1)
+        );
+        let reopened = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS + 1).unwrap();
+        assert_eq!(logical_property_rows(dir.path(), "CON", false), 0);
+        assert_eq!(logical_property_rows(dir.path(), "AUX", true), 0);
+        assert_eq!(logical_property_rows(dir.path(), "con", false), 1);
+        assert_eq!(logical_property_rows(dir.path(), "aux", true), 1);
+        let rows = crate::read_node_property_rows(dir.path(), "con").unwrap();
+        assert_eq!(rows[&to_bytes(&b)]["name"], IrLiteral::Str("con".into()));
+        drop(reopened);
+    }
+
+    #[test]
     fn delete_nodes_drops_their_property_rows() {
         let dir = TempDir::new().unwrap();
         let (a, b) = (new_v7(), new_v7());
@@ -1190,14 +1259,15 @@ mod tests {
     fn edge_deletion_fails_closed_on_corrupt_topology_for_both_staging_paths() {
         let (dir, _a, _b, _c) = chain();
         let (captured, _) = crate::capture_graph_files(dir.path()).unwrap();
-        let inventory =
-            crate::AuthenticatedPropertyInventory::from_entries_at_root(dir.path(), captured.files)
-                .unwrap();
-        fs::write(
-            dir.path().join("topology/edges/KNOWS.parquet"),
-            b"not parquet",
+        let inventory = crate::AuthenticatedPropertyInventory::from_inventory_at_root(
+            dir.path(),
+            captured,
+            None,
         )
         .unwrap();
+        let paths = inventory.edge_files(Some("KNOWS"));
+        assert_eq!(paths.len(), 1);
+        fs::write(&paths[0].1, b"not parquet").unwrap();
         let target = set(&[new_v7()]);
 
         let mut ordinary = RewriteBatch::new();

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -361,7 +361,28 @@ impl ResolvedProjectGeneration {
                         entry.byte_length,
                     )?;
                 }
-                crate::graph_files::inventory_from_entries(files).map(Some)
+                crate::route_component::authenticate_manifest_routes(
+                    root.format_version,
+                    &files,
+                    |entry| {
+                        crate::read_graph_object_by_digest(
+                            self.container_root(),
+                            &entry.content_sha256,
+                            MAX_SEGMENT_BYTES,
+                        )
+                    },
+                )?;
+                crate::graph_files::inventory_from_entries_with_version(
+                    files,
+                    if root.format_version
+                        == crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
+                    {
+                        crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+                    } else {
+                        crate::GRAPH_FILES_RECORD_VERSION
+                    },
+                )
+                .map(Some)
             }
         }
     }
@@ -391,7 +412,10 @@ impl ResolvedProjectGeneration {
         if snapshot.capability_version != crate::GRAPH_CAPABILITY_VERSION
             || !matches!(
                 snapshot.record_version,
-                crate::GRAPH_FILES_RECORD_VERSION | crate::GRAPH_FILES_V2_RECORD_VERSION
+                crate::GRAPH_FILES_RECORD_VERSION
+                    | crate::GRAPH_FILES_V2_RECORD_VERSION
+                    | crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+                    | crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
             )
             || snapshot.encoding != "json"
         {

--- a/crates/graphforge-storage/src/project_portable_v2.rs
+++ b/crates/graphforge-storage/src/project_portable_v2.rs
@@ -1003,11 +1003,9 @@ fn sync_materialized_tree(root: &Path) -> Result<(), PortableV2Error> {
     }
     directories.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
     for directory in directories {
-        File::open(directory)
-            .and_then(|file| file.sync_all())
-            .map_err(|_| {
-                PortableV2Error::new(PortableV2ErrorCode::Io, "cannot sync staged directory")
-            })?;
+        crate::project_publication::sync_directory(&directory).map_err(|_| {
+            PortableV2Error::new(PortableV2ErrorCode::Io, "cannot sync staged directory")
+        })?;
     }
     Ok(())
 }

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -2142,7 +2142,11 @@ fn reject_windows_reparse_components(path: &Path) -> Result<(), ExportError> {
     let mut current = PathBuf::new();
     for component in path.components() {
         current.push(component.as_os_str());
-        if current.as_os_str().is_empty() {
+        // A Windows prefix is not yet a filesystem root. In particular,
+        // canonicalize produces a verbatim disk prefix (\\?\C:) which cannot
+        // be queried until its following RootDir component has been appended.
+        // Check that root and every subsequent component normally.
+        if matches!(component, std::path::Component::Prefix(_)) || current.as_os_str().is_empty() {
             continue;
         }
         let metadata = fs::symlink_metadata(&current).map_err(storage)?;
@@ -2398,6 +2402,39 @@ fn storage(e: impl std::fmt::Display) -> ExportError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_source_path_retains_no_follow_admission() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("payload.json");
+        fs::write(&source, b"authenticated payload").unwrap();
+        let canonical = source.canonicalize().unwrap();
+        #[cfg(windows)]
+        assert!(matches!(
+            canonical.components().next(),
+            Some(std::path::Component::Prefix(prefix)) if prefix.kind().is_verbatim()
+        ));
+        let mut total = 0;
+        let planned = inspect(
+            &canonical,
+            "data/payload.json",
+            PortableV2ExportLimits::default(),
+            &mut total,
+        )
+        .unwrap();
+        assert_eq!(total, 21);
+        assert_eq!(planned.length, 21);
+        assert_eq!(
+            planned.digest,
+            <[u8; 32]>::from(Sha256::digest(b"authenticated payload"))
+        );
+        let (mut file, _) = open_planned_source(&planned).unwrap();
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).unwrap();
+        assert_eq!(bytes, b"authenticated payload");
+        assert!(open_source_no_follow(&root.path().join("missing.json")).is_err());
+    }
+
     use crate::open_or_initialize_project;
     use arrow::array::StringArray;
     use arrow::record_batch::RecordBatch;

--- a/crates/graphforge-storage/src/project_portable_v2_export.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_export.rs
@@ -2352,7 +2352,7 @@ fn sync_directory_handle(p: &Path) -> std::io::Result<()> {
     use std::os::windows::fs::OpenOptionsExt as _;
     const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
     OpenOptions::new()
-        .read(true)
+        .write(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(p)?
         .sync_all()

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -832,7 +832,7 @@ fn sync_directory_handle(path: &Path) -> std::io::Result<()> {
     use std::os::windows::fs::OpenOptionsExt as _;
     const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
     OpenOptions::new()
-        .read(true)
+        .write(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(path)?
         .sync_all()
@@ -1348,7 +1348,11 @@ fn prepare_compact_import_graph_with_allocation(
             "cannot publish imported compact graph root",
         )
     })?;
-    let file = fs::File::open(&participant.source).map_err(|_| {
+    #[cfg(not(windows))]
+    let file = fs::File::open(&participant.source);
+    #[cfg(windows)]
+    let file = OpenOptions::new().write(true).open(&participant.source);
+    let file = file.map_err(|_| {
         PortableV2Error::new(
             PortableV2ErrorCode::Io,
             "cannot reopen imported compact graph root",

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -1290,7 +1290,11 @@ fn prepare_compact_import_graph_with_allocation(
             "graph tree requires a graph/files participant",
         ));
     };
-    if participant.participant.record_version != crate::GRAPH_FILES_V2_RECORD_VERSION {
+    if !matches!(
+        participant.participant.record_version,
+        crate::GRAPH_FILES_V2_RECORD_VERSION
+            | crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
+    ) {
         return Ok(None);
     }
     let mut lease =
@@ -1306,13 +1310,29 @@ fn prepare_compact_import_graph_with_allocation(
     let mut remaining = entry_count.saturating_mul(2).saturating_add(1024);
     collect_portable_graph_paths(&directory, Path::new(""), &mut paths, &mut remaining)?;
     paths.sort();
-    let (root, _) = crate::graph_object_store::append_graph_files_v2(
-        &lease,
-        graph_tree,
-        &mut crate::graph_object_store::GraphManifestState::empty(),
-        &paths,
-        &[],
-    )
+    let (root, _) = if participant.participant.record_version
+        == crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
+    {
+        let routes = crate::route_component::owned::read_owned_layout_table(&directory)
+            .map_err(|error| storage(&error))?
+            .ok_or_else(|| {
+                PortableV2Error::new(
+                    PortableV2ErrorCode::InvalidStructure,
+                    "mapped compact import requires route authority",
+                )
+            })?;
+        crate::graph_object_store::append_mapped_import_graph_files(
+            &lease, graph_tree, &paths, &routes,
+        )
+    } else {
+        crate::graph_object_store::append_graph_files_v2(
+            &lease,
+            graph_tree,
+            &mut crate::graph_object_store::GraphManifestState::empty(),
+            &paths,
+            &[],
+        )
+    }
     .map_err(|error| storage(&error))?;
     let bytes = crate::graph_manifest::encode_root(&root).map_err(|error| storage(&error))?;
     crate::project_publication::publish_atomic_bytes(
@@ -2090,9 +2110,18 @@ mod tests {
                     vec![Arc::new(ids) as ArrayRef, Arc::new(values)],
                 )
                 .unwrap();
-                let path = tree.join("properties/_untyped.parquet");
+                let table_path = tree.join(crate::route_component::TABLE_FILE);
+                let mut table = crate::route_component::RouteTable::decode(
+                    &fs::read(&table_path).unwrap(),
+                    64 * 1024 * 1024,
+                    100_000,
+                )
+                .unwrap();
+                let component = table.insert("_untyped", 64 * 1024 * 1024, 100_000).unwrap();
+                let path = tree.join(format!("properties/{component}.parquet"));
                 fs::create_dir_all(path.parent().unwrap()).unwrap();
                 crate::graph_projection::write_parquet(&path, &batch).unwrap();
+                fs::write(table_path, table.encode(64 * 1024 * 1024).unwrap()).unwrap();
             });
             if let Some(expected_error) = expected_error {
                 let error = assert_identity_package_rejected(&package);

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -589,8 +589,10 @@ fn cleanup_import_materialization(
             &mut cleanup_budget,
             allocation,
         )?;
+        let directory_identity = directory.identity();
+        drop(directory);
         parent
-            .remove_child_directory_if_identity(name, directory.identity())
+            .remove_child_directory_if_identity(name, directory_identity)
             .map_err(|_| {
                 PortableV2Error::new(
                     PortableV2ErrorCode::Io,
@@ -645,6 +647,9 @@ fn cleanup_import_owner(
             ));
         }
         removed_identities.extend(observed);
+        // Authentication handles deny delete sharing on Windows. The removal
+        // operation rechecks the saved identity after acquiring its own handle.
+        drop(file);
         parent
             .unlink_child_if_identity(name, identity)
             .map_err(|_| {
@@ -688,8 +693,10 @@ fn remove_stable_tree(
                 remaining,
                 allocation,
             )?;
+            let child_identity = child.identity();
+            drop(child);
             directory
-                .remove_child_directory_if_identity(&name, child.identity())
+                .remove_child_directory_if_identity(&name, child_identity)
                 .map_err(|_| {
                     PortableV2Error::new(
                         PortableV2ErrorCode::Io,
@@ -721,6 +728,7 @@ fn remove_stable_tree(
                 ));
             }
             removed_identities.extend(observed);
+            drop(file);
             directory
                 .unlink_child_if_identity(&name, identity)
                 .map_err(|_| {
@@ -1927,6 +1935,36 @@ mod tests {
 
     const HELPER: &str = "project_portable_v2_import::tests::subprocess_crash_import";
     const COOKIE: &str = "graphforge-internal-subprocess-v1";
+
+    #[test]
+    fn authenticated_cleanup_releases_handles_before_removal() {
+        let root = tempfile::tempdir().unwrap();
+        let stage = root.path().join("stage");
+        let owner = root.path().join("stage.owner");
+        fs::create_dir_all(stage.join("nested")).unwrap();
+        fs::create_dir(stage.join("empty")).unwrap();
+        let mut identities = std::collections::BTreeMap::new();
+        for path in [
+            stage.join("payload"),
+            stage.join("nested/payload"),
+            owner.clone(),
+        ] {
+            fs::write(&path, b"authenticated materialization").unwrap();
+            let file = fs::File::open(path).unwrap();
+            record_import_file_identity(&file, &mut identities).unwrap();
+        }
+        let directory = graphforge_filesystem::StableDirectory::open(&stage).unwrap();
+        let stage_identity = directory.identity();
+        drop(directory);
+
+        let receipt =
+            cleanup_import_materialization(&stage, &owner, stage_identity, &identities, None)
+                .unwrap();
+        assert!(!stage.exists());
+        assert!(!owner.exists());
+        assert_eq!(receipt.removed_identity_allocated_bytes, identities);
+        assert!(receipt.parent_sync_confirmed);
+    }
 
     fn supported() -> Vec<ProjectCapability> {
         vec![

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1060,7 +1060,10 @@ fn stage_optional_graph_tree(
     if files_participant.capability_version != crate::GRAPH_CAPABILITY_VERSION
         || !matches!(
             files_participant.record_version,
-            crate::GRAPH_FILES_RECORD_VERSION | crate::GRAPH_FILES_V2_RECORD_VERSION
+            crate::GRAPH_FILES_RECORD_VERSION
+                | crate::GRAPH_FILES_V2_RECORD_VERSION
+                | crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+                | crate::graph_files::GRAPH_FILES_MAPPED_ROOT_RECORD_VERSION
         )
         || files_participant.encoding != ProjectParticipantEncoding::Json.extension()
     {
@@ -1177,6 +1180,13 @@ fn verify_compact_graph_root(
                 MAX_GRAPH_MANIFEST_SEGMENT_BYTES,
             )
         })?;
+    crate::route_component::authenticate_manifest_routes(root.format_version, &files, |entry| {
+        crate::read_graph_object_by_digest(
+            container_root,
+            &entry.content_sha256,
+            MAX_GRAPH_MANIFEST_SEGMENT_BYTES,
+        )
+    })?;
     for entry in files {
         crate::verify_graph_object(container_root, &entry.content_sha256, entry.byte_length)?;
     }
@@ -1195,6 +1205,13 @@ fn verify_compact_graph_root_with_lease(
                 MAX_GRAPH_MANIFEST_SEGMENT_BYTES,
             )
         })?;
+    crate::route_component::authenticate_manifest_routes(root.format_version, &files, |entry| {
+        crate::graph_object_store::read_graph_object_by_digest_with_lease(
+            lease,
+            &entry.content_sha256,
+            MAX_GRAPH_MANIFEST_SEGMENT_BYTES,
+        )
+    })?;
     for entry in files {
         crate::graph_object_store::verify_graph_object_with_lease(
             lease,

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -516,6 +516,28 @@ impl AuthenticatedPropertyInventory {
         })
     }
 
+    /// Return admitted immutable property fragments in oldest-to-newest order.
+    /// The caller must retain this inventory while using its physical paths.
+    #[must_use]
+    pub fn property_fragments(
+        &self,
+        kind: PropertyRouteKind,
+        route: &str,
+    ) -> Vec<PropertyFragment> {
+        let Some(root) = &self.root_path else {
+            return Vec::new();
+        };
+        self.routes
+            .get(&(kind, route.to_owned()))
+            .into_iter()
+            .flatten()
+            .map(|fragment| PropertyFragment {
+                id: fragment.id,
+                path: root.join(&fragment.physical_relative),
+            })
+            .collect()
+    }
+
     /// Canonical property routes admitted into this immutable snapshot.
     pub fn routes(&self, kind: PropertyRouteKind) -> impl Iterator<Item = &str> {
         self.routes

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -248,6 +248,7 @@ pub struct AuthenticatedPropertyInventory {
     root: Option<graphforge_filesystem::StableDirectory>,
     root_path: Option<PathBuf>,
     routes: BTreeMap<(PropertyRouteKind, String), Vec<AuthenticatedPropertyFragment>>,
+    edge_routes: BTreeMap<String, Vec<AdmittedEdgeFile>>,
     schemas: BTreeMap<(PropertyRouteKind, String), arrow::datatypes::SchemaRef>,
     authority_bytes: u64,
     authority_block_equivalents: u64,
@@ -258,6 +259,12 @@ pub struct AuthenticatedPropertyInventory {
     late_decoder_failure_row_countdown: Arc<AtomicU64>,
     #[cfg(test)]
     mutation_barrier: Mutex<Option<Arc<TestMutationBarrier>>>,
+}
+
+#[derive(Debug)]
+struct AdmittedEdgeFile {
+    path: PathBuf,
+    relative_path: String,
 }
 
 /// One-time I/O performed while admitting and authenticating an immutable
@@ -365,6 +372,29 @@ struct RouteSchemaBuilder {
 }
 
 impl AuthenticatedPropertyInventory {
+    /// Return semantic relation names and their admitted physical payload paths.
+    /// The inventory retains the generation lease and route authority.
+    #[must_use]
+    pub fn edge_files(&self, relation: Option<&str>) -> Vec<(String, PathBuf)> {
+        self.edge_routes
+            .iter()
+            .filter(|(route, _)| relation.is_none_or(|expected| expected == route.as_str()))
+            .flat_map(|(route, paths)| paths.iter().map(|path| (route.clone(), path.path.clone())))
+            .collect()
+    }
+
+    pub(crate) fn edge_rewrite_files(&self) -> impl Iterator<Item = (&str, &Path, &str)> {
+        self.edge_routes.iter().flat_map(|(route, files)| {
+            files.iter().map(move |file| {
+                (
+                    route.as_str(),
+                    file.path.as_path(),
+                    file.relative_path.as_str(),
+                )
+            })
+        })
+    }
+
     pub(crate) fn admitted_source_files(
         &self,
         kind: PropertyRouteKind,
@@ -494,6 +524,37 @@ impl AuthenticatedPropertyInventory {
             .map(|(_, route)| route.as_str())
     }
 
+    // Discovery controls wildcard membership; retained authority supplies the exact
+    // semantic spelling without rediscovering or decoding an unauthenticated table.
+    pub(crate) fn discovered_routes(
+        &self,
+        kind: PropertyRouteKind,
+        physical_stems: &[String],
+    ) -> Vec<String> {
+        let physical_stems: BTreeSet<&str> = physical_stems.iter().map(String::as_str).collect();
+        self.routes
+            .iter()
+            .filter(|((candidate, _), fragments)| {
+                *candidate == kind
+                    && fragments.iter().any(|fragment| {
+                        let component =
+                            Path::new(&fragment.entry.relative_path).components().nth(1);
+                        component
+                            .and_then(|part| {
+                                let path = std::path::Path::new(part.as_os_str());
+                                match fragment.layout {
+                                    PropertyFragmentLayout::LegacyFlat => path.file_stem(),
+                                    PropertyFragmentLayout::CanonicalNested => path.file_name(),
+                                }
+                            })
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| physical_stems.contains(name))
+                    })
+            })
+            .map(|((_, route), _)| route.clone())
+            .collect()
+    }
+
     /// Exact one-time admission evidence for this cached inventory.
     #[must_use]
     pub fn open_metrics(&self) -> PropertyInventoryOpenMetrics {
@@ -553,6 +614,55 @@ impl AuthenticatedPropertyInventory {
         Ok(admitted)
     }
 
+    /// Admit a materialized workspace with its explicit captured layout authority.
+    pub fn from_materialized_inventory(
+        generation: &crate::ResolvedProjectGeneration,
+        root: &Path,
+        inventory: crate::GraphFilesInventory,
+    ) -> Result<Self, GfError> {
+        let mut admitted = Self::from_inventory_at_root(root, inventory, None)?;
+        admitted.generation_lease = Some(generation.clone());
+        Ok(admitted)
+    }
+
+    pub(crate) fn from_inventory_at_root(
+        root: &Path,
+        inventory: crate::GraphFilesInventory,
+        requested_route: Option<(PropertyRouteKind, &str)>,
+    ) -> Result<Self, GfError> {
+        let table = crate::route_component::authenticate_manifest_routes(
+            inventory.format_version,
+            &inventory.files,
+            |entry| {
+                use std::io::{Read, Seek};
+                let mut retained =
+                    crate::graph_files::resolve_v1_inventory_entry_retained(root, entry)?;
+                retained.file.rewind().map_err(io_error)?;
+                let mut bytes = Vec::new();
+                retained
+                    .file
+                    .take(entry.byte_length + 1)
+                    .read_to_end(&mut bytes)
+                    .map_err(io_error)?;
+                Ok(bytes)
+            },
+        )?;
+        let edge_routes = if requested_route.is_none() {
+            admit_edge_route_paths(root, &inventory.files, table.as_ref(), false)?
+        } else {
+            BTreeMap::new()
+        };
+        let entries = resolve_versioned_property_entries_for_route(
+            root,
+            inventory.files,
+            requested_route,
+            table.as_ref(),
+        )?;
+        let mut admitted = Self::admit_entries(root, entries, requested_route, table.as_ref())?;
+        admitted.edge_routes = edge_routes;
+        Ok(admitted)
+    }
+
     /// Resolve one route without opening or hashing authenticated entries for
     /// unrelated routes in the pinned generation inventory.
     pub fn from_resolved_generation_for_route(
@@ -573,6 +683,7 @@ impl AuthenticatedPropertyInventory {
                 root_path: None,
                 generation_lease: Some(generation.clone()),
                 routes: BTreeMap::new(),
+                edge_routes: BTreeMap::new(),
                 schemas: BTreeMap::new(),
                 authority_bytes: 0,
                 authority_block_equivalents: 0,
@@ -591,12 +702,56 @@ impl AuthenticatedPropertyInventory {
         let mut admitted = match participant {
             crate::graph_files::GraphFilesParticipant::V1(_) => {
                 let root = generation.graph_tree_root();
-                let entries =
-                    resolve_v1_property_entries_for_route(&root, inventory.files, requested_route)?;
-                Self::admit_entries(&root, entries, requested_route)
+                let route_table = crate::route_component::authenticate_manifest_routes(
+                    inventory.format_version,
+                    &inventory.files,
+                    |entry| {
+                        let mut retained =
+                            crate::graph_files::resolve_v1_inventory_entry_retained(&root, entry)?;
+                        retained.file.rewind().map_err(io_error)?;
+                        let mut bytes = Vec::new();
+                        retained
+                            .file
+                            .take(entry.byte_length + 1)
+                            .read_to_end(&mut bytes)
+                            .map_err(io_error)?;
+                        Ok(bytes)
+                    },
+                )?;
+                let edge_routes = if requested_route.is_none() {
+                    admit_edge_route_paths(&root, &inventory.files, route_table.as_ref(), false)?
+                } else {
+                    BTreeMap::new()
+                };
+                let entries = resolve_versioned_property_entries_for_route(
+                    &root,
+                    inventory.files,
+                    requested_route,
+                    route_table.as_ref(),
+                )?;
+                let mut admitted =
+                    Self::admit_entries(&root, entries, requested_route, route_table.as_ref())?;
+                admitted.edge_routes = edge_routes;
+                Ok::<Self, GfError>(admitted)
             }
             crate::graph_files::GraphFilesParticipant::V2(_) => {
                 let root = generation.container_root();
+                let route_table = crate::route_component::authenticate_manifest_routes(
+                    inventory.format_version,
+                    &inventory.files,
+                    |entry| {
+                        crate::read_graph_object_by_digest(
+                            root,
+                            &entry.content_sha256,
+                            64 * 1024 * 1024,
+                        )
+                    },
+                )?;
+                let edge_routes = if requested_route.is_none() {
+                    admit_edge_route_paths(root, &inventory.files, route_table.as_ref(), true)?
+                } else {
+                    BTreeMap::new()
+                };
                 let entries = inventory
                     .files
                     .into_iter()
@@ -608,7 +763,10 @@ impl AuthenticatedPropertyInventory {
                         Ok((entry, relative.to_path_buf()))
                     })
                     .collect::<Result<Vec<_>, GfError>>()?;
-                Self::admit_entries(root, entries, requested_route)
+                let mut admitted =
+                    Self::admit_entries(root, entries, requested_route, route_table.as_ref())?;
+                admitted.edge_routes = edge_routes;
+                Ok::<Self, GfError>(admitted)
             }
         }?;
         admitted.generation_lease = Some(generation.clone());
@@ -626,9 +784,10 @@ impl AuthenticatedPropertyInventory {
                 (entry, relative)
             })
             .collect();
-        Self::admit_entries(root, entries, None)
+        Self::admit_entries(root, entries, None, None)
     }
 
+    #[cfg(test)]
     fn from_entries_at_root_for_route(
         root: &Path,
         entries: Vec<crate::GraphFileEntry>,
@@ -642,13 +801,14 @@ impl AuthenticatedPropertyInventory {
                 (entry, relative)
             })
             .collect();
-        Self::admit_entries(root, entries, Some((kind, route)))
+        Self::admit_entries(root, entries, Some((kind, route)), None)
     }
 
     fn admit_entries(
         root_path: &Path,
         entries: Vec<(crate::GraphFileEntry, PathBuf)>,
         requested_route: Option<(PropertyRouteKind, &str)>,
+        route_table: Option<&crate::route_component::RouteTable>,
     ) -> Result<Self, GfError> {
         let root = graphforge_filesystem::StableDirectory::open(root_path).map_err(io_error)?;
         #[cfg(test)]
@@ -656,7 +816,11 @@ impl AuthenticatedPropertyInventory {
         let mut routes: BTreeMap<(PropertyRouteKind, String), Vec<AuthenticatedPropertyFragment>> =
             BTreeMap::new();
         for (entry, physical_relative) in entries {
-            let parsed = parse_inventory_property_path(&entry.relative_path)?;
+            let semantic_path = match route_table {
+                Some(table) => table.semantic_relative_path(&entry.relative_path)?,
+                None => entry.relative_path.clone(),
+            };
+            let parsed = parse_inventory_property_path(&semantic_path)?;
             if entry.role != crate::GraphFileRole::Properties {
                 if parsed.is_some() {
                     return Err(corrupt("property inventory entry has the wrong role"));
@@ -734,6 +898,7 @@ impl AuthenticatedPropertyInventory {
             root: Some(root),
             root_path: Some(root_path.to_path_buf()),
             routes,
+            edge_routes: BTreeMap::new(),
             schemas,
             authority_bytes: 0,
             authority_block_equivalents: 0,
@@ -1317,16 +1482,71 @@ fn inventory_entry_reaches_route(
     Ok(requested_route.is_none_or(|requested| (kind, route.as_str()) == requested))
 }
 
+fn admit_edge_route_paths(
+    root: &Path,
+    entries: &[crate::GraphFileEntry],
+    table: Option<&crate::route_component::RouteTable>,
+    cas: bool,
+) -> Result<BTreeMap<String, Vec<AdmittedEdgeFile>>, GfError> {
+    let mut routes = BTreeMap::<String, Vec<AdmittedEdgeFile>>::new();
+    for entry in entries {
+        if !entry.relative_path.starts_with("topology/edges/") {
+            continue;
+        }
+        if entry.role != crate::GraphFileRole::Topology {
+            return Err(corrupt("edge topology entry has the wrong role"));
+        }
+        let semantic = match table {
+            Some(table) => table.semantic_relative_path(&entry.relative_path)?,
+            None => crate::graph_files::legacy_inventory_logical_text(&entry.relative_path)?,
+        };
+        let route = crate::route_component::route_position(&semantic)?
+            .ok_or_else(|| corrupt("edge topology entry lacks relation route"))?;
+        let path = if cas {
+            crate::graph_object_path(root, &entry.content_sha256)?
+        } else {
+            crate::graph_files::resolve_v1_inventory_entry(root, entry)?
+        };
+        routes
+            .entry(route.to_owned())
+            .or_default()
+            .push(AdmittedEdgeFile {
+                path,
+                relative_path: entry.relative_path.clone(),
+            });
+    }
+    Ok(routes)
+}
+
+#[cfg(test)]
 fn resolve_v1_property_entries_for_route(
     root: &Path,
     entries: Vec<crate::GraphFileEntry>,
     requested_route: Option<(PropertyRouteKind, &str)>,
 ) -> Result<Vec<(crate::GraphFileEntry, PathBuf)>, GfError> {
+    resolve_versioned_property_entries_for_route(root, entries, requested_route, None)
+}
+
+fn resolve_versioned_property_entries_for_route(
+    root: &Path,
+    entries: Vec<crate::GraphFileEntry>,
+    requested_route: Option<(PropertyRouteKind, &str)>,
+    route_table: Option<&crate::route_component::RouteTable>,
+) -> Result<Vec<(crate::GraphFileEntry, PathBuf)>, GfError> {
     let mut selected = Vec::new();
     for mut entry in entries {
-        let canonical =
-            crate::graph_files::canonical_inventory_relative_text(&entry.relative_path)?;
-        if !inventory_entry_reaches_route(entry.role, &canonical, requested_route)? {
+        let canonical = match route_table {
+            Some(_) => {
+                crate::graph_files::wire_relative_path(&entry.relative_path)?;
+                entry.relative_path.clone()
+            }
+            None => crate::graph_files::legacy_inventory_logical_text(&entry.relative_path)?,
+        };
+        let semantic = match route_table {
+            Some(table) => table.semantic_relative_path(&canonical)?,
+            None => canonical.clone(),
+        };
+        if !inventory_entry_reaches_route(entry.role, &semantic, requested_route)? {
             continue;
         }
         // Resolve with the original spelling so a legacy backslash-authored
@@ -2004,6 +2224,51 @@ fn add_open_metrics(metrics: &mut PropertyOverlayMetrics, open: PropertyInventor
         .saturating_add(open.authentication_read_calls);
 }
 
+pub(crate) fn authenticated_property_inventory_for_rewrite_route(
+    project: &Path,
+    kind: PropertyRouteKind,
+    route: &str,
+    rewrite: &crate::RewriteBatch,
+) -> Result<AuthenticatedPropertyInventory, GfError> {
+    if project.join(crate::CURRENT_FILE).is_file() {
+        return authenticated_property_inventory_for_route(project, kind, route);
+    }
+    let (inventory, read_calls) = crate::graph_files::capture_rewrite_baseline(project, rewrite)?;
+    let authority_bytes = inventory.total_byte_length;
+    let authority_block_equivalents = inventory.files.iter().fold(0_u64, |blocks, entry| {
+        blocks.saturating_add(entry.byte_length.div_ceil(64 * 1024))
+    });
+    let mut admitted = AuthenticatedPropertyInventory::from_inventory_at_root(
+        project,
+        inventory,
+        Some((kind, route)),
+    )?;
+    admitted.authority_bytes = authority_bytes;
+    admitted.authority_block_equivalents = authority_block_equivalents;
+    admitted.authority_read_calls = read_calls;
+    Ok(admitted)
+}
+
+pub(crate) fn authenticated_property_inventory_for_rewrite(
+    project: &Path,
+    rewrite: &crate::RewriteBatch,
+) -> Result<AuthenticatedPropertyInventory, GfError> {
+    if project.join(crate::CURRENT_FILE).is_file() {
+        return authenticated_property_inventory(project);
+    }
+    let (inventory, read_calls) = crate::graph_files::capture_rewrite_baseline(project, rewrite)?;
+    let authority_bytes = inventory.total_byte_length;
+    let authority_block_equivalents = inventory.files.iter().fold(0_u64, |blocks, entry| {
+        blocks.saturating_add(entry.byte_length.div_ceil(64 * 1024))
+    });
+    let mut admitted =
+        AuthenticatedPropertyInventory::from_inventory_at_root(project, inventory, None)?;
+    admitted.authority_bytes = authority_bytes;
+    admitted.authority_block_equivalents = authority_block_equivalents;
+    admitted.authority_read_calls = read_calls;
+    Ok(admitted)
+}
+
 pub(crate) fn authenticated_property_inventory_for_route(
     project: &Path,
     kind: PropertyRouteKind,
@@ -2023,11 +2288,10 @@ pub(crate) fn authenticated_property_inventory_for_route(
     let authority_block_equivalents = inventory.files.iter().fold(0_u64, |blocks, entry| {
         blocks.saturating_add(entry.byte_length.div_ceil(64 * 1024))
     });
-    let mut admitted = AuthenticatedPropertyInventory::from_entries_at_root_for_route(
+    let mut admitted = AuthenticatedPropertyInventory::from_inventory_at_root(
         project,
-        inventory.files,
-        kind,
-        route,
+        inventory,
+        Some((kind, route)),
     )?;
     admitted.authority_bytes = authority_bytes;
     admitted.authority_block_equivalents = authority_block_equivalents;
@@ -2053,7 +2317,7 @@ pub(crate) fn authenticated_property_inventory(
         blocks.saturating_add(entry.byte_length.div_ceil(64 * 1024))
     });
     let mut admitted =
-        AuthenticatedPropertyInventory::from_entries_at_root(project, inventory.files)?;
+        AuthenticatedPropertyInventory::from_inventory_at_root(project, inventory, None)?;
     admitted.authority_bytes = authority_bytes;
     admitted.authority_block_equivalents = authority_block_equivalents;
     admitted.authority_read_calls = authority_read_calls;
@@ -3498,6 +3762,94 @@ mod tests {
             "intermediate merge output must remain linear in input: {metrics:#?}"
         );
         assert!(budget.peak() <= 1024);
+    }
+
+    #[test]
+    fn mapped_route_admission_does_not_open_unrelated_missing_payload() {
+        let dir = TempDir::new().unwrap();
+        let mut table = crate::route_component::RouteTable::default();
+        let selected = table.insert("CON", 64 * 1024 * 1024, 100_000).unwrap();
+        let unrelated = table.insert("con", 64 * 1024 * 1024, 100_000).unwrap();
+        let relative = format!("properties/{selected}.parquet");
+        fs::create_dir_all(dir.path().join("properties")).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "node_uuid",
+            DataType::FixedSizeBinary(16),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(
+                FixedSizeBinaryArray::try_from_iter(vec![vec![4; 16]].into_iter()).unwrap(),
+            )],
+        )
+        .unwrap();
+        let mut writer = ArrowWriter::try_new(
+            File::create(dir.path().join(&relative)).unwrap(),
+            schema,
+            None,
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let payload = fs::read(dir.path().join(&relative)).unwrap();
+        let table_bytes = table.encode(64 * 1024 * 1024).unwrap();
+        fs::write(
+            dir.path().join(crate::route_component::TABLE_FILE),
+            &table_bytes,
+        )
+        .unwrap();
+        let entry = |relative_path: String, bytes: &[u8], role| crate::GraphFileEntry {
+            relative_path,
+            byte_length: bytes.len() as u64,
+            content_sha256: digest_hex(&Sha256::digest(bytes)),
+            role,
+        };
+        let inventory = crate::graph_files::inventory_from_entries_with_version(
+            vec![
+                entry(relative, &payload, crate::GraphFileRole::Properties),
+                entry(
+                    format!("properties/{unrelated}.parquet"),
+                    b"absent",
+                    crate::GraphFileRole::Properties,
+                ),
+                entry(
+                    crate::route_component::TABLE_FILE.into(),
+                    &table_bytes,
+                    crate::GraphFileRole::Other,
+                ),
+            ],
+            crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION,
+        )
+        .unwrap();
+        let admitted = AuthenticatedPropertyInventory::from_inventory_at_root(
+            dir.path(),
+            inventory.clone(),
+            Some((PropertyRouteKind::Node, "CON")),
+        )
+        .unwrap();
+        assert!(
+            admitted
+                .route_schema(PropertyRouteKind::Node, "CON")
+                .is_some()
+        );
+        assert!(
+            admitted
+                .route_schema(PropertyRouteKind::Node, "con")
+                .is_none()
+        );
+        assert_eq!(
+            admitted.open_metrics().property_authentication_bytes,
+            payload.len() as u64
+        );
+        assert!(
+            AuthenticatedPropertyInventory::from_inventory_at_root(
+                dir.path(),
+                inventory,
+                Some((PropertyRouteKind::Node, "con"))
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/graphforge-storage/src/route_component.rs
+++ b/crates/graphforge-storage/src/route_component.rs
@@ -1,0 +1,541 @@
+//! Contextual reversible semantic routes. Authentication belongs to graph inventory admission.
+//!
+//! Components contain only lowercase ASCII. Exact UTF-8 semantics live in the
+//! authenticated table; neither case folding nor Unicode normalization is applied.
+
+use std::collections::BTreeMap;
+
+use graphforge_core::{GfError, ProjectErrorCode};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub(crate) mod materialize;
+pub(crate) mod owned;
+
+pub(crate) const TABLE_FILE: &str = "semantic-routes.json";
+const FORMAT: &str = "graphforge-semantic-routes";
+const VERSION: u32 = 1;
+const PREFIX: &str = "r-";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Entry {
+    component: String,
+    route: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireTable {
+    format: String,
+    format_version: u32,
+    // A sequence preserves duplicate keys until validation; a JSON map would
+    // silently overwrite them during deserialization.
+    entries: Vec<Entry>,
+}
+
+#[derive(Clone, Default, PartialEq, Eq)]
+pub(crate) struct RouteTable {
+    entries: BTreeMap<String, String>,
+    semantic_bytes: u64,
+}
+
+impl std::fmt::Debug for RouteTable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RouteTable")
+            .field("route_count", &self.entries.len())
+            .field("semantic_bytes", &self.semantic_bytes)
+            .finish()
+    }
+}
+
+impl RouteTable {
+    pub(crate) fn check_insert(
+        &self,
+        route: &str,
+        max_bytes: u64,
+        max_routes: u64,
+    ) -> Result<String, GfError> {
+        validate_semantic_route(route)?;
+        let component = component(route);
+        if let Some(existing) = self.entries.get(&component) {
+            if existing != route {
+                return Err(invalid("semantic route component collision"));
+            }
+        } else {
+            let next_bytes = self
+                .semantic_bytes
+                .checked_add(route.len() as u64)
+                .ok_or_else(|| limit("semantic route byte count overflow"))?;
+            if next_bytes > max_bytes || self.entries.len() as u64 >= max_routes {
+                return Err(limit("semantic route writer budget exceeded"));
+            }
+        }
+        Ok(component)
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        route: &str,
+        max_bytes: u64,
+        max_routes: u64,
+    ) -> Result<String, GfError> {
+        let component = self.check_insert(route, max_bytes, max_routes)?;
+        if !self.entries.contains_key(&component) {
+            self.semantic_bytes += route.len() as u64;
+            self.entries.insert(component.clone(), route.to_owned());
+        }
+        Ok(component)
+    }
+
+    pub(crate) fn route(&self, component: &str) -> Result<&str, GfError> {
+        self.entries
+            .get(component)
+            .map(String::as_str)
+            .ok_or_else(|| invalid("semantic route component is absent from authenticated table"))
+    }
+
+    /// Decode only an authenticated route position; callers retain the original
+    /// physical path for file access and use this spelling for semantic lookup.
+    pub(crate) fn semantic_relative_path(&self, relative: &str) -> Result<String, GfError> {
+        let Some(component) = route_position(relative)? else {
+            return Ok(relative.to_owned());
+        };
+        let route = self.route(component)?;
+        let mut parts = relative.split('/').collect::<Vec<_>>();
+        let index = if parts[0] == "topology" { 2 } else { 1 };
+        let filename = if parts.len() == index + 1 {
+            format!("{route}.parquet")
+        } else {
+            route.to_owned()
+        };
+        parts[index] = &filename;
+        Ok(parts.join("/"))
+    }
+
+    pub(crate) fn validate_paths<'a>(
+        &self,
+        paths: impl IntoIterator<Item = &'a str>,
+    ) -> Result<(), GfError> {
+        let mut used = std::collections::BTreeSet::new();
+        for path in paths {
+            if let Some(component) = route_position(path)? {
+                self.route(component)?;
+                used.insert(component);
+            }
+        }
+        if used.len() != self.entries.len() {
+            return Err(invalid(
+                "semantic route table contains unreferenced entries",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn encode(&self, max_bytes: u64) -> Result<Vec<u8>, GfError> {
+        use serde::ser::{SerializeSeq, SerializeStruct};
+        struct Entries<'a>(&'a BTreeMap<String, String>);
+        impl Serialize for Entries<'_> {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                #[derive(Serialize)]
+                struct BorrowedEntry<'a> {
+                    component: &'a str,
+                    route: &'a str,
+                }
+                let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+                for (component, route) in self.0 {
+                    sequence.serialize_element(&BorrowedEntry { component, route })?;
+                }
+                sequence.end()
+            }
+        }
+        struct Table<'a>(&'a RouteTable);
+        impl Serialize for Table<'_> {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                let mut state = serializer.serialize_struct("RouteTable", 3)?;
+                state.serialize_field("format", FORMAT)?;
+                state.serialize_field("format_version", &VERSION)?;
+                state.serialize_field("entries", &Entries(&self.0.entries))?;
+                state.end()
+            }
+        }
+        struct Output {
+            bytes: Vec<u8>,
+            limit: u64,
+        }
+        impl std::io::Write for Output {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                let total = self
+                    .bytes
+                    .len()
+                    .checked_add(bytes.len())
+                    .ok_or_else(|| std::io::Error::other("route table size overflow"))?;
+                if total as u64 > self.limit {
+                    return Err(std::io::Error::other("route table byte budget exceeded"));
+                }
+                self.bytes.extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let mut output = Output {
+            bytes: Vec::new(),
+            limit: max_bytes.saturating_sub(1),
+        };
+        serde_json::to_writer(&mut output, &Table(self))
+            .map_err(|_| limit("semantic route serialized byte budget exceeded"))?;
+        output.bytes.push(b'\n');
+        Ok(output.bytes)
+    }
+
+    /// The caller admits the inventoried file's byte bound before allocating it.
+    /// Requiring canonical bytes also rejects unknown fields and duplicate JSON
+    /// fields instead of permitting multiple authenticated spellings.
+    pub(crate) fn decode(bytes: &[u8], max_bytes: u64, max_routes: u64) -> Result<Self, GfError> {
+        if bytes.len() as u64 > max_bytes {
+            return Err(limit("semantic route table byte budget exceeded"));
+        }
+        let wire: WireTable =
+            serde_json::from_slice(bytes).map_err(|_| invalid("invalid semantic route table"))?;
+        if wire.format != FORMAT || wire.format_version != VERSION {
+            return Err(GfError::Project {
+                code: ProjectErrorCode::UnsupportedProjectFormat,
+                message: "unsupported semantic route table format".into(),
+            });
+        }
+        if wire.entries.len() as u64 > max_routes {
+            return Err(limit("semantic route table entry budget exceeded"));
+        }
+        let mut table = Self::default();
+        for entry in wire.entries {
+            if table.entries.contains_key(&entry.component) {
+                return Err(invalid("duplicate semantic route component"));
+            }
+            let expected = table.insert(&entry.route, max_bytes, max_routes)?;
+            if expected != entry.component {
+                return Err(invalid("semantic route component digest mismatch"));
+            }
+        }
+        if table.encode(max_bytes)? != bytes {
+            return Err(invalid("noncanonical semantic route table"));
+        }
+        Ok(table)
+    }
+}
+
+pub(crate) fn authenticate_manifest_routes(
+    version: u32,
+    entries: &[crate::GraphFileEntry],
+    read: impl FnOnce(&crate::GraphFileEntry) -> Result<Vec<u8>, GfError>,
+) -> Result<Option<RouteTable>, GfError> {
+    if matches!(version, 3 | 4) {
+        for entry in entries {
+            crate::graph_files::wire_relative_path(&entry.relative_path)?;
+        }
+    }
+    let table_entry = entries
+        .iter()
+        .find(|entry| entry.relative_path == TABLE_FILE);
+    match (version, table_entry) {
+        (1 | 2, None) => Ok(None),
+        (1 | 2, Some(_)) => Err(invalid(
+            "raw graph layout contains reserved semantic route authority",
+        )),
+        (3 | 4, Some(entry)) => {
+            const MAX_BYTES: u64 = 64 * 1024 * 1024;
+            const HEX: &[u8; 16] = b"0123456789abcdef";
+            if entry.byte_length > MAX_BYTES {
+                return Err(limit("semantic route table byte budget exceeded"));
+            }
+            let bytes = read(entry)?;
+            let digest = Sha256::digest(&bytes);
+            let matches = entry.content_sha256.len() == 64
+                && digest
+                    .iter()
+                    .zip(entry.content_sha256.as_bytes().chunks_exact(2))
+                    .all(|(byte, pair)| {
+                        pair[0] == HEX[usize::from(byte >> 4)]
+                            && pair[1] == HEX[usize::from(byte & 15)]
+                    });
+            if bytes.len() as u64 != entry.byte_length || !matches {
+                return Err(invalid("semantic route table authentication mismatch"));
+            }
+            let table = RouteTable::decode(&bytes, MAX_BYTES, 100_000)?;
+            table.validate_paths(entries.iter().map(|entry| entry.relative_path.as_str()))?;
+            Ok(Some(table))
+        }
+        (3 | 4, None) => Err(invalid(
+            "mapped graph layout lacks semantic route authority",
+        )),
+        _ => Err(invalid("unsupported graph route layout")),
+    }
+}
+
+/// Return only a recognized graph route component, never arbitrary path text.
+pub(crate) fn route_position(path: &str) -> Result<Option<&str>, GfError> {
+    let parts = path.split('/').collect::<Vec<_>>();
+    let route = match parts.as_slice() {
+        ["properties" | "edge_properties", flat] => Some(
+            flat.strip_suffix(".parquet")
+                .ok_or_else(|| invalid("invalid property route file"))?,
+        ),
+        ["properties" | "edge_properties", route, file] if file.ends_with(".parquet") => {
+            Some(*route)
+        }
+        ["topology", "edges", flat] => Some(
+            flat.strip_suffix(".parquet")
+                .ok_or_else(|| invalid("invalid topology route file"))?,
+        ),
+        ["topology", "edges", route, file] if file.ends_with(".parquet") => Some(*route),
+        ["properties" | "edge_properties", ..] | ["topology", "edges", ..] => {
+            return Err(invalid("unsupported semantic route path shape"));
+        }
+        _ => None,
+    };
+    Ok(route)
+}
+
+/// Translate a legacy semantic route position without interpreting its spelling
+/// as an encoded component. Non-route path components are left for the ordinary
+/// portable inventory validator.
+pub(crate) fn encode_relative_route(
+    relative: &str,
+    table: &mut RouteTable,
+    max_bytes: u64,
+    max_routes: u64,
+) -> Result<String, GfError> {
+    let Some(route) = route_position(relative)? else {
+        return Ok(relative.to_owned());
+    };
+    let encoded = table.insert(route, max_bytes, max_routes)?;
+    let mut parts = relative.split('/').collect::<Vec<_>>();
+    let index = if parts[0] == "topology" { 2 } else { 1 };
+    let flat = parts.len() == index + 1;
+    let filename = if flat {
+        format!("{encoded}.parquet")
+    } else {
+        encoded
+    };
+    parts[index] = &filename;
+    Ok(parts.join("/"))
+}
+
+pub(crate) fn component(route: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut digest = Sha256::new();
+    digest.update(b"graphforge-semantic-route/1\0");
+    digest.update(route.as_bytes());
+    let mut component = String::with_capacity(PREFIX.len() + 64);
+    component.push_str(PREFIX);
+    for byte in digest.finalize() {
+        component.push(char::from(HEX[usize::from(byte >> 4)]));
+        component.push(char::from(HEX[usize::from(byte & 15)]));
+    }
+    component
+}
+
+fn validate_semantic_route(route: &str) -> Result<(), GfError> {
+    if route.is_empty() || matches!(route, "." | "..") || route.contains(['/', '\0']) {
+        return Err(invalid("semantic route is not canonical"));
+    }
+    Ok(())
+}
+
+fn invalid(message: &str) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::ProjectCorrupt,
+        message: message.into(),
+    }
+}
+
+fn limit(message: &str) -> GfError {
+    GfError::Project {
+        code: ProjectErrorCode::ResourceLimit,
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn exact_semantics_survive_portable_lookup_and_long_names() {
+        let long = "é".repeat(4096);
+        let routes = [
+            "CON",
+            "AUX",
+            "COM1",
+            "LPT9",
+            "CON.foo",
+            "a:b*?<>|\\x",
+            "tail.",
+            "tail ",
+            "Name",
+            "name",
+            "é",
+            "e\u{301}",
+            "r-deadbeef",
+            &long,
+        ];
+        let mut table = RouteTable::default();
+        let mut components = BTreeSet::new();
+        for route in routes {
+            let component = table.insert(route, 65536, 100).unwrap();
+            assert_eq!(component.len(), 66);
+            assert!(
+                component
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+            );
+            assert!(components.insert(component.clone()));
+            assert_eq!(table.route(&component).unwrap(), route);
+        }
+        let bytes = table.encode(65536).unwrap();
+        assert_eq!(
+            RouteTable::decode(&bytes, bytes.len() as u64, 14).unwrap(),
+            table
+        );
+        assert!(RouteTable::decode(&bytes, bytes.len() as u64 - 1, 14).is_err());
+        assert!(RouteTable::decode(&bytes, bytes.len() as u64, 13).is_err());
+    }
+
+    #[test]
+    fn legacy_prefixes_and_normalization_variants_remain_distinct_routes() {
+        let mut table = RouteTable::default();
+        let mut outputs = BTreeSet::new();
+        let prefix_literal = component("CON");
+        for route in ["CON", "con", "é", "e\u{301}", &prefix_literal] {
+            let raw = format!("properties/{route}.parquet");
+            let mapped = encode_relative_route(&raw, &mut table, 4096, 100).unwrap();
+            assert!(outputs.insert(mapped.clone()));
+            assert_eq!(
+                table
+                    .route(route_position(&mapped).unwrap().unwrap())
+                    .unwrap(),
+                route
+            );
+        }
+        let edge = encode_relative_route(
+            "topology/edges/AUX/00000000000000000001.parquet",
+            &mut table,
+            4096,
+            100,
+        )
+        .unwrap();
+        assert_eq!(
+            table
+                .route(route_position(&edge).unwrap().unwrap())
+                .unwrap(),
+            "AUX"
+        );
+        assert_eq!(
+            encode_relative_route("runtime_catalog.parquet", &mut table, 4096, 100).unwrap(),
+            "runtime_catalog.parquet"
+        );
+    }
+
+    #[test]
+    fn mapped_manifest_refuses_hidden_backslash_routes_before_table_read() {
+        let entries = vec![crate::GraphFileEntry {
+            relative_path: "properties\\r-hidden.parquet".into(),
+            byte_length: 1,
+            content_sha256: "0".repeat(64),
+            role: crate::GraphFileRole::Properties,
+        }];
+        for version in [3, 4] {
+            assert!(
+                authenticate_manifest_routes(version, &entries, |_| {
+                    panic!("invalid mapped paths must fail before table IO")
+                })
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn writer_budgets_refuse_before_mutation_with_typed_cause() {
+        let mut table = RouteTable::default();
+        table.insert("CON", 3, 1).unwrap();
+        let before = table.clone();
+        for result in [table.insert("AUX", 3, 2), table.insert("AUX", 6, 1)] {
+            assert!(matches!(
+                result,
+                Err(GfError::Project {
+                    code: ProjectErrorCode::ResourceLimit,
+                    ..
+                })
+            ));
+        }
+        assert_eq!(table, before);
+        assert!(matches!(
+            table.encode(1),
+            Err(GfError::Project {
+                code: ProjectErrorCode::ResourceLimit,
+                ..
+            })
+        ));
+        let bytes = table.encode(4096).unwrap();
+        assert!(matches!(
+            RouteTable::decode(&bytes, 1, 1),
+            Err(GfError::Project {
+                code: ProjectErrorCode::ResourceLimit,
+                ..
+            })
+        ));
+        assert!(matches!(
+            RouteTable::decode(&bytes, 4096, 0),
+            Err(GfError::Project {
+                code: ProjectErrorCode::ResourceLimit,
+                ..
+            })
+        ));
+        assert!(matches!(
+            RouteTable::decode(b"{}", 4096, 1),
+            Err(GfError::Project {
+                code: ProjectErrorCode::ProjectCorrupt,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn malformed_duplicate_and_noncanonical_authority_is_rejected() {
+        let mut table = RouteTable::default();
+        let key = table.insert("CON", 65536, 100).unwrap();
+        let bytes = table.encode(65536).unwrap();
+        let mut wire: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let entry = wire["entries"][0].clone();
+        wire["entries"].as_array_mut().unwrap().push(entry);
+        assert!(RouteTable::decode(&serde_json::to_vec(&wire).unwrap(), 4096, 10).is_err());
+        let mut altered = bytes.clone();
+        let position = altered.windows(3).position(|part| part == b"CON").unwrap();
+        altered[position] = b'c';
+        assert!(RouteTable::decode(&altered, 4096, 10).is_err());
+        assert!(RouteTable::decode(&bytes[..bytes.len() - 1], 4096, 10).is_err());
+        assert!(table.route(&key.to_uppercase()).is_err());
+        for path in [
+            "properties",
+            "properties/r-x/nested/part.parquet",
+            "edge_properties/r-x/nested/part.parquet",
+            "topology/edges/r-x/nested/part.parquet",
+            "properties/not-parquet",
+        ] {
+            assert!(matches!(
+                route_position(path),
+                Err(GfError::Project {
+                    code: ProjectErrorCode::ProjectCorrupt,
+                    ..
+                })
+            ));
+        }
+        assert_eq!(route_position("indexes/some/nested/file").unwrap(), None);
+        for route in ["", ".", "..", "a/b", "a\0b"] {
+            assert!(table.insert(route, 65536, 100).is_err());
+        }
+    }
+}

--- a/crates/graphforge-storage/src/route_component/materialize.rs
+++ b/crates/graphforge-storage/src/route_component/materialize.rs
@@ -1,0 +1,125 @@
+//! Versioned translation at the boundary into an empty private workspace.
+
+use std::io::Write;
+use std::path::Path;
+
+use graphforge_core::GfError;
+use graphforge_filesystem::StableDirectory;
+
+use super::{RouteTable, TABLE_FILE, authenticate_manifest_routes, encode_relative_route, invalid};
+
+pub(crate) struct MaterializationRoutes {
+    pub(crate) destinations: Vec<String>,
+    pub(crate) legacy: bool,
+    table: Option<Vec<u8>>,
+}
+
+impl MaterializationRoutes {
+    pub(crate) fn prepare(
+        inventory: &crate::GraphFilesInventory,
+        read: impl FnOnce(&crate::GraphFileEntry) -> Result<Vec<u8>, GfError>,
+    ) -> Result<Self, GfError> {
+        let admitted =
+            authenticate_manifest_routes(inventory.format_version, &inventory.files, read)?;
+        let legacy = admitted.is_none();
+        if legacy && inventory.files.len() >= 100_000 {
+            return Err(super::limit(
+                "materialized route table exceeds inventory entry budget",
+            ));
+        }
+        let mut table = RouteTable::default();
+        let mut destinations = Vec::with_capacity(inventory.files.len());
+        let mut seen = std::collections::BTreeSet::new();
+        for entry in &inventory.files {
+            let destination = if legacy {
+                let logical =
+                    crate::graph_files::legacy_inventory_logical_text(&entry.relative_path)?;
+                encode_relative_route(&logical, &mut table, 64 * 1024 * 1024, 100_000)?
+            } else {
+                entry.relative_path.clone()
+            };
+            crate::graph_files::wire_relative_path(&destination)?;
+            if !seen.insert(destination.clone()) {
+                return Err(invalid("materialized route destinations collide"));
+            }
+            destinations.push(destination);
+        }
+        Ok(Self {
+            destinations,
+            legacy,
+            table: legacy.then(|| table.encode(64 * 1024 * 1024)).transpose()?,
+        })
+    }
+
+    /// Install only into the caller's empty, unpublished materialization. The
+    /// source inventory remains immutable and retains its original version.
+    pub(crate) fn install_table(
+        &self,
+        target: &Path,
+        evidence: &mut crate::GraphFilesOpenEvidence,
+    ) -> Result<(), GfError> {
+        let Some(bytes) = &self.table else {
+            return Ok(());
+        };
+        let directory = StableDirectory::open(target)
+            .map_err(|_| invalid("materialized route directory cannot be retained"))?;
+        let name = std::ffi::OsString::from(format!(
+            "semantic-routes.json.{}.tmp",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let mut file = directory
+            .create_replaceable_child_file(&name)
+            .map_err(|_| invalid("materialized route table cannot be staged"))?;
+        let identity = graphforge_filesystem::file_identity(&file)
+            .map_err(|_| invalid("materialized route table identity unavailable"))?;
+        let result = (|| {
+            let mut remaining = bytes.as_slice();
+            while !remaining.is_empty() {
+                let written = file
+                    .write(&remaining[..remaining.len().min(64 * 1024)])
+                    .map_err(|_| invalid("materialized route table write failed"))?;
+                if written == 0 {
+                    return Err(invalid("materialized route table write stopped"));
+                }
+                evidence.application_write_bytes = evidence
+                    .application_write_bytes
+                    .checked_add(written as u64)
+                    .ok_or_else(|| invalid("materialized route write bytes overflow"))?;
+                evidence.application_write_calls = evidence
+                    .application_write_calls
+                    .checked_add(1)
+                    .ok_or_else(|| invalid("materialized route write calls overflow"))?;
+                remaining = &remaining[written..];
+            }
+            file.sync_all()
+                .map_err(|_| invalid("materialized route table sync failed"))?;
+            evidence.file_fsync_calls = evidence
+                .file_fsync_calls
+                .checked_add(1)
+                .ok_or_else(|| invalid("materialized file sync count overflow"))?;
+            evidence.fsync_calls = evidence
+                .fsync_calls
+                .checked_add(1)
+                .ok_or_else(|| invalid("materialized sync count overflow"))?;
+            directory
+                .install_child(&name, identity, std::ffi::OsStr::new(TABLE_FILE))
+                .map_err(|_| invalid("materialized route table install failed"))?;
+            directory
+                .sync()
+                .map_err(|_| invalid("materialized route directory sync failed"))?;
+            evidence.directory_fsync_calls = evidence
+                .directory_fsync_calls
+                .checked_add(1)
+                .ok_or_else(|| invalid("materialized directory sync count overflow"))?;
+            evidence.fsync_calls = evidence
+                .fsync_calls
+                .checked_add(1)
+                .ok_or_else(|| invalid("materialized sync count overflow"))?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = directory.unlink_child_if_identity(&name, identity);
+        }
+        result
+    }
+}

--- a/crates/graphforge-storage/src/route_component/owned.rs
+++ b/crates/graphforge-storage/src/route_component/owned.rs
@@ -1,0 +1,970 @@
+//! Explicit admission of a private mutable graph workspace.
+//!
+//! This authority is never used to infer the layout of a published generation.
+//! Its caller owns the workspace; published inputs must first pass versioned
+//! inventory authentication and materialization.
+
+use std::path::Path;
+
+use graphforge_core::GfError;
+use graphforge_filesystem::StableDirectory;
+
+use super::{RouteTable, TABLE_FILE, encode_relative_route, invalid, limit};
+
+const MAX_TABLE_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_ROUTES: u64 = 100_000;
+// The existing rewrite intent permits 16,384 entries, including its table and
+// generation authority. Refuse before staging if one atomic migration cannot fit.
+const MAX_MOVED_FILES: usize = 16_382;
+
+pub(crate) fn admit_owned_workspace(root: &Path) -> Result<RouteTable, GfError> {
+    // Recovery precedes both table detection and catalog reads: a crash may
+    // have installed route files before installing the table in the same intent.
+    let absolute =
+        std::path::absolute(root).map_err(|_| invalid("owned graph root is not absolute"))?;
+    let root = absolute.as_path();
+    crate::durable_rewrite::prepare_owned_layout(
+        root,
+        |directory| prepare_owned_workspace(root, directory),
+        |(table, changed)| {
+            if changed {
+                let (mapped, _) = crate::graph_files::capture_graph_files(root)?;
+                crate::graph_files::authenticate_route_table(root, &mapped)
+            } else {
+                Ok(table)
+            }
+        },
+    )
+}
+
+fn prepare_owned_workspace(
+    root: &Path,
+    directory: &StableDirectory,
+) -> Result<(crate::RewriteBatch, (RouteTable, bool)), GfError> {
+    if let Some(table) = read_owned_layout_table(directory)? {
+        // A live caller may already own another RewriteBatch. Its exact temporary
+        // identities are available at commit, not at this writer-open boundary.
+        // Batch preparation still authenticates the complete payload/table closure.
+        return Ok((crate::RewriteBatch::new(), (table, false)));
+    }
+    remove_owned_migration_temps(directory)?;
+    remove_owned_table_temps(root)?;
+    let inventory = crate::graph_files::capture_owned_route_migration_inventory(root)?;
+    if inventory.format_version == crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION {
+        return Ok((
+            crate::RewriteBatch::new(),
+            (
+                crate::graph_files::authenticate_route_table(root, &inventory)?,
+                false,
+            ),
+        ));
+    }
+    let mut table = RouteTable::default();
+    let mut moves = Vec::new();
+    for entry in &inventory.files {
+        let destination = encode_relative_route(
+            &entry.relative_path,
+            &mut table,
+            MAX_TABLE_BYTES,
+            MAX_ROUTES,
+        )?;
+        if destination != entry.relative_path {
+            if moves.len() == MAX_MOVED_FILES {
+                return Err(limit("semantic route migration exceeds atomic file budget"));
+            }
+            let source = crate::graph_files::resolve_v1_inventory_entry_retained(root, entry)?;
+            moves.push((source, destination, entry));
+        }
+    }
+    let table_bytes = table.encode(MAX_TABLE_BYTES)?;
+    let mut staged = crate::RewriteBatch::new();
+    for (source, relative, expected) in moves {
+        create_destination_parent(directory, &relative)?;
+        let destination = root.join(relative);
+        #[cfg(test)]
+        BEFORE_STAGE.with(|slot| {
+            if let Some(hook) = slot.borrow_mut().take() {
+                hook();
+            }
+        });
+        staged.stage_semantic_route_move(root, directory, &source.path, &destination)?;
+        authenticate_staged_inventory_copy(root, &staged, &destination, &source, expected)?;
+    }
+    staged.stage_named_control_bytes(
+        &root.join(TABLE_FILE),
+        &table_bytes,
+        "semantic-routes.json.migration.",
+    )?;
+    Ok((staged, (table, true)))
+}
+
+pub(crate) fn read_owned_layout_table(
+    root: &StableDirectory,
+) -> Result<Option<RouteTable>, GfError> {
+    use std::io::Read;
+    let mut file = match root.open_child_file(std::ffi::OsStr::new(TABLE_FILE)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(invalid("owned route authority cannot be opened")),
+    };
+    if graphforge_filesystem::file_link_count(&file).ok() != Some(1) {
+        return Err(invalid("owned route authority has ambiguous ownership"));
+    }
+    let identity = graphforge_filesystem::file_identity(&file)
+        .map_err(|_| invalid("owned route authority identity failed"))?;
+    let mut bytes = Vec::new();
+    (&mut file)
+        .take(MAX_TABLE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| invalid("owned route authority read failed"))?;
+    let table = RouteTable::decode(&bytes, MAX_TABLE_BYTES, MAX_ROUTES)?;
+    let named = root
+        .open_child_file(std::ffi::OsStr::new(TABLE_FILE))
+        .map_err(|_| invalid("owned route authority disappeared"))?;
+    if graphforge_filesystem::file_identity(&named).ok() != Some(identity)
+        || graphforge_filesystem::file_identity(&file).ok() != Some(identity)
+        || graphforge_filesystem::file_link_count(&named).ok() != Some(1)
+    {
+        return Err(invalid("owned route authority changed during admission"));
+    }
+    Ok(Some(table))
+}
+
+fn remove_owned_migration_temps(root: &StableDirectory) -> Result<(), GfError> {
+    fn visit(
+        directory: &StableDirectory,
+        depth: usize,
+        visited: &mut usize,
+    ) -> Result<(), GfError> {
+        if depth > 32 {
+            return Err(limit("migration cleanup depth exceeded"));
+        }
+        let names = directory
+            .child_names_bounded(100_000usize.saturating_sub(*visited))
+            .map_err(|_| limit("migration cleanup entry budget exceeded"))?;
+        *visited = visited
+            .checked_add(names.len())
+            .ok_or_else(|| limit("migration cleanup count overflow"))?;
+        if *visited > 100_000 {
+            return Err(limit("migration cleanup entry budget exceeded"));
+        }
+        for name in names {
+            if let Ok(child) = directory.open_child_directory(&name) {
+                visit(&child, depth + 1, visited)?;
+                continue;
+            }
+            let owned = name
+                .to_str()
+                .and_then(|name| name.strip_prefix("semantic-route-move.parquet."))
+                .and_then(|name| name.strip_suffix(".tmp"))
+                .is_some_and(|random| {
+                    !random.is_empty() && random.bytes().all(|byte| byte.is_ascii_alphanumeric())
+                });
+            if !owned {
+                continue;
+            }
+            let file = directory
+                .open_child_file(&name)
+                .map_err(|_| invalid("migration temporary is not regular"))?;
+            if graphforge_filesystem::file_link_count(&file).ok() != Some(1) {
+                return Err(invalid("migration temporary has ambiguous ownership"));
+            }
+            let identity = graphforge_filesystem::file_identity(&file)
+                .map_err(|_| invalid("migration temporary identity failed"))?;
+            drop(file);
+            directory
+                .unlink_child_if_identity(&name, identity)
+                .map_err(|_| invalid("migration temporary cleanup failed"))?;
+            directory
+                .sync()
+                .map_err(|_| invalid("migration cleanup sync failed"))?;
+        }
+        Ok(())
+    }
+    visit(root, 0, &mut 0)
+}
+
+fn create_destination_parent(root: &StableDirectory, relative: &str) -> Result<(), GfError> {
+    let mut directory = root
+        .try_clone()
+        .map_err(|_| invalid("owned graph root changed"))?;
+    let parts = relative.split('/').collect::<Vec<_>>();
+    for name in &parts[..parts.len() - 1] {
+        directory = directory
+            .create_child_directory(std::ffi::OsStr::new(name))
+            .map_err(|_| invalid("owned route destination parent admission failed"))?;
+    }
+    directory
+        .sync()
+        .map_err(|_| invalid("owned route destination parent sync failed"))
+}
+
+fn authenticate_staged_inventory_copy(
+    root: &Path,
+    staged: &crate::RewriteBatch,
+    destination: &Path,
+    source: &crate::graph_files::RetainedV1InventoryEntry,
+    expected: &crate::GraphFileEntry,
+) -> Result<(), GfError> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    let current = crate::graph_files::resolve_v1_inventory_entry_retained(root, expected)?;
+    if current.identity != source.identity {
+        return Err(invalid(
+            "semantic route source identity changed before staging",
+        ));
+    }
+    let temporary = staged
+        .staged_temp(destination)
+        .ok_or_else(|| invalid("semantic route staged copy is absent"))?;
+    let parent = StableDirectory::open(
+        temporary
+            .parent()
+            .ok_or_else(|| invalid("semantic route staged copy has no parent"))?,
+    )
+    .map_err(|_| invalid("semantic route staged copy parent cannot be retained"))?;
+    let mut file = parent
+        .open_child_file(
+            temporary
+                .file_name()
+                .ok_or_else(|| invalid("semantic route staged copy has no name"))?,
+        )
+        .map_err(|_| {
+            invalid("semantic route staged copy cannot be opened without following links")
+        })?;
+    let mut digest = Sha256::new();
+    let mut bytes = 0_u64;
+    let mut buffer = vec![0_u8; 65536].into_boxed_slice();
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .map_err(|_| invalid("semantic route staged copy read failed"))?;
+        if count == 0 {
+            break;
+        }
+        bytes = bytes
+            .checked_add(count as u64)
+            .ok_or_else(|| limit("semantic route staged length overflow"))?;
+        if bytes > expected.byte_length {
+            return Err(invalid("semantic route staged copy length changed"));
+        }
+        digest.update(&buffer[..count]);
+    }
+    let actual = digest
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            use std::fmt::Write as _;
+            write!(&mut output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        });
+    if bytes != expected.byte_length || actual != expected.content_sha256 {
+        return Err(invalid(
+            "semantic route staged copy differs from admitted inventory",
+        ));
+    }
+    Ok(())
+}
+
+fn remove_owned_table_temps(root: &Path) -> Result<(), GfError> {
+    let directory = StableDirectory::open(root)
+        .map_err(|_| invalid("owned route cleanup root admission failed"))?;
+    for name in directory
+        .child_names_bounded(100_000)
+        .map_err(|_| limit("owned route cleanup entry budget exceeded"))?
+    {
+        let recognized = name
+            .to_str()
+            .and_then(|name| name.strip_prefix("semantic-routes.json.migration."))
+            .and_then(|name| name.strip_suffix(".tmp"))
+            .is_some_and(|random| {
+                !random.is_empty() && random.bytes().all(|byte| byte.is_ascii_alphanumeric())
+            });
+        if !recognized {
+            continue;
+        }
+        let file = directory
+            .open_child_file(&name)
+            .map_err(|_| invalid("owned route temporary is not a regular file"))?;
+        if graphforge_filesystem::file_link_count(&file).ok() != Some(1) {
+            return Err(invalid("owned route temporary has ambiguous ownership"));
+        }
+        let identity = graphforge_filesystem::file_identity(&file)
+            .map_err(|_| invalid("owned route temporary identity failed"))?;
+        drop(file);
+        directory
+            .unlink_child_if_identity(&name, identity)
+            .map_err(|_| invalid("owned route temporary changed during cleanup"))?;
+    }
+    directory
+        .sync()
+        .map_err(|_| invalid("owned route cleanup sync failed"))
+}
+
+#[cfg(test)]
+thread_local! {
+    static BEFORE_STAGE: std::cell::RefCell<Option<Box<dyn FnOnce()>>> = const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, FixedSizeBinaryArray, Int64Array, RecordBatch, UInt64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use parquet::arrow::{ArrowWriter, arrow_reader::ParquetRecordBatchReaderBuilder};
+    use std::sync::Arc;
+
+    fn write_legacy_fixture(root: &Path, route: &str) -> Vec<u8> {
+        let property = root.join("properties").join(format!("{route}.parquet"));
+        std::fs::create_dir_all(property.parent().unwrap()).unwrap();
+        let ids = FixedSizeBinaryArray::try_from_iter([[7_u8; 16]].into_iter()).unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("node_uuid", DataType::FixedSizeBinary(16), false),
+            Field::new("rank", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(ids), Arc::new(Int64Array::from(vec![7]))],
+        )
+        .unwrap();
+        let mut writer =
+            ArrowWriter::try_new(std::fs::File::create(&property).unwrap(), schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let edge = root.join("topology/edges/REL.parquet");
+        std::fs::create_dir_all(edge.parent().unwrap()).unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("edge_id", DataType::UInt64, false),
+            Field::new("edge_uuid", DataType::FixedSizeBinary(16), false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(UInt64Array::from(vec![1])),
+                Arc::new(FixedSizeBinaryArray::try_from_iter([[9_u8; 16]].into_iter()).unwrap()),
+            ],
+        )
+        .unwrap();
+        let mut writer =
+            ArrowWriter::try_new(std::fs::File::create(edge).unwrap(), schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        std::fs::read(property).unwrap()
+    }
+
+    #[test]
+    fn concurrent_legacy_admissions_keep_staging_under_rewrite_guard() {
+        let root = tempfile::tempdir().unwrap();
+        let payload = write_legacy_fixture(root.path(), "Legacy");
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        std::thread::scope(|scope| {
+            let path = root.path();
+            let first_barrier = Arc::clone(&barrier);
+            let first = scope.spawn(move || {
+                BEFORE_STAGE.with(|slot| {
+                    *slot.borrow_mut() = Some(Box::new(move || {
+                        // Observe the process-wide rewrite-lock flag at this hook.
+                        // The joined admissions and final inventory below verify the
+                        // concurrent outcome; this flag alone is not ownership proof.
+                        assert!(crate::durable_rewrite::rewrite_lock_is_held());
+                        entered_tx.send(()).unwrap();
+                        first_barrier.wait();
+                    }));
+                });
+                admit_owned_workspace(path).unwrap()
+            });
+            entered_rx.recv().unwrap();
+            let second = scope.spawn(move || {
+                barrier.wait();
+                admit_owned_workspace(path).unwrap()
+            });
+            assert_eq!(
+                first.join().unwrap().encode(MAX_TABLE_BYTES).unwrap(),
+                second.join().unwrap().encode(MAX_TABLE_BYTES).unwrap()
+            );
+        });
+        let (inventory, _) = crate::graph_files::capture_graph_files(root.path()).unwrap();
+        crate::graph_files::authenticate_route_table(root.path(), &inventory).unwrap();
+        assert!(!root.path().join("properties/Legacy.parquet").exists());
+        assert_eq!(
+            std::fs::read(
+                root.path()
+                    .join("properties")
+                    .join(format!("{}.parquet", super::super::component("Legacy")))
+            )
+            .unwrap(),
+            payload
+        );
+    }
+
+    #[test]
+    fn legacy_cas_materialization_translates_routes_before_creating_paths() {
+        let fixture = tempfile::tempdir().unwrap();
+        let payload = write_legacy_fixture(fixture.path(), "Legacy");
+        let cas = tempfile::tempdir().unwrap();
+        let (digest, _) = crate::install_graph_object_bytes(cas.path(), &payload).unwrap();
+        let source_path = crate::graph_object_path(cas.path(), &digest).unwrap();
+        let source_identity = graphforge_filesystem::path_identity(&source_path).unwrap();
+        let long = "長".repeat(2048);
+        let names = ["CON", "con", "A\\B", "ß", long.as_str()];
+        let mut files = names
+            .iter()
+            .map(|route| crate::GraphFileEntry {
+                relative_path: format!("properties/{route}.parquet"),
+                byte_length: payload.len() as u64,
+                content_sha256: digest.clone(),
+                role: crate::GraphFileRole::Properties,
+            })
+            .collect::<Vec<_>>();
+        files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        let inventory = crate::graph_files::inventory_from_entries(files).unwrap();
+        let owner = tempfile::tempdir().unwrap();
+        let target = owner.path().join("private");
+        let evidence = crate::materialize_graph_objects(cas.path(), &inventory, &target).unwrap();
+        assert_eq!(evidence.files_copied, names.len() as u64);
+        assert_eq!(evidence.files_reused, 0);
+        let mapped = crate::capture_graph_files(&target).unwrap().0;
+        assert_eq!(
+            mapped.format_version,
+            crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+        );
+        let table = crate::graph_files::authenticate_route_table(&target, &mapped).unwrap();
+        for route in names {
+            let component = super::super::component(route);
+            assert_eq!(table.route(&component).unwrap(), route);
+            let path = target
+                .join("properties")
+                .join(format!("{component}.parquet"));
+            assert_eq!(std::fs::read(&path).unwrap(), payload);
+            assert_ne!(
+                graphforge_filesystem::path_identity(&path).unwrap(),
+                source_identity
+            );
+        }
+        drop(
+            crate::GraphWriter::open_at(&target, graphforge_core::OntologyMode::Strict, 0).unwrap(),
+        );
+        assert_eq!(
+            std::fs::read(target.join("topology/generation.json"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotFound
+        );
+        drop(
+            crate::GraphWriter::open_at(&target, graphforge_core::OntologyMode::Strict, 1).unwrap(),
+        );
+        assert_eq!(
+            std::fs::read(target.join("topology/generation.json"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotFound
+        );
+        assert_eq!(std::fs::read(&source_path).unwrap(), payload);
+        assert_eq!(
+            graphforge_filesystem::path_identity(&source_path).unwrap(),
+            source_identity
+        );
+    }
+
+    #[test]
+    fn legacy_expanded_materialization_installs_mapped_owned_authority() {
+        let source = tempfile::tempdir().unwrap();
+        let payload = write_legacy_fixture(source.path(), "Legacy");
+        let inventory = crate::capture_graph_files(source.path()).unwrap().0;
+        assert_eq!(inventory.format_version, crate::GRAPH_FILES_RECORD_VERSION);
+        let owner = tempfile::tempdir().unwrap();
+        let target = owner.path().join("private");
+        crate::materialize_graph_tree(source.path(), &inventory, &target).unwrap();
+        assert_eq!(
+            std::fs::read(
+                target
+                    .join("properties")
+                    .join(format!("{}.parquet", super::super::component("Legacy")))
+            )
+            .unwrap(),
+            payload
+        );
+        assert!(!target.join("properties/Legacy.parquet").exists());
+        drop(
+            crate::GraphWriter::open_at(&target, graphforge_core::OntologyMode::Strict, 0).unwrap(),
+        );
+        assert_eq!(
+            std::fs::read(source.path().join("properties/Legacy.parquet")).unwrap(),
+            payload
+        );
+        crate::verify_graph_tree(source.path(), &inventory).unwrap();
+    }
+
+    #[test]
+    fn bare_writer_migrates_legacy_routes_and_reopens_exact_bytes_and_ids() {
+        let root = tempfile::tempdir().unwrap();
+        let original = write_legacy_fixture(root.path(), "Legacy");
+        drop(
+            crate::GraphWriter::open_at(root.path(), graphforge_core::OntologyMode::Strict, 0)
+                .unwrap(),
+        );
+        let mapped = root
+            .path()
+            .join("properties")
+            .join(format!("{}.parquet", super::super::component("Legacy")));
+        assert!(!root.path().join("properties/Legacy.parquet").exists());
+        assert!(!root.path().join("topology/edges/REL.parquet").exists());
+        assert_eq!(std::fs::read(&mapped).unwrap(), original);
+        let generation = std::fs::read(root.path().join("topology/generation.json")).unwrap();
+        drop(
+            crate::GraphWriter::open_at(root.path(), graphforge_core::OntologyMode::Strict, 1)
+                .unwrap(),
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("topology/generation.json")).unwrap(),
+            generation
+        );
+        assert_eq!(std::fs::read(&mapped).unwrap(), original);
+        assert_eq!(crate::catalog::max_edge_id(root.path()).unwrap(), 1);
+        let mut reader =
+            ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(&mapped).unwrap())
+                .unwrap()
+                .build()
+                .unwrap();
+        let batch = reader.next().unwrap().unwrap();
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        assert_eq!(ids.null_count(), 0);
+        assert_eq!(ids.value(0), &[7_u8; 16]);
+        assert_eq!(
+            batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            7
+        );
+        let (inventory, participant) = crate::capture_graph_files(root.path()).unwrap();
+        assert_eq!(
+            inventory.format_version,
+            crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+        );
+        assert_eq!(
+            participant.record_version,
+            crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+        );
+        let table = crate::graph_files::authenticate_route_table(root.path(), &inventory).unwrap();
+        assert_eq!(
+            table.route(&super::super::component("Legacy")).unwrap(),
+            "Legacy"
+        );
+        assert_eq!(table.route(&super::super::component("REL")).unwrap(), "REL");
+    }
+    #[test]
+    fn inventory_source_substitution_before_stage_cannot_be_recaptured() {
+        for same_bytes in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let original = write_legacy_fixture(root.path(), "Legacy");
+            let source = root.path().join("properties/Legacy.parquet");
+            let saved = root.path().join("saved-original.parquet");
+            let substitute = source.clone();
+            BEFORE_STAGE.with(|slot| {
+                *slot.borrow_mut() = Some(Box::new(move || {
+                    std::fs::rename(&substitute, &saved).unwrap();
+                    std::fs::write(
+                        substitute,
+                        if same_bytes {
+                            original.as_slice()
+                        } else {
+                            b"substituted"
+                        },
+                    )
+                    .unwrap();
+                }))
+            });
+            let error =
+                crate::GraphWriter::open_at(root.path(), graphforge_core::OntologyMode::Strict, 0)
+                    .err()
+                    .expect("substitution must refuse");
+            assert!(matches!(
+                error,
+                GfError::Project {
+                    code: graphforge_core::ProjectErrorCode::ProjectCorrupt,
+                    ..
+                }
+            ));
+            assert!(source.exists());
+            assert!(!root.path().join(TABLE_FILE).exists());
+            assert!(
+                !root
+                    .path()
+                    .join("properties")
+                    .join(format!("{}.parquet", super::super::component("Legacy")))
+                    .exists()
+            );
+        }
+    }
+
+    #[test]
+    fn subprocess_migration_crash_reopens_and_preserves_unknown_neighbor() {
+        const CHILD: &str = "GRAPHFORGE_ROUTE_MIGRATION_CHILD";
+        if let Ok(root) = std::env::var(CHILD) {
+            let _ = crate::GraphWriter::open_at(
+                Path::new(&root),
+                graphforge_core::OntologyMode::Strict,
+                0,
+            );
+            panic!("migration failpoint did not terminate child");
+        }
+        for phase in [
+            "rewrite.before_intent",
+            "rewrite.after_preparing_disarm",
+            "rewrite.after_move_install",
+            "rewrite.after_source_retirement",
+            "rewrite.before_generation_authority",
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let original = write_legacy_fixture(root.path(), "Legacy");
+            let neighbor = root.path().join("semantic-routes.json.unknown-partial.tmp");
+            std::fs::write(&neighbor, b"not an owned temporary").unwrap();
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "route_component::owned::tests::subprocess_migration_crash_reopens_and_preserves_unknown_neighbor", "--nocapture"])
+                .env(CHILD, root.path())
+                .env("GRAPHFORGE_PROJECT_FAILPOINTS", "graphforge-internal-subprocess-v1")
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", phase).status().unwrap();
+            assert_eq!(
+                status.code(),
+                Some(crate::project_failpoint::exit_code()),
+                "{phase}"
+            );
+            drop(
+                crate::GraphWriter::open_at(root.path(), graphforge_core::OntologyMode::Strict, 1)
+                    .unwrap(),
+            );
+            drop(
+                crate::GraphWriter::open_at(root.path(), graphforge_core::OntologyMode::Strict, 2)
+                    .unwrap(),
+            );
+            assert_eq!(std::fs::read(&neighbor).unwrap(), b"not an owned temporary");
+            assert!(!root.path().join("properties/Legacy.parquet").exists());
+            assert_eq!(
+                std::fs::read(
+                    root.path()
+                        .join("properties")
+                        .join(format!("{}.parquet", super::super::component("Legacy")))
+                )
+                .unwrap(),
+                original
+            );
+            let (inventory, _) = crate::capture_graph_files(root.path()).unwrap();
+            assert_eq!(
+                inventory.format_version,
+                crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+            );
+        }
+    }
+    #[test]
+    fn rewrite_baseline_excludes_only_exact_retained_temporary_routes() {
+        let root = tempfile::tempdir().unwrap();
+        admit_owned_workspace(root.path()).unwrap();
+        let before = crate::capture_graph_files(root.path()).unwrap().0;
+        let mut batch = crate::RewriteBatch::new();
+        let component = batch.route_component(root.path(), "CON").unwrap();
+        let output = root
+            .path()
+            .join("properties")
+            .join(format!("{component}.parquet"));
+        batch.stage_bytes(&output, b"payload").unwrap();
+        assert_eq!(
+            crate::graph_files::capture_rewrite_baseline(root.path(), &batch)
+                .unwrap()
+                .0,
+            before
+        );
+        let temporary = batch.staged_temp(&output).unwrap().to_path_buf();
+        let unknown = root.path().join("properties/unknown.partial.tmp");
+        std::fs::hard_link(&temporary, &unknown).unwrap();
+        assert!(crate::graph_files::capture_rewrite_baseline(root.path(), &batch).is_err());
+        std::fs::remove_file(&unknown).unwrap();
+        std::fs::write(&unknown, b"unrecognized partial").unwrap();
+        assert!(crate::graph_files::capture_rewrite_baseline(root.path(), &batch).is_err());
+        std::fs::remove_file(&unknown).unwrap();
+        std::fs::rename(&temporary, root.path().join("retained-original")).unwrap();
+        std::fs::write(&temporary, b"payload").unwrap();
+        assert!(crate::graph_files::capture_rewrite_baseline(root.path(), &batch).is_err());
+    }
+
+    #[test]
+    fn route_commit_refuses_linked_authority_and_unregistered_outputs() {
+        let root = tempfile::tempdir().unwrap();
+        admit_owned_workspace(root.path()).unwrap();
+        let before = std::fs::read(root.path().join(TABLE_FILE)).unwrap();
+        for linked in [true, false] {
+            let mut batch = crate::RewriteBatch::new();
+            let registered = batch.route_component(root.path(), "registered").unwrap();
+            let component = if linked {
+                registered
+            } else {
+                super::super::component("unknown")
+            };
+            let output = root
+                .path()
+                .join("properties")
+                .join(format!("{component}.parquet"));
+            batch.stage_bytes(&output, b"payload").unwrap();
+            let alias = root.path().join("table-alias");
+            if linked {
+                std::fs::hard_link(root.path().join(TABLE_FILE), &alias).unwrap();
+            }
+            assert!(matches!(
+                batch.commit_at(root.path()),
+                Err(GfError::Project {
+                    code: graphforge_core::ProjectErrorCode::ProjectCorrupt,
+                    ..
+                })
+            ));
+            assert!(!output.exists());
+            assert_eq!(std::fs::read(root.path().join(TABLE_FILE)).unwrap(), before);
+            if linked {
+                std::fs::remove_file(alias).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn route_authority_reverification_refuses_new_hardlink() {
+        let root = tempfile::tempdir().unwrap();
+        admit_owned_workspace(root.path()).unwrap();
+        let directory = StableDirectory::open(root.path()).unwrap();
+        let mut routes = super::PendingRoutes::default();
+        let component = routes.register(root.path(), "registered").unwrap();
+        let mut batch = crate::RewriteBatch::new();
+        batch
+            .stage_bytes(
+                &root
+                    .path()
+                    .join("properties")
+                    .join(format!("{component}.parquet")),
+                b"payload",
+            )
+            .unwrap();
+        let prior = routes
+            .prepare(root.path(), &directory, &mut batch)
+            .unwrap()
+            .unwrap();
+        std::fs::hard_link(
+            root.path().join(TABLE_FILE),
+            root.path().join("table-alias"),
+        )
+        .unwrap();
+        assert!(matches!(
+            prior.verify(&directory),
+            Err(GfError::Project {
+                code: graphforge_core::ProjectErrorCode::ProjectCorrupt,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn concurrent_batches_extend_current_table_and_reject_independent_override() {
+        let root = tempfile::tempdir().unwrap();
+        admit_owned_workspace(root.path()).unwrap();
+        let mut first = crate::RewriteBatch::new();
+        let mut second = crate::RewriteBatch::new();
+        for (batch, route) in [(&mut first, "CON"), (&mut second, "con")] {
+            let component = batch.route_component(root.path(), route).unwrap();
+            batch
+                .stage_bytes(
+                    &root
+                        .path()
+                        .join("properties")
+                        .join(format!("{component}.parquet")),
+                    route.as_bytes(),
+                )
+                .unwrap();
+        }
+        first.commit_at(root.path()).unwrap();
+        second.commit_at(root.path()).unwrap();
+        let (inventory, _) = crate::capture_graph_files(root.path()).unwrap();
+        let table = crate::graph_files::authenticate_route_table(root.path(), &inventory).unwrap();
+        assert_eq!(table.route(&super::super::component("CON")).unwrap(), "CON");
+        assert_eq!(table.route(&super::super::component("con")).unwrap(), "con");
+        let before = std::fs::read(root.path().join(TABLE_FILE)).unwrap();
+        let mut invalid_batch = crate::RewriteBatch::new();
+        let component = invalid_batch.route_component(root.path(), "third").unwrap();
+        let output = root
+            .path()
+            .join("properties")
+            .join(format!("{component}.parquet"));
+        invalid_batch.stage_bytes(&output, b"third").unwrap();
+        invalid_batch
+            .stage_bytes(&root.path().join(TABLE_FILE), b"independent override")
+            .unwrap();
+        assert!(matches!(
+            invalid_batch.commit_at(root.path()),
+            Err(GfError::Project {
+                code: graphforge_core::ProjectErrorCode::ProjectCorrupt,
+                ..
+            })
+        ));
+        assert_eq!(std::fs::read(root.path().join(TABLE_FILE)).unwrap(), before);
+        assert!(!output.exists());
+    }
+}
+
+/// Semantic registrations belong to one existing rewrite, never a global cache.
+#[derive(Default)]
+pub(crate) struct PendingRoutes {
+    root: Option<std::path::PathBuf>,
+    routes: std::collections::BTreeSet<String>,
+    bytes: u64,
+}
+
+impl PendingRoutes {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.routes.is_empty()
+    }
+
+    pub(crate) fn register(&mut self, root: &Path, route: &str) -> Result<String, GfError> {
+        super::validate_semantic_route(route)?;
+        let root =
+            std::path::absolute(root).map_err(|_| invalid("pending route root is invalid"))?;
+        if self.root.as_ref().is_some_and(|prior| prior != &root) {
+            return Err(invalid(
+                "one rewrite cannot register routes for different roots",
+            ));
+        }
+        if !self.routes.contains(route) {
+            let bytes = self
+                .bytes
+                .checked_add(route.len() as u64)
+                .ok_or_else(|| limit("pending route bytes overflow"))?;
+            if bytes > MAX_TABLE_BYTES || self.routes.len() as u64 >= MAX_ROUTES {
+                return Err(limit("pending semantic route budget exceeded"));
+            }
+            self.routes.insert(route.to_owned());
+            self.bytes = bytes;
+            self.root = Some(root);
+        }
+        Ok(super::component(route))
+    }
+
+    pub(crate) fn prepare(
+        self,
+        root_path: &Path,
+        root: &StableDirectory,
+        batch: &mut crate::RewriteBatch,
+    ) -> Result<Option<TablePrior>, GfError> {
+        use sha2::{Digest, Sha256};
+        use std::io::Read;
+        if self.routes.is_empty() {
+            return Ok(None);
+        }
+        if self.root.as_deref()
+            != Some(
+                std::path::absolute(root_path)
+                    .map_err(|_| invalid("route commit root is invalid"))?
+                    .as_path(),
+            )
+        {
+            return Err(invalid(
+                "registered route root differs from rewrite authority",
+            ));
+        }
+        if batch
+            .staged_paths()
+            .any(|path| path == root_path.join(TABLE_FILE))
+        {
+            return Err(invalid(
+                "rewrite cannot replace route authority independently of registered routes",
+            ));
+        }
+        let mut original = root
+            .open_child_file(std::ffi::OsStr::new(TABLE_FILE))
+            .map_err(|_| invalid("route write requires an admitted owned layout"))?;
+        if graphforge_filesystem::file_link_count(&original).ok() != Some(1) {
+            return Err(invalid("owned route table must have one link"));
+        }
+        let identity = graphforge_filesystem::file_identity(&original)
+            .map_err(|_| invalid("route table identity unavailable"))?;
+        let mut bytes = Vec::new();
+        (&mut original)
+            .take(MAX_TABLE_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| invalid("route table read failed"))?;
+        let mut table = RouteTable::decode(&bytes, MAX_TABLE_BYTES, MAX_ROUTES)?;
+        let prior = TablePrior {
+            _file: original,
+            identity,
+            bytes: bytes.len() as u64,
+            digest: Sha256::digest(&bytes).into(),
+        };
+        let mut emitted = std::collections::BTreeSet::new();
+        for path in batch.staged_paths() {
+            let relative = path
+                .strip_prefix(root_path)
+                .map_err(|_| invalid("registered route destination escaped root"))?;
+            let parts = relative
+                .components()
+                .map(|part| part.as_os_str().to_str())
+                .collect::<Option<Vec<_>>>()
+                .ok_or_else(|| invalid("registered route destination is not UTF-8"))?;
+            if let Some(component) = super::route_position(&parts.join("/"))? {
+                emitted.insert(component.to_owned());
+            }
+        }
+        for route in self.routes {
+            if emitted.contains(&super::component(&route)) {
+                table.insert(&route, MAX_TABLE_BYTES, MAX_ROUTES)?;
+            }
+        }
+        for component in emitted {
+            table.route(&component)?;
+        }
+        let updated = table.encode(MAX_TABLE_BYTES)?;
+        if updated != bytes {
+            batch.stage_named_control_bytes(
+                &root_path.join(TABLE_FILE),
+                &updated,
+                "semantic-routes.json.",
+            )?;
+        }
+        prior.verify(root)?;
+        Ok(Some(prior))
+    }
+}
+
+pub(crate) struct TablePrior {
+    _file: std::fs::File,
+    identity: graphforge_filesystem::FileIdentity,
+    bytes: u64,
+    digest: [u8; 32],
+}
+
+impl TablePrior {
+    pub(crate) fn verify(&self, root: &StableDirectory) -> Result<(), GfError> {
+        use sha2::{Digest, Sha256};
+        use std::io::Read;
+        let file = root
+            .open_child_file(std::ffi::OsStr::new(TABLE_FILE))
+            .map_err(|_| invalid("route table disappeared before commit"))?;
+        if graphforge_filesystem::file_link_count(&file).ok() != Some(1) {
+            return Err(invalid(
+                "owned route table link count changed before commit",
+            ));
+        }
+        if graphforge_filesystem::file_identity(&file).ok() != Some(self.identity) {
+            return Err(invalid("route table identity changed before commit"));
+        }
+        let mut bytes = Vec::new();
+        file.take(self.bytes + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| invalid("route table reauthentication failed"))?;
+        let digest: [u8; 32] = Sha256::digest(&bytes).into();
+        if bytes.len() as u64 != self.bytes || digest != self.digest {
+            return Err(invalid("route table changed before commit"));
+        }
+        Ok(())
+    }
+}

--- a/crates/graphforge-storage/src/semantic_bindings.rs
+++ b/crates/graphforge-storage/src/semantic_bindings.rs
@@ -228,6 +228,10 @@ impl SemanticStorageBindings {
         let source_inventory_sha256 =
             hex(Sha256::digest(crate::encode_inventory(&source_inventory)?).into());
         let retained_rows_scanned = scan_retained_migration_rows(pinned_graph_root)?;
+        let authority = crate::graph_projection::TransformRoutes::from_inventory(
+            pinned_graph_root,
+            source_inventory.clone(),
+        )?;
         let mut projected = Self::project(next, None)?;
         let mut target_property_schemas = next
             .modules
@@ -266,7 +270,7 @@ impl SemanticStorageBindings {
                 .iter()
                 .find(|module| module.id.ontology_id == prior.symbol.module.ontology_id);
             let Some(next_module) = next_module else {
-                if binding_has_retained_data(prior, pinned_graph_root)? {
+                if binding_has_retained_data_with_authority(prior, pinned_graph_root, &authority)? {
                     return Err(corrupt("module removal would orphan retained data"));
                 }
                 operations.push(SemanticMigrationOperation::RemoveEmpty {
@@ -363,7 +367,7 @@ impl SemanticStorageBindings {
                 })
                 .flatten();
             let Some(next_index) = next_index else {
-                if binding_has_retained_data(prior, pinned_graph_root)? {
+                if binding_has_retained_data_with_authority(prior, pinned_graph_root, &authority)? {
                     return Err(corrupt("migration removal would orphan retained data"));
                 }
                 operations.push(SemanticMigrationOperation::RemoveEmpty {
@@ -472,7 +476,11 @@ impl SemanticStorageBindings {
                             && Some(candidate.storage_id) == target_owner_id
                     });
                     if let Some(prior_owner) = prior_owner
-                        && binding_has_retained_data(prior_owner, pinned_graph_root)?
+                        && binding_has_retained_data_with_authority(
+                            prior_owner,
+                            pinned_graph_root,
+                            &authority,
+                        )?
                     {
                         return Err(corrupt(
                             "non-null property addition requires a deterministic typed retained-data backfill",
@@ -650,27 +658,55 @@ impl SemanticStorageBindings {
             }
         }
 
+        let (inventory, _) = crate::capture_graph_files(graph_root)?;
+        let authority = crate::graph_projection::TransformRoutes::from_inventory(
+            graph_root,
+            inventory.clone(),
+        )?;
+        let logical_paths = inventory
+            .files
+            .iter()
+            .map(|entry| {
+                Ok((
+                    authority.semantic_path(&entry.relative_path)?,
+                    PathBuf::from(&entry.relative_path),
+                ))
+            })
+            .collect::<Result<Vec<_>, GfError>>()?;
         let mut route_moves = Vec::new();
+        let mut destinations = crate::route_component::RouteTable::default();
         for binding in &bindings.bindings {
-            let old = match binding.route_kind {
+            let (domain, name) = match binding.route_kind {
                 SemanticRouteKind::Entity => continue,
-                SemanticRouteKind::Relation => PathBuf::from("topology/edges")
-                    .join(format!("{}.parquet", binding.symbol.local_id)),
-                SemanticRouteKind::NodeProperty => PathBuf::from("properties").join(format!(
-                    "{}.parquet",
-                    binding.owner.as_ref().unwrap().local_id
-                )),
-                SemanticRouteKind::EdgeProperty => PathBuf::from("edge_properties").join(format!(
-                    "{}.parquet",
-                    binding.owner.as_ref().unwrap().local_id
-                )),
+                SemanticRouteKind::Relation => ("topology/edges", binding.symbol.local_id.as_str()),
+                SemanticRouteKind::NodeProperty => (
+                    "properties",
+                    binding.owner.as_ref().unwrap().local_id.as_str(),
+                ),
+                SemanticRouteKind::EdgeProperty => (
+                    "edge_properties",
+                    binding.owner.as_ref().unwrap().local_id.as_str(),
+                ),
             };
-            let new = binding
-                .physical_path(Path::new(""))
-                .expect("routed binding");
-            if graph_root.join(&old).exists() && !route_moves.iter().any(|(prior, _)| prior == &old)
-            {
-                route_moves.push((old, new));
+            let flat = format!("{domain}/{name}.parquet");
+            let prefix = format!("{domain}/{name}/");
+            for (logical, physical) in &logical_paths {
+                let destination = if logical == &flat {
+                    Some(format!("{domain}/{}.parquet", binding.route))
+                } else {
+                    logical
+                        .strip_prefix(&prefix)
+                        .map(|fragment| format!("{domain}/{}/{fragment}", binding.route))
+                };
+                if let Some(destination) = destination
+                    && !route_moves.iter().any(|(prior, _)| prior == physical)
+                {
+                    let encoded = crate::graph_projection::encode_transform_path(
+                        &destination,
+                        &mut destinations,
+                    )?;
+                    route_moves.push((physical.clone(), PathBuf::from(encoded)));
+                }
             }
         }
         route_moves.sort();
@@ -866,6 +902,7 @@ impl SemanticStorageBindings {
             .iter()
             .map(|(kind, symbol, owner)| lineage_key(*kind, symbol, owner.as_ref()))
             .collect::<BTreeSet<_>>();
+        let mut removal_authority = None;
         if let Some(previous) = previous {
             for removed in previous.bindings.iter().filter(|binding| {
                 !next_lineages.contains(&lineage_key(
@@ -877,7 +914,15 @@ impl SemanticStorageBindings {
                 let root = graph_root.ok_or_else(|| {
                     corrupt("semantic binding removal requires an exact pinned graph scan")
                 })?;
-                if binding_has_retained_data(removed, root)? {
+                if removal_authority.is_none() {
+                    removal_authority =
+                        Some(crate::graph_projection::TransformRoutes::capture(root)?);
+                }
+                if binding_has_retained_data_with_authority(
+                    removed,
+                    root,
+                    removal_authority.as_ref().expect("admitted above"),
+                )? {
                     return Err(corrupt(
                         "semantic binding removal would orphan retained data",
                     ));
@@ -1096,29 +1141,45 @@ impl SemanticStorageBindings {
         graph_root: &Path,
         inventory: Option<&crate::GraphFilesInventory>,
     ) -> Result<(), GfError> {
+        let captured = crate::capture_graph_files(graph_root)?.0;
+        let inventory = match inventory {
+            Some(inventory) => {
+                if inventory != &captured {
+                    return Err(corrupt(
+                        "semantic route inventory disagrees with the graph tree",
+                    ));
+                }
+                inventory
+            }
+            None => &captured,
+        };
+        let routes = semantic_fragment_inventory(graph_root, inventory)?;
         let expected = self
             .bindings
             .iter()
-            .map(|binding| semantic_route_fragments(binding, graph_root))
+            .map(|binding| Ok::<_, GfError>(binding_fragments(binding, &routes)))
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .flatten()
             .collect::<BTreeSet<_>>();
-        let inventory_paths = inventory.map(|inventory| {
-            inventory
-                .files
-                .iter()
-                .map(|entry| entry.relative_path.as_str())
-                .collect::<BTreeSet<_>>()
-        });
+        let inventory_paths = inventory
+            .files
+            .iter()
+            .map(|entry| entry.relative_path.as_str())
+            .collect::<BTreeSet<_>>();
         validate_no_unlisted_semantic_routes(graph_root, &expected)?;
+        for ((_, route), paths) in &routes {
+            if route.starts_with("s-") && paths.iter().any(|path| !expected.contains(path)) {
+                return Err(corrupt("unlisted opaque semantic route file is present"));
+            }
+        }
         for binding in &self.bindings {
-            for path in semantic_route_fragments(binding, graph_root)? {
+            for path in binding_fragments(binding, &routes) {
                 validate_semantic_route_fragment(
                     binding,
                     &path,
                     graph_root,
-                    inventory_paths.as_ref(),
+                    Some(&inventory_paths),
                     &self.composition_fingerprint,
                 )?;
             }
@@ -1238,26 +1299,57 @@ impl SemanticStorageBindings {
     }
 }
 
+type SemanticFragments = BTreeMap<(String, String), Vec<PathBuf>>;
+
+fn semantic_fragment_inventory(
+    root: &Path,
+    inventory: &crate::GraphFilesInventory,
+) -> Result<SemanticFragments, GfError> {
+    let authority =
+        crate::graph_projection::TransformRoutes::from_inventory(root, inventory.clone())?;
+    let mut routes = BTreeMap::<(String, String), Vec<PathBuf>>::new();
+    for entry in &inventory.files {
+        let logical = authority.semantic_path(&entry.relative_path)?;
+        if let Some(route) = semantic_route_from_wire(&logical) {
+            let domain = if logical.starts_with("topology/edges/") {
+                "topology/edges"
+            } else if logical.starts_with("edge_properties/") {
+                "edge_properties"
+            } else {
+                "properties"
+            };
+            let physical = crate::graph_files::resolve_v1_inventory_entry(root, entry)?;
+            routes
+                .entry((domain.to_owned(), route.to_owned()))
+                .or_default()
+                .push(physical);
+        }
+    }
+    Ok(routes)
+}
+
+fn binding_fragments(binding: &SemanticStorageBinding, routes: &SemanticFragments) -> Vec<PathBuf> {
+    let domain = match binding.route_kind {
+        SemanticRouteKind::Entity => return Vec::new(),
+        SemanticRouteKind::Relation => "topology/edges",
+        SemanticRouteKind::NodeProperty => "properties",
+        SemanticRouteKind::EdgeProperty => "edge_properties",
+    };
+    routes
+        .get(&(domain.to_owned(), binding.route.clone()))
+        .cloned()
+        .unwrap_or_default()
+}
+
 fn semantic_route_fragments(
     binding: &SemanticStorageBinding,
     root: &Path,
 ) -> Result<Vec<PathBuf>, GfError> {
-    match binding.route_kind {
-        SemanticRouteKind::Entity => Ok(Vec::new()),
-        SemanticRouteKind::Relation => Ok(crate::mutator::edge_parquet_files(
-            root,
-            Some(&binding.route),
-        )?
-        .into_iter()
-        .map(|(_, path)| path)
-        .collect()),
-        SemanticRouteKind::NodeProperty => {
-            crate::mutator::property_parquet_files(root, "properties", &binding.route)
-        }
-        SemanticRouteKind::EdgeProperty => {
-            crate::mutator::property_parquet_files(root, "edge_properties", &binding.route)
-        }
-    }
+    let (inventory, _) = crate::capture_graph_files(root)?;
+    Ok(binding_fragments(
+        binding,
+        &semantic_fragment_inventory(root, &inventory)?,
+    ))
 }
 
 fn validate_no_unlisted_semantic_routes(
@@ -1371,7 +1463,8 @@ fn validate_semantic_route_fragment(
 }
 
 impl SemanticStorageBinding {
-    /// Exact physical path for routed data, or none for numeric entity bindings.
+    /// Legacy logical route path, or none for numeric entity bindings.
+    /// Mapped graph files must be resolved through their admitted route inventory.
     #[must_use]
     pub fn physical_path(&self, root: &Path) -> Option<PathBuf> {
         match self.route_kind {
@@ -1490,6 +1583,60 @@ pub fn require_atomic_legacy_migration(graph_root: &Path) -> Result<(), GfError>
 pub struct LegacyRouteMigration {
     completed: Vec<(PathBuf, PathBuf, PathBuf)>,
     committed: bool,
+    table: Option<LegacyTableRollback>,
+    backup_root: PathBuf,
+}
+
+struct LegacyTableRollback {
+    root: PathBuf,
+    previous: Vec<u8>,
+    installed: File,
+    digest: [u8; 32],
+}
+
+impl LegacyTableRollback {
+    fn still_owned(&self) -> bool {
+        use std::io::Read;
+        let Ok(root) = graphforge_filesystem::StableDirectory::open(&self.root) else {
+            return false;
+        };
+        let Ok(mut current) =
+            root.open_child_file(std::ffi::OsStr::new(crate::route_component::TABLE_FILE))
+        else {
+            return false;
+        };
+        let (Ok(actual), Ok(expected)) = (
+            graphforge_filesystem::file_identity(&current),
+            graphforge_filesystem::file_identity(&self.installed),
+        ) else {
+            return false;
+        };
+        if actual != expected || graphforge_filesystem::file_link_count(&current).ok() != Some(1) {
+            return false;
+        }
+        let mut bytes = Vec::new();
+        if current
+            .by_ref()
+            .take(64 * 1024 * 1024 + 1)
+            .read_to_end(&mut bytes)
+            .is_err()
+        {
+            return false;
+        }
+        let digest: [u8; 32] = Sha256::digest(bytes).into();
+        digest == self.digest
+    }
+}
+
+fn replace_legacy_table(root: &Path, bytes: &[u8]) -> Result<(), GfError> {
+    let mut batch = crate::RewriteBatch::new();
+    batch.stage_named_control_bytes(
+        &root.join(crate::route_component::TABLE_FILE),
+        bytes,
+        "semantic-routes.json.",
+    )?;
+    crate::durable_rewrite::commit(batch, root, false, false, false, None)?;
+    Ok(())
 }
 
 impl LegacyRouteMigration {
@@ -1498,6 +1645,7 @@ impl LegacyRouteMigration {
         for (_, _, backup) in &self.completed {
             let _ = std::fs::remove_file(backup);
         }
+        let _ = std::fs::remove_dir(&self.backup_root);
         self.committed = true;
     }
 }
@@ -1505,12 +1653,139 @@ impl LegacyRouteMigration {
 impl Drop for LegacyRouteMigration {
     fn drop(&mut self) {
         if !self.committed {
-            for (old, new, backup) in self.completed.iter().rev() {
-                let _ = std::fs::remove_file(new);
-                let _ = std::fs::rename(backup, old);
+            if self
+                .table
+                .as_ref()
+                .is_some_and(|table| !table.still_owned())
+            {
+                return;
             }
+            for (old, new, backup) in self.completed.iter().rev() {
+                if backup.try_exists().unwrap_or(false) {
+                    let _ = std::fs::remove_file(new);
+                    let _ = std::fs::rename(backup, old);
+                }
+            }
+            if let Some(table) = &self.table {
+                let _ = replace_legacy_table(&table.root, &table.previous);
+            }
+            let _ = std::fs::remove_dir(&self.backup_root);
         }
     }
+}
+
+type PreparedLegacyRouteMoves<'a> = (
+    Vec<(String, String, &'a SemanticStorageBinding)>,
+    BTreeMap<String, String>,
+);
+
+fn prepare_legacy_route_moves<'a>(
+    graph_root: &Path,
+    route_moves: &[(PathBuf, PathBuf)],
+    bindings: &'a SemanticStorageBindings,
+) -> Result<PreparedLegacyRouteMoves<'a>, GfError> {
+    let (before, _) = crate::capture_graph_files(graph_root)?;
+    let authority =
+        crate::graph_projection::TransformRoutes::from_inventory(graph_root, before.clone())?;
+    let source_names = before
+        .files
+        .iter()
+        .map(|entry| {
+            Ok((
+                PathBuf::from(&entry.relative_path),
+                authority.semantic_path(&entry.relative_path)?,
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, GfError>>()?;
+    let mut prepared = Vec::new();
+    let mut moves = BTreeMap::new();
+    for (old, new) in route_moves {
+        let logical_old = source_names
+            .get(old)
+            .ok_or_else(|| corrupt("legacy migration source is absent"))?;
+        let new_wire = new
+            .to_str()
+            .ok_or_else(|| corrupt("legacy destination is not UTF-8"))?
+            .replace('\\', "/");
+        let mut matched = None;
+        for binding in &bindings.bindings {
+            let domain = match binding.route_kind {
+                SemanticRouteKind::Entity => continue,
+                SemanticRouteKind::Relation => "topology/edges",
+                SemanticRouteKind::NodeProperty => "properties",
+                SemanticRouteKind::EdgeProperty => "edge_properties",
+            };
+            let component = crate::route_component::component(&binding.route);
+            let logical = if new_wire == format!("{domain}/{component}.parquet") {
+                Some(format!("{domain}/{}.parquet", binding.route))
+            } else {
+                new_wire
+                    .strip_prefix(&format!("{domain}/{component}/"))
+                    .map(|fragment| format!("{domain}/{}/{fragment}", binding.route))
+            };
+            if let Some(logical) = logical {
+                matched = Some((binding, logical));
+                break;
+            }
+        }
+        let (binding, logical_new) =
+            matched.ok_or_else(|| corrupt("legacy migration destination has no binding"))?;
+        if moves
+            .insert(logical_old.clone(), logical_new.clone())
+            .is_some()
+        {
+            return Err(corrupt("legacy migration repeats a source"));
+        }
+        prepared.push((logical_old.clone(), logical_new, binding));
+    }
+    Ok((prepared, moves))
+}
+
+fn rewrite_legacy_route(
+    backup: &Path,
+    new: &Path,
+    binding: &SemanticStorageBinding,
+    bindings: &SemanticStorageBindings,
+) -> Result<(), GfError> {
+    let builder = admitted_semantic_parquet(backup)?;
+    if builder.schema().fields().len() > MAX_SEMANTIC_PARQUET_COLUMNS {
+        return Err(corrupt("legacy migration column count exceeds limit"));
+    }
+    let mut metadata = builder.schema().metadata().clone();
+    metadata.insert(SEMANTIC_ROUTE_METADATA_KEY.into(), binding.route.clone());
+    if metadata.contains_key(crate::property_overlay::PROPERTY_OVERLAY_FORMAT_KEY) {
+        metadata.insert(
+            crate::property_overlay::PROPERTY_ROUTE_KEY.into(),
+            binding.route.clone(),
+        );
+    }
+    metadata.insert(
+        SEMANTIC_COMPOSITION_METADATA_KEY.into(),
+        bindings.composition_fingerprint.clone(),
+    );
+    let schema = std::sync::Arc::new(arrow::datatypes::Schema::new_with_metadata(
+        builder.schema().fields().clone(),
+        metadata,
+    ));
+    let mut writer = parquet::arrow::ArrowWriter::try_new(
+        File::create(new).map_err(|_| corrupt("legacy migration destination cannot open"))?,
+        schema,
+        None,
+    )
+    .map_err(|_| corrupt("legacy migration writer cannot be built"))?;
+    for batch in builder
+        .with_batch_size(8192)
+        .build()
+        .map_err(|_| corrupt("legacy migration reader cannot be built"))?
+    {
+        writer
+            .write(&batch.map_err(|_| corrupt("legacy migration batch is invalid"))?)
+            .map_err(|_| corrupt("legacy migration batch cannot be written"))?;
+    }
+    writer
+        .close()
+        .map_err(|_| corrupt("legacy migration output cannot close"))?;
+    Ok(())
 }
 
 /// Apply deterministic preflighted route moves and return a rollback guard.
@@ -1520,15 +1795,48 @@ pub fn apply_legacy_route_moves(
     route_moves: &[(PathBuf, PathBuf)],
     bindings: &SemanticStorageBindings,
 ) -> Result<LegacyRouteMigration, GfError> {
-    let mut completed = Vec::new();
-    for (old_relative, new_relative) in route_moves {
-        let old = graph_root.join(old_relative);
-        let new = graph_root.join(new_relative);
-        let binding = bindings
-            .bindings
-            .iter()
-            .find(|binding| binding.physical_path(Path::new("")).as_ref() == Some(new_relative))
-            .ok_or_else(|| corrupt("legacy migration destination has no binding"))?;
+    let (prepared, moves) = prepare_legacy_route_moves(graph_root, route_moves, bindings)?;
+    // Physical layout admission is its own committed, semantics-preserving unit.
+    // Rollback below restores this admitted baseline until semantic publication succeeds.
+    let prior_table = crate::route_component::owned::admit_owned_workspace(graph_root)?;
+    let previous_table = prior_table.encode(64 * 1024 * 1024)?;
+    let (inventory, _) = crate::capture_graph_files(graph_root)?;
+    let mut logical_to_physical = BTreeMap::new();
+    let mut output_table = crate::route_component::RouteTable::default();
+    for entry in &inventory.files {
+        if entry.relative_path == crate::route_component::TABLE_FILE {
+            continue;
+        }
+        let logical = prior_table.semantic_relative_path(&entry.relative_path)?;
+        crate::graph_projection::encode_transform_path(
+            moves.get(&logical).unwrap_or(&logical),
+            &mut output_table,
+        )?;
+        logical_to_physical.insert(
+            logical,
+            crate::graph_files::resolve_v1_inventory_entry(graph_root, entry)?,
+        );
+    }
+    let backup_root = graph_root.join(format!(
+        ".semantic-legacy-backups-{}",
+        graphforge_core::uuid::new_v7()
+    ));
+    std::fs::create_dir(&backup_root)
+        .map_err(|_| corrupt("legacy backup directory cannot be created"))?;
+    let mut migration = LegacyRouteMigration {
+        completed: Vec::new(),
+        committed: false,
+        table: None,
+        backup_root,
+    };
+    for (old_relative, new_relative, binding) in prepared {
+        let old = logical_to_physical
+            .get(&old_relative)
+            .cloned()
+            .ok_or_else(|| corrupt("legacy migration source is absent"))?;
+        let destination =
+            crate::graph_projection::encode_transform_path(&new_relative, &mut output_table)?;
+        let new = graph_root.join(destination);
         if new.exists() {
             return Err(corrupt("legacy migration destination already exists"));
         }
@@ -1537,68 +1845,45 @@ pub fn apply_legacy_route_moves(
             .ok_or_else(|| corrupt("legacy migration destination has no parent"))?;
         std::fs::create_dir_all(parent)
             .map_err(|_| corrupt("legacy migration destination cannot be created"))?;
-        let backup = old.with_extension("parquet.legacy-backup");
+        let backup = migration
+            .backup_root
+            .join(format!("{}.parquet", migration.completed.len()));
         if backup.exists() {
             return Err(corrupt("legacy migration backup already exists"));
         }
         if let Err(error) = std::fs::rename(&old, &backup) {
-            for (prior_old, prior_new, prior_backup) in completed.iter().rev() {
+            for (prior_old, prior_new, prior_backup) in migration.completed.iter().rev() {
                 let _ = std::fs::remove_file(prior_new);
                 let _ = std::fs::rename(prior_backup, prior_old);
             }
             return Err(corrupt(&format!("legacy migration rename failed: {error}")));
         }
-        let rewrite = (|| {
-            let builder = admitted_semantic_parquet(&backup)?;
-            if builder.schema().fields().len() > MAX_SEMANTIC_PARQUET_COLUMNS {
-                return Err(corrupt("legacy migration column count exceeds limit"));
-            }
-            let mut metadata = builder.schema().metadata().clone();
-            metadata.insert(SEMANTIC_ROUTE_METADATA_KEY.into(), binding.route.clone());
-            metadata.insert(
-                SEMANTIC_COMPOSITION_METADATA_KEY.into(),
-                bindings.composition_fingerprint.clone(),
-            );
-            let schema = std::sync::Arc::new(arrow::datatypes::Schema::new_with_metadata(
-                builder.schema().fields().clone(),
-                metadata,
-            ));
-            let mut writer = parquet::arrow::ArrowWriter::try_new(
-                File::create(&new)
-                    .map_err(|_| corrupt("legacy migration destination cannot open"))?,
-                schema,
-                None,
-            )
-            .map_err(|_| corrupt("legacy migration writer cannot be built"))?;
-            for batch in builder
-                .with_batch_size(8192)
-                .build()
-                .map_err(|_| corrupt("legacy migration reader cannot be built"))?
-            {
-                writer
-                    .write(&batch.map_err(|_| corrupt("legacy migration batch is invalid"))?)
-                    .map_err(|_| corrupt("legacy migration batch cannot be written"))?;
-            }
-            writer
-                .close()
-                .map_err(|_| corrupt("legacy migration output cannot close"))?;
-            Ok(())
-        })();
+        let rewrite = rewrite_legacy_route(&backup, &new, binding, bindings);
         if let Err(error) = rewrite {
             let _ = std::fs::remove_file(&new);
             let _ = std::fs::rename(&backup, &old);
-            for (prior_old, prior_new, prior_backup) in completed.iter().rev() {
+            for (prior_old, prior_new, prior_backup) in migration.completed.iter().rev() {
                 let _ = std::fs::remove_file(prior_new);
                 let _ = std::fs::rename(prior_backup, prior_old);
             }
             return Err(error);
         }
-        completed.push((old, new, backup));
+        migration.completed.push((old, new, backup));
     }
-    Ok(LegacyRouteMigration {
-        completed,
-        committed: false,
-    })
+    let bytes = output_table.encode(64 * 1024 * 1024)?;
+    replace_legacy_table(graph_root, &bytes)?;
+    let directory = graphforge_filesystem::StableDirectory::open(graph_root)
+        .map_err(|_| corrupt("legacy route table root cannot be retained"))?;
+    let installed = directory
+        .open_child_file(std::ffi::OsStr::new(crate::route_component::TABLE_FILE))
+        .map_err(|_| corrupt("legacy route table cannot be retained"))?;
+    migration.table = Some(LegacyTableRollback {
+        root: graph_root.to_path_buf(),
+        previous: previous_table,
+        installed,
+        digest: Sha256::digest(bytes).into(),
+    });
+    Ok(migration)
 }
 
 /// Materialize a complete private candidate graph tree without touching the
@@ -1620,6 +1905,10 @@ pub fn materialize_semantic_migration(
         return Err(corrupt("semantic migration batch bound is invalid"));
     }
     let (inventory, _) = crate::capture_graph_files(source_graph_root)?;
+    let source_routes = crate::graph_projection::TransformRoutes::from_inventory(
+        source_graph_root,
+        inventory.clone(),
+    )?;
     let inventory_sha256 = hex(Sha256::digest(crate::encode_inventory(&inventory)?).into());
     if inventory_sha256 != plan.source_inventory_sha256 {
         return Err(corrupt(
@@ -1716,16 +2005,23 @@ pub fn materialize_semantic_migration(
     std::fs::create_dir_all(&staging_graph_root)
         .map_err(|_| corrupt("semantic migration candidate cannot be created"))?;
     let result = (|| {
+        let mut output_table = crate::route_component::RouteTable::default();
         let mut files_materialized = 0_u64;
         let mut rows_rewritten = 0_u64;
         let mut max_batch_rows = 0_usize;
         for entry in &inventory.files {
             checkpoint()?;
+            if entry.relative_path == crate::route_component::TABLE_FILE {
+                continue;
+            }
             let source = crate::graph_files::resolve_v1_inventory_entry(source_graph_root, entry)?;
-            let relative =
-                crate::graph_files::canonical_inventory_relative_path(&entry.relative_path)?;
-            let old_route = semantic_route_from_relative(&relative);
-            let target_relative = migrated_semantic_relative(&relative, &route_moves);
+            let semantic = source_routes.semantic_path(&entry.relative_path)?;
+            let old_route = semantic_route_from_wire(&semantic);
+            let target_relative = migrated_semantic_wire(&semantic, &route_moves);
+            let target_relative = crate::graph_projection::encode_transform_path(
+                &target_relative,
+                &mut output_table,
+            )?;
             let target = staging_graph_root.join(target_relative);
             std::fs::create_dir_all(
                 target
@@ -1833,6 +2129,8 @@ pub fn materialize_semantic_migration(
                 .map_err(|_| corrupt("migration output cannot close"))?;
             files_materialized += 1;
         }
+        crate::graph_projection::install_transform_table(&staging_graph_root, &output_table)?;
+        files_materialized += 1;
         let (verified_source, _) = crate::capture_graph_files(source_graph_root)?;
         if hex(Sha256::digest(crate::encode_inventory(&verified_source)?).into())
             != plan.source_inventory_sha256
@@ -1910,6 +2208,36 @@ pub fn materialize_semantic_migration(
     Ok(evidence)
 }
 
+fn semantic_route_from_wire(relative: &str) -> Option<&str> {
+    let parts = relative.split('/').collect::<Vec<_>>();
+    let route = match parts.as_slice() {
+        ["topology", "edges", route]
+        | ["topology", "edges", route, _]
+        | ["properties" | "edge_properties", route]
+        | ["properties" | "edge_properties", route, _] => *route,
+        _ => return None,
+    };
+    Some(route.strip_suffix(".parquet").unwrap_or(route)).filter(|route| route.starts_with("s-"))
+}
+
+fn migrated_semantic_wire(relative: &str, route_moves: &BTreeMap<String, String>) -> String {
+    let Some(route) = semantic_route_from_wire(relative) else {
+        return relative.to_owned();
+    };
+    let Some(new) = route_moves.get(route) else {
+        return relative.to_owned();
+    };
+    let mut parts = relative.split('/').map(str::to_owned).collect::<Vec<_>>();
+    let index = if parts[0] == "topology" { 2 } else { 1 };
+    parts[index] = if parts.len() == index + 1 {
+        format!("{new}.parquet")
+    } else {
+        new.clone()
+    };
+    parts.join("/")
+}
+
+#[cfg(test)]
 fn semantic_route_from_relative(relative: &Path) -> Option<&str> {
     let parts = relative
         .components()
@@ -1933,6 +2261,7 @@ fn semantic_route_from_relative(relative: &Path) -> Option<&str> {
         .filter(|route| route.starts_with("s-"))
 }
 
+#[cfg(test)]
 fn migrated_semantic_relative(relative: &Path, route_moves: &BTreeMap<String, String>) -> PathBuf {
     let Some(old_route) = semantic_route_from_relative(relative) else {
         return relative.to_path_buf();
@@ -2043,6 +2372,15 @@ fn binding_has_retained_data(
     binding: &SemanticStorageBinding,
     graph_root: &Path,
 ) -> Result<bool, GfError> {
+    let authority = crate::graph_projection::TransformRoutes::capture(graph_root)?;
+    binding_has_retained_data_with_authority(binding, graph_root, &authority)
+}
+
+fn binding_has_retained_data_with_authority(
+    binding: &SemanticStorageBinding,
+    graph_root: &Path,
+    authority: &crate::graph_projection::TransformRoutes,
+) -> Result<bool, GfError> {
     if binding.route_kind == SemanticRouteKind::Entity {
         use arrow::array::{Array, ListArray, UInt32Array};
         for path in crate::catalog::topology_node_files(graph_root)? {
@@ -2092,12 +2430,11 @@ fn binding_has_retained_data(
             .split_once(':')
             .map(|(_, property)| property)
             .ok_or_else(|| corrupt("removal property has no qualified column"))?;
-        let batches = if binding.route_kind == SemanticRouteKind::NodeProperty {
-            crate::catalog::read_properties(graph_root, &binding.route)
-        } else {
-            crate::catalog::read_edge_properties(graph_root, &binding.route)
-        }
-        .map_err(|_| corrupt("removal property overlay cannot be read"))?;
+        let batches = authority.property_batches(
+            graph_root,
+            &binding.route,
+            binding.route_kind == SemanticRouteKind::EdgeProperty,
+        )?;
         for batch in batches {
             let Some(values) = batch.column_by_name(column) else {
                 continue;
@@ -2109,12 +2446,12 @@ fn binding_has_retained_data(
         return Ok(false);
     }
     let paths = match binding.route_kind {
-        SemanticRouteKind::Relation => {
-            crate::mutator::edge_parquet_files(graph_root, Some(&binding.route))?
-                .into_iter()
-                .map(|(_, path)| path)
-                .collect::<Vec<_>>()
-        }
+        SemanticRouteKind::Relation => authority
+            .properties
+            .edge_files(Some(&binding.route))
+            .into_iter()
+            .map(|(_, path)| path)
+            .collect::<Vec<_>>(),
         SemanticRouteKind::Entity
         | SemanticRouteKind::NodeProperty
         | SemanticRouteKind::EdgeProperty => unreachable!("handled above"),
@@ -2707,6 +3044,35 @@ mod tests {
         )
         .unwrap();
         assert_eq!(evidence.plan_digest, first.plan_digest);
+        let source_after = crate::capture_graph_files(source.path()).unwrap().0;
+        assert_eq!(
+            hex(Sha256::digest(crate::encode_inventory(&source_after).unwrap()).into()),
+            first.source_inventory_sha256
+        );
+        let candidate_inventory = crate::capture_graph_files(&candidate).unwrap().0;
+        let table =
+            crate::graph_files::authenticate_route_table(&candidate, &candidate_inventory).unwrap();
+        table
+            .validate_paths(
+                candidate_inventory
+                    .files
+                    .iter()
+                    .map(|entry| entry.relative_path.as_str()),
+            )
+            .unwrap();
+        let routes = candidate_inventory
+            .files
+            .iter()
+            .map(|entry| table.semantic_relative_path(&entry.relative_path).unwrap())
+            .collect::<Vec<_>>();
+        assert!(routes.iter().any(|path| {
+            path.starts_with(&format!("properties/{}/", renamed_entity.route))
+                || path == &format!("properties/{}.parquet", renamed_entity.route)
+        }));
+        assert!(!routes.iter().any(
+            |path| path.starts_with(&format!("properties/{}/", entity.route))
+                || path == &format!("properties/{}.parquet", entity.route)
+        ));
         first.bindings.validate_physical_routes(&candidate).unwrap();
         let batches = crate::catalog::read_properties(&candidate, &renamed_entity.route).unwrap();
         let schema = batches.first().unwrap().schema();
@@ -3207,8 +3573,7 @@ mod tests {
         assert!(admitted_semantic_parquet(&path).is_err());
     }
 
-    #[test]
-    fn unambiguous_legacy_routes_rewrite_with_metadata_and_reopen() {
+    fn legacy_migration_fixture() -> (tempfile::TempDir, CompiledComposition) {
         use std::collections::HashMap;
 
         let composition = compiled("1");
@@ -3241,6 +3606,13 @@ mod tests {
             .unwrap();
         writer.flush().unwrap();
 
+        drop(writer);
+        (dir, composition)
+    }
+
+    #[test]
+    fn unambiguous_legacy_routes_rewrite_with_metadata_and_reopen() {
+        let (dir, composition) = legacy_migration_fixture();
         let projection =
             SemanticStorageBindings::project_legacy_unambiguous(&composition, dir.path()).unwrap();
         assert!(!projection.route_moves.is_empty());
@@ -3258,6 +3630,125 @@ mod tests {
             .bindings
             .validate_physical_routes(dir.path())
             .unwrap();
+    }
+
+    #[test]
+    fn legacy_raw_layout_admission_is_preserved_after_semantic_rollback() {
+        let (dir, composition) = legacy_migration_fixture();
+        let mapped = crate::capture_graph_files(dir.path()).unwrap().0;
+        let table = crate::graph_files::authenticate_route_table(dir.path(), &mapped).unwrap();
+        // Produce an actual legacy raw layout; no inventory is relabeled.
+        for entry in &mapped.files {
+            if entry.relative_path == crate::route_component::TABLE_FILE {
+                continue;
+            }
+            let logical = table.semantic_relative_path(&entry.relative_path).unwrap();
+            if logical != entry.relative_path {
+                let source = dir.path().join(&entry.relative_path);
+                let destination = dir.path().join(logical);
+                std::fs::create_dir_all(destination.parent().unwrap()).unwrap();
+                std::fs::rename(&source, &destination).unwrap();
+                let _ = std::fs::remove_dir(source.parent().unwrap());
+            }
+        }
+        std::fs::remove_file(dir.path().join(crate::route_component::TABLE_FILE)).unwrap();
+        let raw = crate::capture_graph_files(dir.path()).unwrap().0;
+        assert_eq!(
+            raw.format_version,
+            crate::graph_files::GRAPH_FILES_RECORD_VERSION
+        );
+        let projection =
+            SemanticStorageBindings::project_legacy_unambiguous(&composition, dir.path()).unwrap();
+        assert_eq!(crate::capture_graph_files(dir.path()).unwrap().0, raw);
+        drop(
+            apply_legacy_route_moves(dir.path(), &projection.route_moves, &projection.bindings)
+                .unwrap(),
+        );
+        let admitted = crate::capture_graph_files(dir.path()).unwrap().0;
+        assert_eq!(
+            admitted.format_version,
+            crate::graph_files::GRAPH_FILES_MAPPED_RECORD_VERSION
+        );
+        let table = crate::graph_files::authenticate_route_table(dir.path(), &admitted).unwrap();
+        table
+            .validate_paths(
+                admitted
+                    .files
+                    .iter()
+                    .map(|entry| entry.relative_path.as_str()),
+            )
+            .unwrap();
+        for prior in &raw.files {
+            if !prior.relative_path.ends_with(".parquet") {
+                continue;
+            }
+            let current = admitted
+                .files
+                .iter()
+                .find(|entry| {
+                    table.semantic_relative_path(&entry.relative_path).unwrap()
+                        == prior.relative_path
+                })
+                .unwrap();
+            assert_eq!(current.content_sha256, prior.content_sha256);
+            assert_eq!(current.byte_length, prior.byte_length);
+        }
+    }
+
+    #[test]
+    fn legacy_migration_rollback_restores_admitted_table_and_refuses_foreign_table() {
+        let (dir, composition) = legacy_migration_fixture();
+        let baseline = crate::capture_graph_files(dir.path()).unwrap().0;
+        let projection =
+            SemanticStorageBindings::project_legacy_unambiguous(&composition, dir.path()).unwrap();
+        assert_eq!(
+            crate::capture_graph_files(dir.path()).unwrap().0,
+            baseline,
+            "planning is read-only"
+        );
+        let migration =
+            apply_legacy_route_moves(dir.path(), &projection.route_moves, &projection.bindings)
+                .unwrap();
+        let transformed = crate::capture_graph_files(dir.path()).unwrap().0;
+        let table = crate::graph_files::authenticate_route_table(dir.path(), &transformed).unwrap();
+        table
+            .validate_paths(
+                transformed
+                    .files
+                    .iter()
+                    .map(|entry| entry.relative_path.as_str()),
+            )
+            .unwrap();
+        assert!(
+            transformed
+                .files
+                .iter()
+                .filter(|entry| entry.relative_path != crate::route_component::TABLE_FILE)
+                .all(|entry| !table
+                    .semantic_relative_path(&entry.relative_path)
+                    .unwrap()
+                    .contains("/KNOWS"))
+        );
+        drop(migration);
+        assert_eq!(crate::capture_graph_files(dir.path()).unwrap().0, baseline);
+
+        let migration =
+            apply_legacy_route_moves(dir.path(), &projection.route_moves, &projection.bindings)
+                .unwrap();
+        let table_path = dir.path().join(crate::route_component::TABLE_FILE);
+        let foreign = b"foreign replacement must be retained";
+        std::fs::rename(&table_path, dir.path().join("retained-table.outside-graph")).unwrap();
+        std::fs::write(&table_path, foreign).unwrap();
+        let files = migration
+            .completed
+            .iter()
+            .map(|(_, new, _)| (new.clone(), std::fs::read(new).unwrap()))
+            .collect::<Vec<_>>();
+        drop(migration);
+        assert_eq!(std::fs::read(&table_path).unwrap(), foreign);
+        for (path, bytes) in files {
+            assert_eq!(std::fs::read(path).unwrap(), bytes);
+        }
     }
 
     #[test]
@@ -3326,9 +3817,14 @@ mod tests {
             .validate_physical_routes_with_inventory(dir.path(), Some(&inventory))
             .unwrap();
         let mut omitted = inventory.clone();
+        let authority =
+            crate::graph_projection::TransformRoutes::from_inventory(dir.path(), inventory.clone())
+                .unwrap();
         omitted.files.retain(|entry| {
-            entry.relative_path != format!("topology/edges/{}.parquet", relation.route)
+            authority.semantic_path(&entry.relative_path).unwrap()
+                != format!("topology/edges/{}.parquet", relation.route)
         });
+        assert_eq!(omitted.files.len() + 1, inventory.files.len());
         omitted.file_count = omitted.files.len() as u64;
         assert!(
             bindings
@@ -3462,14 +3958,18 @@ mod tests {
             .unwrap();
         second.flush().unwrap();
 
-        let fragments = crate::property_overlay::enumerate_property_fragments(
-            dir.path(),
-            crate::PropertyRouteKind::Node,
-            &entity.route,
-        )
-        .unwrap();
+        let inventory = crate::capture_graph_files(dir.path()).unwrap().0;
+        let fragments = semantic_fragment_inventory(dir.path(), &inventory)
+            .unwrap()
+            .remove(&("properties".to_owned(), entity.route.clone()))
+            .unwrap();
         assert_eq!(fragments.len(), 2);
-        let rows = crate::catalog::read_properties(dir.path(), &entity.route).unwrap();
+        let authority =
+            crate::graph_projection::TransformRoutes::from_inventory(dir.path(), inventory.clone())
+                .unwrap();
+        let rows = authority
+            .property_batches(dir.path(), &entity.route, false)
+            .unwrap();
         let names = rows[0]
             .column_by_name("name")
             .and_then(|column| column.as_any().downcast_ref::<arrow::array::StringArray>())
@@ -3483,7 +3983,6 @@ mod tests {
             .unwrap();
         for fragment in fragments {
             let relative = fragment
-                .path
                 .strip_prefix(dir.path())
                 .unwrap()
                 .to_str()

--- a/crates/graphforge-storage/src/staging.rs
+++ b/crates/graphforge-storage/src/staging.rs
@@ -119,6 +119,7 @@ pub(crate) fn is_staged_temp_name(name: &std::ffi::OsStr) -> bool {
 pub struct RewriteBatch {
     /// `(staged temp, final destination)` in insertion = commit order.
     staged: Vec<(NamedTempFile, PathBuf)>,
+    pending_routes: crate::route_component::owned::PendingRoutes,
     property_windows: BTreeMap<PropertyWindowKey, PendingPropertyWindow>,
     moves: BTreeMap<PathBuf, crate::durable_rewrite::moves::SourceRetirement>,
 }
@@ -144,6 +145,18 @@ impl RewriteBatch {
         Self::default()
     }
 
+    pub(crate) fn route_component(&mut self, root: &Path, route: &str) -> Result<String, GfError> {
+        self.pending_routes.register(root, route)
+    }
+
+    pub(crate) fn prepare_registered_routes(
+        &mut self,
+        root_path: &Path,
+        root: &graphforge_filesystem::StableDirectory,
+    ) -> Result<Option<crate::route_component::owned::TablePrior>, GfError> {
+        std::mem::take(&mut self.pending_routes).prepare(root_path, root, self)
+    }
+
     /// Stage a contained file move in the durable rewrite transaction.
     ///
     /// The destination must be absent. The exact source is authenticated again
@@ -158,13 +171,51 @@ impl RewriteBatch {
         source: &Path,
         destination: &Path,
     ) -> Result<(), GfError> {
+        self.stage_move_with_prefix(project_root, source, destination, "move.parquet.")
+    }
+
+    pub(crate) fn stage_semantic_route_move(
+        &mut self,
+        project_root: &Path,
+        directory: &graphforge_filesystem::StableDirectory,
+        source: &Path,
+        destination: &Path,
+    ) -> Result<(), GfError> {
         if self.staged.iter().any(|(_, path)| path == destination) {
             return Err(GfError::Storage(
                 "duplicate rewrite move destination".into(),
             ));
         }
-        let (temporary, retirement) =
-            crate::durable_rewrite::moves::stage(project_root, source, destination)?;
+        let (temporary, retirement) = crate::durable_rewrite::moves::stage_retained(
+            project_root,
+            directory,
+            source,
+            destination,
+            "semantic-route-move.parquet.",
+        )?;
+        self.moves.insert(destination.to_owned(), retirement);
+        self.staged.push((temporary, destination.to_owned()));
+        Ok(())
+    }
+
+    fn stage_move_with_prefix(
+        &mut self,
+        project_root: &Path,
+        source: &Path,
+        destination: &Path,
+        temporary_prefix: &str,
+    ) -> Result<(), GfError> {
+        if self.staged.iter().any(|(_, path)| path == destination) {
+            return Err(GfError::Storage(
+                "duplicate rewrite move destination".into(),
+            ));
+        }
+        let (temporary, retirement) = crate::durable_rewrite::moves::stage(
+            project_root,
+            source,
+            destination,
+            temporary_prefix,
+        )?;
         self.moves.insert(destination.to_owned(), retirement);
         self.staged.push((temporary, destination.to_owned()));
         Ok(())
@@ -181,12 +232,38 @@ impl RewriteBatch {
 
     /// Stage an authenticated control record in the same rename unit as graph data.
     pub(crate) fn stage_bytes(&mut self, final_path: &Path, bytes: &[u8]) -> Result<(), GfError> {
+        self.stage_control_bytes(final_path, bytes, None)
+    }
+
+    pub(crate) fn stage_named_control_bytes(
+        &mut self,
+        final_path: &Path,
+        bytes: &[u8],
+        prefix: &str,
+    ) -> Result<(), GfError> {
+        self.stage_control_bytes(final_path, bytes, Some(prefix))
+    }
+
+    fn stage_control_bytes(
+        &mut self,
+        final_path: &Path,
+        bytes: &[u8],
+        prefix: Option<&str>,
+    ) -> Result<(), GfError> {
         self.refuse_move_replacement(final_path)?;
         let parent = final_path
             .parent()
             .ok_or_else(|| GfError::Storage("staged control record has no parent".into()))?;
         std::fs::create_dir_all(parent).map_err(|error| io_err(&error))?;
-        let mut temp = NamedTempFile::new_in(parent).map_err(|error| io_err(&error))?;
+        let mut temp = if let Some(prefix) = prefix {
+            tempfile::Builder::new()
+                .prefix(prefix)
+                .suffix(".tmp")
+                .tempfile_in(parent)
+        } else {
+            NamedTempFile::new_in(parent)
+        }
+        .map_err(|error| io_err(&error))?;
         let uuid_participant = final_path
             .components()
             .any(|component| component.as_os_str() == "uuid-membership");
@@ -450,7 +527,7 @@ impl RewriteBatch {
                 "reserved graph authority must commit through its sealed publication path".into(),
             ));
         }
-        if !self.moves.is_empty() {
+        if !self.moves.is_empty() || !self.pending_routes.is_empty() {
             crate::durable_rewrite::commit(self, project_root, false, false, false, None)?;
             return Ok(());
         }
@@ -509,6 +586,24 @@ impl RewriteBatch {
     #[cfg(test)]
     pub(crate) fn commit_unsealed_for_test(self) -> Result<(), GfError> {
         self.commit_unsealed()
+    }
+
+    pub(crate) fn retained_temporary_identities(
+        &self,
+    ) -> Result<BTreeMap<PathBuf, graphforge_filesystem::FileIdentity>, GfError> {
+        self.staged
+            .iter()
+            .map(|(file, _)| {
+                let identity = graphforge_filesystem::file_identity(file.as_file())
+                    .map_err(|error| io_err(&error))?;
+                if graphforge_filesystem::path_identity(file.path()).ok() != Some(identity) {
+                    return Err(GfError::Storage(
+                        "rewrite temporary identity changed".into(),
+                    ));
+                }
+                Ok((file.path().to_path_buf(), identity))
+            })
+            .collect()
     }
 
     /// The staged destination paths, in insertion (= commit) order.

--- a/crates/graphforge-storage/src/storage_attribution.rs
+++ b/crates/graphforge-storage/src/storage_attribution.rs
@@ -876,7 +876,10 @@ impl StorageAttributionSnapshot {
 /// Classify one authenticated graph inventory path.
 #[must_use]
 pub fn classify_graph_artifact(relative_path: &str) -> ArtifactCategory {
-    if relative_path == "topology/runtime_entity_label_encoding.json" {
+    if matches!(
+        relative_path,
+        "topology/runtime_entity_label_encoding.json" | "semantic-routes.json"
+    ) {
         return ArtifactCategory::CatalogAndManifests;
     }
     let path = Path::new(relative_path);
@@ -1523,7 +1526,13 @@ mod tests {
             classify_graph_artifact("topology/runtime_entity_label_encoding.json"),
             ArtifactCategory::CatalogAndManifests
         );
+        assert_eq!(
+            classify_graph_artifact("semantic-routes.json"),
+            ArtifactCategory::CatalogAndManifests
+        );
         for unknown in [
+            "semantic-routes.json/unknown",
+            "semantic-routes.json.tmp",
             "topology/runtime_entity_label_encoding.json/unknown",
             "topology/runtime_entity_label_encoding.json.tmp",
         ] {

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -1682,7 +1682,8 @@ pub struct AuthenticatedUuidIndexSnapshot {
     graph_root_identity: graphforge_filesystem::FileIdentity,
     root: graphforge_filesystem::StableDirectory,
     root_identity: graphforge_filesystem::FileIdentity,
-    manifest_file: File,
+    manifest_file: Option<File>,
+    manifest_bytes: u64,
     manifest_identity: graphforge_filesystem::FileIdentity,
     manifest_sha256: String,
     manifest: Manifest,
@@ -2673,10 +2674,7 @@ impl AuthenticatedUuidIndexSnapshot {
     }
 
     fn snapshot_authentication_bytes(&self) -> u64 {
-        let manifest_bytes = self
-            .manifest_file
-            .metadata()
-            .map_or(0, |metadata| metadata.len());
+        let manifest_bytes = self.manifest_bytes;
         self.manifest
             .runs
             .iter()
@@ -2815,7 +2813,8 @@ impl AuthenticatedUuidIndexSnapshot {
             graph_root_identity,
             root,
             root_identity,
-            manifest_file,
+            manifest_bytes: body.len() as u64,
+            manifest_file: Some(manifest_file),
             manifest_identity,
             manifest_sha256,
             manifest,
@@ -2953,7 +2952,8 @@ impl AuthenticatedUuidIndexSnapshot {
             graph_root_identity,
             root,
             root_identity,
-            manifest_file,
+            manifest_bytes: body.len() as u64,
+            manifest_file: Some(manifest_file),
             manifest_identity,
             manifest_sha256,
             manifest,
@@ -3040,10 +3040,13 @@ impl AuthenticatedUuidIndexSnapshot {
         if self.root.identity() != self.root_identity {
             return Err(storage_err("UUID index root identity changed"));
         }
-        if graphforge_filesystem::file_identity(&self.manifest_file).map_err(storage_err)?
+        let manifest_file = self
+            .manifest_file
+            .as_ref()
+            .ok_or_else(|| storage_err("UUID manifest descriptor is suspended for publication"))?;
+        if graphforge_filesystem::file_identity(manifest_file).map_err(storage_err)?
             != self.manifest_identity
-            || graphforge_filesystem::file_link_count(&self.manifest_file).map_err(storage_err)?
-                != 1
+            || graphforge_filesystem::file_link_count(manifest_file).map_err(storage_err)? != 1
             || self.manifest_sha256.len() != 64
         {
             return Err(storage_err("retained UUID manifest identity changed"));
@@ -3077,6 +3080,44 @@ impl AuthenticatedUuidIndexSnapshot {
                 }
             }
         }
+        Ok(())
+    }
+
+    fn suspend_owned_manifest(&mut self) {
+        if self.cas_source_paths.is_none() {
+            self.manifest_file.take();
+        }
+    }
+
+    fn restore_owned_manifest(&mut self) -> Result<(), GfError> {
+        if self.manifest_file.is_some() {
+            return Ok(());
+        }
+        self.root.revalidate_named().map_err(storage_err)?;
+        let mut file = open_uuid_child_file(&self.root, std::ffi::OsStr::new(MANIFEST))?;
+        if graphforge_filesystem::file_identity(&file).map_err(storage_err)?
+            != self.manifest_identity
+            || graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1
+        {
+            return Err(storage_err("suspended UUID manifest identity changed"));
+        }
+        let body = read_bounded(&mut file, MAX_MANIFEST_BYTES)?;
+        if hex_sha256(&body) != self.manifest_sha256
+            || serde_json::from_slice::<Manifest>(&body).map_err(storage_err)? != self.manifest
+        {
+            return Err(storage_err(
+                "suspended UUID manifest authentication changed",
+            ));
+        }
+        self.authenticated_bytes = self
+            .authenticated_bytes
+            .checked_add(body.len() as u64)
+            .ok_or_else(|| storage_err("UUID restoration byte count overflow"))?;
+        self.authenticated_blocks = self
+            .authenticated_blocks
+            .checked_add(1)
+            .ok_or_else(|| storage_err("UUID restoration block count overflow"))?;
+        self.manifest_file = Some(file);
         Ok(())
     }
 
@@ -3125,7 +3166,8 @@ impl AuthenticatedUuidIndexSnapshot {
         self.manifest_identity =
             graphforge_filesystem::file_identity(&manifest_file).map_err(storage_err)?;
         self.manifest_sha256 = hex_sha256(&body);
-        self.manifest_file = manifest_file;
+        self.manifest_bytes = body.len() as u64;
+        self.manifest_file = Some(manifest_file);
         self.manifest = manifest;
         self.runs = next_runs;
         self.authenticated_bytes = 0;
@@ -5474,6 +5516,11 @@ pub(crate) enum CommittedUuidTopologyRewrite {
     },
 }
 
+#[cfg(test)]
+thread_local! {
+    static FAIL_AFTER_MANIFEST_SUSPEND: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 /// Commit topology and its UUID participant under the one durable rewrite lock.
 #[allow(clippy::too_many_lines)] // One sealed participant lifecycle; order is the invariant.
 pub(crate) fn commit_uuid_topology_rewrite(
@@ -5656,8 +5703,19 @@ pub(crate) fn commit_uuid_topology_rewrite(
                 .as_ref()
                 .map(PreparedV4OrdinalDelta::auxiliary_receipt)
                 .or(receipt);
+            if token.is_some()
+                && let Some(value) = snapshot.as_mut()
+            {
+                value.suspend_owned_manifest();
+            }
             *prepared_from_callback.borrow_mut() = token;
             *prepared_v4_from_callback.borrow_mut() = prepared_ordinal;
+            #[cfg(test)]
+            if FAIL_AFTER_MANIFEST_SUSPEND.replace(false) {
+                return Err(storage_err(
+                    "injected manifest suspension preparation error",
+                ));
+            }
             Ok(receipt)
         });
     let commit =
@@ -5667,24 +5725,55 @@ pub(crate) fn commit_uuid_topology_rewrite(
     let committed = match commit {
         Ok(value) => value,
         Err(error) => {
-            let (Some(token), Some((prior, next))) = (token.as_ref(), generations.get()) else {
-                return Err(error);
-            };
-            let membership_outcome = reconcile_uuid_auxiliary(&root, prior, next, token)?;
-            let outcome = if let Some(v4) = v4_token.as_ref() {
-                let ordinal_outcome = reconcile_v4_ordinal_auxiliary(&root, prior, next, v4)?;
-                if membership_outcome != ordinal_outcome {
-                    return Err(storage_err(
-                        "v3 and v4 auxiliary reconciliation outcomes disagree",
-                    ));
+            let outcome = (|| {
+                let (Some(token), Some((prior, next))) = (token.as_ref(), generations.get()) else {
+                    return Ok(None);
+                };
+                let membership = reconcile_uuid_auxiliary(&root, prior, next, token)?;
+                if let Some(v4) = v4_token.as_ref() {
+                    let ordinal = reconcile_v4_ordinal_auxiliary(&root, prior, next, v4)?;
+                    if membership != ordinal {
+                        return Err(storage_err(
+                            "v3 and v4 auxiliary reconciliation outcomes disagree",
+                        ));
+                    }
                 }
-                ordinal_outcome
-            } else {
-                membership_outcome
-            };
+                Ok(Some((membership, next.topology)))
+            })();
             match outcome {
-                crate::durable_rewrite::AuxiliaryReconcileOutcome::Committed => Some(next.topology),
-                crate::durable_rewrite::AuxiliaryReconcileOutcome::NotCommitted => {
+                Ok(Some((
+                    crate::durable_rewrite::AuxiliaryReconcileOutcome::Committed,
+                    generation,
+                ))) => Some(generation),
+                Ok(Some((crate::durable_rewrite::AuxiliaryReconcileOutcome::NotCommitted, _))) => {
+                    if let Some(value) = snapshot.as_mut()
+                        && let Err(restore) = value.restore_owned_manifest()
+                    {
+                        *snapshot = None;
+                        return Err(storage_err(format!(
+                            "{error}; UUID snapshot restoration failed: {restore}"
+                        )));
+                    }
+                    return Err(error);
+                }
+                Err(reconcile) => {
+                    if snapshot
+                        .as_ref()
+                        .is_some_and(|value| value.manifest_file.is_none())
+                    {
+                        *snapshot = None;
+                    }
+                    return Err(storage_err(format!(
+                        "{error}; UUID reconciliation failed: {reconcile}"
+                    )));
+                }
+                Ok(None) => {
+                    if snapshot
+                        .as_ref()
+                        .is_some_and(|value| value.manifest_file.is_none())
+                    {
+                        *snapshot = None;
+                    }
                     return Err(error);
                 }
             }
@@ -5693,9 +5782,13 @@ pub(crate) fn commit_uuid_topology_rewrite(
     let mut committed_metrics = UuidIndexAppendMetrics::default();
     let committed_v4_metrics = v4_token.as_ref().map(|token| token.metrics().clone());
     if let (Some(generation), Some(token)) = (committed, token.as_ref()) {
-        token.verify_generation(generation)?;
-        if let Some(v4) = v4_token.as_ref() {
-            v4.verify_generation(generation)?;
+        if let Err(error) = token.verify_generation(generation).and_then(|()| {
+            v4_token
+                .as_ref()
+                .map_or(Ok(()), |v4| v4.verify_generation(generation))
+        }) {
+            *snapshot = None;
+            return Err(error);
         }
         committed_metrics = token.metrics().clone();
         let refresh = injected_snapshot_refresh_failure().map_or_else(
@@ -11960,6 +12053,122 @@ pub(crate) mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("authentication failed")
+        );
+    }
+
+    #[test]
+    fn owned_manifest_suspension_restores_exact_authority_and_rejects_tampering() {
+        let (dir, _, _) = fixture();
+        rebuild_uuid_membership_indexes(dir.path(), UuidIndexBuildLimits::default()).unwrap();
+        let mut snapshot =
+            AuthenticatedUuidIndexSnapshot::open_at_generation(dir.path(), 0).unwrap();
+        let identity = snapshot.manifest_identity;
+        let path = dir.path().join(INDEX_DIR).join(MANIFEST);
+        let original = fs::read(&path).unwrap();
+        snapshot.suspend_owned_manifest();
+        assert!(snapshot.revalidate().is_err());
+        snapshot.restore_owned_manifest().unwrap();
+        assert_eq!(snapshot.manifest_identity, identity);
+        snapshot.revalidate().unwrap();
+        snapshot.suspend_owned_manifest();
+        fs::write(&path, [original.as_slice(), b"\n"].concat()).unwrap();
+        assert!(snapshot.restore_owned_manifest().is_err());
+        assert!(snapshot.manifest_file.is_none());
+        fs::write(&path, &original).unwrap();
+        snapshot.restore_owned_manifest().unwrap();
+        snapshot.suspend_owned_manifest();
+        let replacement = path.with_extension("replacement");
+        fs::write(&replacement, original).unwrap();
+        fs::rename(&replacement, &path).unwrap();
+        assert!(snapshot.restore_owned_manifest().is_err());
+    }
+
+    #[test]
+    fn owned_manifest_returned_error_restores_snapshot_for_same_process_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut snapshot = None;
+        let make_batch = || {
+            let mut batch = crate::RewriteBatch::new();
+            batch
+                .stage_bytes(&dir.path().join("topology/nodes.parquet"), b"fixture")
+                .unwrap();
+            batch
+        };
+        let first = Uuid::from_u128(201);
+        let second = Uuid::from_u128(202);
+        commit_uuid_topology_rewrite(
+            dir.path(),
+            make_batch(),
+            &UuidTopologyDelta {
+                nodes: vec![(first, 1)],
+                edges: Vec::new(),
+                deleted_nodes: Vec::new(),
+                deleted_edges: Vec::new(),
+            },
+            &mut snapshot,
+        )
+        .unwrap();
+        let old = snapshot.as_ref().unwrap().manifest_identity;
+        FAIL_AFTER_MANIFEST_SUSPEND.set(true);
+        let delta = UuidTopologyDelta {
+            nodes: vec![(second, 2)],
+            edges: Vec::new(),
+            deleted_nodes: Vec::new(),
+            deleted_edges: Vec::new(),
+        };
+        let error = commit_uuid_topology_rewrite(dir.path(), make_batch(), &delta, &mut snapshot)
+            .err()
+            .unwrap();
+        assert!(error.to_string().contains("injected manifest suspension"));
+        let restored = snapshot.as_ref().unwrap();
+        assert_eq!(restored.manifest_identity, old);
+        restored.revalidate().unwrap();
+        assert_eq!(crate::read_topology_generation(dir.path()).unwrap(), 1);
+        commit_uuid_topology_rewrite(dir.path(), make_batch(), &delta, &mut snapshot).unwrap();
+        assert_eq!(
+            snapshot
+                .as_mut()
+                .unwrap()
+                .lookup_node_surrogates(&[first, second])
+                .unwrap()
+                .0,
+            [Some(1), Some(2)]
+        );
+    }
+
+    #[test]
+    fn owned_manifest_same_writer_successive_flushes_preserve_incremental_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = Uuid::from_u128(101);
+        let second = Uuid::from_u128(102);
+        let mut writer =
+            crate::GraphWriter::open_at(dir.path(), graphforge_core::OntologyMode::Strict, 1)
+                .unwrap();
+        writer
+            .create_node(first, graphforge_value::EntityTypeId::decode(0).unwrap())
+            .unwrap();
+        writer.flush().unwrap();
+        let path = dir.path().join(INDEX_DIR).join(MANIFEST);
+        let old = graphforge_filesystem::path_identity(&path).unwrap();
+        writer
+            .create_node(second, graphforge_value::EntityTypeId::decode(0).unwrap())
+            .unwrap();
+        writer
+            .create_edge(Uuid::from_u128(103), "CON", &first, &second)
+            .unwrap();
+        writer.flush().unwrap();
+        assert_ne!(graphforge_filesystem::path_identity(&path).unwrap(), old);
+        assert_eq!(crate::read_topology_generation(dir.path()).unwrap(), 2);
+        assert_eq!(
+            writer
+                .topology_write_work()
+                .uuid_prior_topology_rows_decoded,
+            0
+        );
+        let mut index = UuidMembershipIndex::open(dir.path()).unwrap();
+        assert_eq!(
+            index.lookup_node_surrogates(&[first, second]).unwrap().0,
+            [Some(1), Some(2)]
         );
     }
 

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -292,8 +292,49 @@ pub(crate) fn write_replay_overlay_streaming(
     overlay: &crate::graph_delta_journal::ReplayOverlay,
     limits: crate::graph_delta_journal::GraphDeltaJournalLimits,
 ) -> Result<(), GfError> {
-    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    let mut target_routes = crate::route_component::owned::admit_owned_workspace(target)?;
+    let property_inventory = crate::AuthenticatedPropertyInventory::from_inventory_at_root(
+        source,
+        source_inventory.clone(),
+        None,
+    )?;
+    let node_scan = stream_replay_nodes(source, target, overlay, limits)?;
 
+    validate_replay_edge_endpoints(overlay, &node_scan)?;
+    stream_replay_edges(
+        target,
+        &property_inventory,
+        &mut target_routes,
+        overlay,
+        limits,
+        &node_scan,
+    )?;
+    stream_replay_properties(
+        target,
+        &property_inventory,
+        overlay,
+        limits,
+        false,
+        &mut target_routes,
+    )?;
+    stream_replay_properties(
+        target,
+        &property_inventory,
+        overlay,
+        limits,
+        true,
+        &mut target_routes,
+    )?;
+    replace_private_replay_route_table(target, &target_routes)
+}
+
+fn stream_replay_nodes(
+    source: &Path,
+    target: &Path,
+    overlay: &crate::graph_delta_journal::ReplayOverlay,
+    limits: crate::graph_delta_journal::GraphDeltaJournalLimits,
+) -> Result<ReplayNodeAuthority, GfError> {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     let node_path = source.join("topology/nodes.parquet");
     let output_node_path = target.join("topology/nodes.parquet");
     let node_scan = scan_replay_node_authority(&node_path, overlay, limits)?;
@@ -385,15 +426,7 @@ pub(crate) fn write_replay_overlay_streaming(
     }
     writer.close().map_err(pq_err)?;
 
-    validate_replay_edge_endpoints(overlay, &node_scan)?;
-    stream_replay_edges(source, target, overlay, limits, &node_scan)?;
-    let property_inventory = crate::AuthenticatedPropertyInventory::from_entries_at_root(
-        source,
-        source_inventory.files.clone(),
-    )?;
-    stream_replay_properties(target, &property_inventory, overlay, limits, false)?;
-    stream_replay_properties(target, &property_inventory, overlay, limits, true)?;
-    Ok(())
+    Ok(node_scan)
 }
 
 struct ReplayNodeAuthority {
@@ -659,33 +692,21 @@ fn replay_node_batch(
 
 #[allow(clippy::too_many_lines)] // Two bounded passes keep validation and emission consistent.
 fn stream_replay_edges(
-    source: &Path,
     target: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    route_table: &mut crate::route_component::RouteTable,
     overlay: &crate::graph_delta_journal::ReplayOverlay,
     limits: crate::graph_delta_journal::GraphDeltaJournalLimits,
     nodes: &ReplayNodeAuthority,
 ) -> Result<(), GfError> {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-    let source_dir = source.join("topology/edges");
     let target_dir = target.join("topology/edges");
     fs::create_dir_all(&target_dir).map_err(|error| io_err(&error))?;
-    let mut relations = std::collections::BTreeSet::new();
-    if source_dir.exists() {
-        for entry in fs::read_dir(&source_dir).map_err(|error| io_err(&error))? {
-            let entry = entry.map_err(|error| io_err(&error))?;
-            let path = entry.path();
-            if path
-                .extension()
-                .is_some_and(|extension| extension == "parquet")
-            {
-                let stem = path
-                    .file_stem()
-                    .and_then(std::ffi::OsStr::to_str)
-                    .ok_or_else(|| pq_err("edge Parquet stem is not UTF-8"))?;
-                relations.insert(stem.to_owned());
-            }
-        }
-    }
+    let mut relations = inventory
+        .edge_files(None)
+        .into_iter()
+        .map(|(route, _)| route)
+        .collect::<std::collections::BTreeSet<_>>();
     relations.extend(
         overlay
             .edges
@@ -697,13 +718,14 @@ fn stream_replay_edges(
         sum.saturating_add(64).saturating_add(relation.len())
     });
     for relation in relations {
-        let source_path = source_dir.join(format!("{relation}.parquet"));
-        let target_path = target_dir.join(format!("{relation}.parquet"));
+        let source_paths = inventory.edge_files(Some(&relation));
+        let component = route_table.insert(&relation, 64 * 1024 * 1024, 100_000)?;
+        let target_path = target_dir.join(format!("{component}.parquet"));
         let mut existing_overlay = HashSet::new();
         let mut base_max = 0_u64;
         let mut base_rows = 0_usize;
-        if source_path.exists() {
-            let input = fs::File::open(&source_path).map_err(|error| io_err(&error))?;
+        for (_, source_path) in &source_paths {
+            let input = fs::File::open(source_path).map_err(|error| io_err(&error))?;
             let reader = ParquetRecordBatchReaderBuilder::try_new(input)
                 .map_err(pq_err)?
                 .with_batch_size(limits.max_batch_rows)
@@ -774,11 +796,13 @@ fn stream_replay_edges(
             .capacity()
             .saturating_mul(std::mem::size_of::<&str>() + 8)
             .saturating_add(relation_authority_bytes)
-            .saturating_add(if source_path.exists() {
-                parquet_reader_metadata_reservation(&source_path)?
-            } else {
-                0
-            });
+            .saturating_add(
+                source_paths
+                    .iter()
+                    .try_fold(0_usize, |maximum, (_, path)| {
+                        Ok::<_, GfError>(maximum.max(parquet_reader_metadata_reservation(path)?))
+                    })?,
+            );
         admit_replay_writer(
             overlay.estimated_memory(),
             nodes
@@ -795,8 +819,8 @@ fn stream_replay_edges(
             Some(replay_writer_properties(limits.max_batch_rows)),
         )
         .map_err(pq_err)?;
-        if source_path.exists() {
-            let input = fs::File::open(&source_path).map_err(|error| io_err(&error))?;
+        for (_, source_path) in &source_paths {
+            let input = fs::File::open(source_path).map_err(|error| io_err(&error))?;
             let reader = ParquetRecordBatchReaderBuilder::try_new(input)
                 .map_err(pq_err)?
                 .with_batch_size(limits.max_batch_rows)
@@ -838,6 +862,11 @@ fn stream_replay_edges(
             writer.flush().map_err(pq_err)?;
         }
         writer.close().map_err(pq_err)?;
+        for (_, path) in crate::mutator::edge_parquet_files(target, Some(&component))? {
+            if path != target_path {
+                fs::remove_file(&path).map_err(|error| io_err(&error))?;
+            }
+        }
     }
     Ok(())
 }
@@ -902,6 +931,7 @@ fn stream_replay_properties(
     overlay: &crate::graph_delta_journal::ReplayOverlay,
     limits: crate::graph_delta_journal::GraphDeltaJournalLimits,
     edge: bool,
+    route_table: &mut crate::route_component::RouteTable,
 ) -> Result<(), GfError> {
     let operations = if edge {
         &overlay.edge_properties
@@ -935,7 +965,15 @@ fn stream_replay_properties(
     // Legacy flat baselines are admitted as generation zero fragments and are
     // resolved through the same byte-charged chunk path. There is no second
     // unbounded flat-file replay fallback.
-    stream_replay_property_fragments(target, inventory, overlay, limits, edge, fragment_routes)
+    stream_replay_property_fragments(
+        target,
+        inventory,
+        overlay,
+        limits,
+        edge,
+        fragment_routes,
+        route_table,
+    )
 }
 
 fn stream_replay_property_fragments(
@@ -945,17 +983,17 @@ fn stream_replay_property_fragments(
     limits: crate::graph_delta_journal::GraphDeltaJournalLimits,
     edge: bool,
     routes: std::collections::BTreeSet<String>,
+    route_table: &mut crate::route_component::RouteTable,
 ) -> Result<(), GfError> {
-    let scratch = tempfile::tempdir().map_err(|error| io_err(&error))?;
     for route in routes {
-        stream_replay_property_route(
+        stream_replay_property_route_with_table(
             target,
             inventory,
             overlay,
             limits,
             edge,
             &route,
-            scratch.path(),
+            route_table,
         )?;
     }
     Ok(())
@@ -1161,8 +1199,9 @@ fn open_replay_property_fragment(
         PROPERTY_OVERLAY_FORMAT_KEY, PROPERTY_ROUTE_KEY, PROPERTY_TOMBSTONE_FIELD,
         PropertyFragmentId,
     };
+    let component = crate::route_component::component(route);
     let prior_generation =
-        crate::property_overlay::enumerate_property_fragments(target, kind, route)?
+        crate::property_overlay::enumerate_property_fragments(target, kind, &component)?
             .last()
             .map_or(0, |fragment| fragment.id.generation);
     let generation = prior_generation
@@ -1192,7 +1231,7 @@ fn open_replay_property_fragment(
     } else {
         "properties"
     };
-    let path = target.join(subdir).join(route).join(
+    let path = target.join(subdir).join(component).join(
         PropertyFragmentId {
             generation,
             ordinal: 0,
@@ -1216,15 +1255,16 @@ fn open_replay_property_fragment(
     })
 }
 
-fn stream_replay_property_route(
+fn stream_replay_property_route_with_table(
     target: &Path,
     inventory: &crate::AuthenticatedPropertyInventory,
     overlay: &crate::graph_delta_journal::ReplayOverlay,
     limits: crate::graph_delta_journal::GraphDeltaJournalLimits,
     edge: bool,
     route: &str,
-    _scratch: &Path,
+    route_table: &mut crate::route_component::RouteTable,
 ) -> Result<(), GfError> {
+    route_table.check_insert(route, 64 * 1024 * 1024, 100_000)?;
     let (kind, operations) = replay_property_route_context(overlay, edge);
     let target_names = replay_property_target_names(overlay, operations, edge, route);
     let touched_rows = u64::try_from(target_names.len()).unwrap_or(u64::MAX);
@@ -1322,7 +1362,40 @@ fn stream_replay_property_route(
         .writer
         .close()
         .map_err(pq_err)?;
+    route_table.insert(route, 64 * 1024 * 1024, 100_000)?;
     Ok(())
+}
+
+fn replace_private_replay_route_table(
+    target: &Path,
+    table: &crate::route_component::RouteTable,
+) -> Result<(), GfError> {
+    let mut batch = RewriteBatch::new();
+    batch.stage_named_control_bytes(
+        &target.join(crate::route_component::TABLE_FILE),
+        &table.encode(64 * 1024 * 1024)?,
+        "semantic-routes.json.",
+    )?;
+    crate::durable_rewrite::commit(batch, target, false, false, false, None)?;
+    crate::capture_graph_files(target)?;
+    Ok(())
+}
+
+#[cfg(test)]
+fn stream_replay_property_route(
+    target: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    overlay: &crate::graph_delta_journal::ReplayOverlay,
+    limits: crate::graph_delta_journal::GraphDeltaJournalLimits,
+    edge: bool,
+    route: &str,
+    _scratch: &Path,
+) -> Result<(), GfError> {
+    let mut table = crate::route_component::owned::admit_owned_workspace(target)?;
+    stream_replay_property_route_with_table(
+        target, inventory, overlay, limits, edge, route, &mut table,
+    )?;
+    replace_private_replay_route_table(target, &table)
 }
 
 type ReplayPropertyOperations =
@@ -2027,6 +2100,7 @@ impl GraphWriter {
     /// Returns [`GfError::Storage`] if the directory cannot be created.
     pub fn open_at(dir: &Path, mode: OntologyMode, now_micros: i64) -> Result<Self, GfError> {
         fs::create_dir_all(dir).map_err(|e| io_err(&e))?;
+        crate::route_component::owned::admit_owned_workspace(dir)?;
         // Continue surrogate assignment from the on-disk maximum so a writer
         // opened on an existing project appends rather than colliding with /
         // overwriting prior rows. Absent files → max 0 → start at 1.
@@ -3242,14 +3316,13 @@ impl GraphWriter {
             // for monotonic writer sessions.
             let first = rows.first().map_or(0, |row| row.edge_id);
             let last = rows.last().map_or(first, |row| row.edge_id);
-            let existing = crate::mutator::edge_parquet_files(&self.dir, Some(&stem))?;
+            let component = staged.route_component(&self.dir, &stem)?;
+            let existing = crate::mutator::edge_parquet_files(&self.dir, Some(&component))?;
             let path = if existing.is_empty() {
-                // Retain the v1 flat route for the first fragment so existing
-                // projects and external readers remain forward-compatible.
-                edges_dir.join(format!("{stem}.parquet"))
+                edges_dir.join(format!("{component}.parquet"))
             } else {
                 edges_dir
-                    .join(&stem)
+                    .join(&component)
                     .join(format!("{first:020}-{last:020}.parquet"))
             };
             if path.exists() || staged.staged_temp(&path).is_some() {
@@ -4322,28 +4395,36 @@ fn decode_edge_property_rows(batches: &[RecordBatch]) -> Result<Vec<EdgePropRow>
 /// Decode every persisted node-property row while retaining its canonical
 /// [`IrLiteral`] type. This is the bounded base decoder used by authoritative
 /// graph-delta replay; callers must apply their own aggregate replay budget.
-pub(crate) fn read_all_node_properties(dir: &Path) -> Result<Vec<TypedPropertyRow>, GfError> {
+pub(crate) fn read_all_node_properties(
+    dir: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+) -> Result<Vec<TypedPropertyRow>, GfError> {
     let mut rows = Vec::new();
-    for stem in crate::catalog::list_property_stems(dir) {
-        let batches = crate::catalog::read_properties(dir, &stem).map_err(pq_err)?;
+    for stem in inventory.routes(crate::PropertyRouteKind::Node) {
+        let batches =
+            crate::catalog::read_properties_from_inventory(dir, inventory, stem).map_err(pq_err)?;
         rows.extend(
             decode_property_rows(&batches)?
                 .into_iter()
-                .map(|row| (stem.clone(), row.node_uuid, row.props)),
+                .map(|row| (stem.to_owned(), row.node_uuid, row.props)),
         );
     }
     Ok(rows)
 }
 
 /// Edge-property analogue of [`read_all_node_properties`].
-pub(crate) fn read_all_edge_properties(dir: &Path) -> Result<Vec<TypedPropertyRow>, GfError> {
+pub(crate) fn read_all_edge_properties(
+    dir: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+) -> Result<Vec<TypedPropertyRow>, GfError> {
     let mut rows = Vec::new();
-    for stem in crate::catalog::list_edge_property_stems(dir) {
-        let batches = crate::catalog::read_edge_properties(dir, &stem).map_err(pq_err)?;
+    for stem in inventory.routes(crate::PropertyRouteKind::Edge) {
+        let batches = crate::catalog::read_edge_properties_from_inventory(dir, inventory, stem)
+            .map_err(pq_err)?;
         rows.extend(
             decode_edge_property_rows(&batches)?
                 .into_iter()
-                .map(|row| (stem.clone(), row.edge_uuid, row.props)),
+                .map(|row| (stem.to_owned(), row.edge_uuid, row.props)),
         );
     }
     Ok(rows)
@@ -4426,6 +4507,31 @@ pub fn read_node_property_rows(
         .collect())
 }
 
+/// Read typed node rows through an explicitly admitted generation inventory.
+pub fn read_node_property_rows_from_inventory(
+    dir: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    route: &str,
+) -> Result<HashMap<[u8; 16], HashMap<String, IrLiteral>>, GfError> {
+    let mut rows = HashMap::new();
+    crate::catalog::visit_property_overlay_batched_with_inventory(
+        dir,
+        Some(inventory),
+        route,
+        false,
+        8_192,
+        |batch| {
+            let decoded = decode_property_rows(std::slice::from_ref(batch)).map_err(|error| {
+                datafusion::common::DataFusionError::Execution(error.to_string())
+            })?;
+            rows.extend(decoded.into_iter().map(|row| (row.node_uuid, row.props)));
+            Ok(true)
+        },
+    )
+    .map_err(pq_err)?;
+    Ok(rows)
+}
+
 /// Count non-null properties owned by the selected persisted entities across
 /// every dynamic-schema property partition.
 pub fn count_entity_properties<S: std::hash::BuildHasher>(
@@ -4436,17 +4542,32 @@ pub fn count_entity_properties<S: std::hash::BuildHasher>(
     if targets.is_empty() {
         return Ok(0);
     }
+    let inventory = crate::property_overlay::authenticated_property_inventory_for_rewrite(
+        dir,
+        &RewriteBatch::new(),
+    )?;
+    count_entity_properties_from_inventory(dir, &inventory, targets, is_edge)
+}
+
+/// Count selected entity properties through the caller's admitted route inventory.
+pub fn count_entity_properties_from_inventory<S: std::hash::BuildHasher>(
+    dir: &Path,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    targets: &HashSet<[u8; 16], S>,
+    is_edge: bool,
+) -> Result<u64, GfError> {
     let mut count = 0u64;
-    let stems = if is_edge {
-        crate::catalog::list_edge_property_stems(dir)
+    let kind = if is_edge {
+        crate::PropertyRouteKind::Edge
     } else {
-        crate::catalog::list_property_stems(dir)
+        crate::PropertyRouteKind::Node
     };
+    let stems = inventory.routes(kind);
     for stem in stems {
         let batches = if is_edge {
-            crate::catalog::read_edge_properties(dir, &stem)
+            crate::catalog::read_edge_properties_from_inventory(dir, inventory, stem)
         } else {
-            crate::catalog::read_properties(dir, &stem)
+            crate::catalog::read_properties_from_inventory(dir, inventory, stem)
         }
         .map_err(pq_err)?;
         if is_edge {
@@ -5631,10 +5752,11 @@ fn complete_node_property_window(
 ) -> Result<CompletedPropertyWindow<PropRow>, GfError> {
     let rows = merge_node_property_window(rows);
     let targets = rows.iter().map(|row| row.node_uuid).collect();
-    let inventory = crate::property_overlay::authenticated_property_inventory_for_route(
+    let inventory = crate::property_overlay::authenticated_property_inventory_for_rewrite_route(
         dir,
         crate::PropertyRouteKind::Node,
         route,
+        staged,
     )?;
     let (mut complete, _) = crate::read_authenticated_property_snapshots_for_inventory(
         &inventory,
@@ -5701,10 +5823,11 @@ fn complete_edge_property_window(
 ) -> Result<CompletedPropertyWindow<EdgePropRow>, GfError> {
     let rows = merge_edge_property_window(rows);
     let targets = rows.iter().map(|row| row.edge_uuid).collect();
-    let inventory = crate::property_overlay::authenticated_property_inventory_for_route(
+    let inventory = crate::property_overlay::authenticated_property_inventory_for_rewrite_route(
         dir,
         crate::PropertyRouteKind::Edge,
         route,
+        staged,
     )?;
     let (mut complete, _) = crate::read_authenticated_property_snapshots_for_inventory(
         &inventory,
@@ -5766,21 +5889,6 @@ fn complete_edge_property_window(
         &after,
     )?;
     Ok((rows, Some(schema), inventory.generation_authority()))
-}
-
-pub(crate) fn stage_property_tombstones<S: std::hash::BuildHasher>(
-    staged: &mut RewriteBatch,
-    dir: &Path,
-    kind: crate::property_overlay::PropertyRouteKind,
-    route: &str,
-    uuids: &HashSet<[u8; 16], S>,
-) -> Result<(), GfError> {
-    if uuids.is_empty() {
-        return Ok(());
-    }
-    let inventory =
-        crate::property_overlay::authenticated_property_inventory_for_route(dir, kind, route)?;
-    stage_property_tombstones_from_inventory(staged, dir, &inventory, kind, route, uuids)
 }
 
 /// Stage whole-row tombstones using an already authenticated generation inventory.
@@ -6051,7 +6159,8 @@ pub(crate) fn seal_property_windows(
                 });
             }
         }
-        if enumerate_property_fragments(dir, key.kind, &key.route)?
+        let component = staged.route_component(dir, &key.route)?;
+        if enumerate_property_fragments(dir, key.kind, &component)?
             .iter()
             .any(|fragment| fragment.id.generation >= generation)
         {
@@ -6076,7 +6185,7 @@ pub(crate) fn seal_property_windows(
             crate::property_overlay::PropertyRouteKind::Node => "properties",
             crate::property_overlay::PropertyRouteKind::Edge => "edge_properties",
         };
-        let destination = dir.join(subdir).join(&key.route).join(
+        let destination = dir.join(subdir).join(component).join(
             PropertyFragmentId {
                 generation,
                 ordinal: 0,
@@ -6119,13 +6228,19 @@ mod tests {
 
     const TS: i64 = 1_700_000_000_000_000;
 
+    fn test_inventory(dir: &Path) -> crate::AuthenticatedPropertyInventory {
+        let (files, _) = crate::capture_graph_files(dir).unwrap();
+        crate::AuthenticatedPropertyInventory::from_inventory_at_root(dir, files, None).unwrap()
+    }
+
     #[test]
     fn delta_replay_new_routes_start_and_continue_live_schema_authority() {
         let project = TempDir::new().unwrap();
         let (empty_files, _) = crate::capture_graph_files(project.path()).unwrap();
-        let empty = crate::AuthenticatedPropertyInventory::from_entries_at_root(
+        let empty = crate::AuthenticatedPropertyInventory::from_inventory_at_root(
             project.path(),
-            empty_files.files,
+            empty_files,
+            None,
         )
         .unwrap();
         let mut limits = crate::GraphDeltaJournalLimits::default();
@@ -6174,9 +6289,10 @@ mod tests {
         .unwrap();
 
         let (files, _) = crate::capture_graph_files(project.path()).unwrap();
-        let created = crate::AuthenticatedPropertyInventory::from_entries_at_root(
+        let created = crate::AuthenticatedPropertyInventory::from_inventory_at_root(
             project.path(),
-            files.files,
+            files,
+            None,
         )
         .unwrap();
         let summary_count = |schema: &SchemaRef, key: &str| {
@@ -6236,9 +6352,10 @@ mod tests {
         .unwrap();
 
         let (files, _) = crate::capture_graph_files(project.path()).unwrap();
-        let reopened = crate::AuthenticatedPropertyInventory::from_entries_at_root(
+        let reopened = crate::AuthenticatedPropertyInventory::from_inventory_at_root(
             project.path(),
-            files.files,
+            files,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -6392,9 +6509,12 @@ mod tests {
         reopened.flush().unwrap();
 
         let (captured, _) = crate::capture_graph_files(dir.path()).unwrap();
-        let inventory =
-            crate::AuthenticatedPropertyInventory::from_entries_at_root(dir.path(), captured.files)
-                .unwrap();
+        let inventory = crate::AuthenticatedPropertyInventory::from_inventory_at_root(
+            dir.path(),
+            captured,
+            None,
+        )
+        .unwrap();
         let scratch = TempDir::new().unwrap();
         let mut rows = Vec::new();
         inventory
@@ -6639,10 +6759,17 @@ mod tests {
             .unwrap();
         second.flush().unwrap();
 
-        let fragments = crate::mutator::edge_parquet_files(dir.path(), Some("KNOWS")).unwrap();
+        let fragments = crate::mutator::edge_parquet_files(
+            dir.path(),
+            Some(&crate::route_component::component("KNOWS")),
+        )
+        .unwrap();
         assert_eq!(fragments.len(), 2);
         assert!(fragments.iter().any(|(_, path)| {
-            path.parent().and_then(Path::file_name) == Some(std::ffi::OsStr::new("KNOWS"))
+            path.parent().and_then(Path::file_name)
+                == Some(std::ffi::OsStr::new(&crate::route_component::component(
+                    "KNOWS",
+                )))
         }));
         let work = second.topology_write_work();
         assert_eq!(work.existing_rows_rewritten, 0);
@@ -6652,11 +6779,15 @@ mod tests {
         assert_eq!(work.rows_encoded, 1);
         assert_eq!(work.shard_count, 1);
         assert!(work.output_bytes > 0);
-        let rows = crate::catalog::read_edges(dir.path(), "KNOWS", OntologyMode::Strict)
-            .unwrap()
-            .into_iter()
-            .map(|batch| batch.num_rows())
-            .sum::<usize>();
+        let rows = crate::catalog::read_edges_from_inventory(
+            &test_inventory(dir.path()),
+            "KNOWS",
+            OntologyMode::Strict,
+        )
+        .unwrap()
+        .into_iter()
+        .map(|batch| batch.num_rows())
+        .sum::<usize>();
         assert_eq!(rows, 2, "ordinary direct reader must union all fragments");
     }
 
@@ -6750,8 +6881,12 @@ mod tests {
             .unwrap();
         second.flush().unwrap();
 
-        let fragments =
-            crate::mutator::property_parquet_files(dir.path(), "properties", "_untyped").unwrap();
+        let fragments = crate::mutator::property_parquet_files(
+            dir.path(),
+            "properties",
+            &crate::route_component::component("_untyped"),
+        )
+        .unwrap();
         assert_eq!(fragments.len(), 2);
         let rows = read_node_property_rows(dir.path(), "_untyped").unwrap();
         assert_eq!(rows.len(), 2);
@@ -7424,8 +7559,11 @@ mod tests {
     fn empty_flush_creates_no_directories() {
         let dir = TempDir::new().unwrap();
         let mut w = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS).unwrap();
+        // Owned layout admission creates only its protocol metadata. Empty flush
+        // must add no data files or rewrite that admitted metadata.
+        let before = crate::capture_graph_files(dir.path()).unwrap().0;
         w.flush().unwrap();
-        assert!(!dir.path().join("topology").exists());
+        assert_eq!(crate::capture_graph_files(dir.path()).unwrap().0, before);
         assert!(!dir.path().join("properties").exists());
     }
 
@@ -7658,11 +7796,15 @@ mod tests {
         kind: crate::property_overlay::PropertyRouteKind,
         route: &str,
     ) -> PathBuf {
-        crate::property_overlay::enumerate_property_fragments(dir, kind, route)
-            .unwrap()
-            .pop()
-            .expect("property route has a committed fragment")
-            .path
+        crate::property_overlay::enumerate_property_fragments(
+            dir,
+            kind,
+            &crate::route_component::component(route),
+        )
+        .unwrap()
+        .pop()
+        .expect("property route has a committed fragment")
+        .path
     }
 
     #[test]
@@ -7753,7 +7895,7 @@ mod tests {
             !crate::property_overlay::enumerate_property_fragments(
                 dir.path(),
                 crate::property_overlay::PropertyRouteKind::Node,
-                "Person",
+                &crate::route_component::component("Person"),
             )
             .unwrap()
             .is_empty()
@@ -8029,9 +8171,16 @@ mod tests {
         let removed = to_bytes(&removed);
         let resurrected = to_bytes(&resurrected);
         let mut staged = RewriteBatch::new();
-        stage_property_tombstones(
+        let inventory = crate::property_overlay::authenticated_property_inventory_for_route(
+            dir.path(),
+            crate::PropertyRouteKind::Node,
+            "_untyped",
+        )
+        .unwrap();
+        stage_property_tombstones_authenticated(
             &mut staged,
             dir.path(),
+            &inventory,
             crate::PropertyRouteKind::Node,
             "_untyped",
             &HashSet::from([removed, resurrected]),
@@ -8240,6 +8389,18 @@ mod tests {
         let legacy = property_snapshots_to_batch("_untyped", false, legacy_rows)
             .unwrap()
             .unwrap();
+        drop(writer);
+        let table_path = dir.path().join(crate::route_component::TABLE_FILE);
+        assert_eq!(
+            crate::route_component::RouteTable::decode(
+                &fs::read(&table_path).unwrap(),
+                64 * 1024 * 1024,
+                100_000
+            )
+            .unwrap(),
+            crate::route_component::RouteTable::default()
+        );
+        fs::remove_file(&table_path).unwrap();
         fs::create_dir_all(dir.path().join("properties")).unwrap();
         let mut parquet = parquet::arrow::ArrowWriter::try_new(
             File::create(dir.path().join("properties/_untyped.parquet")).unwrap(),
@@ -8249,6 +8410,8 @@ mod tests {
         .unwrap();
         parquet.write(&legacy).unwrap();
         parquet.close().unwrap();
+        let migrated = GraphWriter::open_at(dir.path(), OntologyMode::Exploratory, TS).unwrap();
+        drop(migrated);
 
         set_node_properties(
             dir.path(),
@@ -8269,7 +8432,7 @@ mod tests {
         let fragments = crate::property_overlay::enumerate_property_fragments(
             dir.path(),
             crate::property_overlay::PropertyRouteKind::Node,
-            "_untyped",
+            &crate::route_component::component("_untyped"),
         )
         .unwrap();
         assert_eq!(fragments.first().unwrap().id.generation, 0);
@@ -8459,9 +8622,10 @@ mod tests {
             !read_edge_props(dir.path(), "KNOWS").contains_key(&to_bytes(&e1)),
             "cancelled edge's props never hit disk"
         );
-        let edges = crate::catalog::read_parquet_or_empty(
-            &dir.path().join("topology/edges/_exploratory.parquet"),
-            EXPLORATORY_EDGE_SCHEMA.clone(),
+        let edges = crate::catalog::read_edges_from_inventory(
+            &test_inventory(dir.path()),
+            "*",
+            OntologyMode::Exploratory,
         )
         .unwrap();
         let total: usize = edges.iter().map(RecordBatch::num_rows).sum();

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -3014,10 +3014,21 @@ impl GraphWriter {
     /// Returns [`GfError::Storage`] on any I/O, Arrow, or Parquet failure.
     pub fn flush(&mut self) -> Result<(), GfError> {
         let mut staged = RewriteBatch::new();
-        self.flush_into(&mut staged)?;
+        self.flush_into(&mut staged).map_err(|error| match error {
+            GfError::Storage(message) => {
+                GfError::Storage(format!("graph flush staging: {message}"))
+            }
+            other => other,
+        })?;
         let pending = self.take_pending_delta();
-        if let Some(generation) =
-            self.commit_topology_aware_with_uuid_index(staged, Vec::new(), Vec::new())?
+        if let Some(generation) = self
+            .commit_topology_aware_with_uuid_index(staged, Vec::new(), Vec::new())
+            .map_err(|error| match error {
+                GfError::Storage(message) => {
+                    GfError::Storage(format!("graph flush commit: {message}"))
+                }
+                other => other,
+            })?
         {
             // A pure-append flush (only CREATEs reach `GraphWriter`): record the
             // delta segment so the adjacency index can serve the new edges

--- a/crates/graphforge-storage/tests/filtered_read.rs
+++ b/crates/graphforge-storage/tests/filtered_read.rs
@@ -23,8 +23,7 @@ use graphforge_storage::io_stats::{
     FilteredReadObserver, FilteredReadPruning, FilteredReadStrategy, FilteredReadTable,
 };
 use graphforge_storage::{
-    GraphWriter, TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, read_edges_filtered,
-    read_nodes_filtered_observed,
+    GraphWriter, TOPOLOGY_NODES_SCHEMA, TYPED_EDGE_SCHEMA, read_nodes_filtered_observed,
 };
 use graphforge_value::EntityTypeId;
 
@@ -395,4 +394,27 @@ fn unexpected_dense_rows_are_discarded_before_conservative_retry() {
     assert_eq!(pruning[0].validation_fallbacks, 1);
     assert_eq!(pruning[1].strategy, FilteredReadStrategy::RowGroupPredicate);
     assert_eq!(pruning[1].metadata_fallbacks, 0);
+}
+
+fn admitted_inventory(
+    root: &std::path::Path,
+) -> std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    graphforge_storage::GraphCatalog::open(root, None, &graphforge_ir::RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
+fn read_edges_filtered(
+    root: &std::path::Path,
+    route: &str,
+    mode: OntologyMode,
+    ids: &HashSet<u64>,
+) -> Result<Vec<arrow::record_batch::RecordBatch>, datafusion::error::DataFusionError> {
+    graphforge_storage::read_edges_filtered_from_inventory(
+        &admitted_inventory(root),
+        route,
+        mode,
+        ids,
+    )
 }

--- a/crates/graphforge-storage/tests/graph_delta_journal.rs
+++ b/crates/graphforge-storage/tests/graph_delta_journal.rs
@@ -11,9 +11,8 @@ use graphforge_storage::{
     GraphFilesInventory, GraphWriter, ProjectCapability, ProjectGenerationRequest,
     ProjectStageOutcome, PropertyOverlayLimits, PropertyRouteKind, PropertySnapshotRow,
     capture_graph_files, decode_delta_run, decode_graph_delta_value, delta_run_relative_path,
-    empty_workspace_participants, encode_delta_run, encode_graph_delta_value,
-    enumerate_property_fragments, list_delta_runs, materialize_replayed_graph_tree,
-    open_or_initialize_project, publish_graph_delta, read_edges, read_nodes,
+    empty_workspace_participants, encode_delta_run, encode_graph_delta_value, list_delta_runs,
+    materialize_replayed_graph_tree, open_or_initialize_project, publish_graph_delta, read_nodes,
     reconstruct_graph_state, resolve_project_generation, stage_project_generation_with_graph_tree,
     visit_authenticated_property_snapshots,
 };
@@ -321,19 +320,22 @@ fn topology_replay_admission_is_path_specific_and_never_creates_rejected_output(
     let inventory = generation.graph_files_inventory().unwrap().unwrap();
     let source_nodes =
         fs::read(generation.graph_tree_root().join("topology/nodes.parquet")).unwrap();
-    let source_edges = fs::read(
-        generation
-            .graph_tree_root()
-            .join("topology/edges/KNOWS.parquet"),
-    )
-    .unwrap();
+    let source_inventory =
+        graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(&generation)
+            .unwrap();
+    let source_edge = source_inventory.edge_files(Some("KNOWS"))[0].1.clone();
+    let edge_relative = source_edge
+        .strip_prefix(generation.graph_tree_root())
+        .unwrap()
+        .to_path_buf();
+    let source_edges = fs::read(&source_edge).unwrap();
 
     let mut observed_node_rejection = false;
     let mut observed_edge_rejection = false;
     for kibibytes in (256..=768).step_by(16) {
         let target = tempfile::tempdir().unwrap();
         let node_output = target.path().join("topology/nodes.parquet");
-        let edge_output = target.path().join("topology/edges/KNOWS.parquet");
+        let edge_output = target.path().join(&edge_relative);
         let result = materialize_replayed_graph_tree(
             &generation.graph_tree_root(),
             &inventory,
@@ -1191,4 +1193,30 @@ fn committed_checksum_valid_invalid_literal_values_preserve_authority() {
             "invalid shared literal must not mutate committed authority: {malformed}"
         );
     }
+}
+
+fn admitted_inventory(
+    root: &std::path::Path,
+) -> std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    graphforge_storage::GraphCatalog::open(root, None, &graphforge_ir::RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
+fn enumerate_property_fragments(
+    root: &std::path::Path,
+    kind: graphforge_storage::PropertyRouteKind,
+    route: &str,
+) -> Result<Vec<graphforge_storage::property_overlay::PropertyFragment>, graphforge_storage::GfError>
+{
+    Ok(admitted_inventory(root).property_fragments(kind, route))
+}
+
+fn read_edges(
+    root: &std::path::Path,
+    route: &str,
+    mode: OntologyMode,
+) -> Result<Vec<arrow::record_batch::RecordBatch>, datafusion::error::DataFusionError> {
+    graphforge_storage::read_edges_from_inventory(&admitted_inventory(root), route, mode)
 }

--- a/crates/graphforge-storage/tests/graph_writer.rs
+++ b/crates/graphforge-storage/tests/graph_writer.rs
@@ -14,9 +14,8 @@ use graphforge_core::uuid::new_v7;
 use graphforge_ir::{IrLiteral, RuntimeCatalog};
 use graphforge_storage::{
     EdgePropertyTable, GraphCatalog, GraphWriter, PropertyOverlayLimits, PropertyRouteKind,
-    PropertySnapshotRow, PropertyTable, delete_edges, enumerate_property_fragments,
-    read_topology_generation, remove_edge_properties, set_edge_properties_rewrite,
-    visit_authenticated_property_snapshots,
+    PropertySnapshotRow, PropertyTable, delete_edges, read_topology_generation,
+    remove_edge_properties, set_edge_properties_rewrite, visit_authenticated_property_snapshots,
 };
 
 /// Fixed timestamp so written Parquet is deterministic.
@@ -56,7 +55,11 @@ async fn strict_mode_round_trip_nodes_and_edges() {
 
     // Files landed where the reader expects them.
     assert!(dir.path().join("topology/nodes.parquet").exists());
-    assert!(dir.path().join("topology/edges/KNOWS.parquet").exists());
+    assert!(
+        admitted_inventory(dir.path()).edge_files(Some("KNOWS"))[0]
+            .1
+            .exists()
+    );
 
     // Reload. GraphCatalog registers `edges_<name>` from the runtime catalog's
     // relation types, so intern KNOWS first.
@@ -107,8 +110,8 @@ async fn exploratory_mode_routes_to_catch_all_files() {
 
     // Catch-all files exist.
     assert!(
-        dir.path()
-            .join("topology/edges/_exploratory.parquet")
+        admitted_inventory(dir.path()).edge_files(Some("_exploratory"))[0]
+            .1
             .exists()
     );
     assert_canonical_fragments(dir.path(), PropertyRouteKind::Node, "_untyped", 1);
@@ -343,7 +346,25 @@ fn assert_canonical_fragments(
             fragment.path.file_name().unwrap().to_str().unwrap(),
             fragment.id.file_name()
         );
-        assert_eq!(fragment.path.parent().unwrap().file_name().unwrap(), route);
+        let table: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(dir.join("semantic-routes.json")).unwrap())
+                .unwrap();
+        let component = fragment
+            .path
+            .parent()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let matches = table["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|entry| entry["component"].as_str() == Some(component))
+            .collect::<Vec<_>>();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0]["route"].as_str(), Some(route));
     }
 }
 
@@ -984,4 +1005,22 @@ fn property_only_flush_does_not_bump_topology_generation() {
     // An empty flush stages nothing and must not bump either.
     w.flush().unwrap();
     assert_eq!(read_topology_generation(dir.path()).unwrap(), 1);
+}
+
+fn admitted_inventory(
+    root: &std::path::Path,
+) -> std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    graphforge_storage::GraphCatalog::open(root, None, &graphforge_ir::RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
+fn enumerate_property_fragments(
+    root: &std::path::Path,
+    kind: graphforge_storage::PropertyRouteKind,
+    route: &str,
+) -> Result<Vec<graphforge_storage::property_overlay::PropertyFragment>, graphforge_storage::GfError>
+{
+    Ok(admitted_inventory(root).property_fragments(kind, route))
 }

--- a/crates/graphforge-storage/tests/io_stats.rs
+++ b/crates/graphforge-storage/tests/io_stats.rs
@@ -22,9 +22,7 @@ use parquet::file::properties::WriterProperties;
 use graphforge_core::uuid::{Uuid, new_v7};
 use graphforge_core::{OntologyMode, TypeId};
 use graphforge_storage::io_stats;
-use graphforge_storage::{
-    GraphWriter, read_edges, read_edges_filtered, read_nodes, read_nodes_filtered,
-};
+use graphforge_storage::{GraphWriter, read_nodes, read_nodes_filtered};
 use graphforge_value::EntityTypeId;
 
 const TS: i64 = 1_700_000_000_000_000;
@@ -308,4 +306,35 @@ fn dense_selection_uses_shard_local_id_range_and_gaps_fall_back() {
     assert_eq!(fallback.node_dense_row_selection_reads, 0);
     assert_eq!(fallback.node_row_group_predicate_reads, 1);
     assert_eq!(fallback.node_metadata_fallbacks, 1);
+}
+
+fn admitted_inventory(
+    root: &std::path::Path,
+) -> std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    graphforge_storage::GraphCatalog::open(root, None, &graphforge_ir::RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
+fn read_edges_filtered(
+    root: &std::path::Path,
+    route: &str,
+    mode: OntologyMode,
+    ids: &HashSet<u64>,
+) -> Result<Vec<arrow::record_batch::RecordBatch>, datafusion::error::DataFusionError> {
+    graphforge_storage::read_edges_filtered_from_inventory(
+        &admitted_inventory(root),
+        route,
+        mode,
+        ids,
+    )
+}
+
+fn read_edges(
+    root: &std::path::Path,
+    route: &str,
+    mode: OntologyMode,
+) -> Result<Vec<arrow::record_batch::RecordBatch>, datafusion::error::DataFusionError> {
+    graphforge_storage::read_edges_from_inventory(&admitted_inventory(root), route, mode)
 }

--- a/crates/graphforge-storage/tests/property_overlay_scale.rs
+++ b/crates/graphforge-storage/tests/property_overlay_scale.rs
@@ -12,8 +12,7 @@ use graphforge_core::{OntologyMode, TypeId};
 use graphforge_ir::IrLiteral;
 use graphforge_storage::{
     GraphWriter, PropertyFragmentId, PropertyOverlayLimits, PropertyRouteKind, delete_nodes,
-    enumerate_property_fragments, remove_node_properties, set_node_properties,
-    visit_authenticated_property_snapshots,
+    remove_node_properties, set_node_properties, visit_authenticated_property_snapshots,
 };
 use graphforge_value::EntityTypeId;
 use sha2::{Digest, Sha256};
@@ -604,4 +603,22 @@ fn production_property_overlay_n_2n_4n_is_disk_growing_and_memory_bounded() {
             && pair[1].per_record_seeks == 0
     }));
     eprintln!("property-overlay-scale-evidence={evidence:#?}");
+}
+
+fn admitted_inventory(
+    root: &std::path::Path,
+) -> std::sync::Arc<graphforge_storage::AuthenticatedPropertyInventory> {
+    graphforge_storage::GraphCatalog::open(root, None, &graphforge_ir::RuntimeCatalog::new())
+        .unwrap()
+        .admitted_inventory()
+        .unwrap()
+}
+
+fn enumerate_property_fragments(
+    root: &std::path::Path,
+    kind: graphforge_storage::PropertyRouteKind,
+    route: &str,
+) -> Result<Vec<graphforge_storage::property_overlay::PropertyFragment>, graphforge_storage::GfError>
+{
+    Ok(admitted_inventory(root).property_fragments(kind, route))
 }

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -217,18 +217,67 @@ authenticates an existing inventory once per publication sequence; individual
 updates cannot substitute a caller-owned cache and do not rescan all prior
 descriptors. Open resolves the bounded manifest and verifies every selected
 payload before exposing the generation. Ordinary API open and restore dispatch
-on the declared participant version: version 1 keeps its pinned-tree/copy
-behavior, while version 2 materializes authenticated CAS objects at the same
-workspace-relative paths and replays authoritative deltas into a distinct
-private workspace so immutable CAS hard links are never modified in place.
-Version 1
-expanded inventories remain readable and can be migrated without changing
-`CURRENT` until the complete version-2 generation is durable.
+on the declared participant version. Expanded inventories use version 1 for
+legacy raw routes and version 3 for mapped routes; compact CAS roots use
+version 2 for raw routes and version 4 for mapped routes. The descriptor and
+payload must agree. Immutable generations remain unchanged while a writable
+facade materializes an authenticated private workspace.
+
+### Semantic routes and portable filenames
+
+Node labels and edge relations are semantic UTF-8 identifiers, not filesystem
+components. Rust owns their translation at every node-property, edge-property,
+and topology-relation path boundary. A physical route component is `r-` followed
+by the 64 lowercase hexadecimal digits of SHA-256 over the exact semantic UTF-8
+bytes. Its length is always 66 bytes, including for long semantic names.
+
+The graph-owned `semantic-routes.json` control record reverses each component to
+its exact semantic route. It belongs to the authenticated graph-files inventory
+and travels with publication and portable export/import. Decoding verifies the
+table digest, canonical serialization, unique entries, component derivation,
+and resource budgets. Every physical route must resolve through the table;
+unreferenced table entries are rejected. A digest collision between distinct
+semantic routes is a typed refusal, never an overwrite. The table is bounded to
+64 MiB and 100,000 entries; exceeding a budget fails explicitly.
+
+No case folding or Unicode normalization changes a semantic identifier. Names
+such as `CON`, `AUX`, trailing-dot names, normalization variants, and literal
+`r-` prefixes retain their original meaning in public results and metadata.
+Readers use authenticated layout authority, never filename-prefix guessing.
+Legacy versions 1 and 2 cannot contain the reserved mapping record; mapped
+versions 3 and 4 require it. Older readers reject the new versions rather than
+interpreting an encoded component as a semantic name.
+
+Legacy migration operates only in an owned private workspace. It authenticates
+source identity and bytes, stages the encoded files and complete mapping in the
+same durable rewrite, and recovers that rewrite before reading route authority.
+Physical migration preserves graph UUIDs, ranks, values, and semantic generation
+counters. An authenticated legacy publication must be translated while copying
+into the private workspace, so Windows never needs to create an intermediate
+raw reserved filename. Published trees and CAS objects remain immutable.
+
+Mapping updates share the graph rewrite transaction. Writers authenticate the
+current mapping under the rewrite lock before extending it, and transformations
+that remove or rename physical routes rebuild the mapping from their emitted
+inventory. Path containment, no-follow opens, native identity, link-count,
+collision, and exact-inventory checks still apply to encoded paths.
+
+Construction checkpoint version 8 selects mapped output explicitly. Versions 6
+and 7 retain their original encoding when resumed; versions 7 and 8 use the
+same compact detail codec. Mapped construction publication combines the
+retained parent routes with newly emitted routes and verifies the complete
+mapping before installing the version-4 manifest. Legacy parent payloads can
+retain their authenticated CAS objects while their logical route paths change.
+
+Read sessions retain one admitted route inventory with their catalog and
+adjacency provider. Publishing a later generation replaces the facade's
+provider; an existing lazy stream keeps its original inventory and private
+index artifacts through completion.
 
 ### Immutable property snapshots
 
 Node and edge properties use `full-snapshot-v1` fragments under
-`properties/<route>/<generation>-<ordinal>.parquet` (fixed-width decimal identity) and the corresponding
+`properties/<component>/<generation>-<ordinal>.parquet` (fixed-width decimal identity) and the corresponding
 `edge_properties` tree. Each row is the complete property state for one UUID;
 an explicit tombstone deletes the whole row. Admission authenticates every
 canonical generation and ordinal named by the committed graph-files inventory.
@@ -557,8 +606,9 @@ Conventions:
   publish bounded delta segments; a full rebuild compacts them into sharded bases.
 - **Determinism (R-ADJ-2).** Full rebuild streams each typed edge file once; `out` entries
   sort by `(src_id, edge_id)` and `in` entries by `(dst_id, edge_id)` — the `edge_id`
-  tie-break makes shard bytes reproducible from `topology/` alone. `_all.{out,in}.csr.json` are
-  the same sorts over the union of all typed files plus `_exploratory.parquet`. The manifest's
+  tie-break makes shard bytes reproducible from `topology/` alone. The `_all` relation's
+  indexes use the same sorts over the union of typed and exploratory edges. Cache filenames
+  use portable route components; the manifest retains exact semantic relation names. The manifest's
   `built_at` is excluded from the determinism guarantee.
 - **Bounded build.** Projected Parquet batches feed sorted spill runs. Bounded-fan-in merge
   passes (64 runs by default) emit rows directly into hard-capped shard sinks; they never
@@ -609,8 +659,9 @@ Graph traversal reads only the topology layer. No property columns are read unle
 | `updated_at` | `Timestamp(Microseconds, UTC)` | |
 
 The first label in a node's creation pattern is its immutable **primary label**.
-`properties/<ENTITY>.parquet` continues to use that primary label as its file stem;
-adding secondary labels therefore cannot orphan or relocate properties.
+The property route continues to use that primary label, encoded through the
+semantic-route mapping for its physical path; adding secondary labels therefore
+cannot orphan or relocate properties.
 Unlabelled nodes route to `_untyped`. A v0.5 node participant must contain both
 fields with the frozen schema; an earlier development schema is unsupported.
 
@@ -690,7 +741,8 @@ manifest digests. If the ordinal facet is absent while current v3 is canonical,
 discovery returns a typed rebuild requirement. A present ordinal path must pass
 authenticated open and never falls back to v3 when malformed or substituted.
 
-New publications use a compact version-2 `graph/files` root. Payloads and
+New mapped publications use a compact version-4 `graph/files` root, retaining
+the version-2 radix representation with explicit mapped-route authority. Payloads and
 fixed-depth radix nodes live once in the project content-addressed object
 store; a generation stores only its root reference and logical totals. Updates
 copy at most one bounded SHA-256 nibble path and retain exact-path collision
@@ -700,13 +752,14 @@ descriptors before mutations become visible; they are acknowledged only after
 CURRENT advances. Reopen traverses the authenticated radix and hashes every
 selected payload object. Post-CURRENT GC traces every remaining generation
 root and defers while an optimistic attempt or CAS publication lease is live.
-Version-1 expanded inventories remain readable and are migrated under the same
-CAS publication lease before a writable facade publishes version 2.
+Legacy expanded and compact inventories remain readable. A writable facade
+migrates their raw routes in its private workspace before publishing the mapped
+layout under the CAS publication lease.
 
 The authoritative write census is executable: topology node and edge shards,
 node and edge properties, graph deltas, catalog records, extension-owned graph
 records, and the generation/runtime-catalog/runtime-label control files must
-all appear in the revision descriptor journal and resolve to the same v2
+all appear in the revision descriptor journal and resolve to the same authenticated
 logical inventory. Rebuildable adjacency and UUID-membership artifacts live
 under `.graphforge-cache/` and are rejected as graph authority. Parquet write
 sites share `RewriteBatch` plus `commit_topology_aware`; the three control-file
@@ -720,8 +773,10 @@ digests, ordering, duplicate references, wrong depth, and corrupt objects.
 
 ### Properties layer (warm path)
 
-**`properties/ENTITY_TYPE.parquet`** (legacy first fragment) and
-**`properties/ENTITY_TYPE/<generation>-<ordinal>.parquet`** (immutable construction fragments)
+**`properties/<component>.parquet`** (flat first fragment) and
+**`properties/<component>/<generation>-<ordinal>.parquet`** (immutable construction fragments).
+The mapped component resolves to the semantic entity type; legacy raw layouts
+use the entity type directly at the same route position.
 
 | Column | Arrow type | Notes |
 |---|---|---|

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -124,9 +124,14 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_every_adjacency_read_has_exactly_one_visibility_guard(self) -> None:
         source = (GATE.ROOT / "crates/graphforge-api/src/analyst.rs").read_text()
-        calls = list(re.finditer(r"self\.adjacency_provider\.revalidate\(\);", source))
+        calls = list(
+            re.finditer(
+                r"let adjacency_provider = self\.adjacency_provider_for_session\(\);", source
+            )
+        )
         self.assertEqual(len(calls), 12)
         for call in calls:
+            self.assertRegex(source[call.end() :], r"^\s*adjacency_provider\.revalidate\(\);")
             prefix = source[max(0, call.start() - 240) : call.start()]
             self.assertEqual(prefix.count(".adjacency_visibility"), 1)
             self.assertRegex(

--- a/tests/contracts/property-overlay-v1.json
+++ b/tests/contracts/property-overlay-v1.json
@@ -34,6 +34,7 @@
       "AuthenticatedPropertyInventory", "AuthenticatedPropertyInventory::edge_files",
       "AuthenticatedPropertyInventory::from_materialized_generation",
       "AuthenticatedPropertyInventory::from_materialized_inventory",
+      "AuthenticatedPropertyInventory::property_fragments",
       "AuthenticatedPropertyInventory::from_resolved_generation",
       "AuthenticatedPropertyInventory::from_resolved_generation_for_route",
       "AuthenticatedPropertyInventory::generation_uuid", "AuthenticatedPropertyInventory::open_metrics",
@@ -112,7 +113,7 @@
     "unselected_validation":{"path":"crates/graphforge-storage/src/property_overlay.rs", "symbol":"targeted_reader_validates_unselected_rows_before_value_pruning", "markers":["read_authenticated_property_snapshots_for", "strictly sorted"]},
     "incremental_all_generation_authority":{"path":"crates/graphforge-storage/src/property_overlay.rs", "symbol":"bounded_external_merge_emits_exact_newest_snapshot_and_tombstone", "markers":["uuid_b", "keep", "tombstone"]},
     "bounded_scale":{"path":"crates/graphforge-storage/src/property_overlay.rs", "symbol":"targeted_reader_n_2n_4n_has_bounded_retention_and_exact_work", "markers":["peak_buffered_bytes", "physical_rows"]},
-    "production_bounded_scale":{"path":"crates/graphforge-storage/tests/property_overlay_scale.rs", "symbol":"production_property_overlay_n_2n_4n_is_disk_growing_and_memory_bounded", "markers":["property_fragment_allocated_bytes", "property_fragment_block_equivalents", "graph_tree_allocated_bytes", "prior_fragments_unchanged", "authentication_bytes", "authentication_block_equivalents", "authentication_read_calls", "authority_authentication_bytes", "property_authentication_bytes", "authenticated_snapshot_bytes", "authenticated_snapshot_peak_bytes", "RSS_STARTUP_ALLOWANCE_BYTES", "decoder_bytes", "total_read_bound", "spool_input_bytes", "checked_mul", "spill_bound", "per_record_seeks"], "source_sha256":"14ba9d000e6520f60c17fa4be29e773ce09e065bc1543df7638d01d62314ef73"},
+    "production_bounded_scale":{"path":"crates/graphforge-storage/tests/property_overlay_scale.rs", "symbol":"production_property_overlay_n_2n_4n_is_disk_growing_and_memory_bounded", "markers":["property_fragment_allocated_bytes", "property_fragment_block_equivalents", "graph_tree_allocated_bytes", "prior_fragments_unchanged", "authentication_bytes", "authentication_block_equivalents", "authentication_read_calls", "authority_authentication_bytes", "property_authentication_bytes", "authenticated_snapshot_bytes", "authenticated_snapshot_peak_bytes", "RSS_STARTUP_ALLOWANCE_BYTES", "decoder_bytes", "total_read_bound", "spool_input_bytes", "checked_mul", "spill_bound", "per_record_seeks"], "source_sha256":"e19c276c267af129ede26f664a0eb6ad06b3e3d6f542f2c3ab855a4fc4dab8b0"},
     "authenticated_writeback":{"path":"crates/graphforge-storage/src/writer.rs", "symbol":"reopened_property_patch_seals_a_complete_authenticated_snapshot", "markers":["AuthenticatedPropertyInventory", "patched"]},
     "bounded_write_window":{"path":"crates/graphforge-storage/src/writer.rs", "symbol":"same_window_set_then_remove_seals_one_ordered_snapshot", "markers":["property_window_count", "prior_property_generation"]}
   }

--- a/tests/contracts/property-overlay-v1.json
+++ b/tests/contracts/property-overlay-v1.json
@@ -31,7 +31,9 @@
       "visit_authenticated_property_snapshots"
     ],
     "property_overlay_module": [
-      "AuthenticatedPropertyInventory", "AuthenticatedPropertyInventory::from_materialized_generation",
+      "AuthenticatedPropertyInventory", "AuthenticatedPropertyInventory::edge_files",
+      "AuthenticatedPropertyInventory::from_materialized_generation",
+      "AuthenticatedPropertyInventory::from_materialized_inventory",
       "AuthenticatedPropertyInventory::from_resolved_generation",
       "AuthenticatedPropertyInventory::from_resolved_generation_for_route",
       "AuthenticatedPropertyInventory::generation_uuid", "AuthenticatedPropertyInventory::open_metrics",

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "7f90abeea4449e9c8dea94444c5510126ee913a56b8038f52e416501fdd86d99",
+  "sha256": "5c9c967f919fba3cad7a2104bd99d926ccf5b6c0e68d599cb23a0e590419ccdc",
   "entries": [
     {
       "name": "graphforge-api",
@@ -1086,7 +1086,7 @@
           "features": [],
           "optional": false,
           "uses_default_features": true,
-          "kind": "dev",
+          "kind": null,
           "target": null
         },
         {


### PR DESCRIPTION
## Description

Valid semantic routes such as `CON`, `AUX`, punctuation, trailing dots, and Unicode variants could become filesystem names that fail on another supported host. Encode route components as fixed-length lowercase digests and retain exact UTF-8 names in an authenticated reverse table. Public graph semantics remain unchanged.

Closes #976.

## Changes

- Apply mapped routes to topology, properties, construction, rewrites, publication, and portable transport. Expanded layouts 1/3 and compact layouts 2/4 distinguish legacy and mapped representations explicitly.
- Migrate authenticated legacy inputs in private workspaces through durable moves. Preserve immutable published trees, CAS objects, exact inventories, and typed refusals.
- Bind readers and adjacency providers to admitted inventories; retain old lazy streams and private indexes across writes while refreshing subsequent queries.
- Correct Windows handle lifetimes for UUID publication and authenticated import cleanup, use writable durability handles, and admit complete canonical roots before inspecting path components. Identity checks and no-follow checks remain in place.
- Exercise mapped full export/verify/import/reopen, projected export/verify with its existing typed import refusal, legacy recovery, and adversarial routes in the existing Windows/macOS lanes.
- Update the benchmark dependency lock and ownership-growth evidence for path-hash radix inventories, whose physical node counts can vary while logical files remain constant. Preserve positivity, upper bounds, byte slopes, and complete owner reconciliation.

## Validation

- On the refreshed tree, all four mapped API lifecycle tests pass; formatting, `make pre-push-fast`, and `make gate-registry-check` pass. Rebase range-diff confirms all nine feature patches are unchanged atop main's merged list extraction.
- Focused canonical-source and nested authenticated-cleanup regressions pass, as do strict storage Clippy checks. Independent review verified the four cleanup handle lifetimes and their callers.
- Retained native validation includes API/exec/storage unit tests, 48 catalog tests, 25 persistent-adjacency tests, legacy recovery, retained-stream/planner tests, construction crash retries, 29 ordinary ladder tests, and the complete fixed-hop suite (17 active tests; existing release-only ignores unchanged).
- Full local `make pre-push` is not reported green: the feature run stopped linking host-selected Python 3.14. The separately configured main-based run reaches the unchanged storage fixture that explicitly uses this host's tmpfs `/tmp` and is rejected by native filesystem admission; #1192 tracks that fixture defect. No admission bypass, mount change, or test skip was used.
- Hosted CI at `80220675` passed all 99 Bazel targets and non-Windows lanes. At `852f8691`, the complete Windows lane—including mapped portable round trips—passed. The refreshed exact-head gate remains required before merge.

## Compatibility and review focus

Mapped layouts require readers supporting versions 3/4; older readers reject them. Existing raw layouts retain explicit legacy handling. Mapping admission is bounded to 64 MiB and 100,000 routes and never normalizes semantic identifiers. Review mapping transactions, retained inventory lifetimes, and legacy private-copy boundaries together: these consumers jointly provide the required end-to-end round trip.
