### PR TITLE
docs(architecture): record native GraphForge execution boundary

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -300,6 +300,7 @@ export default defineConfig({
                   slug: 'adr/0025-storage-value-contract',
                 },
                 { label: '0026 Read plan resources', slug: 'adr/0026-read-plan-resources' },
+                { label: '0027 Native runtime boundary', slug: 'adr/0027-native-runtime-boundary' },
               ],
             },
           ],

--- a/docs-site/scripts/sync-content.mjs
+++ b/docs-site/scripts/sync-content.mjs
@@ -145,6 +145,7 @@ const PAGES = [
   'adr/0024-storage-format-exceptions.md',
   'adr/0025-storage-value-contract.md',
   'adr/0026-read-plan-resources.md',
+  'adr/0027-native-runtime-boundary.md',
   'releases/roadmap.md',
   'legal/licensing.md',
   'community/security.md',

--- a/docs/adr/0027-native-runtime-boundary.md
+++ b/docs/adr/0027-native-runtime-boundary.md
@@ -1,0 +1,56 @@
+# ADR 0027: Native GraphForge execution boundary
+
+**Status:** Accepted
+**Date:** 2026-09-09
+**Decider:** Project maintainer
+**Related:** [#495](https://github.com/CurateLabs/graphforge/issues/495), [#1198](https://github.com/CurateLabs/graphforge/issues/1198), [ADR 0001](0001-rust-core.md)
+
+## Context
+
+GraphForge targets native graph computation through its Rust API, Python data
+science workflows, Node applications and servers, and CLI. Rust owns behavior;
+bindings project the same engine and Arrow results.
+
+Issue #495 proposed a second execution environment inside browsers and Web
+Workers, initially with in-memory storage and a selected query/algorithm profile.
+That would require a distinct memory, scheduling, concurrency, persistence and
+compatibility contract. Sharing Rust source does not make browser constraints
+identical to the native runtime or remove the additional testing and maintenance.
+The proposal has not established a browser-only user requirement sufficient to
+justify that commitment. Local or private computation does not inherently require
+execution inside a browser; native applications can keep data on the user's device.
+
+## Options considered
+
+- Maintain a browser/Worker WASM engine with its own supported feature profile,
+  enabling browser-only computation but adding another execution and validation target.
+- Keep GraphForge execution native and let browser applications consume its results,
+  preserving the native product focus but requiring a native host for GraphForge queries.
+
+## Decision
+
+Keep GraphForge execution native. Do not maintain or promise a browser/Worker
+WASM GraphForge engine, binding, reduced query profile, or browser storage backend.
+Close #495 as not planned and remove its milestone assignment. Leave M15 open
+and available for reassignment rather than presenting WASM as scheduled work.
+
+Browser applications may consume results produced by native GraphForge. This
+requires neither a browser engine nor moving visualization into GraphForge Core.
+This decision does not introduce a server, transport, or mandatory cloud service.
+Rust remains the semantic owner and Python and Node remain thin native bindings.
+
+Reconsider browser execution only with a concrete browser-only user requirement,
+explicit resource and persistence guarantees, a supported API/algorithm profile,
+and an agreed validation and maintenance budget. A new ADR must approve that
+change before it becomes a supported target or roadmap commitment.
+
+## Consequences
+
+Native runtime work does not acquire browser compatibility or parity obligations.
+Browser-only offline GraphForge execution and zero-backend GraphForge demos are
+not supported product promises. Consumers requiring GraphForge computation need
+a native runtime, local or remote according to their own deployment requirements.
+
+This is a product support boundary, not a claim that Rust cannot compile to WASM.
+It requires no runtime code removal and makes no new decision about unrelated
+bindings. It supplements ADR 0001's Rust ownership rule; it does not supersede it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ are not retained in this tree.
 | 0024 | [Storage format exceptions for GFDR and compiled ontologies](0024-storage-format-exceptions.md) | `0024-storage-format-exceptions.md` |
 | 0025 | [Storage values have a compiler-independent contract](0025-storage-value-contract.md) | `0025-storage-value-contract.md` |
 | 0026 | [Read plans bind resources in execution](0026-read-plan-resources.md) | `0026-read-plan-resources.md` |
+| 0027 | [Native GraphForge execution boundary](0027-native-runtime-boundary.md) | `0027-native-runtime-boundary.md` |
 
 ## Numbering
 

--- a/docs/engineering/adrs/README.md
+++ b/docs/engineering/adrs/README.md
@@ -63,3 +63,4 @@ Keeper set after #2730 (mirrors [`../../adr/README.md`](../../adr/README.md)):
 | 0024 | Storage format exceptions for GFDR and compiled ontologies | Accepted | [`../../adr/0024-storage-format-exceptions.md`](../../adr/0024-storage-format-exceptions.md) |
 | 0025 | Storage values have a compiler-independent contract | Accepted (extraction pending) | [`../../adr/0025-storage-value-contract.md`](../../adr/0025-storage-value-contract.md) |
 | 0026 | Read plans bind resources in execution | Accepted | [`../../adr/0026-read-plan-resources.md`](../../adr/0026-read-plan-resources.md) |
+| 0027 | Native GraphForge execution boundary | Accepted | [`../../adr/0027-native-runtime-boundary.md`](../../adr/0027-native-runtime-boundary.md) |


### PR DESCRIPTION
Record the maintainer decision declining browser/Worker WASM execution as a supported GraphForge target. ADR 0027 explains the distinct runtime constraints and maintenance cost, preserves native Rust/Python/Node/CLI ownership, and requires a concrete browser-only need plus an explicit support decision before reconsideration.

Closes #1198. Related #495 was closed as not planned; M15 remains open, empty, and available for assignment. Existing accepted ADRs are unchanged. Both decision indexes and published navigation include the new record.

Validation: documentation sync generated 111 pages; Node syntax checks pass for the navigation and sync script; `make gate-registry-check` passes (14 tests); `git diff --check` passes. Documentation only; no runtime change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791582816&installation_model_id=20486&pr_number=1199&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1199&signature=2df4eb7b71807021476c25d8c0fcbab0ecd2904a6c77228dd751aa2664105c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->