### PR TITLE
fix(storage): retire authenticated construction predecessors

### DIFF
--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -275,18 +275,35 @@ impl GraphConstructionSession<'_> {
             token.checkpoint()?;
         }
         let _visibility = self.graph.graph_visibility.lock()?;
-        let encoding = self.prepare_encoding(cancellation)?;
-        if let Some(token) = cancellation {
-            token.checkpoint()?;
-        }
         let target = derived_uuid(self.session_uuid, b"generation");
         let transaction = derived_uuid(self.session_uuid, b"transaction");
-        let published = self.inner.publish_canonical_with_cancellation(
-            &encoding,
-            target,
-            transaction,
-            || cancellation.is_some_and(crate::CancellationToken::is_cancelled),
-        )?;
+        let published = if let Some(replay) =
+            self.inner
+                .replay_committed_publication(target, transaction, || {
+                    cancellation.is_some_and(crate::CancellationToken::is_cancelled)
+                })? {
+            let current = graphforge_storage::resolve_project_generation(
+                self.graph.resolved_generation.container_root(),
+            )?;
+            if current.generation_uuid() != replay.generation_uuid {
+                return Ok(GraphConstructionPublicationReceipt {
+                    generation_uuid: replay.generation_uuid,
+                    idempotent_replay: true,
+                });
+            }
+            replay
+        } else {
+            let encoding = self.prepare_encoding(cancellation)?;
+            if let Some(token) = cancellation {
+                token.checkpoint()?;
+            }
+            self.inner.publish_canonical_with_cancellation(
+                &encoding,
+                target,
+                transaction,
+                || cancellation.is_some_and(crate::CancellationToken::is_cancelled),
+            )?
+        };
 
         let refresh = (|| {
             let root = self.graph.resolved_generation.container_root();
@@ -703,6 +720,11 @@ mod tests {
         );
         drop(rejected);
 
+        // Keep the lazy old-generation stream unpolled while child construction
+        // retires both private predecessors and advances CURRENT.
+        let old_stream = graph
+            .execute_stream("MATCH (n:Person) RETURN n.node_uuid")
+            .unwrap();
         let added_node = Uuid::now_v7();
         let added_edge = Uuid::now_v7();
         let mut child = graph.begin_graph_construction(budgets).unwrap();
@@ -718,7 +740,37 @@ mod tests {
             .unwrap();
         let child_receipt = child.seal_and_publish().unwrap();
         assert_ne!(child_receipt.generation_uuid, first.generation_uuid);
+        assert_eq!(
+            child
+                .progress()
+                .evidence
+                .current_merge_temporary_allocated_bytes,
+            0
+        );
         drop(child);
+        use futures::TryStreamExt;
+        let old_batches: Vec<RecordBatch> = graph
+            .block_on(async {
+                old_stream
+                    .try_collect()
+                    .await
+                    .map_err(|error| GfError::Storage(format!("{error}")))
+            })
+            .unwrap();
+        let old_ids: std::collections::BTreeSet<Uuid> = old_batches
+            .iter()
+            .flat_map(|batch| {
+                let ids = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
+                (0..batch.num_rows())
+                    .map(|row| Uuid::from_slice(ids.value(row)).unwrap())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(old_ids, node_ids.into_iter().collect());
 
         let resolved_child = graphforge_storage::resolve_project_generation(&root).unwrap();
         assert_eq!(
@@ -775,6 +827,29 @@ mod tests {
                 .generation_uuid(),
             child_receipt.generation_uuid
         );
+        drop(child_replay);
+        let mut historical_replay = graph
+            .resume_graph_construction(session_uuid, budgets)
+            .unwrap();
+        let historical = historical_replay.seal_and_publish().unwrap();
+        assert!(historical.idempotent_replay);
+        assert_eq!(historical.generation_uuid, first.generation_uuid);
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&root)
+                .unwrap()
+                .generation_uuid(),
+            child_receipt.generation_uuid
+        );
+        drop(historical_replay);
+        let current_index = graphforge_storage::UuidMembershipIndex::open(&graph.dir).unwrap();
+        assert_eq!(
+            current_index.count(graphforge_storage::UuidIndexKind::Node),
+            4
+        );
+        assert_eq!(
+            current_index.count(graphforge_storage::UuidIndexKind::Edge),
+            3
+        );
     }
 
     #[test]
@@ -803,6 +878,7 @@ mod tests {
                 evidence.publication_application_read_bytes,
                 evidence.cas_application_read_bytes,
                 evidence.hydration_application_read_bytes,
+                evidence.recovery_application_read_bytes,
             ]
             .into_iter()
             .try_fold(0_u64, u64::checked_add)
@@ -819,6 +895,7 @@ mod tests {
                 (evidence.publication_application_read_bytes, 2),
                 (evidence.cas_application_read_bytes, 24),
                 (evidence.hydration_application_read_bytes, 24),
+                (evidence.recovery_application_read_bytes, 24),
                 (reconciled, 80),
             ] {
                 assert!(
@@ -847,6 +924,7 @@ mod tests {
                     evidence.encode_application_read_bytes,
                     evidence.cas_application_read_bytes,
                     evidence.hydration_application_read_bytes,
+                    evidence.recovery_application_read_bytes,
                     reconciled,
                 ],
             ));

--- a/crates/graphforge-api/src/resumable_construction/codec_tests.rs
+++ b/crates/graphforge-api/src/resumable_construction/codec_tests.rs
@@ -216,8 +216,8 @@ fn compact_public_construction_reopens_and_round_trips_exact_graph() {
     let control: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&checkpoint).unwrap()).unwrap();
     assert_eq!(
-        control["format_version"], 8,
-        "public new sessions use compact details with mapped output"
+        control["format_version"], 9,
+        "public new sessions use successor-bound payload reclamation"
     );
     let mut session = graph
         .resume_graph_construction(session_id, budgets)

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -4179,6 +4179,7 @@ const LINEARITY_PHASE_FIELDS: [&str; 7] = [
 
 #[derive(Clone, Copy)]
 enum RetainedMetricPolicy {
+    StructurallyZero,
     ScaleBearing,
     FilesystemQuantized,
     InventoryDerived,
@@ -4352,7 +4353,7 @@ const LINEARITY_RETAINED_FIELDS: [(&str, &str, RetainedMetricPolicy); 33] = [
     (
         "construction.current_merge_temporary_allocated_bytes",
         "/storage/construction/current_merge_temporary_allocated_bytes",
-        RetainedMetricPolicy::FilesystemQuantized,
+        RetainedMetricPolicy::StructurallyZero,
     ),
 ];
 
@@ -5687,7 +5688,16 @@ fn validate_category_taxonomy(
     for field in 0..6 {
         let values =
             std::array::from_fn(|rung| observations[rung].category_metrics[staging_key][field]);
-        if field < 4 {
+        if matches!(field, 0 | 2) {
+            // Completed version-nine construction retains only encoded payloads.
+            // These controlled fixtures keep route/schema/shard counts fixed;
+            // input chunk growth must not leave more retained objects.
+            if values[0] == 0 || values[0] != values[1] || values[0] != values[2] {
+                return Err(format!(
+                    "{staging_key}.field_{field} retained encoding inventory changed: {values:?}"
+                ));
+            }
+        } else if field < 4 {
             validate_affine_metric(
                 &format!("{staging_key}.field_{field}"),
                 values,
@@ -6110,6 +6120,11 @@ fn validate_lifecycle_metric_policies_for_axis(
             observations[2].retained[name],
         ];
         match policy {
+            RetainedMetricPolicy::StructurallyZero => {
+                if values != [0, 0, 0] {
+                    return Err(format!("{name} retains superseded construction payloads"));
+                }
+            }
             RetainedMetricPolicy::ScaleBearing => {
                 validate_affine_metric(name, values, denominators)?;
             }
@@ -6231,9 +6246,9 @@ fn synthetic_category_metrics(axis: LinearityAxis, factor: u64) -> BTreeMap<Stri
     metrics.insert(
         "construction.construction_staging".into(),
         [
-            6 + 2 * factor,
+            8,
             100 + 900 * factor,
-            6 + 2 * factor,
+            8,
             100 + 900 * factor,
             4096 * factor,
             8192 * factor,
@@ -6327,6 +6342,7 @@ fn synthetic_linearity_observations_for_axis(
                 .iter()
                 .map(|(name, _, policy)| {
                     let value = match policy {
+                        RetainedMetricPolicy::StructurallyZero => 0,
                         RetainedMetricPolicy::ScaleBearing => 100 + 900 * factor,
                         RetainedMetricPolicy::FilesystemQuantized => 4096 * factor,
                         RetainedMetricPolicy::InventoryDerived => {
@@ -6783,6 +6799,24 @@ fn controlled_fixture_policies_reject_coherent_zero_and_excess_work() {
         }
         validate_lifecycle_metric_policies_for_axis(axis, &observations)
             .expect("catalog text lengths may gain digits without adding objects");
+        let mut retained_chunks = observations.clone();
+        for (rung, observation) in retained_chunks.iter_mut().enumerate() {
+            for metrics in [
+                &mut observation.category_metrics,
+                &mut observation.category_authority_metrics,
+            ] {
+                let staging = metrics
+                    .get_mut("construction.construction_staging")
+                    .unwrap();
+                staging[0] += rung as u64;
+                staging[2] += rung as u64;
+            }
+        }
+        assert!(
+            validate_lifecycle_metric_policies_for_axis(axis, &retained_chunks)
+                .unwrap_err()
+                .contains("retained encoding inventory changed")
+        );
         for (category, field) in [
             ("catalog_and_manifests", 1),
             ("catalog_and_manifests", 3),
@@ -7174,6 +7208,16 @@ fn lifecycle_metric_policy_accepts_bounded_fixed_protocol_and_rejects_false_grow
         u64::MAX,
     );
     assert!(validate_lifecycle_metric_policies(&excess_retained_shape).is_err());
+
+    let mut one_retained_shape_block = observations.clone();
+    one_retained_shape_block[2].retained.insert(
+        "construction.current_merge_temporary_allocated_bytes".into(),
+        4096,
+    );
+    assert!(
+        validate_lifecycle_metric_policies(&one_retained_shape_block).is_err(),
+        "even one surviving shape block violates completed supersession"
+    );
 
     let fsync_index = LINEARITY_PHASE_FIELDS
         .iter()

--- a/crates/graphforge-storage/src/construction_detail_codec.rs
+++ b/crates/graphforge-storage/src/construction_detail_codec.rs
@@ -11,7 +11,7 @@ impl DetailCodec {
     pub(crate) fn from_version(version: u32) -> io::Result<Self> {
         match version {
             6 => Ok(Self::Legacy),
-            7 | 8 => Ok(Self::Compact),
+            7..=9 => Ok(Self::Compact),
             _ => Err(invalid("unsupported construction detail version")),
         }
     }

--- a/crates/graphforge-storage/src/construction_detail_codec.rs
+++ b/crates/graphforge-storage/src/construction_detail_codec.rs
@@ -198,7 +198,9 @@ mod tests {
         assert_eq!(DetailCodec::from_version(6).unwrap(), DetailCodec::Legacy);
         assert_eq!(DetailCodec::from_version(7).unwrap(), DetailCodec::Compact);
         assert!(DetailCodec::from_version(5).is_err());
-        assert!(DetailCodec::from_version(9).is_err());
+        assert_eq!(DetailCodec::from_version(8).unwrap(), DetailCodec::Compact);
+        assert_eq!(DetailCodec::from_version(9).unwrap(), DetailCodec::Compact);
+        assert!(DetailCodec::from_version(10).is_err());
     }
 }
 

--- a/crates/graphforge-storage/src/construction_detail_tests.rs
+++ b/crates/graphforge-storage/src/construction_detail_tests.rs
@@ -130,7 +130,7 @@ mod compact_details {
             assert_eq!(evidence.authority_read_bytes, expected);
             assert!(evidence.decoded_bytes > 0);
         }
-        assert!(DetailCodec::from_version(9).is_err());
+        assert!(DetailCodec::from_version(10).is_err());
         assert_eq!(
             DetailCodec::from_version(7).unwrap(),
             DetailCodec::from_version(8).unwrap()
@@ -172,7 +172,7 @@ mod compact_details {
         for generation in [2, 3] {
             let (_source, mut session, shape) =
                 ordinal_append_session(&root, generation, u128::from(generation + 2), 1);
-            assert_eq!(session.checkpoint.format_version, 8);
+            assert_eq!(session.checkpoint.format_version, 9);
             let encoding = session.encode_canonical(&shape, generation).unwrap();
             let path = session
                 .root

--- a/crates/graphforge-storage/src/construction_lifecycle_tests.rs
+++ b/crates/graphforge-storage/src/construction_lifecycle_tests.rs
@@ -1,0 +1,580 @@
+// Real multi-level construction measurements, sharing the writer test fixtures.
+mod lifecycle_budget {
+    use super::*;
+
+    fn small_session(path: &Path) -> GraphConstructionSession {
+        GraphConstructionSession::open_with_mode(
+            path,
+            Uuid::from_u128(119_500),
+            0,
+            graphforge_core::OntologyMode::Exploratory,
+            GraphConstructionBudgets::default(),
+        )
+        .unwrap()
+    }
+
+    fn complete_small(session: &mut GraphConstructionSession) {
+        if session.state() == GraphConstructionState::Staging {
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "nodes",
+                    &node_property_batch(1, 3),
+                )
+                .unwrap();
+            session
+                .append(
+                    ConstructionChunkKind::Edge,
+                    "edges",
+                    &edge_property_batch(100, 2),
+                )
+                .unwrap();
+            session.seal().unwrap();
+        }
+        let encoded = session.prepare_canonical_encoding(1).unwrap();
+        session
+            .publish_canonical(&encoded, Uuid::from_u128(119_501), Uuid::from_u128(119_502))
+            .unwrap();
+    }
+
+    #[test]
+    fn supersession_crash_child() {
+        let Ok(path) = std::env::var("GF_SUPERSESSION_CRASH_ROOT") else {
+            return;
+        };
+        let mut session = small_session(Path::new(&path));
+        complete_small(&mut session);
+    }
+
+    #[test]
+    fn supersession_crashes_reconcile_removed_allocations_and_replay() {
+        for boundary in [
+            "supersession.shape_authenticated",
+            "supersession.encoded_authenticated",
+            "supersession.before_unlink",
+            "supersession.after_unlink",
+            "supersession.after_sync",
+            "supersession.after_checkpoint",
+            "supersession.before_sync",
+            "supersession.before_inputs_checkpoint",
+            "supersession.before_shape_checkpoint",
+            "supersession.shape_after_unlink",
+            "supersession.shape_after_sync",
+        ] {
+            let root = TempDir::new().unwrap();
+            crate::open_or_initialize_project(root.path()).unwrap();
+            let prior = std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap();
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "graph_construction::tests::lifecycle_budget::supersession_crash_child",
+                ])
+                .env("GF_SUPERSESSION_CRASH_ROOT", root.path())
+                .env(
+                    "GF_CONSTRUCTION_FAILPOINT_COOKIE",
+                    "graphforge-construction-test-v1",
+                )
+                .env("GF_CONSTRUCTION_FAILPOINT", boundary)
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), Some(86), "{boundary}");
+            assert_eq!(
+                std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap(),
+                prior
+            );
+            let mut recovered = small_session(root.path());
+            complete_small(&mut recovered);
+            assert!(recovered.checkpoint.inputs_retired);
+            assert!(recovered.checkpoint.shape_retired);
+            assert_eq!(
+                recovered.evidence().current_merge_temporary_allocated_bytes,
+                0
+            );
+            let current = recovered.evidence().storage_current.clone();
+            let peak = recovered
+                .evidence()
+                .storage_transient_peak_total_allocated_bytes;
+            drop(recovered);
+            let mut replay = small_session(root.path());
+            complete_small(&mut replay);
+            assert_eq!(replay.evidence().storage_current, current);
+            assert_eq!(
+                replay
+                    .evidence()
+                    .storage_transient_peak_total_allocated_bytes,
+                peak
+            );
+        }
+    }
+
+    #[test]
+    fn supersession_returned_errors_preserve_prior_authority_and_retry() {
+        for boundary in [
+            "supersession.shape_authenticated",
+            "supersession.encoded_authenticated",
+            "supersession.before_unlink",
+            "supersession.after_unlink",
+            "supersession.after_sync",
+            "supersession.after_checkpoint",
+            "supersession.before_sync",
+            "supersession.before_inputs_checkpoint",
+            "supersession.before_shape_checkpoint",
+            "supersession.shape_after_unlink",
+            "supersession.shape_after_sync",
+        ] {
+            let root = TempDir::new().unwrap();
+            crate::open_or_initialize_project(root.path()).unwrap();
+            let prior = std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap();
+            let mut session = small_session(root.path());
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "nodes",
+                    &node_property_batch(1, 3),
+                )
+                .unwrap();
+            session.seal().unwrap();
+            supersession::set_returned_failure(Some(boundary));
+            let result = session.prepare_canonical_encoding(1);
+            supersession::set_returned_failure(None);
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("injected returned failure"),
+                "{boundary}"
+            );
+            assert_eq!(
+                std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap(),
+                prior
+            );
+            // Retry on the SAME object first, then resume from durable controls.
+            let encoded = session.prepare_canonical_encoding(1).unwrap();
+            let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+            assert_eq!(shape.node_count, 3);
+            assert_eq!(
+                session.encode_canonical(&shape, 1).unwrap().generation,
+                encoded.generation
+            );
+            drop(session);
+            let mut resumed = small_session(root.path());
+            complete_small(&mut resumed);
+            assert_eq!(
+                resumed.evidence().current_merge_temporary_allocated_bytes,
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn supersession_corrupt_successors_and_replaced_predecessors_fail_closed() {
+        for case in ["shape", "encoding", "replacement", "receipt_chain"] {
+            let root = TempDir::new().unwrap();
+            crate::open_or_initialize_project(root.path()).unwrap();
+            let prior = std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap();
+            let mut session = small_session(root.path());
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "nodes",
+                    &node_property_batch(1, 3),
+                )
+                .unwrap();
+            session.seal().unwrap();
+            let boundary = if case == "encoding" {
+                "supersession.encoded_authenticated"
+            } else {
+                "supersession.shape_authenticated"
+            };
+            supersession::set_returned_failure(Some(boundary));
+            let failed = session.prepare_canonical_encoding(1);
+            supersession::set_returned_failure(None);
+            assert!(failed.is_err());
+            let input = session.read_receipt(0).unwrap();
+            let path = match case {
+                "shape" => session.root.path().join(
+                    read_completed_shape_outputs(&session.root, &session.checkpoint).unwrap()[0]
+                        .name
+                        .clone(),
+                ),
+                "encoding" => {
+                    let output = session
+                        .root
+                        .open_child_directory(OsStr::new("encoded-v1"))
+                        .unwrap();
+                    let inventory = crate::graph_construction_encoding::read_inventory(&output)
+                        .unwrap()
+                        .unwrap();
+                    output
+                        .path()
+                        .join("graph")
+                        .join(&inventory.artifacts[0].path)
+                }
+                "replacement" => session.root.path().join(&input.parquet.name),
+                "receipt_chain" => session.root.path().join(receipt_name(0)),
+                _ => unreachable!(),
+            };
+            let bytes = std::fs::read(&path).unwrap();
+            if case == "replacement" {
+                std::fs::rename(&path, root.path().join("preserved-original")).unwrap();
+                std::fs::write(&path, &bytes).unwrap();
+            } else if case == "receipt_chain" {
+                let mut receipt: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+                receipt["input_sha256"] = "0".repeat(64).into();
+                std::fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+            } else {
+                let mut corrupt = bytes.clone();
+                corrupt[0] ^= 1;
+                std::fs::write(&path, corrupt).unwrap();
+            }
+            let allocation = session.evidence().storage_current.clone();
+            let error = session.prepare_canonical_encoding(1).unwrap_err();
+            assert!(
+                error.to_string().contains(match case {
+                    "shape" => "payload digest changed",
+                    "encoding" => "canonical artifact differs",
+                    "replacement" => "predecessor identity changed",
+                    "receipt_chain" => "receipt tail changed",
+                    _ => unreachable!(),
+                }),
+                "{case}: {error}"
+            );
+            assert_eq!(session.evidence().storage_current, allocation);
+            assert_eq!(
+                std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap(),
+                prior
+            );
+            assert!(path.exists());
+        }
+    }
+
+    #[test]
+    fn supersession_requires_every_committed_shape_writer_receipt() {
+        for missing in [true, false] {
+            let root = TempDir::new().unwrap();
+            crate::open_or_initialize_project(root.path()).unwrap();
+            let mut session = small_session(root.path());
+            session
+                .append(
+                    ConstructionChunkKind::Node,
+                    "nodes",
+                    &node_property_batch(1, 3),
+                )
+                .unwrap();
+            session.seal().unwrap();
+            supersession::set_returned_failure(Some("supersession.encoded_authenticated"));
+            let failed = session.prepare_canonical_encoding(1);
+            supersession::set_returned_failure(None);
+            assert!(failed.is_err());
+            let outputs = read_completed_shape_outputs(&session.root, &session.checkpoint).unwrap();
+            let path = session
+                .root
+                .path()
+                .join(shape_receipt_name(&outputs[0].name));
+            if missing {
+                std::fs::remove_file(&path).unwrap();
+            } else {
+                let mut receipt = outputs[0].clone();
+                receipt.sha256 = "0".repeat(64);
+                std::fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+            }
+            let current = session.evidence().storage_current.clone();
+            assert!(session.prepare_canonical_encoding(1).is_err());
+            assert!(!session.checkpoint.shape_retired);
+            assert_eq!(session.evidence().storage_current, current);
+            for output in outputs {
+                assert!(session.root.path().join(output.name).exists());
+            }
+        }
+    }
+
+    #[test]
+    fn supersession_all_published_replay_paths_refuse_corrupt_public_payload() {
+        let root = TempDir::new().unwrap();
+        crate::open_or_initialize_project(root.path()).unwrap();
+        let mut session = small_session(root.path());
+        session
+            .append(
+                ConstructionChunkKind::Node,
+                "nodes",
+                &node_property_batch(1, 3),
+            )
+            .unwrap();
+        session.seal().unwrap();
+        let encoding = session.prepare_canonical_encoding(1).unwrap();
+        let target = Uuid::from_u128(119_501);
+        let transaction = Uuid::from_u128(119_502);
+        session
+            .publish_canonical(&encoding, target, transaction)
+            .unwrap();
+        assert!(session.checkpoint.shape_retired);
+        let current = std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap();
+        let selected = crate::resolve_project_generation(root.path()).unwrap();
+        let inventory = selected.graph_files_inventory().unwrap().unwrap();
+        let entry = inventory
+            .files
+            .iter()
+            .find(|entry| entry.relative_path.ends_with(".parquet"))
+            .unwrap();
+        let path = crate::graph_object_path(root.path(), &entry.content_sha256).unwrap();
+        let permissions = std::fs::metadata(&path).unwrap().permissions();
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes[0] ^= 1;
+        std::fs::rename(&path, root.path().join("saved-public-payload")).unwrap();
+        std::fs::write(&path, bytes).unwrap();
+        std::fs::set_permissions(&path, permissions).unwrap();
+        for result in [
+            session
+                .replay_committed_publication(target, transaction, || false)
+                .map(|_| ()),
+            session
+                .publish_canonical(&encoding, target, transaction)
+                .map(|_| ()),
+        ] {
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("digest does not match its address")
+            );
+        }
+        drop(session);
+        let error = GraphConstructionSession::open_with_mode(
+            root.path(),
+            Uuid::from_u128(119_500),
+            0,
+            graphforge_core::OntologyMode::Exploratory,
+            GraphConstructionBudgets::default(),
+        )
+        .err()
+        .unwrap();
+        assert!(
+            error
+                .to_string()
+                .contains("digest does not match its address")
+        );
+        assert_eq!(
+            std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap(),
+            current
+        );
+    }
+
+    #[test]
+    fn supersession_cancellation_during_authentication_and_removal_is_recoverable() {
+        for cancel_after in [2, 6, 12, 24, u64::MAX] {
+            let root = TempDir::new().unwrap();
+            crate::open_or_initialize_project(root.path()).unwrap();
+            let prior = std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap();
+            let mut session = small_session(root.path());
+            for chunk in 0..8 {
+                session
+                    .append(
+                        ConstructionChunkKind::Node,
+                        &format!("nodes-{chunk}"),
+                        &node_property_batch(1 + chunk * 256, 256),
+                    )
+                    .unwrap();
+            }
+            session.seal().unwrap();
+            supersession::set_returned_failure(Some("supersession.shape_authenticated"));
+            assert!(session.prepare_canonical_encoding(1).is_err());
+            supersession::set_returned_failure(None);
+            let predecessor = session
+                .root
+                .path()
+                .join(session.read_receipt(0).unwrap().parquet.name);
+            let mut polls = 0;
+            let error = session
+                .reclaim_superseded_payloads_cancellable(&mut || {
+                    polls += 1;
+                    polls >= cancel_after || (cancel_after == u64::MAX && !predecessor.exists())
+                })
+                .unwrap_err();
+            assert!(error.to_string().contains("construction cancelled"));
+            if cancel_after == u64::MAX {
+                assert!(!predecessor.exists());
+            } else {
+                assert_eq!(polls, cancel_after);
+            }
+            assert_eq!(
+                std::fs::read(root.path().join(crate::CURRENT_FILE)).unwrap(),
+                prior
+            );
+            drop(session);
+            let mut resumed = small_session(root.path());
+            complete_small(&mut resumed);
+            assert_eq!(
+                resumed.evidence().current_merge_temporary_allocated_bytes,
+                0
+            );
+            let error = resumed
+                .replay_committed_publication(Uuid::from_u128(119_501), Uuid::from_u128(119_502), {
+                    let mut polls = 0;
+                    move || {
+                        polls += 1;
+                        polls >= 3
+                    }
+                })
+                .unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("construction ordinal authentication cancelled"),
+                "{error}"
+            );
+            assert!(resumed.publication_committed());
+        }
+    }
+
+    fn census(root: &Path) -> serde_json::Value {
+        let mut pending = vec![root.to_path_buf()];
+        let mut seen = BTreeSet::new();
+        let mut groups = BTreeMap::<&str, (u64, u64, u64)>::new();
+        while let Some(path) = pending.pop() {
+            let metadata = std::fs::symlink_metadata(&path).unwrap();
+            assert!(!metadata.file_type().is_symlink());
+            if metadata.is_dir() {
+                pending.extend(std::fs::read_dir(path).unwrap().map(|e| e.unwrap().path()));
+                continue;
+            }
+            let file = File::open(&path).unwrap();
+            let identity = file_identity(&file).unwrap();
+            let key = (identity.volume_serial, identity.file_id);
+            if !seen.insert(key) {
+                continue;
+            }
+            let name = path.file_name().unwrap().to_str().unwrap();
+            let group = if path.components().any(|c| c.as_os_str() == "encoded-v1") {
+                "encoded"
+            } else if name.ends_with(".json") || name.ends_with(".lock") {
+                "control"
+            } else if name.starts_with("chunk-") {
+                "accepted_inputs"
+            } else {
+                "shape_and_merge"
+            };
+            let usage = graphforge_filesystem::file_space_usage(&file).unwrap();
+            let totals = groups.entry(group).or_default();
+            totals.0 += usage.logical_bytes;
+            totals.1 += usage.allocated_bytes;
+            totals.2 += 1;
+        }
+        serde_json::to_value(groups).unwrap()
+    }
+
+    #[test]
+    fn construction_lifecycle_multilevel_allocation_baseline() {
+        for scale in [1_u64, 2, 4] {
+            let mut before = None;
+            for version in [8, 9] {
+                let root = TempDir::new().unwrap();
+                crate::open_or_initialize_project(root.path()).unwrap();
+                let budgets = GraphConstructionBudgets {
+                    merge_fan_in: 2,
+                    max_batch_rows: 4096,
+                    max_run_records: 16384,
+                    ..Default::default()
+                };
+                let mut session = GraphConstructionSession::open_internal_with_format(
+                    root.path(),
+                    root.path(),
+                    Uuid::new_v4(),
+                    0,
+                    graphforge_core::OntologyMode::Exploratory,
+                    None,
+                    budgets,
+                    crate::filesystem_admission::ProjectLifecycleMode::Durable,
+                    None,
+                    version,
+                )
+                .unwrap();
+                for chunk in 0..2 {
+                    session
+                        .append(
+                            ConstructionChunkKind::Node,
+                            &format!("nodes-{chunk}"),
+                            &node_batch(1 + chunk * 4096, 4096),
+                        )
+                        .unwrap();
+                }
+                for chunk in 0..8 * scale {
+                    session
+                        .append(
+                            ConstructionChunkKind::Edge,
+                            &format!("edges-{chunk}"),
+                            &edge_batch(1_000_000 + u128::from(chunk) * 4096, 4096),
+                        )
+                        .unwrap();
+                }
+                let append = census(session.root.path());
+                session.seal().unwrap();
+                let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+                assert_eq!((shape.node_count, shape.edge_count), (8192, 32768 * scale));
+                assert!(session.evidence().merge_passes >= 3);
+                let shaped = census(session.root.path());
+                let encoding = session.encode_canonical(&shape, 1).unwrap();
+                let encoded = census(session.root.path());
+                let publication = session
+                    .publish_canonical(&encoding, Uuid::new_v4(), Uuid::new_v4())
+                    .unwrap();
+                let published = census(session.root.path());
+                let selected = crate::resolve_project_generation(root.path()).unwrap();
+                assert_eq!(selected.generation_uuid(), publication.generation_uuid);
+                let admitted =
+                    crate::AuthenticatedPropertyInventory::from_resolved_generation(&selected)
+                        .unwrap();
+                let edges = crate::read_edges_from_inventory(
+                    &admitted,
+                    "*",
+                    graphforge_core::OntologyMode::Exploratory,
+                )
+                .unwrap();
+                assert_eq!(
+                    edges.iter().map(RecordBatch::num_rows).sum::<usize>() as u64,
+                    32768 * scale
+                );
+                let current = session.evidence().storage_current
+                    [&crate::ArtifactCategory::ConstructionStaging]
+                    .allocated_bytes;
+                let peak = session
+                    .evidence()
+                    .storage_transient_peak_total_allocated_bytes;
+                if version == 8 {
+                    before = Some((current, peak));
+                } else {
+                    let (old_current, old_peak) = before.unwrap();
+                    // Removing both full predecessor representations must at least
+                    // halve payload retention and lower the actual simultaneous peak.
+                    assert!(current * 2 < old_current);
+                    assert!(peak < old_peak);
+                    assert_eq!(
+                        session.evidence().current_merge_temporary_allocated_bytes,
+                        0
+                    );
+                    assert!(published.get("accepted_inputs").is_none());
+                    assert!(published.get("shape_and_merge").is_none());
+                    // Explicit authentication/removal passes stay below eight input
+                    // payload reads plus the small fixed manifest/control allowance.
+                    assert!(
+                        session.evidence().recovery_application_read_bytes
+                            <= session.evidence().write_bytes * 8 + (16 << 20)
+                    );
+                }
+                println!(
+                    "LIFECYCLE_BASELINE {}",
+                    serde_json::json!({
+                        "version": version, "scale": scale, "nodes":8192, "edges":32768 * scale,
+                        "append":append, "shape":shaped, "encode":encoded, "publication":published,
+                        "payload_current":session.evidence().storage_current,
+                        "payload_peak":session.evidence().storage_transient_peak_total_allocated_bytes,
+                        "phase_reads": {
+                            "shape":session.evidence().shape_application_read_bytes,
+                            "encoding":session.evidence().encode_application_read_bytes,
+                            "recovery_and_supersession":session.evidence().recovery_application_read_bytes,
+                        },
+                    })
+                );
+            }
+        }
+    }
+}

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -7,6 +7,7 @@
 //! sealing path. A generation-last publisher consumes the sealed inventory.
 
 mod shaping_merge;
+mod supersession;
 #[cfg(test)]
 use shaping_merge::online_merge_name_slot_bound;
 use shaping_merge::{
@@ -43,7 +44,7 @@ use crate::UuidIndexKind;
 use crate::construction_detail_codec::{DetailCodec, DetailValidator};
 use crate::uuid_membership::{AuthenticatedUuidIndexSnapshot, UuidConstructionSnapshotWork};
 
-const FORMAT_VERSION: u32 = 8;
+const FORMAT_VERSION: u32 = 9;
 const PRIVATE_ROOT: &str = ".graphforge-construction";
 const SESSION_LOCK: &str = "session.lock";
 const CHECKPOINT: &str = "checkpoint.json";
@@ -574,13 +575,13 @@ pub struct GraphConstructionEvidence {
     /// Hydration durability barriers completed on containing directories.
     #[serde(default)]
     pub hydration_directory_fsync_operations: u64,
-    /// Artifact bytes authenticated while repairing an interrupted append.
+    /// Artifact bytes authenticated during recovery or successor-bound reclamation.
     #[serde(default)]
     pub recovery_application_read_bytes: u64,
-    /// Bounded artifact reads used by interrupted-append recovery.
+    /// Bounded artifact reads used by recovery or successor-bound reclamation.
     #[serde(default)]
     pub recovery_application_read_operations: u64,
-    /// Synchronization barriers for checkpointing newly observed resume reads.
+    /// Directory and checkpoint synchronization barriers for recovery/reclamation.
     #[serde(default)]
     pub recovery_checkpoint_fsync_operations: u64,
     /// New canonical graph payload bytes emitted by encoding.
@@ -942,6 +943,10 @@ impl GraphConstructionEvidence {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 /// Publisher input produced from a sealed construction session.
+///
+/// Version-nine artifact names are durable receipt references: after encoding,
+/// their private payloads may be retired. Pass this handle back to the session
+/// encoder for authenticated replay rather than opening the named files.
 pub struct ConstructionShape {
     /// Ontology mode authenticated at session open and used for physical routing.
     pub ontology_mode: graphforge_core::OntologyMode,
@@ -1127,6 +1132,7 @@ pub struct ConstructionChunkReceipt {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)] // Independent persisted facts; retirement flags preserve v6–8 wire compatibility.
 struct Checkpoint {
     format_version: u32,
     operation_uuid: Uuid,
@@ -1156,6 +1162,10 @@ struct Checkpoint {
     shape_authority_sha256: Option<String>,
     #[serde(default)]
     encoding_inventory_sha256: Option<String>,
+    #[serde(default)]
+    inputs_retired: bool,
+    #[serde(default)]
+    shape_retired: bool,
     base_work: UuidConstructionSnapshotWork,
     evidence: GraphConstructionEvidence,
 }
@@ -1283,6 +1293,47 @@ impl Drop for GraphConstructionSession {
 }
 
 impl GraphConstructionSession {
+    /// Authenticate an already committed publication without preparing private
+    /// encoding, using its exact immutable generation after `CURRENT` advances.
+    /// Returns `None` if the transaction has not committed yet.
+    ///
+    /// # Errors
+    /// Refuses changed session, transaction, generation or successor payload authority.
+    pub fn replay_committed_publication(
+        &mut self,
+        target_generation_uuid: Uuid,
+        transaction_uuid: Uuid,
+        mut cancelled: impl FnMut() -> bool,
+    ) -> Result<Option<crate::ProjectPublicationReceipt>, GfError> {
+        reject_cancelled(&mut cancelled)?;
+        self.revalidate_authority()?;
+        if !matches!(
+            self.checkpoint.publication_state,
+            Some(
+                ConstructionPublicationState::Publishing | ConstructionPublicationState::Published
+            )
+        ) {
+            return Ok(None);
+        }
+        let Some(published) =
+            crate::published_project_transaction(&self.project_path, transaction_uuid)?
+        else {
+            if self.publication_committed() {
+                return Err(storage("published construction transaction is absent"));
+            }
+            return Ok(None);
+        };
+        if published.generation_uuid != target_generation_uuid {
+            return Err(storage("published construction target changed"));
+        }
+        self.finish_publication_cancellable(
+            target_generation_uuid,
+            &hex(&published.generation_manifest_sha256),
+            &mut cancelled,
+        )?;
+        Ok(Some(published))
+    }
+
     /// Durably bind the sealed private inventory to the one target that the
     /// existing project publisher will stage. This records replay authority;
     /// it does not install objects, stage a generation, or mutate `CURRENT`.
@@ -1354,10 +1405,33 @@ impl GraphConstructionSession {
         target_generation_uuid: Uuid,
         target_generation_manifest_sha256: &str,
     ) -> Result<ConstructionPublicationReceipt, GfError> {
-        recover_publication(&self.project_path, &self.root, &mut self.checkpoint)?;
+        self.finish_publication_cancellable(
+            target_generation_uuid,
+            target_generation_manifest_sha256,
+            &mut || false,
+        )
+    }
+
+    fn finish_publication_cancellable(
+        &mut self,
+        target_generation_uuid: Uuid,
+        target_generation_manifest_sha256: &str,
+        cancelled: &mut impl FnMut() -> bool,
+    ) -> Result<ConstructionPublicationReceipt, GfError> {
+        recover_publication_cancellable(
+            &self.project_path,
+            &self.root,
+            &mut self.checkpoint,
+            cancelled,
+        )?;
         if self.checkpoint.publication_state == Some(ConstructionPublicationState::Published) {
             let receipt = read_publication_receipt(&self.root, &self.checkpoint)?;
-            authenticate_published_target(&self.project_path, &self.checkpoint, &receipt)?;
+            authenticate_published_target(
+                &self.project_path,
+                &mut self.checkpoint,
+                &receipt,
+                cancelled,
+            )?;
             if receipt.target_generation_uuid == target_generation_uuid
                 && receipt.target_generation_manifest_sha256 == target_generation_manifest_sha256
             {
@@ -1385,7 +1459,12 @@ impl GraphConstructionSession {
             target_generation_uuid,
             target_generation_manifest_sha256: target_generation_manifest_sha256.to_owned(),
         };
-        authenticate_published_target(&self.project_path, &self.checkpoint, &provisional)?;
+        authenticate_published_target(
+            &self.project_path,
+            &mut self.checkpoint,
+            &provisional,
+            cancelled,
+        )?;
         let receipt = provisional;
         install_control(&self.root, PUBLICATION_RECEIPT, &receipt)?;
         self.checkpoint.publication_state = Some(ConstructionPublicationState::Published);
@@ -1415,6 +1494,7 @@ impl GraphConstructionSession {
         mut cancelled: impl FnMut() -> bool,
     ) -> Result<GraphConstructionEncoding, GfError> {
         self.revalidate_authority()?;
+        self.reclaim_superseded_payloads_cancellable(&mut cancelled)?;
         if self.checkpoint.state != GraphConstructionState::Sealed
             || self.checkpoint.publication_state != Some(ConstructionPublicationState::Sealed)
         {
@@ -1472,6 +1552,7 @@ impl GraphConstructionSession {
                 replace_checkpoint_control(&self.root, &self.checkpoint)?;
             }
         }
+        self.reclaim_superseded_payloads_cancellable(&mut cancelled)?;
         Ok(encoded)
     }
 
@@ -1510,9 +1591,10 @@ impl GraphConstructionSession {
             if published.generation_uuid != target_generation_uuid {
                 return Err(storage("published construction target changed"));
             }
-            self.finish_publication(
+            self.finish_publication_cancellable(
                 target_generation_uuid,
                 &hex(&published.generation_manifest_sha256),
+                &mut cancelled,
             )?;
             return Ok(published);
         }
@@ -1524,9 +1606,10 @@ impl GraphConstructionSession {
                 if published.generation_uuid != target_generation_uuid {
                     return Err(storage("published construction target changed"));
                 }
-                self.finish_publication(
+                self.finish_publication_cancellable(
                     target_generation_uuid,
                     &hex(&published.generation_manifest_sha256),
+                    &mut cancelled,
                 )?;
                 return Ok(published);
             }
@@ -1841,9 +1924,11 @@ impl GraphConstructionSession {
                 crate::ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
             };
         construction_failpoint("publication.after_current_before_receipt");
-        self.finish_publication(
+        self.finish_publication_cancellable(
             target_generation_uuid,
             &hex(&publication.generation_manifest_sha256),
+            // CURRENT already committed; finish recording its durable receipt.
+            &mut || false,
         )?;
         Ok(publication)
     }
@@ -2443,6 +2528,8 @@ impl GraphConstructionSession {
                 edge_schema_sha256: BTreeSet::new(),
                 shape_authority_sha256: None,
                 encoding_inventory_sha256: None,
+                inputs_retired: false,
+                shape_retired: false,
                 base_work,
                 evidence,
             };
@@ -2538,6 +2625,7 @@ impl GraphConstructionSession {
                 });
         }
         session.revalidate_authority()?;
+        session.reclaim_superseded_payloads()?;
         let repaired_parent_phases = repair_unshaped_parent_phase_bytes(&mut session.checkpoint)?;
         if repaired_parent_phases
             || resumed_parent_work.bytes != 0
@@ -2599,6 +2687,7 @@ impl GraphConstructionSession {
             return Err(storage("only a sealed session can be prepared"));
         }
         if self.checkpoint.encoding_inventory_sha256.is_some() {
+            self.reclaim_superseded_payloads_cancellable(&mut cancelled)?;
             let encoded = self
                 .root
                 .open_child_directory(OsStr::new("encoded-v1"))
@@ -2635,12 +2724,20 @@ impl GraphConstructionSession {
         parent_topology_generation: u64,
         budgets: GraphConstructionBudgets,
     ) -> Result<Self, GfError> {
-        Self::open_with_mode(
+        // Historical mechanics fixtures use retained v8 payloads and some use
+        // the synthetic pre-container parent authority. V9 lifecycle tests
+        // select their format explicitly and use real project containers.
+        Self::open_internal_with_format(
+            project_dir,
             project_dir,
             operation_uuid,
             parent_topology_generation,
             graphforge_core::OntologyMode::Exploratory,
+            None,
             budgets,
+            crate::filesystem_admission::ProjectLifecycleMode::Durable,
+            None,
+            8,
         )
     }
 
@@ -3100,9 +3197,12 @@ impl GraphConstructionSession {
             return Err(storage("only a sealed session can be shaped"));
         }
         reject_cancelled(&mut cancelled)?;
-        if let Some(shape) =
-            read_completed_shape(&self.root, &self.checkpoint, authenticate_completed_outputs)?
-        {
+        if let Some(shape) = read_completed_shape(
+            &self.root,
+            &self.checkpoint,
+            authenticate_completed_outputs && !self.has_encoding_successor(),
+        )? {
+            self.reclaim_superseded_payloads_cancellable(&mut cancelled)?;
             return Ok(shape);
         }
         reject_existing_merge_artifacts(&self.root)?;
@@ -3496,6 +3596,7 @@ impl GraphConstructionSession {
         construction_failpoint("shape.after_complete_inventory");
         replace_checkpoint_control(&self.root, &self.checkpoint)?;
         construction_failpoint("shape.after_evidence_checkpoint");
+        self.reclaim_superseded_payloads_cancellable(&mut cancelled)?;
         Ok(shape)
     }
 
@@ -4640,8 +4741,10 @@ fn recover_shape_intent(
         {
             return Err(storage("complete shape manifest inventory is incomplete"));
         }
-        for output in &intent.outputs {
-            authenticate_shaped_output(root, output)?;
+        if checkpoint.format_version < 9 || checkpoint.encoding_inventory_sha256.is_none() {
+            for output in &intent.outputs {
+                authenticate_shaped_output(root, output)?;
+            }
         }
         let expected_shape_authority = shape_authority_sha256(shape, &intent.outputs)?;
         if intent.shape_authority_sha256.as_deref() != Some(&expected_shape_authority) {
@@ -4985,10 +5088,19 @@ fn read_publication_receipt(
     Ok(receipt)
 }
 
+fn recover_publication(
+    project_dir: &Path,
+    root: &StableDirectory,
+    checkpoint: &mut Checkpoint,
+) -> Result<(), GfError> {
+    recover_publication_cancellable(project_dir, root, checkpoint, &mut || false)
+}
+
 fn authenticate_published_target(
     project_dir: &Path,
-    checkpoint: &Checkpoint,
+    checkpoint: &mut Checkpoint,
     receipt: &ConstructionPublicationReceipt,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<(), GfError> {
     let target = crate::resolve_generation_by_uuid(project_dir, receipt.target_generation_uuid)
         .map_err(|error| storage(format!("published target cannot be authenticated: {error}")))?;
@@ -5014,13 +5126,17 @@ fn authenticate_published_target(
             "project publication journal differs from construction publication authority",
         ));
     }
+    if checkpoint.format_version >= 9 {
+        supersession::authenticate_public_successor(&target, &mut checkpoint.evidence, cancelled)?;
+    }
     Ok(())
 }
 
-fn recover_publication(
+fn recover_publication_cancellable(
     project_dir: &Path,
     root: &StableDirectory,
     checkpoint: &mut Checkpoint,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<(), GfError> {
     let intent = match root.open_child_file(OsStr::new(PUBLICATION_INTENT)) {
         Ok(mut file) => {
@@ -5047,7 +5163,7 @@ fn recover_publication(
     };
     if receipt_exists {
         let receipt = read_publication_receipt(root, checkpoint)?;
-        authenticate_published_target(project_dir, checkpoint, &receipt)?;
+        authenticate_published_target(project_dir, checkpoint, &receipt, cancelled)?;
         if checkpoint.publication_state == Some(ConstructionPublicationState::Publishing) {
             checkpoint.publication_state = Some(ConstructionPublicationState::Published);
             replace_checkpoint_control(root, checkpoint)?;
@@ -7673,6 +7789,10 @@ fn validate_checkpoint(
             .is_some_and(|digest| !is_canonical_sha256(digest))
         || checkpoint.encoding_inventory_sha256.is_some()
             && checkpoint.shape_authority_sha256.is_none()
+        || checkpoint.inputs_retired
+            && (checkpoint.format_version < 9 || checkpoint.shape_authority_sha256.is_none())
+        || checkpoint.shape_retired
+            && (checkpoint.format_version < 9 || checkpoint.encoding_inventory_sha256.is_none())
         || match checkpoint.state {
             GraphConstructionState::Staging | GraphConstructionState::Aborted => {
                 checkpoint.publication_state.is_some()
@@ -8297,7 +8417,7 @@ fn validate_chunk_id(value: &str) -> Result<(), GfError> {
     Ok(())
 }
 
-fn reject_cancelled(cancelled: &mut impl FnMut() -> bool) -> Result<(), GfError> {
+pub(super) fn reject_cancelled(cancelled: &mut impl FnMut() -> bool) -> Result<(), GfError> {
     if cancelled() {
         return Err(storage("construction cancelled"));
     }
@@ -8356,6 +8476,7 @@ fn hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     include!("construction_detail_tests.rs");
+    include!("construction_lifecycle_tests.rs");
     use std::sync::Arc;
 
     use arrow::array::{BinaryArray, FixedSizeBinaryArray, Int64Array, StringArray};
@@ -11838,11 +11959,10 @@ mod tests {
             project.path()
         ));
         let operation = Uuid::from_u128(9_340);
-        let mut session = GraphConstructionSession::open_with_mode(
+        let mut session = GraphConstructionSession::open(
             project.path(),
             operation,
             2,
-            graphforge_core::OntologyMode::Exploratory,
             GraphConstructionBudgets::default(),
         )
         .unwrap();
@@ -11943,11 +12063,10 @@ mod tests {
         writer.close().unwrap();
         let operation = Uuid::from_u128(1156);
         let open = || {
-            GraphConstructionSession::open_with_mode(
+            GraphConstructionSession::open(
                 project.path(),
                 operation,
                 2,
-                graphforge_core::OntologyMode::Exploratory,
                 GraphConstructionBudgets::default(),
             )
             .unwrap()
@@ -12033,11 +12152,10 @@ mod tests {
     fn completed_encoding_replay_reauthenticates_retained_parent_payload() {
         let project = nonempty_project_generation_two();
         let operation = Uuid::from_u128(9_343);
-        let mut session = GraphConstructionSession::open_with_mode(
+        let mut session = GraphConstructionSession::open(
             project.path(),
             operation,
             2,
-            graphforge_core::OntologyMode::Exploratory,
             GraphConstructionBudgets::default(),
         )
         .unwrap();
@@ -12062,11 +12180,10 @@ mod tests {
     fn generation_one_parent_uses_streamed_binary_carry_and_authenticates_result() {
         let project = nonempty_project_with_nodes(2);
         let operation = Uuid::from_u128(9_341);
-        let mut session = GraphConstructionSession::open_with_mode(
+        let mut session = GraphConstructionSession::open(
             project.path(),
             operation,
             1,
-            graphforge_core::OntologyMode::Exploratory,
             GraphConstructionBudgets::default(),
         )
         .unwrap();

--- a/crates/graphforge-storage/src/graph_construction/supersession.rs
+++ b/crates/graphforge-storage/src/graph_construction/supersession.rs
@@ -1,0 +1,496 @@
+//! Version-nine predecessor removal under existing durable successor authority.
+//! Receipts remain installed so interruption needs no second cleanup journal.
+use super::{
+    ArtifactReceipt, BLOCK_BYTES, Digest, GfError, GraphConstructionEncoding,
+    GraphConstructionEvidence, GraphConstructionSession, OsStr, Read, ReadWork, Sha256,
+    StableDirectory, account_cache_release, account_encoding_cache_release,
+    canonical_artifact_target, checked_category_remove, compact_parent_inventory,
+    construction_failpoint, control_sha256, decode_bounded, file_identity, file_link_count, hex,
+    is_shape_artifact_name, read_completed_shape, read_completed_shape_outputs,
+    record_active_identity_remove, replace_checkpoint_control, shape_receipt_name, storage,
+};
+
+impl GraphConstructionSession {
+    pub(super) fn has_encoding_successor(&self) -> bool {
+        self.checkpoint.format_version >= 9 && self.checkpoint.encoding_inventory_sha256.is_some()
+    }
+
+    pub(super) fn reclaim_superseded_payloads(&mut self) -> Result<(), GfError> {
+        self.reclaim_superseded_payloads_cancellable(&mut || false)
+    }
+
+    pub(super) fn reclaim_superseded_payloads_cancellable(
+        &mut self,
+        cancelled: &mut impl FnMut() -> bool,
+    ) -> Result<(), GfError> {
+        super::reject_cancelled(cancelled)?;
+        if self.checkpoint.format_version < 9 || self.checkpoint.shape_authority_sha256.is_none() {
+            return Ok(());
+        }
+        // Retained parent payloads are authenticated through counted CAS reads
+        // below. Do not add an uncounted snapshot revalidation pass here.
+        self.project.revalidate_named().map_err(storage)?;
+        self.root.revalidate_named().map_err(storage)?;
+        if !self
+            .checkpoint
+            .project_identity
+            .matches(self.project.identity())
+            || !self
+                .checkpoint
+                .session_identity
+                .matches(self.root.identity())
+        {
+            return Err(storage("supersession private authority changed"));
+        }
+        let _retained_successor_leases = if self.has_encoding_successor() {
+            let output = self
+                .root
+                .open_child_directory(OsStr::new("encoded-v1"))
+                .map_err(storage)?;
+            let inventory = crate::graph_construction_encoding::read_inventory(&output)?
+                .ok_or_else(|| storage("supersession encoding inventory is absent"))?;
+            if Some(crate::graph_construction_encoding::inventory_authority_sha256(&inventory)?)
+                != self.checkpoint.encoding_inventory_sha256
+                || Some(&inventory.shape_authority_sha256)
+                    != self.checkpoint.shape_authority_sha256.as_ref()
+            {
+                return Err(storage("supersession encoding authority changed"));
+            }
+            let work = crate::graph_construction_encoding::authenticate_inventory_payloads(
+                &output, &inventory, cancelled,
+            )?;
+            self.record_supersession_reads(work.input_read_bytes, work.input_read_operations)?;
+            account_encoding_cache_release(&work, &mut self.checkpoint.evidence)?;
+            self.authenticate_retained_successors(&inventory, cancelled)?
+        } else {
+            read_completed_shape(&self.root, &self.checkpoint, false)?
+                .ok_or_else(|| storage("supersession shape is absent"))?;
+            for receipt in read_completed_shape_outputs(&self.root, &self.checkpoint)? {
+                let work = authenticate_payload(&self.root, &receipt, cancelled)?;
+                self.record_supersession_reads(work.bytes, work.operations)?;
+                account_cache_release(work.cache_release, &mut self.checkpoint.evidence)?;
+            }
+            None
+        };
+
+        // Authenticate the complete immutable receipt chain BEFORE any removal.
+        let mut previous = None;
+        for sequence in 0..self.checkpoint.next_sequence {
+            super::reject_cancelled(cancelled)?;
+            let receipt = self.read_receipt(sequence)?;
+            if receipt.prior_receipt_sha256 != previous {
+                return Err(storage("supersession receipt chain changed"));
+            }
+            previous = Some(control_sha256(&receipt)?);
+        }
+        if previous != self.checkpoint.last_receipt_sha256 {
+            return Err(storage("supersession receipt tail changed"));
+        }
+        supersession_boundary(if self.has_encoding_successor() {
+            "supersession.encoded_authenticated"
+        } else {
+            "supersession.shape_authenticated"
+        })?;
+        for sequence in 0..self.checkpoint.next_sequence {
+            super::reject_cancelled(cancelled)?;
+            let receipt = self.read_receipt(sequence)?;
+            for artifact in [&receipt.parquet, &receipt.identities, &receipt.details]
+                .into_iter()
+                .chain(receipt.endpoints.iter())
+            {
+                self.retire_payload(artifact, false, self.checkpoint.inputs_retired, cancelled)?;
+            }
+        }
+        self.checkpoint.inputs_retired = true;
+        supersession_boundary("supersession.before_inputs_checkpoint")?;
+        self.checkpoint_supersession()?;
+        if self.has_encoding_successor() {
+            self.retire_shape_payloads(cancelled)?;
+            self.checkpoint.shape_retired = true;
+            supersession_boundary("supersession.before_shape_checkpoint")?;
+        }
+        self.checkpoint_supersession()?;
+        supersession_boundary("supersession.after_checkpoint")?;
+        Ok(())
+    }
+
+    fn retire_shape_payloads(
+        &mut self,
+        cancelled: &mut impl FnMut() -> bool,
+    ) -> Result<(), GfError> {
+        for expected in read_completed_shape_outputs(&self.root, &self.checkpoint)? {
+            super::reject_cancelled(cancelled)?;
+            let mut file = self
+                .root
+                .open_child_file(OsStr::new(&shape_receipt_name(&expected.name)))
+                .map_err(storage)?;
+            let actual: ArtifactReceipt = decode_bounded(&mut file)?;
+            if actual != expected {
+                return Err(storage("supersession completed output receipt changed"));
+            }
+        }
+        // Every surviving shape output has a writer receipt. Keep these
+        // controls, including obsolete-run receipts, as retry authority.
+        for name in self.root.child_names().map_err(storage)? {
+            super::reject_cancelled(cancelled)?;
+            let Some(name) = name.to_str() else { continue };
+            if !name.starts_with("shape-receipt-") {
+                continue;
+            }
+            let mut file = self
+                .root
+                .open_child_file(OsStr::new(name))
+                .map_err(storage)?;
+            if file_link_count(&file).map_err(storage)? != 1 {
+                return Err(storage("supersession writer receipt has extra links"));
+            }
+            let receipt: ArtifactReceipt = decode_bounded(&mut file)?;
+            if shape_receipt_name(&receipt.name) != name {
+                return Err(storage("supersession writer receipt ownership changed"));
+            }
+            if !is_shape_artifact_name(&receipt.name) && canonical_artifact_target(&receipt.name) {
+                continue;
+            }
+            if !is_shape_artifact_name(&receipt.name) {
+                return Err(storage("supersession writer receipt artifact changed"));
+            }
+            self.retire_payload(&receipt, true, self.checkpoint.shape_retired, cancelled)?;
+        }
+        if self
+            .checkpoint
+            .evidence
+            .current_merge_temporary_allocated_bytes
+            != 0
+        {
+            return Err(storage("supersession shape inventory is incomplete"));
+        }
+        Ok(())
+    }
+
+    fn authenticate_retained_successors(
+        &mut self,
+        encoding: &GraphConstructionEncoding,
+        cancelled: &mut impl FnMut() -> bool,
+    ) -> Result<
+        Option<(
+            crate::ResolvedProjectGeneration,
+            crate::graph_object_store::GraphObjectReadLease,
+        )>,
+        GfError,
+    > {
+        if encoding.retained_artifacts.is_empty() {
+            if encoding.evidence.retained_index_runs != 0 {
+                return Err(storage("retained-index evidence lacks references"));
+            }
+            return Ok(None);
+        }
+        let parent = crate::resolve_generation_by_uuid(
+            &self.project_path,
+            self.checkpoint.parent_generation_uuid,
+        )?;
+        if hex(&parent.manifest_sha256()) != self.checkpoint.parent_generation_manifest_sha256 {
+            return Err(storage("supersession parent manifest changed"));
+        }
+        let lease = crate::graph_object_store::begin_graph_object_read(&self.project_path)?;
+        let (inventory, work) = compact_parent_inventory(&parent)?;
+        self.record_supersession_reads(work.bytes, work.operations)?;
+        let inventory =
+            inventory.ok_or_else(|| storage("supersession compact parent is absent"))?;
+        let manifest = inventory
+            .files
+            .iter()
+            .find(|entry| entry.relative_path == "topology/uuid-membership/manifest.json")
+            .ok_or_else(|| storage("supersession parent UUID manifest is absent"))?;
+        let (_manifest, work, released) = lease.open_for_construction(
+            &manifest.content_sha256,
+            manifest.byte_length,
+            cancelled,
+        )?;
+        self.record_supersession_reads(work.read_bytes, work.read_calls)?;
+        account_cache_release(released, &mut self.checkpoint.evidence)?;
+        let mut previous = None;
+        for retained in &encoding.retained_artifacts {
+            if previous.is_some_and(|name: &str| name >= retained.target_path.as_str())
+                || !retained
+                    .target_path
+                    .starts_with("topology/uuid-membership/")
+                || retained.source_root != self.project_path.to_string_lossy()
+                || retained.source_root_volume != self.project.identity().volume_serial
+                || retained.source_root_file_id != hex(&self.project.identity().file_id)
+                || retained.parent_manifest_sha256 != manifest.content_sha256
+            {
+                return Err(storage("supersession retained parent authority changed"));
+            }
+            previous = Some(retained.target_path.as_str());
+            let entry = inventory
+                .files
+                .iter()
+                .find(|entry| entry.relative_path == retained.target_path)
+                .ok_or_else(|| storage("supersession retained parent artifact is absent"))?;
+            let source = crate::graph_object_path(&self.project_path, &entry.content_sha256)?;
+            if entry.content_sha256 != retained.sha256
+                || entry.byte_length != retained.bytes
+                || source
+                    .strip_prefix(&self.project_path)
+                    .map_err(storage)?
+                    .to_string_lossy()
+                    != retained.source_path
+            {
+                return Err(storage("supersession retained parent artifact changed"));
+            }
+            let (file, work, released) =
+                lease.open_for_construction(&entry.content_sha256, entry.byte_length, cancelled)?;
+            let identity = file_identity(file.as_ref()).map_err(storage)?;
+            if identity.volume_serial != retained.source_volume
+                || hex(&identity.file_id) != retained.source_file_id
+            {
+                return Err(storage("supersession retained parent identity changed"));
+            }
+            self.record_supersession_reads(work.read_bytes, work.read_calls)?;
+            account_cache_release(released, &mut self.checkpoint.evidence)?;
+        }
+        Ok(Some((parent, lease)))
+    }
+
+    fn checkpoint_supersession(&mut self) -> Result<(), GfError> {
+        let mut next = self.checkpoint.clone();
+        next.evidence.recovery_checkpoint_fsync_operations = next
+            .evidence
+            .recovery_checkpoint_fsync_operations
+            .checked_add(3)
+            .ok_or_else(|| storage("supersession checkpoint synchronization count overflow"))?;
+        replace_checkpoint_control(&self.root, &next)?;
+        self.checkpoint = next;
+        Ok(())
+    }
+
+    fn record_supersession_reads(&mut self, bytes: u64, operations: u64) -> Result<(), GfError> {
+        self.checkpoint.evidence.recovery_application_read_bytes = self
+            .checkpoint
+            .evidence
+            .recovery_application_read_bytes
+            .checked_add(bytes)
+            .ok_or_else(|| storage("supersession read bytes overflow"))?;
+        self.checkpoint
+            .evidence
+            .recovery_application_read_operations = self
+            .checkpoint
+            .evidence
+            .recovery_application_read_operations
+            .checked_add(operations)
+            .ok_or_else(|| storage("supersession read operations overflow"))?;
+        Ok(())
+    }
+
+    fn retire_payload(
+        &mut self,
+        receipt: &ArtifactReceipt,
+        shaped: bool,
+        completed: bool,
+        cancelled: &mut impl FnMut() -> bool,
+    ) -> Result<(), GfError> {
+        super::reject_cancelled(cancelled)?;
+        let key = format!(
+            "{:016x}:{}",
+            receipt.identity.volume_serial, receipt.identity.file_id
+        );
+        let active = self
+            .checkpoint
+            .evidence
+            .storage_active_identity_allocated_bytes
+            .get(&key)
+            .copied();
+        match self.root.open_child_file(OsStr::new(&receipt.name)) {
+            Ok(file) => {
+                if completed {
+                    return Err(storage("supersession retired predecessor reappeared"));
+                }
+                let identity = file_identity(&file).map_err(storage)?;
+                if !receipt.identity.matches(identity)
+                    || file_link_count(&file).map_err(storage)? != 1
+                {
+                    return Err(storage("supersession predecessor identity changed"));
+                }
+                if active != Some(receipt.allocated_bytes) {
+                    return Err(storage(
+                        "supersession predecessor allocation authority changed",
+                    ));
+                }
+                drop(file);
+                let work = authenticate_payload(&self.root, receipt, cancelled)?;
+                self.record_supersession_reads(work.bytes, work.operations)?;
+                account_cache_release(work.cache_release, &mut self.checkpoint.evidence)?;
+                supersession_boundary("supersession.before_unlink")?;
+                self.root
+                    .unlink_child_if_identity(OsStr::new(&receipt.name), identity)
+                    .map_err(storage)?;
+                supersession_boundary("supersession.after_unlink")?;
+                if shaped {
+                    supersession_boundary("supersession.shape_after_unlink")?;
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if completed {
+                    return Ok(());
+                }
+            }
+            Err(error) => return Err(storage(error)),
+        }
+        // Even a previously missing name must cross the directory durability
+        // barrier before a retry releases its still-persisted allocation.
+        supersession_boundary("supersession.before_sync")?;
+        self.root.sync().map_err(storage)?;
+        self.checkpoint
+            .evidence
+            .recovery_checkpoint_fsync_operations = self
+            .checkpoint
+            .evidence
+            .recovery_checkpoint_fsync_operations
+            .checked_add(1)
+            .ok_or_else(|| storage("supersession directory synchronization count overflow"))?;
+        supersession_boundary("supersession.after_sync")?;
+        if shaped {
+            supersession_boundary("supersession.shape_after_sync")?;
+        }
+        if let Some(allocated) = active {
+            if allocated != receipt.allocated_bytes {
+                return Err(storage(
+                    "supersession missing predecessor allocation changed",
+                ));
+            }
+            let category = crate::ArtifactCategory::ConstructionStaging;
+            let evidence = &self.checkpoint.evidence;
+            let reported = checked_category_remove(
+                &evidence.storage_current[&category],
+                receipt.bytes,
+                allocated,
+            )?;
+            let authority = checked_category_remove(
+                &evidence.storage_receipt_category_authorities[&category],
+                receipt.bytes,
+                allocated,
+            )?;
+            let merge_bytes = if shaped {
+                evidence
+                    .current_merge_temporary_allocated_bytes
+                    .checked_sub(allocated)
+                    .ok_or_else(|| storage("supersession merge allocation underflow"))?
+            } else {
+                evidence.current_merge_temporary_allocated_bytes
+            };
+            let evidence = &mut self.checkpoint.evidence;
+            record_active_identity_remove(evidence, &key)?;
+            evidence.storage_current.insert(category, reported);
+            evidence
+                .storage_receipt_category_authorities
+                .insert(category, authority);
+            evidence.current_merge_temporary_allocated_bytes = merge_bytes;
+        }
+        Ok(())
+    }
+}
+
+#[allow(clippy::unnecessary_wraps)] // Test builds inject returned I/O failures at these same boundaries.
+fn supersession_boundary(name: &str) -> Result<(), GfError> {
+    construction_failpoint(name);
+    #[cfg(test)]
+    if RETURNED_FAILURE.with(|point| point.borrow().as_deref() == Some(name)) {
+        return Err(storage(format!("injected returned failure at {name}")));
+    }
+    Ok(())
+}
+
+pub(super) fn authenticate_public_successor(
+    target: &crate::ResolvedProjectGeneration,
+    evidence: &mut GraphConstructionEvidence,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<(), GfError> {
+    let (inventory, mut work) = compact_parent_inventory(target)?;
+    let inventory =
+        inventory.ok_or_else(|| storage("published supersession successor is not compact"))?;
+    let lease = crate::graph_object_store::begin_graph_object_read(target.container_root())?;
+    for entry in &inventory.files {
+        let (_file, io, released) =
+            lease.open_for_construction(&entry.content_sha256, entry.byte_length, cancelled)?;
+        work.bytes = work
+            .bytes
+            .checked_add(io.read_bytes)
+            .ok_or_else(|| storage("successor read bytes overflow"))?;
+        work.operations = work
+            .operations
+            .checked_add(io.read_calls)
+            .ok_or_else(|| storage("successor read calls overflow"))?;
+        account_cache_release(released, evidence)?;
+    }
+    evidence.recovery_application_read_bytes = evidence
+        .recovery_application_read_bytes
+        .checked_add(work.bytes)
+        .ok_or_else(|| storage("successor authentication bytes overflow"))?;
+    evidence.recovery_application_read_operations = evidence
+        .recovery_application_read_operations
+        .checked_add(work.operations)
+        .ok_or_else(|| storage("successor authentication calls overflow"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+thread_local! {
+    static RETURNED_FAILURE: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(super) fn set_returned_failure(point: Option<&str>) {
+    RETURNED_FAILURE.with(|current| *current.borrow_mut() = point.map(str::to_owned));
+}
+
+fn authenticate_payload(
+    root: &StableDirectory,
+    receipt: &ArtifactReceipt,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Result<ReadWork, GfError> {
+    let file = root
+        .open_child_file(OsStr::new(&receipt.name))
+        .map_err(storage)?;
+    if !receipt
+        .identity
+        .matches(file_identity(&file).map_err(storage)?)
+        || file_link_count(&file).map_err(storage)? != 1
+    {
+        return Err(storage("supersession payload identity changed"));
+    }
+    let mut reader = graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(storage)?;
+    let mut work = ReadWork::default();
+    let mut digest = Sha256::new();
+    let mut block = vec![0; BLOCK_BYTES];
+    let result = (|| {
+        loop {
+            super::reject_cancelled(cancelled)?;
+            let count = reader.read(&mut block).map_err(storage)?;
+            if count == 0 {
+                break;
+            }
+            digest.update(&block[..count]);
+            work.bytes = work
+                .bytes
+                .checked_add(count as u64)
+                .ok_or_else(|| storage("supersession payload size overflow"))?;
+            work.operations += 1;
+        }
+        if work.bytes != receipt.bytes || hex(&digest.finalize()) != receipt.sha256 {
+            return Err(storage("supersession payload digest changed"));
+        }
+        Ok(())
+    })();
+    let released = reader.finish().map_err(storage);
+    match (result, released) {
+        (Ok(()), Ok(released)) => {
+            work.cache_release = released;
+            Ok(work)
+        }
+        (Err(primary), Ok(_)) => Err(primary),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(primary), Err(secondary)) => Err(storage(format!(
+            "{primary}; cache release failed: {secondary}"
+        ))),
+    }
+}

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -2400,9 +2400,10 @@ fn directory_for(
     Ok((directory, name))
 }
 
-fn authenticate_file(
+fn authenticate_file_cancellable(
     path: &str,
     file: File,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<
     (
         ConstructionEncodedArtifact,
@@ -2419,6 +2420,7 @@ fn authenticate_file(
     file.rewind().map_err(storage)?;
     let authentication = (|| -> Result<ConstructionEncodedArtifact, GfError> {
         loop {
+            crate::graph_construction::reject_cancelled(cancelled)?;
             let read = file.read(&mut buffer).map_err(storage)?;
             if read == 0 {
                 break;
@@ -2564,10 +2566,52 @@ fn is_encoding_temp(name: &str) -> bool {
     })
 }
 
-fn authenticate_inventory(
+pub(crate) fn authenticate_inventory(
     root: &StableDirectory,
     inventory: &GraphConstructionEncoding,
     parent_index: Option<&AuthenticatedUuidIndexSnapshot>,
+) -> Result<GraphConstructionEncodingEvidence, GfError> {
+    let evidence = authenticate_inventory_payloads(root, inventory, &mut || false)?;
+    if inventory.retained_artifacts.is_empty() {
+        if inventory.evidence.retained_index_runs != 0 {
+            return Err(storage("retained-index evidence lacks references"));
+        }
+    } else {
+        let parent = parent_index
+            .ok_or_else(|| storage("retained artifacts lack authenticated parent snapshot"))?;
+        let mut previous = None;
+        let mut references = Vec::with_capacity(inventory.retained_artifacts.len());
+        for retained in &inventory.retained_artifacts {
+            if previous.is_some_and(|value: &str| value >= retained.target_path.as_str()) {
+                return Err(storage(
+                    "retained artifact targets are not unique and sorted",
+                ));
+            }
+            references.push(
+                crate::uuid_membership::ConstructionReferenceAuthentication {
+                    source_root: &retained.source_root,
+                    source_root_volume: retained.source_root_volume,
+                    source_root_file_id: &retained.source_root_file_id,
+                    source_path: &retained.source_path,
+                    source_volume: retained.source_volume,
+                    source_file_id: &retained.source_file_id,
+                    target_path: &retained.target_path,
+                    bytes: retained.bytes,
+                    sha256: &retained.sha256,
+                    parent_manifest_sha256: &retained.parent_manifest_sha256,
+                },
+            );
+            previous = Some(retained.target_path.as_str());
+        }
+        parent.authenticate_construction_references(&references)?;
+    }
+    Ok(evidence)
+}
+
+pub(crate) fn authenticate_inventory_payloads(
+    root: &StableDirectory,
+    inventory: &GraphConstructionEncoding,
+    cancelled: &mut impl FnMut() -> bool,
 ) -> Result<GraphConstructionEncodingEvidence, GfError> {
     if inventory.root != ENCODED_ROOT
         || inventory.shape_inputs_sha256.len() != 64
@@ -2601,7 +2645,8 @@ fn authenticate_inventory(
         let file = directory
             .open_child_file(OsStr::new(&name))
             .map_err(storage)?;
-        let (actual, released, operations) = authenticate_file(&expected.path, file)?;
+        let (actual, released, operations) =
+            authenticate_file_cancellable(&expected.path, file, cancelled)?;
         if &actual != expected {
             return Err(storage("canonical artifact differs from inventory"));
         }
@@ -2616,39 +2661,6 @@ fn authenticate_inventory(
             "input read operations",
         )?;
         account_cache_release(released, &mut evidence)?;
-    }
-    if inventory.retained_artifacts.is_empty() {
-        if inventory.evidence.retained_index_runs != 0 {
-            return Err(storage("retained-index evidence lacks references"));
-        }
-    } else {
-        let parent = parent_index
-            .ok_or_else(|| storage("retained artifacts lack authenticated parent snapshot"))?;
-        let mut previous = None;
-        let mut references = Vec::with_capacity(inventory.retained_artifacts.len());
-        for retained in &inventory.retained_artifacts {
-            if previous.is_some_and(|value: &str| value >= retained.target_path.as_str()) {
-                return Err(storage(
-                    "retained artifact targets are not unique and sorted",
-                ));
-            }
-            references.push(
-                crate::uuid_membership::ConstructionReferenceAuthentication {
-                    source_root: &retained.source_root,
-                    source_root_volume: retained.source_root_volume,
-                    source_root_file_id: &retained.source_root_file_id,
-                    source_path: &retained.source_path,
-                    source_volume: retained.source_volume,
-                    source_file_id: &retained.source_file_id,
-                    target_path: &retained.target_path,
-                    bytes: retained.bytes,
-                    sha256: &retained.sha256,
-                    parent_manifest_sha256: &retained.parent_manifest_sha256,
-                },
-            );
-            previous = Some(retained.target_path.as_str());
-        }
-        parent.authenticate_construction_references(&references)?;
     }
     Ok(evidence)
 }

--- a/docs/book/architecture/construction-supersession.md
+++ b/docs/book/architecture/construction-supersession.md
@@ -1,0 +1,150 @@
+# Construction supersession review
+
+Issue #1195; source baseline `345b0108` (full source identity and measured
+fixtures accompany the implementation evidence). Correctness and recovery take
+precedence over allocation savings.
+
+## Existing guarantees and consumers
+
+| Representation | Authority and consumer | Required lifetime |
+| --- | --- | --- |
+| Accepted Parquet, UUID, detail and endpoint runs | Ordered chunk receipts ending at the checkpoint digest; seal and shape validate and consume them | Until complete shape and its checkpoint binding are durable |
+| Intermediate sorted runs | Session directory identity, writer receipts, allocation identities; later merge levels | Until their merge consumer completes; existing merge cleanup handles this |
+| Completed shape and remaining merged runs | Complete shape inventory binds output identities/digests; encoder consumes them | Until checkpoint-bound encoding has authenticated successor payloads |
+| Encoded graph and indexes | Encoding inventory digest in checkpoint; CAS publication consumes them | Through publication and compatible encoding replay |
+| Published graph and retained parent | Immutable generation, manifest, CAS and generation leases; ordinary queries, streams and portable export | Governed by generation retention; never construction cleanup candidates |
+| Chunk, shape, encoding and publication controls | Session/project identity, pinned parent, digest chain and transaction | Retain for idempotency, replay, ownership and accounting reconciliation |
+
+Before:
+
+```mermaid
+flowchart LR
+    A[Accepted inputs] --> S[Complete shape]
+    S --> E[Encoded graph]
+    E --> P[Published generation]
+    R[Session reopen] --> S
+    F[Facade publication replay] --> E
+    A -. retained through export and clean import .-> P
+    S -. retained through export and clean import .-> P
+```
+
+The retained-input requirement is an implementation dependency, not an
+additional user-visible data version. Published generation readers and active
+streams do not consume private accepted or shaped files. Existing versions
+6–8 nevertheless promise these replay dependencies and must continue unchanged.
+
+## Decision
+
+Use existing complete shape, checkpoint-bound encoding and publication
+authority as supersession boundaries in a new construction checkpoint version.
+Keep the existing staging/sealed/publishing/published states. Two monotonic
+completion bits in the existing checkpoint distinguish completed input and
+shape removal. These are necessary because filesystems reuse inode identities:
+an old missing predecessor receipt must not debit a new encoded file that
+later reuses its inode. No new payload writer runs until the preceding removal
+completion checkpoint is durable. Retain receipts;
+do not introduce another publication journal or user-visible cleanup operation.
+
+After:
+
+```mermaid
+flowchart LR
+    A[Accepted inputs] --> S[Durable authenticated shape]
+    S --> X[Remove accepted payloads by receipt identity]
+    S --> E[Durable authenticated encoding]
+    E --> Y[Remove shaped payloads by receipt identity]
+    E --> P[Published generation with leases]
+    R[Session reopen] --> E
+    F[Publication replay] --> P
+```
+
+Alternatives considered: publication-only cleanup lowers late retained storage
+but leaves the earlier encoding peak unchanged; a separate retirement journal
+duplicates eligibility already established by durable successor bindings. The
+selected approach removes two predecessor dependencies without adding another
+state machine. It does add a format-version distinction so older readers fail
+closed instead of interpreting missing inputs using the former contract.
+
+The publication receipt alone is insufficient successor authentication.
+Version nine therefore authenticates the immutable public inventory and every
+CAS payload, holding generation/object leases through validation. An encoding successor must match the checkpoint digest
+and authenticate its files, including required parent references.
+
+Missing eligible predecessor files can be reconciled only after successor
+authentication. Replacement identities, unexpected links, corrupt successors
+and failed synchronization remain errors. Allocation transitions record
+confirmed removal; historical maxima are never reduced. Crash/error coverage
+must include unlink-before-sync and sync-before-checkpoint, repeated resume,
+legacy continuation and replay after CURRENT advances.
+
+## Measurement and completion gates
+
+The deterministic `construction_lifecycle_multilevel_allocation_baseline`
+fixture uses 8,192 nodes and 32,768/65,536/131,072 edges, 4,096-row chunks and
+fan-in two. It measures accepted, shaped, encoded and published boundaries
+using physical file identities to count aliases once. Columns for each owner
+are logical bytes, allocated bytes and unique physical objects. Its phase
+census is retained storage at that boundary; historical simultaneous peaks
+come from the existing allocation transitions, never a sum of owner peaks.
+
+The count of public lifecycle states is unchanged; the private format adds two
+monotonic completion facts and no journal. There are still three transient
+payload representations during construction, but only encoding remains after
+its successor boundary (instead of accepted inputs, shape and encoding).
+`ConstructionShape` names are receipt references after encoding; replay through
+the session remains supported, while callers must not open retired private
+paths. Cancellation is polled per bounded payload read and between removals;
+a cancellation after partial removal resumes using the same durable receipts.
+After `CURRENT` commits, final receipt recording completes without cancellation.
+
+The small-fixture report does not establish S22 or S26 savings. #901/#900/#745
+retain the named-host ladder, available-capacity and 15% reserve gates. Public
+facade tests must also prove values, schema, external UUIDs, reopen, query,
+export, verification and clean-import equivalence.
+
+## Paired deterministic measurements
+
+Measured on native Linux x86_64 with Rust 1.96.0
+(`ac68faa20`, 2026-05-25), based on source
+`345b01085d8566a492b9364eedbf0bb68d0a5a2c` plus this issue's focused diff.
+The regression runs versions 8 and 9 in the **same binary**, using identical
+UUIDs, Arrow batches, fan-in and row bounds. The PR records the tested head.
+Graph format and permanent payload encoding are unchanged. UUIDs are sequential
+synthetic values; this is a lifecycle comparison, not a compression benchmark.
+
+Reproduce on an admitted native filesystem (including `TMPDIR`):
+
+```bash
+CARGO_TARGET_DIR=/path/to/isolated-target TMPDIR=/path/to/native-tmp \
+  cargo test -p graphforge-storage --lib graph_construction -- --nocapture
+CARGO_TARGET_DIR=/path/to/isolated-target TMPDIR=/path/to/native-tmp \
+  cargo test -p graphforge-api --lib resumable_construction
+CARGO_TARGET_DIR=/path/to/isolated-target TMPDIR=/path/to/native-tmp \
+  cargo test -p graphforge-api --test scale_g500_ladder
+```
+
+All quantities below are raw allocated bytes from the construction payload
+ledger. They exclude receipt/control files, reported independently by the
+physical census. The peak is the historical simultaneous payload union.
+
+| Edges | v8 retained | v9 retained | v8 peak | v9 peak | Added authenticated read bytes |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 32,768 | 23,425,024 | 4,644,864 | 23,425,024 | 20,873,216 | 41,813,311 |
+| 65,536 | 44,494,848 | 8,249,344 | 44,494,848 | 40,435,712 | 79,132,926 |
+| 131,072 | 86,634,496 | 15,458,304 | 86,634,496 | 79,560,704 | 153,770,992 |
+
+Retained payload decreases about 80–82%; the earlier peak decreases only about
+8–11%. The latter remains a real limitation. Authentication uses fixed 1-MiB
+reads for private retirement payloads and 64-KiB reads for CAS successors;
+the encoding authenticator retains its existing fixed buffer. The fixture enforces recovery/supersession reads
+below eight accepted-input payload writes plus 16 MiB, zero retained merge
+bytes, and at least a halving of retained payload. Existing public full-lifecycle
+checks retain RSS, buffered-call, phase, physical-identity and peak budgets.
+
+Version nine leaves no accepted or shaped payload objects at publication.
+For each phase, `LIFECYCLE_BASELINE` emits logical bytes, allocated bytes and
+physical objects for accepted inputs, shape/merge, encoding and controls;
+physical identity deduplication prevents counting hard-link aliases twice.
+The encoding census includes its JSON controls, unlike the payload ledger.
+The permanent public project, export and import are separate owners in the
+existing full-lifecycle ladder and are not included in the table above.

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -262,8 +262,11 @@ that remove or rename physical routes rebuild the mapping from their emitted
 inventory. Path containment, no-follow opens, native identity, link-count,
 collision, and exact-inventory checks still apply to encoded paths.
 
-Construction checkpoint version 8 selects mapped output explicitly. Versions 6
-and 7 retain their original encoding when resumed; versions 7 and 8 use the
+Construction checkpoint versions 8 and 9 select mapped output explicitly. Version
+9 also reclaims accepted payloads after authenticated shape and shaped payloads
+after authenticated encoding; see [construction supersession](construction-supersession.md).
+Versions 6
+and 7 retain their original encoding when resumed; versions 7–9 use the
 same compact detail codec. Mapped construction publication combines the
 retained parent routes with newly emitted routes and verifies the complete
 mapping before installing the version-4 manifest. Legacy parent payloads can

--- a/docs/development/g500-certification.md
+++ b/docs/development/g500-certification.md
@@ -192,11 +192,12 @@ the filesystem quantization checks. Source/import categories still reconcile
 field-for-field with storage-owned authorities. Coherently changing those
 ledgers to zero or excessive growth does not bypass the policy tests.
 
-Completed construction retains authenticated shape/merge files for replay.
-Their current allocated bytes are measured against the retained native file
-inventory and checked with filesystem allocation quantization, alongside the
-other retained outputs; this counter is not structurally zero. Intermediate
-merge input removals subtract their actual allocations.
+Construction versions 6–8 retain authenticated shape/merge files for replay.
+Version 9 supersedes them with checkpoint-bound authenticated encoding and
+records identity-bound removal after directory synchronization. New-construction
+linearity fixtures require zero retained shape allocation, while preserving
+the historical peak and reconciling current allocation against the native file
+inventory. See [construction supersession](../book/architecture/construction-supersession.md).
 
 Ordered query admission recognizes the explicit `ordered_one_hop` and
 `ordered_two_hop` leaf families alongside the existing Expand/sort paths. The


### PR DESCRIPTION
New construction sessions retire accepted payloads after authenticated durable shape, then retire shaped/merged payloads after checkpoint-bound encoding authentication. This removes replay dependencies that retained both full predecessors through publication/export/import. Version 9 reuses existing checkpoints and receipts; versions 6–8 retain their compatibility behavior.

Removal verifies ownership, identity, links and digest, synchronizes unlink before releasing allocation, and reconciles interrupted cleanup without reducing historical peaks. Published replay authenticates the immutable successor after CURRENT advances. Cancellation reaches bounded authentication/removal work, and active public streams retain their original generation.

The paired multi-level 1x/2x/4x fixture reduces retained construction payload by 80–82% and its historical simultaneous peak by 8–11%. Added authentication I/O and raw bytes are recorded in `docs/book/architecture/construction-supersession.md`. These small fixtures do not establish S22/S26 admission; #901/#900 retain the shared host ladder.

Validation:
- `cargo test -p graphforge-storage --lib graph_construction -- --nocapture`: 99 passed, including crash, returned-error, corruption, cancellation, legacy continuation and paired allocation tests.
- `cargo test -p graphforge-api --lib resumable_construction`: 6 passed, including exact portable round trip and an unpolled old-generation stream across child retirement/publication.
- `cargo test -p graphforge-api --test scale_g500_ladder`: 29 passed, including full lifecycle 1x/2x/4x budgets and million-edge replay.
- API BDD: 118 passed; advisory whole-corpus TCK: 3897/3897 passed.
- Workspace Clippy, formatting, `make pre-push-fast`, and `make gate-registry-check` passed. Full `make pre-push` completed all core and binding tests successfully, then failed the coverage ledger at 91.28% against the 95% floor. This repository-wide shortfall is already tracked in #360 (its documented main baseline was 90.96%). The run used a private native `/tmp` mount namespace because the existing hardcoded native-filesystem test rejects the host's tmpfs `/tmp`; the filesystem test passed in that namespace. Required exact-head CI, including Bazel, bindings and platform checks, passed on `0b3f3d1461a0e2a772e60cbb777defd6a52feb18` ([run](https://github.com/CurateLabs/graphforge/actions/runs/34418774138)). No coverage floor was lowered.
- Independent reviews covered deletion authority, accounting, cancellation, stream retention and fixture-specific budget changes; findings were verified and addressed.

Closes #1195
