### PR TITLE
test(storage): establish permanent ownership and compaction budgets

### DIFF
--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "30f5fd15462196c741cda03c05604373758ae8a21e39b725b483719429012b26",
+  "checksum": "6a40a06e42157027df4fb5b43e623e477cd821b17bd6a2670363a11b508a094b",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -1081,6 +1081,7 @@
             "default",
             "ffi",
             "ipc",
+            "ipc_compression",
             "json",
             "prettyprint",
             "pyarrow"

--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -206,6 +206,17 @@ gf_rust_integration_test(
 )
 
 gf_rust_integration_test(
+    name = "permanent_storage_budgets",
+    srcs = ["tests/permanent_storage_budgets.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    env = {"RUST_TEST_THREADS": "1"},
+    size = "large",
+    timeout = "long",
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
     name = "scale_g500_ladder",
     srcs = ["tests/scale_g500_ladder.rs"],
     compile_data = [
@@ -553,6 +564,7 @@ test_suite(
         ":public_lifecycle_conformance",
         ":release_load_construction",
         ":resumable_construction_surface",
+        ":permanent_storage_budgets",
         ":scale_g500_ladder",
         ":scale_g500_scale20",
         ":strict_runtime_properties",

--- a/crates/graphforge-api/Cargo.toml
+++ b/crates/graphforge-api/Cargo.toml
@@ -40,6 +40,8 @@ fs4 = "1.1"
 uuid = { workspace = true }
 
 [dev-dependencies]
+# Assessment-only IPC codec experiments; production writers remain unchanged.
+arrow = { workspace = true, features = ["ipc_compression"] }
 cucumber = { workspace = true }
 tokio = { workspace = true }
 graphforge-cypher = { path = "../graphforge-cypher" }

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -1,0 +1,894 @@
+//! Reproducible permanent ownership and candidate-codec assessment (#1196).
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write,
+    fs::File,
+    path::Path,
+    sync::Arc,
+    time::Instant,
+};
+
+use arrow::{
+    array::{Array, ArrayRef, FixedSizeBinaryArray, Int64Array, ListArray, StringArray},
+    datatypes::{DataType, Field, Schema},
+    record_batch::RecordBatch,
+};
+use graphforge_api::{
+    CONSTRUCTION_EDGE_SCHEMA, CONSTRUCTION_NODE_SCHEMA, GraphConstructionBudgets, GraphForge,
+    OperationId, PortableSelection, PortableV2ExportRequest, PortableV2ImportRequest,
+    PortableVerifyRequest, verify_portable_v2,
+};
+use graphforge_core::portable::{
+    PortableV2Limits, PortableV2Mode, PortableV2Output, PortableV2SelectionProfile,
+};
+use parquet::{
+    arrow::{ArrowWriter, arrow_reader::ParquetRecordBatchReaderBuilder},
+    basic::{Compression, ZstdLevel},
+    file::properties::WriterProperties,
+};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+type Node = (Uuid, String, Option<i64>);
+type Edge = (Uuid, Uuid, Uuid, String, Option<i64>, Option<String>);
+
+#[derive(Clone, Copy)]
+enum Identifiers {
+    Sequential,
+    Random,
+}
+
+#[derive(Clone, Copy)]
+struct Fixture {
+    name: &'static str,
+    nodes: usize,
+    edges: usize,
+    routes: usize,
+    identifiers: Identifiers,
+    properties: bool,
+    adjacency: bool,
+    heterogeneous: bool,
+}
+
+fn id(domain: u8, row: usize, random: bool) -> Uuid {
+    if random {
+        let digest = Sha256::digest(format!("graphforge-1196/{domain}/{row}"));
+        Uuid::from_slice(&digest[..16]).unwrap()
+    } else {
+        Uuid::from_u128((u128::from(domain) << 120) | (row as u128 + 1))
+    }
+}
+
+fn rows(f: Fixture) -> (Vec<Node>, Vec<Edge>) {
+    let nodes = (0..f.nodes)
+        .map(|i| {
+            (
+                id(1, i, matches!(f.identifiers, Identifiers::Random)),
+                format!("Node{}", i % f.routes),
+                (f.properties && i % 7 != 0 && (!f.heterogeneous || (i / 1024).is_multiple_of(2)))
+                    .then_some(i64::try_from(i).unwrap() - 2048),
+            )
+        })
+        .collect::<Vec<_>>();
+    let edges = (0..f.edges)
+        .map(|i| {
+            (
+                id(2, i, matches!(f.identifiers, Identifiers::Random)),
+                nodes[i % f.nodes].0,
+                nodes[(i * 7919 + i / f.nodes) % f.nodes].0,
+                format!("REL{}", i % f.routes),
+                (f.properties && i % 5 != 0).then_some(i64::try_from(i).unwrap() * 17),
+                (f.properties && i % 11 != 0 && (!f.heterogeneous || (i / 1024).is_multiple_of(2)))
+                    .then(|| {
+                        if i % 2 == 0 {
+                            format!("group-{}", i % 16)
+                        } else {
+                            format!("unique-value-{i:020}")
+                        }
+                    }),
+            )
+        })
+        .collect();
+    (nodes, edges)
+}
+
+fn uuids(ids: impl Iterator<Item = Uuid>) -> ArrayRef {
+    Arc::new(FixedSizeBinaryArray::try_from_iter(ids.map(|id| *id.as_bytes())).unwrap())
+}
+
+fn construct(path: &Path, f: Fixture, nodes: &[Node], edges: &[Edge]) {
+    let graph = GraphForge::new(path.to_str()).unwrap();
+    let mut session = graph
+        .begin_graph_construction(GraphConstructionBudgets {
+            max_batch_rows: 1024,
+            max_run_records: 4096,
+            merge_fan_in: 2,
+            ..Default::default()
+        })
+        .unwrap();
+    for (chunk, rows) in nodes.chunks(1024).enumerate() {
+        let mut fields = CONSTRUCTION_NODE_SCHEMA.fields().to_vec();
+        let mut arrays = vec![
+            uuids(rows.iter().map(|row| row.0)),
+            Arc::new(StringArray::from(
+                rows.iter().map(|row| row.1.as_str()).collect::<Vec<_>>(),
+            )) as ArrayRef,
+        ];
+        if f.properties && (!f.heterogeneous || chunk.is_multiple_of(2)) {
+            fields.push(Arc::new(Field::new("score", DataType::Int64, true)));
+            arrays.push(Arc::new(Int64Array::from(
+                rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+            )));
+        }
+        session
+            .append_nodes(
+                &format!("nodes-{chunk}"),
+                &RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays).unwrap(),
+            )
+            .unwrap();
+    }
+    for (chunk, rows) in edges.chunks(1024).enumerate() {
+        let mut fields = CONSTRUCTION_EDGE_SCHEMA.fields().to_vec();
+        let mut arrays = vec![
+            uuids(rows.iter().map(|row| row.0)),
+            Arc::new(StringArray::from(
+                rows.iter().map(|row| row.3.as_str()).collect::<Vec<_>>(),
+            )) as ArrayRef,
+            uuids(rows.iter().map(|row| row.1)),
+            uuids(rows.iter().map(|row| row.2)),
+        ];
+        if f.properties {
+            fields.push(Arc::new(Field::new("weight", DataType::Int64, true)));
+            arrays.push(Arc::new(Int64Array::from(
+                rows.iter().map(|row| row.4).collect::<Vec<_>>(),
+            )));
+            if !f.heterogeneous || chunk.is_multiple_of(2) {
+                fields.push(Arc::new(Field::new("text", DataType::Utf8, true)));
+                arrays.push(Arc::new(StringArray::from(
+                    rows.iter().map(|row| row.5.as_deref()).collect::<Vec<_>>(),
+                )));
+            }
+        }
+        session
+            .append_edges(
+                &format!("edges-{chunk}"),
+                &RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays).unwrap(),
+            )
+            .unwrap();
+    }
+    session.seal_and_publish().unwrap();
+}
+
+fn uuid_at(batch: &RecordBatch, column: usize, row: usize) -> Uuid {
+    Uuid::from_slice(
+        batch
+            .column(column)
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap()
+            .value(row),
+    )
+    .unwrap()
+}
+fn int_at(batch: &RecordBatch, column: usize, row: usize) -> Option<i64> {
+    (!batch.column(column).is_null(row)).then(|| {
+        batch
+            .column(column)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(row)
+    })
+}
+
+fn verify_graph(
+    graph: &GraphForge,
+    f: Fixture,
+    expected_nodes: &[Node],
+    expected_edges: &[Edge],
+) -> String {
+    let node_query = if f.properties {
+        "MATCH (n) RETURN n.node_uuid, labels(n), n.score"
+    } else {
+        "MATCH (n) RETURN n.node_uuid, labels(n)"
+    };
+    let mut nodes = Vec::new();
+    for batch in graph.execute(node_query).unwrap().batches {
+        let labels = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            let values = labels.value(row);
+            let values = values.as_any().downcast_ref::<StringArray>().unwrap();
+            assert_eq!(values.len(), 1);
+            nodes.push((
+                uuid_at(&batch, 0, row),
+                values.value(0).to_owned(),
+                if f.properties {
+                    int_at(&batch, 2, row)
+                } else {
+                    None
+                },
+            ));
+        }
+    }
+    let edge_query = if f.properties {
+        "MATCH (a)-[r]->(b) RETURN r.edge_uuid, a.node_uuid, b.node_uuid, type(r), r.weight, r.text"
+    } else {
+        "MATCH (a)-[r]->(b) RETURN r.edge_uuid, a.node_uuid, b.node_uuid, type(r)"
+    };
+    let mut edges = Vec::new();
+    for batch in graph.execute(edge_query).unwrap().batches {
+        let routes = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            let text = if f.properties && !batch.column(5).is_null(row) {
+                Some(
+                    batch
+                        .column(5)
+                        .as_any()
+                        .downcast_ref::<StringArray>()
+                        .unwrap()
+                        .value(row)
+                        .to_owned(),
+                )
+            } else {
+                None
+            };
+            edges.push((
+                uuid_at(&batch, 0, row),
+                uuid_at(&batch, 1, row),
+                uuid_at(&batch, 2, row),
+                routes.value(row).to_owned(),
+                if f.properties {
+                    int_at(&batch, 4, row)
+                } else {
+                    None
+                },
+                text,
+            ));
+        }
+    }
+    nodes.sort();
+    edges.sort();
+    let mut expected_nodes = expected_nodes.to_vec();
+    let mut expected_edges = expected_edges.to_vec();
+    expected_nodes.sort();
+    expected_edges.sort();
+    assert_eq!(nodes, expected_nodes);
+    assert_eq!(edges, expected_edges);
+    let mut fingerprint = String::new();
+    for byte in Sha256::digest(serde_json::to_vec(&(nodes, edges)).unwrap()) {
+        write!(fingerprint, "{byte:02x}").unwrap();
+    }
+    fingerprint
+}
+
+fn round_trip(root: &Path, source: &Path, f: Fixture, nodes: &[Node], edges: &[Edge]) -> String {
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let fingerprint = verify_graph(&graph, f, nodes, edges);
+    let limits = PortableV2Limits::default();
+    let package = root.join("graph.gfpb");
+    let exported = graph
+        .export_portable_v2(
+            &PortableV2ExportRequest {
+                selection: PortableSelection::Current,
+                output_path: package.clone(),
+                representation: PortableV2Output::Bundle,
+                profile: PortableV2SelectionProfile::Complete,
+                subset: None,
+                limits,
+            },
+            None,
+            |_| {},
+        )
+        .unwrap();
+    let verified = verify_portable_v2(
+        &PortableVerifyRequest {
+            input: package.clone(),
+            mode: PortableV2Mode::Full,
+            limits,
+        },
+        None,
+    )
+    .unwrap();
+    assert_eq!(exported.package_digest, verified.package_digest);
+    drop(graph);
+    let imported_path = root.join("imported");
+    let imported = GraphForge::import_portable_v2(
+        &imported_path,
+        &PortableV2ImportRequest {
+            input: package,
+            operation_id: OperationId(Uuid::from_u128(1196)),
+            limits,
+        },
+        None,
+    )
+    .unwrap();
+    assert_eq!(exported.package_digest, imported.package_digest);
+    let imported = GraphForge::new(imported_path.to_str()).unwrap();
+    assert_eq!(verify_graph(&imported, f, nodes, edges), fingerprint);
+    fingerprint
+}
+
+fn parquet_experiment(source: &Path) -> Value {
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let inventory = selected.graph_files_inventory().unwrap().unwrap();
+    let mut seen = BTreeSet::new();
+    let mut sizes = [0_u64; 3];
+    let mut encode_ns = [0_u128; 3];
+    let mut decode_ns = [0_u128; 3];
+    let mut original_bytes = 0_u64;
+    for entry in &inventory.files {
+        if !entry.relative_path.ends_with(".parquet") || !seen.insert(entry.content_sha256.clone())
+        {
+            continue;
+        }
+        let path = graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(&path).unwrap())
+            .unwrap()
+            .with_batch_size(4096);
+        let schema = reader.schema().clone();
+        let original = reader
+            .build()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        original_bytes += entry.byte_length;
+        for (slot, compression) in [
+            Compression::UNCOMPRESSED,
+            Compression::ZSTD(ZstdLevel::try_new(1).unwrap()),
+            Compression::ZSTD(ZstdLevel::try_new(3).unwrap()),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let start = Instant::now();
+            let mut bytes = Vec::new();
+            let mut writer = ArrowWriter::try_new(
+                &mut bytes,
+                schema.clone(),
+                Some(
+                    WriterProperties::builder()
+                        .set_compression(compression)
+                        .build(),
+                ),
+            )
+            .unwrap();
+            for batch in &original {
+                writer.write(batch).unwrap();
+            }
+            writer.close().unwrap();
+            encode_ns[slot] += start.elapsed().as_nanos();
+            sizes[slot] += bytes.len() as u64;
+            let start = Instant::now();
+            let decoded = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))
+                .unwrap()
+                .with_batch_size(4096)
+                .build()
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            decode_ns[slot] += start.elapsed().as_nanos();
+            assert_eq!(
+                decoded, original,
+                "codec {compression:?} must preserve schema, UUIDs, values and nulls"
+            );
+        }
+    }
+    assert!(original_bytes > 0);
+    json!({"production_parquet_bytes": original_bytes, "normalized_bytes_uncompressed_zstd1_zstd3":sizes,
+        "encode_elapsed_ns":encode_ns, "decode_elapsed_ns":decode_ns})
+}
+
+fn pack_identity_records(original: &[u8]) -> Vec<u8> {
+    assert_eq!(original.len() % 32, 0);
+    let mut packed = Vec::with_capacity(original.len() / 32 * 25);
+    for record in original.chunks_exact(32) {
+        assert_eq!(
+            &record[17..24],
+            &[0; 7],
+            "only reserved zero padding is omitted"
+        );
+        packed.extend_from_slice(&record[..17]);
+        packed.extend_from_slice(&record[24..32]);
+    }
+    packed
+}
+
+#[test]
+fn packed_identity_candidate_preserves_full_width_and_tombstone_boundaries() {
+    for uuid in [[0; 16], [255; 16]] {
+        for kind in 0..=3_u8 {
+            for surrogate in [0_u64, 1, u32::MAX.into(), u64::from(u32::MAX) + 1, u64::MAX] {
+                let mut original = [0; 32];
+                original[..16].copy_from_slice(&uuid);
+                original[16] = kind;
+                original[24..32].copy_from_slice(&surrogate.to_be_bytes());
+                let packed = pack_identity_records(&original);
+                assert_eq!(&packed[..16], &uuid);
+                assert_eq!(packed[16], kind);
+                assert_eq!(
+                    u64::from_be_bytes(packed[17..25].try_into().unwrap()),
+                    surrogate
+                );
+            }
+        }
+    }
+}
+
+fn adjacency_codec_experiment(source: &Path) -> Value {
+    use arrow::ipc::{
+        CompressionType,
+        reader::FileReader,
+        writer::{FileWriter, IpcWriteOptions},
+    };
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    selected.graph_files_inventory().unwrap().unwrap();
+    let mut pending = vec![selected.graph_tree_root()];
+    let mut sizes = [0_u64; 3];
+    let mut allocations = [0_u64; 3];
+    let mut encode_ns = [0_u128; 3];
+    let mut decode_ns = [0_u128; 3];
+    let mut source_bytes = 0_u64;
+    let mut shards = 0_u64;
+    let mut largest_decoded_batch = 0_usize;
+    while let Some(directory) = pending.pop() {
+        for entry in std::fs::read_dir(directory).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_dir() {
+                pending.push(entry.path());
+                continue;
+            }
+            if entry
+                .path()
+                .extension()
+                .is_none_or(|extension| extension != "csr")
+            {
+                continue;
+            }
+            let reader = FileReader::try_new(File::open(entry.path()).unwrap(), None).unwrap();
+            let schema = reader.schema();
+            let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+            source_bytes += entry.metadata().unwrap().len();
+            shards += 1;
+            for batch in &batches {
+                largest_decoded_batch = largest_decoded_batch.max(batch.get_array_memory_size());
+            }
+            for (slot, compression) in [
+                None,
+                Some(CompressionType::LZ4_FRAME),
+                Some(CompressionType::ZSTD),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                let started = Instant::now();
+                let mut bytes = Vec::new();
+                let options = IpcWriteOptions::default()
+                    .try_with_compression(compression)
+                    .unwrap();
+                let mut writer =
+                    FileWriter::try_new_with_options(&mut bytes, &schema, options).unwrap();
+                for batch in &batches {
+                    writer.write(batch).unwrap();
+                }
+                writer.finish().unwrap();
+                drop(writer);
+                encode_ns[slot] += started.elapsed().as_nanos();
+                sizes[slot] += bytes.len() as u64;
+                allocations[slot] += (bytes.len() as u64).div_ceil(4096) * 4096;
+                let started = Instant::now();
+                let decoded = FileReader::try_new(std::io::Cursor::new(bytes), None)
+                    .unwrap()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap();
+                assert_eq!(
+                    decoded, batches,
+                    "IPC compression preserves every full-width value and schema"
+                );
+                decode_ns[slot] += started.elapsed().as_nanos();
+            }
+        }
+    }
+    assert!(shards > 0);
+    json!({"shards":shards,"source_bytes":source_bytes,"normalized_bytes_none_lz4_zstd":sizes,
+        "estimated_allocated_bytes_at_4096":allocations,"encode_elapsed_ns":encode_ns,"decode_elapsed_ns":decode_ns,
+        "largest_decoded_batch_array_bytes":largest_decoded_batch,"production_format_changed":false})
+}
+
+fn identity_padding_experiment(source: &Path) -> Value {
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let inventory = selected.graph_files_inventory().unwrap().unwrap();
+    let mut records = 0_u64;
+    let mut runs = 0_u64;
+    for entry in &inventory.files {
+        let name = Path::new(&entry.relative_path)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        if !entry.relative_path.starts_with("topology/uuid-membership/")
+            || !name.starts_with("identities-")
+        {
+            continue;
+        }
+        let original = std::fs::read(
+            graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap(),
+        )
+        .unwrap();
+        let packed = pack_identity_records(&original);
+        let mut restored = Vec::with_capacity(original.len());
+        for record in packed.chunks_exact(25) {
+            restored.extend_from_slice(&record[..17]);
+            restored.extend_from_slice(&[0; 7]);
+            restored.extend_from_slice(&record[17..25]);
+        }
+        assert_eq!(restored, original);
+        // Fixed-width binary search retains exact UUID/kind ordering. Exercise
+        // beginning, midpoint and last identifiers rather than surrogate-only keys.
+        let packed_rows = packed.chunks_exact(25).collect::<Vec<_>>();
+        for row in [
+            0,
+            packed_rows.len() / 2,
+            packed_rows.len().saturating_sub(1),
+        ] {
+            if packed_rows.is_empty() {
+                continue;
+            }
+            let key = &original[row * 32..row * 32 + 17];
+            let found = packed_rows
+                .binary_search_by(|record| record[..17].cmp(key))
+                .unwrap();
+            assert_eq!(
+                &packed_rows[found][17..25],
+                &original[row * 32 + 24..row * 32 + 32]
+            );
+        }
+        records += (original.len() / 32) as u64;
+        runs += 1;
+    }
+    assert!(records > 0);
+    json!({"identity_runs":runs,"records":records,"current_record_bytes":records * 32,
+        "packed_record_bytes":records * 25,"removable_reserved_padding_bytes":records * 7,
+        "production_format_changed":false})
+}
+
+#[test]
+fn permanent_sequential_single_route() {
+    assess(Fixture {
+        name: "sequential_single_route",
+        nodes: 4097,
+        edges: 65537,
+        routes: 1,
+        identifiers: Identifiers::Sequential,
+        properties: false,
+        adjacency: false,
+        heterogeneous: false,
+    });
+}
+#[test]
+fn permanent_random_single_route() {
+    assess(Fixture {
+        name: "random_single_route",
+        nodes: 8193,
+        edges: 65537,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: false,
+        adjacency: false,
+        heterogeneous: false,
+    });
+}
+#[test]
+fn permanent_random_properties_eight_routes() {
+    assess(Fixture {
+        name: "random_properties_eight_routes",
+        nodes: 4097,
+        edges: 65537,
+        routes: 8,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: true,
+        heterogeneous: false,
+    });
+}
+
+#[test]
+fn permanent_heterogeneous_property_schemas() {
+    assess(Fixture {
+        name: "heterogeneous_property_schemas",
+        nodes: 4097,
+        edges: 65537,
+        routes: 4,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: true,
+    });
+}
+
+fn digest_hex(bytes: &[u8]) -> String {
+    let mut result = String::new();
+    for byte in Sha256::digest(bytes) {
+        write!(result, "{byte:02x}").unwrap();
+    }
+    result
+}
+
+type ManifestEntry = graphforge_storage::GraphFileEntry;
+fn build_manifest_candidate(
+    entries: &[(String, ManifestEntry)],
+    depth: usize,
+    objects: &mut BTreeMap<String, Vec<u8>>,
+) -> String {
+    let mut end = depth;
+    while end < 64
+        && entries
+            .iter()
+            .all(|entry| entry.0.as_bytes()[end] == entries[0].0.as_bytes()[end])
+    {
+        end += 1;
+    }
+    let prefix = &entries[0].0[depth..end];
+    assert!(
+        entries.len() <= 8 || end < 64,
+        "oversized hash collision bucket is unsupported"
+    );
+    let node = if entries.len() <= 8 {
+        json!({"format":"graphforge-graph-manifest-radix-node","version":3,"depth":depth,"prefix":prefix,
+            "kind":"bucket","entries":entries.iter().map(|entry| &entry.1).collect::<Vec<_>>()})
+    } else {
+        let mut groups = BTreeMap::<u8, Vec<(String, ManifestEntry)>>::new();
+        for entry in entries {
+            groups
+                .entry(entry.0.as_bytes()[end])
+                .or_default()
+                .push(entry.clone());
+        }
+        let children = groups
+            .into_iter()
+            .map(|(nibble, group)| {
+                (
+                    char::from(nibble).to_string(),
+                    build_manifest_candidate(&group, end + 1, objects),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        json!({"format":"graphforge-graph-manifest-radix-node","version":3,"depth":depth,"prefix":prefix,"kind":"branch","children":children})
+    };
+    let bytes = serde_json::to_vec(&node).unwrap();
+    let digest = digest_hex(&bytes);
+    objects.insert(digest.clone(), bytes);
+    digest
+}
+fn lookup_manifest_candidate(
+    root: &str,
+    path: &str,
+    objects: &BTreeMap<String, Vec<u8>>,
+) -> Option<ManifestEntry> {
+    let key = digest_hex(path.as_bytes());
+    let mut current = root.to_owned();
+    loop {
+        let bytes = &objects[&current];
+        assert_eq!(digest_hex(bytes), current);
+        let node: Value = serde_json::from_slice(bytes).unwrap();
+        let depth = usize::try_from(node["depth"].as_u64().unwrap()).unwrap();
+        let prefix = node["prefix"].as_str().unwrap();
+        if !key[depth..].starts_with(prefix) {
+            return None;
+        }
+        if node["kind"] == "bucket" {
+            let entries: Vec<ManifestEntry> =
+                serde_json::from_value(node["entries"].clone()).unwrap();
+            assert!(entries.len() <= 8);
+            return entries
+                .into_iter()
+                .find(|entry| entry.relative_path == path);
+        }
+        node["children"][&key[depth + prefix.len()..=depth + prefix.len()]]
+            .as_str()?
+            .clone_into(&mut current);
+    }
+}
+fn bucket_manifest_experiment(source: &Path) -> Value {
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let participant = selected
+        .participant_snapshot(
+            graphforge_storage::GRAPH_CAPABILITY_ID,
+            graphforge_storage::GRAPH_FILES_FAMILY,
+        )
+        .unwrap()
+        .unwrap();
+    let root: Value = serde_json::from_slice(&participant.bytes).unwrap();
+    let entries = selected.graph_files_inventory().unwrap().unwrap().files;
+    let mut original = BTreeMap::new();
+    let mut pending = vec![root["root_node_sha256"].as_str().unwrap().to_owned()];
+    while let Some(digest) = pending.pop() {
+        if original.contains_key(&digest) {
+            continue;
+        }
+        assert!(original.len() <= 2 * entries.len() + 1);
+        let bytes =
+            std::fs::read(graphforge_storage::graph_object_path(source, &digest).unwrap()).unwrap();
+        assert_eq!(digest_hex(&bytes), digest);
+        let node: Value = serde_json::from_slice(&bytes).unwrap();
+        match node["kind"].as_str().unwrap() {
+            "branch" => pending.extend(
+                node["children"]
+                    .as_object()
+                    .unwrap()
+                    .values()
+                    .map(|child| child.as_str().unwrap().to_owned()),
+            ),
+            "leaf" => {}
+            other => panic!("unsupported assessment manifest node {other}"),
+        }
+        original.insert(digest, bytes);
+    }
+    let mut keyed = entries
+        .iter()
+        .map(|entry| (digest_hex(entry.relative_path.as_bytes()), entry.clone()))
+        .collect::<Vec<_>>();
+    keyed.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut candidate = BTreeMap::new();
+    let root = build_manifest_candidate(&keyed, 0, &mut candidate);
+    for entry in &entries {
+        assert_eq!(
+            lookup_manifest_candidate(&root, &entry.relative_path, &candidate),
+            Some(entry.clone())
+        );
+    }
+    assert!(lookup_manifest_candidate(&root, "absent-assessment-payload", &candidate).is_none());
+    let original_allocated: u64 = original
+        .keys()
+        .map(|digest| {
+            let file =
+                File::open(graphforge_storage::graph_object_path(source, digest).unwrap()).unwrap();
+            graphforge_filesystem::file_space_usage(&file)
+                .unwrap()
+                .allocated_bytes
+        })
+        .sum();
+    let candidate_logical: usize = candidate.values().map(Vec::len).sum();
+    let candidate_quantized: usize = candidate
+        .values()
+        .map(|bytes| bytes.len().div_ceil(4096) * 4096)
+        .sum();
+    json!({"source_manifest_objects":original.len(),"source_manifest_allocated_bytes":original_allocated,
+        "candidate_bucket_capacity":8,"candidate_objects":candidate.len(),"candidate_logical_bytes":candidate_logical,
+        "candidate_estimated_allocated_bytes_at_4096":candidate_quantized,"authenticated_lookups_checked":entries.len(),
+        "production_format_changed":false})
+}
+
+fn validate_storage_budgets(f: Fixture, storage: &graphforge_storage::StorageAttributionSnapshot) {
+    use graphforge_storage::ArtifactCategory as Category;
+    let nodes = f.nodes as u64;
+    let edges = f.edges as u64;
+    let routes = f.routes as u64;
+    let node_shards = nodes.div_ceil(1024) * routes;
+    let edge_shards = edges.div_ceil(1024) * routes;
+    // Input batches bound fragment counts. Allow one footer/header block per
+    // Parquet fragment, and one allocation block of EOF rounding per object.
+    // These are payload/representation ceilings, not measured-value multipliers.
+    for (category, object_limit, logical_limit) in [
+        (
+            Category::TopologyNodes,
+            node_shards,
+            48 * nodes + 2048 * node_shards,
+        ),
+        (
+            Category::TopologyEdges,
+            edge_shards,
+            96 * edges + 2048 * edge_shards,
+        ),
+        (
+            Category::Properties,
+            if f.properties {
+                node_shards + edge_shards
+            } else {
+                0
+            },
+            if f.properties {
+                64 * (nodes + edges) + 2048 * (node_shards + edge_shards)
+            } else {
+                0
+            },
+        ),
+        // 32-byte UUID/kind/ordinal rows plus up to 64 bytes/node of independent
+        // forward/reverse ordinal/surrogate authority and bounded manifests.
+        (
+            Category::UuidAndSurrogates,
+            32,
+            32 * (nodes + edges) + 64 * nodes + 131_072,
+        ),
+        // Enabled sparse inbound/outbound CSR stores endpoints and edge identity
+        // plus offsets/routes; absent adjacency must remain exactly absent.
+        (
+            Category::Adjacency,
+            if f.adjacency { 8 * routes + 16 } else { 0 },
+            if f.adjacency {
+                80 * edges + 16 * nodes + 8192 * (routes + 1)
+            } else {
+                0
+            },
+        ),
+    ] {
+        let totals = &storage.categories[&category];
+        assert!(
+            totals.physical_objects <= object_limit,
+            "{category:?} object budget: {totals:?}"
+        );
+        assert!(
+            totals.physical_logical_bytes <= logical_limit,
+            "{category:?} logical budget {logical_limit}: {totals:?}"
+        );
+        assert!(
+            totals.allocated_bytes
+                <= totals.physical_logical_bytes + 4096 * totals.physical_objects,
+            "{category:?} allocation exceeds one 4-KiB EOF rounding block per object"
+        );
+    }
+    let controls = &storage.categories[&Category::CatalogAndManifests];
+    let payload_objects = storage.physical_objects - controls.physical_objects;
+    assert!(controls.physical_objects <= 2 * payload_objects + 32);
+    assert!(controls.physical_logical_bytes <= 2048 * payload_objects + 65536);
+    assert!(
+        controls.allocated_bytes
+            <= controls.physical_logical_bytes + 4096 * controls.physical_objects
+    );
+}
+
+fn assess(f: Fixture) {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let (nodes, edges) = rows(f);
+    let started = Instant::now();
+    construct(&source, f, &nodes, &edges);
+    let construction_ns = started.elapsed().as_nanos();
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let unindexed = graph.storage_attribution().unwrap();
+    assert_eq!(
+        unindexed.categories[&graphforge_storage::ArtifactCategory::Adjacency].allocated_bytes,
+        0
+    );
+    validate_storage_budgets(
+        Fixture {
+            adjacency: false,
+            ..f
+        },
+        &unindexed,
+    );
+    // Candidate codecs inspect construction's published payload generation.
+    // Adjacency publication may switch to a generation-owned graph tree.
+    let experiment = parquet_experiment(&source);
+    let identity_experiment = identity_padding_experiment(&source);
+    let manifest_experiment = bucket_manifest_experiment(&source);
+    if f.adjacency {
+        graph.rebuild_adjacency(None).unwrap();
+    }
+    let adjacency_experiment = f.adjacency.then(|| adjacency_codec_experiment(&source));
+    let storage = graph.storage_attribution().unwrap();
+    storage.validate_for_qualification().unwrap();
+    validate_storage_budgets(f, &storage);
+    assert_eq!(
+        storage.categories[&graphforge_storage::ArtifactCategory::Adjacency].allocated_bytes > 0,
+        f.adjacency,
+        "unbuilt and built adjacency are distinct measured capabilities"
+    );
+    drop(graph);
+    let fingerprint = round_trip(root.path(), &source, f, &nodes, &edges);
+    println!(
+        "PERMANENT_STORAGE_ASSESSMENT {}",
+        json!({"fixture":f.name,"nodes":f.nodes,"edges":f.edges,"routes":f.routes,"random_ids":matches!(f.identifiers, Identifiers::Random),"properties":f.properties,"heterogeneous_schemas":f.heterogeneous,"adjacency_built":f.adjacency,"unindexed_allocated_bytes":unindexed.allocated_bytes,"unindexed_categories":unindexed.categories,
+            "construction_elapsed_ns":construction_ns,"semantic_fingerprint":fingerprint,
+            "permanent": {"logical_bytes":storage.logical_bytes,"physical_logical_bytes":storage.physical_logical_bytes,"allocated_bytes":storage.allocated_bytes,"physical_objects":storage.physical_objects,"categories":storage.categories},
+            "adjacency_codec_experiment":adjacency_experiment,"parquet_experiment":experiment,"identity_padding_experiment":identity_experiment,"manifest_bucket_experiment":manifest_experiment})
+    );
+}

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -73,6 +73,11 @@ bytes; the separate attribution report remains the authority for permanent alloc
 
 ## Candidate decisions
 
+The maintainer explicitly waived backward compatibility on 2026-09-10 because
+GraphForge is pre-v1. The selected repairs do not require legacy codecs or
+migration machinery. Current-format authentication, active snapshots, exact
+semantics, recovery and bounded resource use remain required.
+
 Experiments rewrite identical Arrow batches and assert exact decoded equality.
 They do not publish a candidate production format. Normalized uncompressed
 Parquet matches measured source bytes in these fixtures, but codec comparisons
@@ -82,9 +87,9 @@ single-run exploratory observations, not performance acceptance thresholds.
 | Candidate | Quantified evidence and bounded follow-up | Tradeoffs and compatibility |
 | --- | --- | --- |
 | Parquet Zstd level 1 (#1202) | Random fixtures save 23–25% of Parquet bytes; sequential fixture saves 81.5%. Production follow-up must reproduce these fixture reductions and exact public round trips. | Lower storage/read I/O; additional encode/decode CPU. Keep bounded row groups, existing checksums and reader codec support. Level 3 is slightly worse for random fixtures. |
-| Remove membership reserved padding (#1203) | 69,634 actual records: 2,228,288→1,740,850 bytes, saving exactly 487,438 raw bytes; 73,730 records save 516,110. | This is a 25-byte candidate, not a narrower identifier. Requires versioned readers/writers and mixed legacy/new runs, full u64/kind/tombstone boundaries, recovery and bounded binary search. Physical savings depend on file rounding and migration overlap. |
-| Bounded manifest buckets (#1204) | Heterogeneous fixture: 750 node objects / 3,072,000 allocated bytes versus 238 candidate objects / estimated 974,848 bytes at 4 KiB. All 544 file entries resolve with SHA-authenticated lookup. | Fewer small-file reads/allocations; a lookup decodes up to eight entries. Production must bound serialized bytes as well as entry count, preserve legacy nodes, split/update/delete correctly, reject corruption and preserve active snapshots. Estimate excludes root metadata, history and migration overlap. |
-| CSR IPC compression (#1205) | 18 shards: 4,920,564 bytes uncompressed, 2,320,564 LZ4, 1,324,020 Zstd. Estimated allocated bytes: 4,972,544→1,363,968 with Zstd. Largest decoded batch arrays: 3,322,008 bytes (not process RSS). Exact schemas and values match. | Cold lookup gains lower read I/O but incurs decompression CPU and temporary buffers; warm decoded cache behavior remains similar. Preserve full u64 fields and shard boundaries; budget decode memory and support legacy IPC before changing writes. |
+| Remove membership reserved padding (#1203) | 69,634 actual records: 2,228,288→1,740,850 bytes, saving exactly 487,438 raw bytes; 73,730 records save 516,110. | This is a 25-byte candidate, not a narrower identifier. Requires consistent current-format readers/writers, full u64/kind/tombstone boundaries, recovery and bounded binary search. Physical savings depend on file rounding. |
+| Bounded manifest buckets (#1204) | Heterogeneous fixture: 750 node objects / 3,072,000 allocated bytes versus 238 candidate objects / estimated 974,848 bytes at 4 KiB. All 544 file entries resolve with SHA-authenticated lookup. | Fewer small-file reads/allocations; a lookup decodes up to eight entries. Production must bound serialized bytes as well as entry count, split/update/delete correctly, reject corruption and preserve active snapshots. Estimate excludes root metadata and history. |
+| CSR IPC compression (#1205) | 18 shards: 4,920,564 bytes uncompressed, 2,320,564 LZ4, 1,324,020 Zstd. Estimated allocated bytes: 4,972,544→1,363,968 with Zstd. Largest decoded batch arrays: 3,322,008 bytes (not process RSS). Exact schemas and values match. | Cold lookup gains lower read I/O but incurs decompression CPU and temporary buffers; warm decoded cache behavior remains similar. Preserve full u64 fields and shard boundaries; budget decode memory before changing writes. |
 | Delete repeated identity or directional indexes | No change: distinct access and recovery contracts remain in use. | No evidence that removal preserves bounded membership, reverse hydration or relation/union traversal. |
 
 ## Regression ceilings

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -9,9 +9,18 @@ queries after reopen and after export → full verification → clean import.
 ## Reproduction
 
 The fixture is `crates/graphforge-api/tests/permanent_storage_budgets.rs`.
-The initial measurements below use main `345b01085d8566a492b9364eedbf0bb68d0a5a2c`
-plus that assessment fixture; the integrated baseline is recorded below when
-validation completes. Rust is 1.96.0 (`ac68faa20`), Arrow/Parquet 58.4.0.
+The integrated runtime source is `83a153f164faa2f7dc276e593719ec71e7e0bc9e`,
+based on merged lifecycle main `0539c8eed0be6c5de9b5a7ef83b265e5f3dc0f79`.
+All five tests passed on OVHC-AGENCY, Linux 7.0.0-30, process-root ext4.
+Rust is 1.96.0 (`ac68faa20`), Arrow/Parquet 58.4.0.
+[Raw aggregate evidence](../../development/evidence/permanent-storage-1196.json)
+records each numerator, denominator and semantic fingerprint. The standalone
+serial test binary took 449.10 seconds; `/usr/bin/time -v` measured 268,780 KiB
+maximum RSS, 397.56 user seconds and 31.65 system seconds. These include the
+entire construction/query/export/import assessment, not codec-only memory or CPU.
+The binary was built with `cargo test ... --no-run` before timing, so compilation
+is excluded. The initial pre-lifecycle baseline reproduced the same permanent
+bytes and exact semantic fingerprints.
 Run on an admitted native filesystem with 4096-byte allocation blocks:
 
 ```sh
@@ -46,7 +55,10 @@ categories are topology nodes 135,168; topology edges 7,307,264; properties
 5,488,640; UUID/surrogates 2,523,136; adjacency 5,050,368; manifests/catalog
 335,872. The executable report emits every category's logical bytes, physical
 logical bytes, allocated bytes, references and unique objects for every fixture.
-No graph values or UUIDs are included in that aggregate report.
+No graph values or UUIDs are included in that aggregate report. The indexed
+case has 37 adjacency references and 37 physical objects, establishing that its
+18 CSR shard files are physically distinct. The codec experiment sums shard-file
+bytes; the separate attribution report remains the authority for permanent allocation.
 
 ## Authority and access contracts
 

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -1,0 +1,104 @@
+# Permanent storage assessment (#1196)
+
+This assessment measures one authoritative published graph. Construction inputs,
+private staging, the portable package and the clean import are separate owners.
+It uses `GraphForge::storage_attribution`, including physical-object deduplication,
+and executes exact UUID, endpoint, label, relationship and nullable-property
+queries after reopen and after export → full verification → clean import.
+
+## Reproduction
+
+The fixture is `crates/graphforge-api/tests/permanent_storage_budgets.rs`.
+The initial measurements below use main `345b01085d8566a492b9364eedbf0bb68d0a5a2c`
+plus that assessment fixture; the integrated baseline is recorded below when
+validation completes. Rust is 1.96.0 (`ac68faa20`), Arrow/Parquet 58.4.0.
+Run on an admitted native filesystem with 4096-byte allocation blocks:
+
+```sh
+CARGO_TARGET_DIR=/path/to/isolated-target TMPDIR=/path/on/native-root \
+  cargo test -p graphforge-api --test permanent_storage_budgets -- --nocapture --test-threads=1
+```
+
+All fixtures contain 65,537 edges. Sequential IDs use an explicit domain byte
+and increasing integer; random IDs use all 128 bits from a deterministic SHA-256
+prefix, without a UUID version mask. Construction chunks contain 1,024 records,
+merge fan-in is two, and the maximum run contains 4,096 records. Routes alternate
+by row, including parallel edges and self loops. Properties include nullable
+integers, repeated categorical strings and distinct strings. The heterogeneous
+case alternates chunks that omit a property field entirely. These definitions
+cross chunk, merge and route boundaries and preserve external identities.
+
+## Measured permanent ownership
+
+Bytes are raw bytes, not MB. Adjacency is absent except in the explicitly indexed
+case. The indexed publication currently changes manifest representation; its
+smaller total despite adding CSR is therefore not a claim that indexes are free.
+
+| Fixture | Nodes | Routes | Permanent allocated | Physical logical | Parquet bytes | Zstd level 1 candidate |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Sequential, no properties | 4,097 | 1 | 8,388,608 | 7,813,955 | 5,262,627 | 973,925 |
+| Random, no properties | 8,193 | 1 | 8,929,280 | 8,266,084 | 5,318,519 | 4,015,814 |
+| Random, properties, CSR built | 4,097 | 8 | 20,840,448 | 17,962,542 | 10,231,116 | 7,845,372 |
+| Random, heterogeneous properties | 4,097 | 4 | 14,929,920 | 11,219,825 | 8,357,272 | 6,398,839 |
+
+The eight-route case before CSR is 21,446,656 allocated bytes. Its indexed
+categories are topology nodes 135,168; topology edges 7,307,264; properties
+5,488,640; UUID/surrogates 2,523,136; adjacency 5,050,368; manifests/catalog
+335,872. The executable report emits every category's logical bytes, physical
+logical bytes, allocated bytes, references and unique objects for every fixture.
+No graph values or UUIDs are included in that aggregate report.
+
+## Authority and access contracts
+
+| Representation and source | Meaning and consumer | Retention requirement |
+| --- | --- | --- |
+| Node/edge Parquet, `graph_construction_encoding.rs` | Canonical external UUIDs, endpoint UUIDs, runtime label/type IDs, surrogates and property routing; scan and hydration readers | Preserve exact values, schema and nulls. Runtime catalog IDs are not ontology IDs. |
+| Property Parquet, same encoder | Typed values and routing/tombstone metadata; selective property hydration | Similar identity columns provide joins and are not proven redundant. |
+| Membership v3, `uuid_membership.rs` | UUID16 + kind1 + reserved7 + surrogate8; sorted membership and conflict probes, including tombstones | SHA, ordering, full-width surrogate and kind remain authoritative for bounded reopen/probes. |
+| Ordinal v4, `ordinal_identity_v4.rs` | UUID→ordinal records (24 bytes), ordinal→UUID (16 bytes), tombstones | Forward and reverse probes serve different access directions; do not delete either based on repeated UUID bytes. |
+| CSR shard v1, `adjacency.rs` | Arrow IPC lists of full-width u64 edge/neighbor IDs and offsets; per-relation and union in/out traversal | Whole bounded shard is authenticated and decoded on cache miss. Union and relation indexes serve distinct queries. |
+| Patricia node v2, `graph_manifest.rs` | SHA-addressed path→full file metadata; authenticated lookup and copy-on-write publication | Every entry digest, length, kind and path remains protected; active generations retain old nodes. |
+
+## Candidate decisions
+
+Experiments rewrite identical Arrow batches and assert exact decoded equality.
+They do not publish a candidate production format. Normalized uncompressed
+Parquet matches measured source bytes in these fixtures, but codec comparisons
+are explicitly against the normalized baseline. Elapsed encode/decode times are
+single-run exploratory observations, not performance acceptance thresholds.
+
+| Candidate | Quantified evidence and bounded follow-up | Tradeoffs and compatibility |
+| --- | --- | --- |
+| Parquet Zstd level 1 (#1202) | Random fixtures save 23–25% of Parquet bytes; sequential fixture saves 81.5%. Production follow-up must reproduce these fixture reductions and exact public round trips. | Lower storage/read I/O; additional encode/decode CPU. Keep bounded row groups, existing checksums and reader codec support. Level 3 is slightly worse for random fixtures. |
+| Remove membership reserved padding (#1203) | 69,634 actual records: 2,228,288→1,740,850 bytes, saving exactly 487,438 raw bytes; 73,730 records save 516,110. | This is a 25-byte candidate, not a narrower identifier. Requires versioned readers/writers and mixed legacy/new runs, full u64/kind/tombstone boundaries, recovery and bounded binary search. Physical savings depend on file rounding and migration overlap. |
+| Bounded manifest buckets (#1204) | Heterogeneous fixture: 750 node objects / 3,072,000 allocated bytes versus 238 candidate objects / estimated 974,848 bytes at 4 KiB. All 544 file entries resolve with SHA-authenticated lookup. | Fewer small-file reads/allocations; a lookup decodes up to eight entries. Production must bound serialized bytes as well as entry count, preserve legacy nodes, split/update/delete correctly, reject corruption and preserve active snapshots. Estimate excludes root metadata, history and migration overlap. |
+| CSR IPC compression (#1205) | 18 shards: 4,920,564 bytes uncompressed, 2,320,564 LZ4, 1,324,020 Zstd. Estimated allocated bytes: 4,972,544→1,363,968 with Zstd. Largest decoded batch arrays: 3,322,008 bytes (not process RSS). Exact schemas and values match. | Cold lookup gains lower read I/O but incurs decompression CPU and temporary buffers; warm decoded cache behavior remains similar. Preserve full u64 fields and shard boundaries; budget decode memory and support legacy IPC before changing writes. |
+| Delete repeated identity or directional indexes | No change: distinct access and recovery contracts remain in use. | No evidence that removal preserves bounded membership, reverse hydration or relation/union traversal. |
+
+## Regression ceilings
+
+These are fixture-specific ceilings, not universal bytes-per-edge promises.
+Let N/E be fixture rows and R its routes. The test allows at most
+`ceil(N/1024)*R` node fragments and `ceil(E/1024)*R` edge fragments, an intentionally
+conservative upper bound from construction's chunk/route partitioning.
+Topology logical ceilings allow 48 bytes/node and 96 bytes/edge plus 2 KiB per
+possible fragment; this covers the fixed-width identity/surrogate columns and
+these fixtures' Parquet framing/dictionaries. Property rows allow 64 bytes plus
+the same fragment framing allowance, covering their fixed integer and bounded
+string payloads. These allowances must be reconsidered if fixture schemas change.
+
+UUID bytes allow 32 per identity, 64 per node for forward/reverse authorities,
+and 128 KiB for manifests. At most 32 UUID objects allows bounded run and ordinal
+fragments for these configurations. CSR allows 80 bytes/edge plus 16 bytes/node
+and 8 KiB per route/union: u64 edge/neighbor pairs occur in in/out relation and
+union paths, with room for offsets and framing. Manifests allow 2 KiB per payload
+object plus 64 KiB controls and at most twice the payload count plus 32 objects.
+These ceilings detect representation amplification while allowing format compaction.
+
+Allocated bytes are separately bounded by physical logical bytes plus 4096 bytes
+per unique object. The 4-KiB rounding assumption belongs to the measured host;
+it is not a portable guarantee for arbitrary allocation units. Each category is
+checked independently, so added CSR cannot hide growing topology or manifests.
+Final production repairs also require recovery, snapshot, corruption and resource
+budgets appropriate to their changed surface. Larger-scale confirmation reuses
+#900's admitted ladder; this assessment does not authorize S24/S26 execution.

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -1,5 +1,8 @@
 # Storage Architecture
 
+See the [permanent storage assessment](permanent-storage-assessment.md) for
+source-backed ownership baselines, lossless codec experiments and regression budgets.
+
 **Status:** v0.5.0 — Parquet project storage shipped
 **Last Updated:** 2026-08-30
 

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -87,6 +87,7 @@ Authoritative machine-readable map: `tools/bazel/parity/migration_target_map.jso
 | `graphforge-api` | `algorithm_public_surface` | `integration-test` | `crates/graphforge-api/tests/algorithm_public_surface.rs` | `//crates/graphforge-api:algorithm_public_surface` | `mapped` | #8 |
 | `graphforge-api` | `search_public_surface` | `integration-test` | `crates/graphforge-api/tests/search_public_surface.rs` | `//crates/graphforge-api:search_public_surface` | `mapped` | #8 |
 | `graphforge-api` | `scale_g500_scale20` | `integration-test` | `crates/graphforge-api/tests/scale_g500_scale20.rs` | `//crates/graphforge-api:scale_g500_scale20` | `mapped` | #710 |
+| `graphforge-api` | `permanent_storage_budgets` | `integration-test` | `crates/graphforge-api/tests/permanent_storage_budgets.rs` | `//crates/graphforge-api:permanent_storage_budgets` | `mapped` | #1196 permanent ownership and lossless codec assessment |
 | `graphforge-api` | `scale_g500_ladder` | `integration-test` | `crates/graphforge-api/tests/scale_g500_ladder.rs` | `//crates/graphforge-api:scale_g500_ladder` | `mapped` | #736 |
 | `graphforge-api` | `provider_public_surface` | `integration-test` | `crates/graphforge-api/tests/provider_public_surface.rs` | `//crates/graphforge-api:provider_public_surface` | `mapped` | #8 |
 | `graphforge-api` | `m4_entry_baseline` | `integration-test` | `crates/graphforge-api/tests/m4_entry_baseline.rs` | `//crates/graphforge-api:m4_entry_baseline` | `mapped` | #8 |

--- a/docs/development/evidence/permanent-storage-1196.json
+++ b/docs/development/evidence/permanent-storage-1196.json
@@ -1,0 +1,847 @@
+{
+  "source_commit": "83a153f164faa2f7dc276e593719ec71e7e0bc9e",
+  "integrated_main": "0539c8eed0be6c5de9b5a7ef83b265e5f3dc0f79",
+  "toolchain": "rustc 1.96.0 (ac68faa20 2026-05-25)",
+  "arrow_parquet": "58.4.0",
+  "host": "OVHC-AGENCY",
+  "kernel": "7.0.0-30-generic",
+  "filesystem": "ext4 on process-root volume",
+  "allocation_block_bytes": 4096,
+  "command": "cargo test -p graphforge-api --test permanent_storage_budgets --no-run; then /usr/bin/time -v <built permanent_storage_budgets binary> --nocapture --test-threads=1",
+  "result": {
+    "passed": 5,
+    "failed": 0,
+    "elapsed_seconds": 449.1,
+    "process_max_rss_kib": 268780,
+    "process_user_seconds": 397.56,
+    "process_system_seconds": 31.65
+  },
+  "resource_scope": "Whole serial test process: construction, candidate experiments, exact queries, export, verification and clean import. Not codec-only RSS/CPU and not an S22/S26 qualification.",
+  "fixtures": [
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 32585370852,
+      "edges": 65537,
+      "fixture": "heterogeneous_property_schemas",
+      "heterogeneous_schemas": true,
+      "identity_padding_experiment": {
+        "current_record_bytes": 2228288,
+        "identity_runs": 2,
+        "packed_record_bytes": 1740850,
+        "production_format_changed": false,
+        "records": 69634,
+        "removable_reserved_padding_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 544,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 974848,
+        "candidate_logical_bytes": 194662,
+        "candidate_objects": 238,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 3072000,
+        "source_manifest_objects": 750
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          223578374,
+          275459408,
+          276902601
+        ],
+        "encode_elapsed_ns": [
+          826052221,
+          994867913,
+          1023920722
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          8357272,
+          6398839,
+          6420637
+        ],
+        "production_parquet_bytes": 8357272
+      },
+      "permanent": {
+        "allocated_bytes": 14929920,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 3104768,
+            "logical_bytes": 371637,
+            "logical_references": 758,
+            "physical_logical_bytes": 371637,
+            "physical_objects": 758
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 3010560,
+            "logical_bytes": 2628136,
+            "logical_references": 266,
+            "physical_logical_bytes": 2628136,
+            "physical_objects": 266
+          },
+          "topology_edges": {
+            "allocated_bytes": 6172672,
+            "logical_bytes": 5609280,
+            "logical_references": 257,
+            "physical_logical_bytes": 5609280,
+            "physical_objects": 257
+          },
+          "topology_nodes": {
+            "allocated_bytes": 118784,
+            "logical_bytes": 116475,
+            "logical_references": 5,
+            "physical_logical_bytes": 116475,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 2523136,
+            "logical_bytes": 2494297,
+            "logical_references": 12,
+            "physical_logical_bytes": 2494297,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 11219825,
+        "physical_logical_bytes": 11219825,
+        "physical_objects": 1295
+      },
+      "properties": true,
+      "random_ids": true,
+      "routes": 4,
+      "semantic_fingerprint": "5c704d8bf7e1851e1631e6f36bc37495f9d9d9e1e9b94950e84310b545824ec2",
+      "unindexed_allocated_bytes": 14929920,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 3104768,
+          "logical_bytes": 371637,
+          "logical_references": 758,
+          "physical_logical_bytes": 371637,
+          "physical_objects": 758
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 3010560,
+          "logical_bytes": 2628136,
+          "logical_references": 266,
+          "physical_logical_bytes": 2628136,
+          "physical_objects": 266
+        },
+        "topology_edges": {
+          "allocated_bytes": 6172672,
+          "logical_bytes": 5609280,
+          "logical_references": 257,
+          "physical_logical_bytes": 5609280,
+          "physical_objects": 257
+        },
+        "topology_nodes": {
+          "allocated_bytes": 118784,
+          "logical_bytes": 116475,
+          "logical_references": 5,
+          "physical_logical_bytes": 116475,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2523136,
+          "logical_bytes": 2494297,
+          "logical_references": 12,
+          "physical_logical_bytes": 2494297,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": true,
+      "adjacency_codec_experiment": {
+        "decode_elapsed_ns": [
+          5656325,
+          111756602,
+          40124615
+        ],
+        "encode_elapsed_ns": [
+          3806917,
+          196795157,
+          115537747
+        ],
+        "estimated_allocated_bytes_at_4096": [
+          4972544,
+          2351104,
+          1363968
+        ],
+        "largest_decoded_batch_array_bytes": 3322008,
+        "normalized_bytes_none_lz4_zstd": [
+          4920564,
+          2320564,
+          1324020
+        ],
+        "production_format_changed": false,
+        "shards": 18,
+        "source_bytes": 4920564
+      },
+      "construction_elapsed_ns": 38130959897,
+      "edges": 65537,
+      "fixture": "random_properties_eight_routes",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 2228288,
+        "identity_runs": 2,
+        "packed_record_bytes": 1740850,
+        "production_format_changed": false,
+        "records": 69634,
+        "removable_reserved_padding_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 1080,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 1372160,
+        "candidate_logical_bytes": 359810,
+        "candidate_objects": 335,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 5959680,
+        "source_manifest_objects": 1455
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          377274994,
+          443486142,
+          446263805
+        ],
+        "encode_elapsed_ns": [
+          1243810057,
+          1478204228,
+          1498936474
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          10231116,
+          7845372,
+          7861925
+        ],
+        "production_parquet_bytes": 10231116
+      },
+      "permanent": {
+        "allocated_bytes": 20840448,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 5050368,
+            "logical_bytes": 4930822,
+            "logical_references": 37,
+            "physical_logical_bytes": 4930822,
+            "physical_objects": 37
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 335872,
+            "logical_bytes": 309922,
+            "logical_references": 8,
+            "physical_logical_bytes": 309922,
+            "physical_objects": 8
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 5488640,
+            "logical_bytes": 3805992,
+            "logical_references": 546,
+            "physical_logical_bytes": 3805992,
+            "physical_objects": 546
+          },
+          "topology_edges": {
+            "allocated_bytes": 7307264,
+            "logical_bytes": 6303882,
+            "logical_references": 513,
+            "physical_logical_bytes": 6303882,
+            "physical_objects": 513
+          },
+          "topology_nodes": {
+            "allocated_bytes": 135168,
+            "logical_bytes": 117627,
+            "logical_references": 5,
+            "physical_logical_bytes": 117627,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 2523136,
+            "logical_bytes": 2494297,
+            "logical_references": 12,
+            "physical_logical_bytes": 2494297,
+            "physical_objects": 12
+          }
+        },
+        "logical_bytes": 17962542,
+        "physical_logical_bytes": 17962542,
+        "physical_objects": 1121
+      },
+      "properties": true,
+      "random_ids": true,
+      "routes": 8,
+      "semantic_fingerprint": "1a4578d5b5d6c474b1fd9de5478fd2afe0f69e1456f3964d410bc6e0fd3e8b51",
+      "unindexed_allocated_bytes": 21446656,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 5992448,
+          "logical_bytes": 728070,
+          "logical_references": 1463,
+          "physical_logical_bytes": 728070,
+          "physical_objects": 1463
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 5488640,
+          "logical_bytes": 3805992,
+          "logical_references": 546,
+          "physical_logical_bytes": 3805992,
+          "physical_objects": 546
+        },
+        "topology_edges": {
+          "allocated_bytes": 7307264,
+          "logical_bytes": 6303882,
+          "logical_references": 513,
+          "physical_logical_bytes": 6303882,
+          "physical_objects": 513
+        },
+        "topology_nodes": {
+          "allocated_bytes": 135168,
+          "logical_bytes": 117627,
+          "logical_references": 5,
+          "physical_logical_bytes": 117627,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2523136,
+          "logical_bytes": 2494297,
+          "logical_references": 12,
+          "physical_logical_bytes": 2494297,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 22675561251,
+      "edges": 65537,
+      "fixture": "random_single_route",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 2359360,
+        "identity_runs": 2,
+        "packed_record_bytes": 1843250,
+        "production_format_changed": false,
+        "records": 73730,
+        "removable_reserved_padding_bytes": 516110
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 90,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 151552,
+        "candidate_logical_bytes": 30310,
+        "candidate_objects": 37,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 499712,
+        "source_manifest_objects": 122
+      },
+      "nodes": 8193,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          54905110,
+          73588562,
+          74361975
+        ],
+        "encode_elapsed_ns": [
+          343178438,
+          422543943,
+          452822184
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          5318519,
+          4015814,
+          4047391
+        ],
+        "production_parquet_bytes": 5318519
+      },
+      "permanent": {
+        "allocated_bytes": 8929280,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 532480,
+            "logical_bytes": 62970,
+            "logical_references": 130,
+            "physical_logical_bytes": 62970,
+            "physical_objects": 130
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "topology_edges": {
+            "allocated_bytes": 5246976,
+            "logical_bytes": 5089052,
+            "logical_references": 65,
+            "physical_logical_bytes": 5089052,
+            "physical_objects": 65
+          },
+          "topology_nodes": {
+            "allocated_bytes": 233472,
+            "logical_bytes": 226439,
+            "logical_references": 9,
+            "physical_logical_bytes": 226439,
+            "physical_objects": 9
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 2916352,
+            "logical_bytes": 2887623,
+            "logical_references": 12,
+            "physical_logical_bytes": 2887623,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 8266084,
+        "physical_logical_bytes": 8266084,
+        "physical_objects": 213
+      },
+      "properties": false,
+      "random_ids": true,
+      "routes": 1,
+      "semantic_fingerprint": "6ce665fa15e02a8781492c112961d22d14fa79e33d0fd22bbedfc29958308030",
+      "unindexed_allocated_bytes": 8929280,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 532480,
+          "logical_bytes": 62970,
+          "logical_references": 130,
+          "physical_logical_bytes": 62970,
+          "physical_objects": 130
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 5246976,
+          "logical_bytes": 5089052,
+          "logical_references": 65,
+          "physical_logical_bytes": 5089052,
+          "physical_objects": 65
+        },
+        "topology_nodes": {
+          "allocated_bytes": 233472,
+          "logical_bytes": 226439,
+          "logical_references": 9,
+          "physical_logical_bytes": 226439,
+          "physical_objects": 9
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2916352,
+          "logical_bytes": 2887623,
+          "logical_references": 12,
+          "physical_logical_bytes": 2887623,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 21899367730,
+      "edges": 65537,
+      "fixture": "sequential_single_route",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 2228288,
+        "identity_runs": 2,
+        "packed_record_bytes": 1740850,
+        "production_format_changed": false,
+        "records": 69634,
+        "removable_reserved_padding_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 86,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 126976,
+        "candidate_logical_bytes": 28137,
+        "candidate_objects": 31,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 466944,
+        "source_manifest_objects": 114
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          86435312,
+          130275739,
+          123881411
+        ],
+        "encode_elapsed_ns": [
+          479204570,
+          594293938,
+          605830582
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          5262627,
+          973925,
+          960425
+        ],
+        "production_parquet_bytes": 5262627
+      },
+      "permanent": {
+        "allocated_bytes": 8388608,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 499712,
+            "logical_bytes": 60059,
+            "logical_references": 122,
+            "physical_logical_bytes": 60059,
+            "physical_objects": 122
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "topology_edges": {
+            "allocated_bytes": 5246976,
+            "logical_bytes": 5145316,
+            "logical_references": 65,
+            "physical_logical_bytes": 5145316,
+            "physical_objects": 65
+          },
+          "topology_nodes": {
+            "allocated_bytes": 118784,
+            "logical_bytes": 114283,
+            "logical_references": 5,
+            "physical_logical_bytes": 114283,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 2523136,
+            "logical_bytes": 2494297,
+            "logical_references": 12,
+            "physical_logical_bytes": 2494297,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 7813955,
+        "physical_logical_bytes": 7813955,
+        "physical_objects": 201
+      },
+      "properties": false,
+      "random_ids": false,
+      "routes": 1,
+      "semantic_fingerprint": "57f3deaf6829d02e203e90a4c5c69f9e7b2949a647aa0a0ac82684550722b805",
+      "unindexed_allocated_bytes": 8388608,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 499712,
+          "logical_bytes": 60059,
+          "logical_references": 122,
+          "physical_logical_bytes": 60059,
+          "physical_objects": 122
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 5246976,
+          "logical_bytes": 5145316,
+          "logical_references": 65,
+          "physical_logical_bytes": 5145316,
+          "physical_objects": 65
+        },
+        "topology_nodes": {
+          "allocated_bytes": 118784,
+          "logical_bytes": 114283,
+          "logical_references": 5,
+          "physical_logical_bytes": 114283,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2523136,
+          "logical_bytes": 2494297,
+          "logical_references": 12,
+          "physical_logical_bytes": 2494297,
+          "physical_objects": 9
+        }
+      }
+    }
+  ]
+}

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "5c9c967f919fba3cad7a2104bd99d926ccf5b6c0e68d599cb23a0e590419ccdc",
+  "sha256": "1f73c7e20543f5cdb8657e4e3a8d0a9cace73beff21fb280429fd4077c4bcf58",
   "entries": [
     {
       "name": "graphforge-api",
@@ -16,6 +16,18 @@
           "optional": false,
           "uses_default_features": true,
           "kind": null,
+          "target": null
+        },
+        {
+          "name": "arrow",
+          "req": "^58",
+          "features": [
+            "ipc_compression",
+            "prettyprint"
+          ],
+          "optional": false,
+          "uses_default_features": true,
+          "kind": "dev",
           "target": null
         },
         {

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -1,7 +1,7 @@
 {
   "schema": "graphforge.bazel-migration-target-map.v1",
   "issue": 6,
-  "cargo_target_count": 123,
+  "cargo_target_count": 124,
   "targets": [
     {
       "package": "graphforge-api",
@@ -1232,6 +1232,16 @@
       "bazel_label": "//crates/graphforge-portable-oci:graphforge_portable_oci",
       "exception_id": null,
       "notes": "#1021; unit tests `//crates/graphforge-portable-oci:graphforge_portable_oci_test`"
+    },
+    {
+      "package": "graphforge-api",
+      "target": "permanent_storage_budgets",
+      "class": "integration-test",
+      "source": "crates/graphforge-api/tests/permanent_storage_budgets.rs",
+      "status": "mapped",
+      "bazel_label": "//crates/graphforge-api:permanent_storage_budgets",
+      "exception_id": null,
+      "notes": "#1196 permanent ownership and codec assessment"
     }
   ],
   "exceptions": [


### PR DESCRIPTION
The permanent-storage assessment now attributes one authoritative published project and tests exact UUIDs, endpoints, labels/types and nullable properties across reopen, export, full verification and clean import. Four deterministic fixtures cover random/sequential identities, route and schema variation, shard boundaries and absent/built adjacency.

Lossless experiments quantify four focused repairs: Parquet Zstd (#1202), reserved membership padding (#1203), bounded manifest buckets (#1204), and CSR compression (#1205). The decision report maps each representation to its consumers and correctness obligations, distinguishes physical ownership from candidate estimates, and retains indexes whose distinct access contracts are still required. Production writers are unchanged; IPC compression is enabled only as an assessment dev dependency. The maintainer’s pre-v1 scope waives backward compatibility and migration machinery for the selected repairs.

Integrated evidence is committed in `docs/development/evidence/permanent-storage-1196.json`, based on runtime source `83a153f164faa2f7dc276e593719ec71e7e0bc9e` above merged lifecycle main `0539c8ee`. All five tests passed in 449.10 seconds with 268,780 KiB whole-process peak RSS. These are bounded synthetic measurements, not S22/S26 qualification.

Validation:
- `cargo test -p graphforge-api --test permanent_storage_budgets --no-run`, then the standalone binary with `--nocapture --test-threads=1`: 5 passed, exact decoded candidate equality and full public round trips.
- `cargo clippy -p graphforge-api --test permanent_storage_budgets -- -D warnings`: passed.
- Formatting, `make pre-push-fast`, `make gate-registry-check`, Cargo/Bazel feature drift and migration-ledger checks passed.
- New integration target is included in the authoritative Bazel API suite. Independent review found no blocking correctness issue; final measurements and physical shard accounting address its documentation findings.

Closes #1196
