### PR TITLE
fix(storage): compress permanent construction Parquet with Zstd

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -325,6 +325,8 @@ fn parquet_experiment(source: &Path) -> Value {
     let mut encode_ns = [0_u128; 3];
     let mut decode_ns = [0_u128; 3];
     let mut original_bytes = 0_u64;
+    let mut original_allocated = 0_u64;
+    let mut normalized_allocated = [0_u64; 3];
     for entry in &inventory.files {
         if !entry.relative_path.ends_with(".parquet") || !seen.insert(entry.content_sha256.clone())
         {
@@ -334,6 +336,17 @@ fn parquet_experiment(source: &Path) -> Value {
         let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(&path).unwrap())
             .unwrap()
             .with_batch_size(4096);
+        for group in reader.metadata().row_groups() {
+            for column in group.columns() {
+                assert!(
+                    matches!(column.compression(), Compression::ZSTD(_)),
+                    "permanent construction Parquet must use the selected Zstd codec"
+                );
+            }
+        }
+        original_allocated += graphforge_filesystem::file_space_usage(&File::open(&path).unwrap())
+            .unwrap()
+            .allocated_bytes;
         let schema = reader.schema().clone();
         let original = reader
             .build()
@@ -367,6 +380,7 @@ fn parquet_experiment(source: &Path) -> Value {
             writer.close().unwrap();
             encode_ns[slot] += start.elapsed().as_nanos();
             sizes[slot] += bytes.len() as u64;
+            normalized_allocated[slot] += (bytes.len() as u64).div_ceil(4096) * 4096;
             let start = Instant::now();
             let decoded = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))
                 .unwrap()
@@ -383,7 +397,7 @@ fn parquet_experiment(source: &Path) -> Value {
         }
     }
     assert!(original_bytes > 0);
-    json!({"production_parquet_bytes": original_bytes, "normalized_bytes_uncompressed_zstd1_zstd3":sizes,
+    json!({"production_parquet_bytes": original_bytes, "production_parquet_allocated_bytes":original_allocated, "normalized_allocated_bytes_at_4096":normalized_allocated, "normalized_bytes_uncompressed_zstd1_zstd3":sizes,
         "encode_elapsed_ns":encode_ns, "decode_elapsed_ns":decode_ns})
 }
 
@@ -868,6 +882,16 @@ fn assess(f: Fixture) {
     // Candidate codecs inspect construction's published payload generation.
     // Adjacency publication may switch to a generation-owned graph tree.
     let experiment = parquet_experiment(&source);
+    if matches!(f.identifiers, Identifiers::Random) {
+        let actual = experiment["production_parquet_bytes"].as_u64().unwrap();
+        let uncompressed = experiment["normalized_bytes_uncompressed_zstd1_zstd3"][0]
+            .as_u64()
+            .unwrap();
+        assert!(
+            actual * 5 <= uncompressed * 4,
+            "random-identity fixtures must retain the measured at-least-20% Parquet reduction"
+        );
+    }
     let identity_experiment = identity_padding_experiment(&source);
     let manifest_experiment = bucket_manifest_experiment(&source);
     if f.adjacency {

--- a/crates/graphforge-storage/src/construction_lifecycle_tests.rs
+++ b/crates/graphforge-storage/src/construction_lifecycle_tests.rs
@@ -509,6 +509,7 @@ mod lifecycle_budget {
                 let append = census(session.root.path());
                 session.seal().unwrap();
                 let shape = session.shape_canonical_with_cancellation(|| false).unwrap();
+                let shape_peak = session.evidence().storage_transient_peak_total_allocated_bytes;
                 assert_eq!((shape.node_count, shape.edge_count), (8192, 32768 * scale));
                 assert!(session.evidence().merge_passes >= 3);
                 let shaped = census(session.root.path());
@@ -540,13 +541,27 @@ mod lifecycle_budget {
                     .evidence()
                     .storage_transient_peak_total_allocated_bytes;
                 if version == 8 {
-                    before = Some((current, peak));
+                    before = Some((current, peak, shape_peak));
                 } else {
-                    let (old_current, old_peak) = before.unwrap();
-                    // Removing both full predecessor representations must at least
-                    // halve payload retention and lower the actual simultaneous peak.
+                    let (old_current, old_peak, old_shape_peak) = before.unwrap();
+                    // Compression can move both variants' maximum into shaping,
+                    // before retirement can reduce it. Keep the strict retention
+                    // benefit, no peak regression against the compressed control,
+                    // and a strict reduction against the source-bound uncompressed
+                    // v8 baseline in construction-supersession.md (#1195).
                     assert!(current * 2 < old_current);
-                    assert!(peak < old_peak);
+                    assert!(peak <= old_peak);
+                    let uncompressed_peak = match scale {
+                        1 => 23_425_024,
+                        2 => 44_494_848,
+                        4 => 86_634_496,
+                        _ => unreachable!("fixed fixture scales"),
+                    };
+                    assert!(peak < uncompressed_peak);
+                    if peak == old_peak {
+                        assert_eq!(peak, shape_peak);
+                        assert_eq!(old_peak, old_shape_peak);
+                    }
                     assert_eq!(
                         session.evidence().current_merge_temporary_allocated_bytes,
                         0

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -4602,6 +4602,16 @@ fn write_parquet(
     batch: &RecordBatch,
     evidence: &mut GraphConstructionEvidence,
 ) -> Result<ArtifactReceipt, GfError> {
+    write_parquet_with_properties(root, name, batch, None, evidence)
+}
+
+fn write_parquet_with_properties(
+    root: &StableDirectory,
+    name: &str,
+    batch: &RecordBatch,
+    properties: Option<parquet::file::properties::WriterProperties>,
+    evidence: &mut GraphConstructionEvidence,
+) -> Result<ArtifactReceipt, GfError> {
     let temporary = artifact_temp(name);
     let file = root
         .create_replaceable_child_file(OsStr::new(&temporary))
@@ -4609,7 +4619,8 @@ fn write_parquet(
     let identity = file_identity(&file).map_err(storage)?;
     let hashing = HashingWriter::new(file)?;
     let buffered = BufWriter::with_capacity(BLOCK_BYTES, hashing);
-    let mut parquet = ArrowWriter::try_new(buffered, batch.schema(), None).map_err(storage)?;
+    let mut parquet =
+        ArrowWriter::try_new(buffered, batch.schema(), properties).map_err(storage)?;
     parquet.write(batch).map_err(storage)?;
     parquet.finish().map_err(storage)?;
     parquet.sync().map_err(storage)?;
@@ -6315,7 +6326,13 @@ fn build_runtime_catalog(
         }
     }
     let output = "shaped-runtime-catalog.parquet";
-    let receipt = write_parquet(root, output, &catalog.to_record_batch(), evidence)?;
+    let receipt = write_parquet_with_properties(
+        root,
+        output,
+        &catalog.to_record_batch(),
+        Some(crate::graph_construction_encoding::permanent_parquet_properties()?),
+        evidence,
+    )?;
     record_shape_artifact_install(evidence, &receipt)?;
     evidence.merge_fsync_operations = evidence
         .merge_fsync_operations

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -31,6 +31,8 @@ use graphforge_ontology::{QualifiedSymbol, SymbolKind};
 use graphforge_value::{EntityTypeId, RelationTypeId, TaggedTypeId};
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::basic::{Compression, ZstdLevel};
+use parquet::file::properties::WriterProperties;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -2150,7 +2152,11 @@ fn write_parquet(
             digest: Sha256::new(),
         },
         batch.schema(),
-        None,
+        Some(
+            WriterProperties::builder()
+                .set_compression(Compression::ZSTD(ZstdLevel::try_new(1).map_err(storage)?))
+                .build(),
+        ),
     )
     .map_err(storage)?;
     writer.write(batch).map_err(storage)?;

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -2121,6 +2121,14 @@ fn write_surrogate_tails(
     Ok(())
 }
 
+/// One codec policy for permanent construction payloads, including the catalog
+/// that is shaped privately and then published byte-for-byte.
+pub(crate) fn permanent_parquet_properties() -> Result<WriterProperties, GfError> {
+    Ok(WriterProperties::builder()
+        .set_compression(Compression::ZSTD(ZstdLevel::try_new(1).map_err(storage)?))
+        .build())
+}
+
 fn write_parquet(
     root: &StableDirectory,
     relative: &str,
@@ -2152,11 +2160,7 @@ fn write_parquet(
             digest: Sha256::new(),
         },
         batch.schema(),
-        Some(
-            WriterProperties::builder()
-                .set_compression(Compression::ZSTD(ZstdLevel::try_new(1).map_err(storage)?))
-                .build(),
-        ),
+        Some(permanent_parquet_properties()?),
     )
     .map_err(storage)?;
     writer.write(batch).map_err(storage)?;

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -119,3 +119,39 @@ checked independently, so added CSR cannot hide growing topology or manifests.
 Final production repairs also require recovery, snapshot, corruption and resource
 budgets appropriate to their changed surface. Larger-scale confirmation reuses
 #900's admitted ladder; this assessment does not authorize S24/S26 execution.
+
+## Construction Parquet repair (#1202)
+
+New permanent construction payloads use Zstd level 1, including the runtime
+catalog produced during shaping and copied into the publication. Row-group,
+dictionary, schema, hashing, cache-release and durability behavior stay as before.
+Accepted input and private merge Parquet are outside this permanent-output policy.
+This repair does not yet change mutation or delta replay writers; their separate
+resource admission requires the publishing-policy follow-up requested under #1194.
+
+[Repair measurements](../../development/evidence/permanent-parquet-1202.json)
+record source `87a5b19f` on the same host and toolchain as the assessment. All five
+facade tests passed, including exact reopen/query/export/full-verify/clean-import
+oracles and every production column's codec. Random-ID Parquet payloads remain
+below 80% of their same-layout uncompressed control.
+
+| Fixture | Baseline permanent allocation | New permanent allocation | New Parquet payload | New Parquet allocation |
+| --- | ---: | ---: | ---: | ---: |
+| Sequential | 8,388,608 | 4,112,384 | 973,925 | 1,097,728 |
+| Random | 8,929,280 | 7,585,792 | 4,015,814 | 4,145,152 |
+| Eight property routes, CSR built | 20,840,448 | 18,644,992 | 7,845,372 | 10,743,808 |
+| Heterogeneous properties | 14,929,920 | 13,086,720 | 6,398,839 | 7,467,008 |
+
+The serial assessment took 393.65 seconds and peaked at 270,208 KiB RSS, versus
+449.10 seconds and 268,780 KiB before the repair. These are exploratory whole-test
+measurements, not isolated codec costs or proof of a timing improvement. Raw
+results include per-fixture encode/decode times and process filesystem I/O;
+process I/O includes queries and portable copies and is not a publication-only
+byte counter.
+
+The paired lifecycle test also passes at 1x/2x/4x. Compression moves the maximum
+allocation into shaping: the reclaimed and retained controls can now tie at that
+phase. The test verifies both measured phase peaks when they tie, no increase
+against the compressed retained control, strict reduction against the frozen
+pre-compression control, and the original strict retained-allocation reduction.
+Compression does not retroactively remove a historical shaping peak.

--- a/docs/development/evidence/permanent-parquet-1202.json
+++ b/docs/development/evidence/permanent-parquet-1202.json
@@ -1,0 +1,860 @@
+{
+  "source_commit": "87a5b19fea45dac124fef77be86f8b8f772f1154",
+  "command": "/usr/bin/time -v /home/ubuntu/code/graphforge-target-1195/debug/deps/permanent_storage_budgets-c514423ca6fb68a2 --nocapture --test-threads=1",
+  "result": "5 passed; 0 failed",
+  "wall_seconds": 393.65,
+  "maximum_resident_kib": 270208,
+  "filesystem_input_512_byte_blocks": 4845680,
+  "filesystem_output_512_byte_blocks": 3279320,
+  "fixtures": [
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 28322374066,
+      "edges": 65537,
+      "fixture": "heterogeneous_property_schemas",
+      "heterogeneous_schemas": true,
+      "identity_padding_experiment": {
+        "current_record_bytes": 2228288,
+        "identity_runs": 2,
+        "packed_record_bytes": 1740850,
+        "production_format_changed": false,
+        "records": 69634,
+        "removable_reserved_padding_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 544,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 974848,
+        "candidate_logical_bytes": 194598,
+        "candidate_objects": 238,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 3072000,
+        "source_manifest_objects": 750
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          174686937,
+          207625347,
+          207776057
+        ],
+        "encode_elapsed_ns": [
+          668231299,
+          832562091,
+          863762489
+        ],
+        "normalized_allocated_bytes_at_4096": [
+          9310208,
+          7467008,
+          7483392
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          8357272,
+          6398839,
+          6420637
+        ],
+        "production_parquet_allocated_bytes": 7467008,
+        "production_parquet_bytes": 6398839
+      },
+      "permanent": {
+        "allocated_bytes": 13086720,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 3104768,
+            "logical_bytes": 371612,
+            "logical_references": 758,
+            "physical_logical_bytes": 371612,
+            "physical_objects": 758
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 2265088,
+            "logical_bytes": 1877949,
+            "logical_references": 266,
+            "physical_logical_bytes": 1877949,
+            "physical_objects": 266
+          },
+          "topology_edges": {
+            "allocated_bytes": 5091328,
+            "logical_bytes": 4428564,
+            "logical_references": 257,
+            "physical_logical_bytes": 4428564,
+            "physical_objects": 257
+          },
+          "topology_nodes": {
+            "allocated_bytes": 102400,
+            "logical_bytes": 88869,
+            "logical_references": 5,
+            "physical_logical_bytes": 88869,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 2523136,
+            "logical_bytes": 2494333,
+            "logical_references": 12,
+            "physical_logical_bytes": 2494333,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 9261327,
+        "physical_logical_bytes": 9261327,
+        "physical_objects": 1295
+      },
+      "properties": true,
+      "random_ids": true,
+      "routes": 4,
+      "semantic_fingerprint": "5c704d8bf7e1851e1631e6f36bc37495f9d9d9e1e9b94950e84310b545824ec2",
+      "unindexed_allocated_bytes": 13086720,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 3104768,
+          "logical_bytes": 371612,
+          "logical_references": 758,
+          "physical_logical_bytes": 371612,
+          "physical_objects": 758
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 2265088,
+          "logical_bytes": 1877949,
+          "logical_references": 266,
+          "physical_logical_bytes": 1877949,
+          "physical_objects": 266
+        },
+        "topology_edges": {
+          "allocated_bytes": 5091328,
+          "logical_bytes": 4428564,
+          "logical_references": 257,
+          "physical_logical_bytes": 4428564,
+          "physical_objects": 257
+        },
+        "topology_nodes": {
+          "allocated_bytes": 102400,
+          "logical_bytes": 88869,
+          "logical_references": 5,
+          "physical_logical_bytes": 88869,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2523136,
+          "logical_bytes": 2494333,
+          "logical_references": 12,
+          "physical_logical_bytes": 2494333,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": true,
+      "adjacency_codec_experiment": {
+        "decode_elapsed_ns": [
+          5453188,
+          104366215,
+          35769416
+        ],
+        "encode_elapsed_ns": [
+          2434537,
+          184019974,
+          105458317
+        ],
+        "estimated_allocated_bytes_at_4096": [
+          4972544,
+          2351104,
+          1363968
+        ],
+        "largest_decoded_batch_array_bytes": 3322008,
+        "normalized_bytes_none_lz4_zstd": [
+          4920564,
+          2320564,
+          1324020
+        ],
+        "production_format_changed": false,
+        "shards": 18,
+        "source_bytes": 4920564
+      },
+      "construction_elapsed_ns": 34336997249,
+      "edges": 65537,
+      "fixture": "random_properties_eight_routes",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 2228288,
+        "identity_runs": 2,
+        "packed_record_bytes": 1740850,
+        "production_format_changed": false,
+        "records": 69634,
+        "removable_reserved_padding_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 1080,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 1372160,
+        "candidate_logical_bytes": 359535,
+        "candidate_objects": 335,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 5959680,
+        "source_manifest_objects": 1455
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          331559427,
+          378456359,
+          380710471
+        ],
+        "encode_elapsed_ns": [
+          1104109785,
+          1339967763,
+          1373662171
+        ],
+        "normalized_allocated_bytes_at_4096": [
+          12939264,
+          10743808,
+          10747904
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          10231116,
+          7845372,
+          7861925
+        ],
+        "production_parquet_allocated_bytes": 10743808,
+        "production_parquet_bytes": 7845372
+      },
+      "permanent": {
+        "allocated_bytes": 18644992,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 5050368,
+            "logical_bytes": 4930822,
+            "logical_references": 37,
+            "physical_logical_bytes": 4930822,
+            "physical_objects": 37
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 335872,
+            "logical_bytes": 309543,
+            "logical_references": 8,
+            "physical_logical_bytes": 309543,
+            "physical_objects": 8
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 4337664,
+            "logical_bytes": 2576971,
+            "logical_references": 546,
+            "physical_logical_bytes": 2576971,
+            "physical_objects": 546
+          },
+          "topology_edges": {
+            "allocated_bytes": 6295552,
+            "logical_bytes": 5174833,
+            "logical_references": 513,
+            "physical_logical_bytes": 5174833,
+            "physical_objects": 513
+          },
+          "topology_nodes": {
+            "allocated_bytes": 102400,
+            "logical_bytes": 90021,
+            "logical_references": 5,
+            "physical_logical_bytes": 90021,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 2523136,
+            "logical_bytes": 2494333,
+            "logical_references": 12,
+            "physical_logical_bytes": 2494333,
+            "physical_objects": 12
+          }
+        },
+        "logical_bytes": 15576523,
+        "physical_logical_bytes": 15576523,
+        "physical_objects": 1121
+      },
+      "properties": true,
+      "random_ids": true,
+      "routes": 8,
+      "semantic_fingerprint": "1a4578d5b5d6c474b1fd9de5478fd2afe0f69e1456f3964d410bc6e0fd3e8b51",
+      "unindexed_allocated_bytes": 19251200,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 5992448,
+          "logical_bytes": 727691,
+          "logical_references": 1463,
+          "physical_logical_bytes": 727691,
+          "physical_objects": 1463
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 4337664,
+          "logical_bytes": 2576971,
+          "logical_references": 546,
+          "physical_logical_bytes": 2576971,
+          "physical_objects": 546
+        },
+        "topology_edges": {
+          "allocated_bytes": 6295552,
+          "logical_bytes": 5174833,
+          "logical_references": 513,
+          "physical_logical_bytes": 5174833,
+          "physical_objects": 513
+        },
+        "topology_nodes": {
+          "allocated_bytes": 102400,
+          "logical_bytes": 90021,
+          "logical_references": 5,
+          "physical_logical_bytes": 90021,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2523136,
+          "logical_bytes": 2494333,
+          "logical_references": 12,
+          "physical_logical_bytes": 2494333,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 22413401824,
+      "edges": 65537,
+      "fixture": "random_single_route",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 2359360,
+        "identity_runs": 2,
+        "packed_record_bytes": 1843250,
+        "production_format_changed": false,
+        "records": 73730,
+        "removable_reserved_padding_bytes": 516110
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 90,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 151552,
+        "candidate_logical_bytes": 30310,
+        "candidate_objects": 37,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 499712,
+        "source_manifest_objects": 122
+      },
+      "nodes": 8193,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          51383832,
+          67020308,
+          67513411
+        ],
+        "encode_elapsed_ns": [
+          316925050,
+          391226331,
+          417160223
+        ],
+        "normalized_allocated_bytes_at_4096": [
+          5488640,
+          4145152,
+          4145152
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          5318519,
+          4015814,
+          4047391
+        ],
+        "production_parquet_allocated_bytes": 4145152,
+        "production_parquet_bytes": 4015814
+      },
+      "permanent": {
+        "allocated_bytes": 7585792,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 532480,
+            "logical_bytes": 63098,
+            "logical_references": 130,
+            "physical_logical_bytes": 63098,
+            "physical_objects": 130
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "topology_edges": {
+            "allocated_bytes": 3936256,
+            "logical_bytes": 3841869,
+            "logical_references": 65,
+            "physical_logical_bytes": 3841869,
+            "physical_objects": 65
+          },
+          "topology_nodes": {
+            "allocated_bytes": 200704,
+            "logical_bytes": 170753,
+            "logical_references": 9,
+            "physical_logical_bytes": 170753,
+            "physical_objects": 9
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 2916352,
+            "logical_bytes": 2887659,
+            "logical_references": 12,
+            "physical_logical_bytes": 2887659,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 6963379,
+        "physical_logical_bytes": 6963379,
+        "physical_objects": 213
+      },
+      "properties": false,
+      "random_ids": true,
+      "routes": 1,
+      "semantic_fingerprint": "6ce665fa15e02a8781492c112961d22d14fa79e33d0fd22bbedfc29958308030",
+      "unindexed_allocated_bytes": 7585792,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 532480,
+          "logical_bytes": 63098,
+          "logical_references": 130,
+          "physical_logical_bytes": 63098,
+          "physical_objects": 130
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 3936256,
+          "logical_bytes": 3841869,
+          "logical_references": 65,
+          "physical_logical_bytes": 3841869,
+          "physical_objects": 65
+        },
+        "topology_nodes": {
+          "allocated_bytes": 200704,
+          "logical_bytes": 170753,
+          "logical_references": 9,
+          "physical_logical_bytes": 170753,
+          "physical_objects": 9
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2916352,
+          "logical_bytes": 2887659,
+          "logical_references": 12,
+          "physical_logical_bytes": 2887659,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 18934388902,
+      "edges": 65537,
+      "fixture": "sequential_single_route",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 2228288,
+        "identity_runs": 2,
+        "packed_record_bytes": 1740850,
+        "production_format_changed": false,
+        "records": 69634,
+        "removable_reserved_padding_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 86,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 126976,
+        "candidate_logical_bytes": 28133,
+        "candidate_objects": 31,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 466944,
+        "source_manifest_objects": 114
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          47314505,
+          71389256,
+          70381349
+        ],
+        "encode_elapsed_ns": [
+          297011918,
+          376003085,
+          382433691
+        ],
+        "normalized_allocated_bytes_at_4096": [
+          5373952,
+          1097728,
+          1097728
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          5262627,
+          973925,
+          960425
+        ],
+        "production_parquet_allocated_bytes": 1097728,
+        "production_parquet_bytes": 973925
+      },
+      "permanent": {
+        "allocated_bytes": 4112384,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 499712,
+            "logical_bytes": 60183,
+            "logical_references": 122,
+            "physical_logical_bytes": 60183,
+            "physical_objects": 122
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "topology_edges": {
+            "allocated_bytes": 1052672,
+            "logical_bytes": 944705,
+            "logical_references": 65,
+            "physical_logical_bytes": 944705,
+            "physical_objects": 65
+          },
+          "topology_nodes": {
+            "allocated_bytes": 36864,
+            "logical_bytes": 26028,
+            "logical_references": 5,
+            "physical_logical_bytes": 26028,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 2523136,
+            "logical_bytes": 2494333,
+            "logical_references": 12,
+            "physical_logical_bytes": 2494333,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 3525249,
+        "physical_logical_bytes": 3525249,
+        "physical_objects": 201
+      },
+      "properties": false,
+      "random_ids": false,
+      "routes": 1,
+      "semantic_fingerprint": "57f3deaf6829d02e203e90a4c5c69f9e7b2949a647aa0a0ac82684550722b805",
+      "unindexed_allocated_bytes": 4112384,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 499712,
+          "logical_bytes": 60183,
+          "logical_references": 122,
+          "physical_logical_bytes": 60183,
+          "physical_objects": 122
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 1052672,
+          "logical_bytes": 944705,
+          "logical_references": 65,
+          "physical_logical_bytes": 944705,
+          "physical_objects": 65
+        },
+        "topology_nodes": {
+          "allocated_bytes": 36864,
+          "logical_bytes": 26028,
+          "logical_references": 5,
+          "physical_logical_bytes": 26028,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2523136,
+          "logical_bytes": 2494333,
+          "logical_references": 12,
+          "physical_logical_bytes": 2494333,
+          "physical_objects": 9
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Construction published uncompressed topology, properties and runtime catalogs. Use Zstd level 1 for these permanent payloads, preserving schema, dictionary/row-group defaults, hashing, cache release and durable publication. Runtime catalog encoding during shaping uses the same policy because those bytes become permanent.

Random-ID facade fixtures now publish 4,015,814 / 7,845,372 / 6,398,839 Parquet bytes, each below 80% of its same-layout uncompressed control. Exact reopen/query/export/full-verify/clean-import oracles pass. Source-bound raw allocation, timing, RSS and I/O evidence is committed. The lifecycle peak test verifies shaping-bound ties against the compressed control and strict improvement against the frozen uncompressed baseline.

Validation: 99 construction tests, 6 API resumable tests, 29 ladder tests and all 5 permanent-storage tests pass. Workspace clippy, formatting, make pre-push-fast and make gate-registry-check pass. Independent review found no blocking issues. Full pre-push on the preceding lifecycle work ran native/binding suites but failed the existing coverage floor tracked by #360; no full-pre-push green claim is made here.

Permanent encoding policy across replay, mutation, compaction, projections and other production publishers is separately required by #1213, including per-path resource evidence. This PR remains construction-scoped.

Closes #1202

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791594220&installation_model_id=20486&pr_number=1214&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1214&signature=a3a3fbb4476629cf8057714f02996a6a15991ffacc4a51d180b419e2f7b5a921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->