### PR TITLE
fix(storage): pack permanent membership with authenticated variable framing

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -521,7 +521,9 @@ fn identity_padding_experiment(source: &Path) -> Value {
     let selected = graphforge_storage::resolve_project_generation(source).unwrap();
     let inventory = selected.graph_files_inventory().unwrap().unwrap();
     let mut records = 0_u64;
+    let mut edges = 0_u64;
     let mut runs = 0_u64;
+    let mut current_bytes = 0_u64;
     for entry in &inventory.files {
         let name = Path::new(&entry.relative_path)
             .file_name()
@@ -533,45 +535,50 @@ fn identity_padding_experiment(source: &Path) -> Value {
         {
             continue;
         }
-        let original = std::fs::read(
+        let bytes = std::fs::read(
             graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap(),
         )
         .unwrap();
-        let packed = pack_identity_records(&original);
-        let mut restored = Vec::with_capacity(original.len());
-        for record in packed.chunks_exact(25) {
-            restored.extend_from_slice(&record[..17]);
-            restored.extend_from_slice(&[0; 7]);
-            restored.extend_from_slice(&record[17..25]);
-        }
-        assert_eq!(restored, original);
-        // Fixed-width binary search retains exact UUID/kind ordering. Exercise
-        // beginning, midpoint and last identifiers rather than surrogate-only keys.
-        let packed_rows = packed.chunks_exact(25).collect::<Vec<_>>();
-        for row in [
-            0,
-            packed_rows.len() / 2,
-            packed_rows.len().saturating_sub(1),
-        ] {
-            if packed_rows.is_empty() {
-                continue;
+        let mut cursor = bytes.as_slice();
+        let mut prior: Option<[u8; 16]> = None;
+        while !cursor.is_empty() {
+            assert!(cursor.len() >= 17);
+            let uuid: [u8; 16] = cursor[..16].try_into().unwrap();
+            assert!(prior.is_none_or(|prior| prior < uuid));
+            prior = Some(uuid);
+            let kind = cursor[16];
+            assert!(kind <= 3);
+            let width = if kind == 1 { 17 } else { 25 };
+            assert!(cursor.len() >= width);
+            let surrogate = if kind == 1 {
+                0
+            } else {
+                u64::from_be_bytes(cursor[17..25].try_into().unwrap())
+            };
+            // Expand only in the test to quantify the previous physical representation.
+            // This is not a legacy reader or production migration path.
+            let mut expanded = [0_u8; 32];
+            expanded[..17].copy_from_slice(&cursor[..17]);
+            expanded[24..].copy_from_slice(&surrogate.to_be_bytes());
+            let packed = pack_identity_records(&expanded);
+            assert_eq!(&packed[..width], &cursor[..width]);
+            if kind == 1 {
+                assert_eq!(&packed[17..], &[0; 8]);
+                edges += 1;
             }
-            let key = &original[row * 32..row * 32 + 17];
-            let found = packed_rows
-                .binary_search_by(|record| record[..17].cmp(key))
-                .unwrap();
-            assert_eq!(
-                &packed_rows[found][17..25],
-                &original[row * 32 + 24..row * 32 + 32]
-            );
+            records += 1;
+            cursor = &cursor[width..];
         }
-        records += (original.len() / 32) as u64;
+        current_bytes += bytes.len() as u64;
         runs += 1;
     }
     assert!(records > 0);
-    json!({"identity_runs":runs,"records":records,"current_record_bytes":records * 32,
-        "packed_record_bytes":records * 25,"removable_reserved_padding_bytes":records * 7,
-        "production_format_changed":false})
+    assert_eq!(current_bytes, records * 25 - edges * 8);
+    assert!(current_bytes <= records * 25);
+    json!({"identity_runs":runs,"records":records,"live_edge_records":edges,
+        "current_record_bytes":current_bytes,"previous_32_byte_baseline":records * 32,
+        "reserved_padding_saved_bytes":records * 7,"defined_zero_edge_saved_bytes":edges * 8,
+        "production_format_changed":true})
 }
 
 #[test]

--- a/crates/graphforge-storage/src/durable_rewrite.rs
+++ b/crates/graphforge-storage/src/durable_rewrite.rs
@@ -1305,8 +1305,8 @@ fn valid_uuid_receipt(receipt: &AuxiliaryReceipt) -> bool {
             receipt.path.as_str()
         ),
         (
-            "uuid-membership/v3",
-            3,
+            "uuid-membership/v5",
+            5,
             "topology/uuid-membership/topology-receipt.json"
         ) | (
             "uuid-membership/v4",
@@ -1469,8 +1469,8 @@ mod tests {
     fn auxiliary_receipt_must_name_and_digest_an_exact_staged_entry() {
         let mut valid = intent();
         valid.auxiliary = Some(AuxiliaryReceipt {
-            kind: "uuid-membership/v3".to_owned(),
-            schema_version: 3,
+            kind: "uuid-membership/v5".to_owned(),
+            schema_version: 5,
             path: valid.entries[0].destination.clone(),
             digest: valid.entries[0].sha256.clone(),
             bytes: valid.entries[0].bytes,
@@ -1502,8 +1502,8 @@ mod tests {
 
         let mut legacy = intent();
         legacy.auxiliary = Some(AuxiliaryReceipt {
-            kind: "uuid-membership/v3".to_owned(),
-            schema_version: 3,
+            kind: "uuid-membership/v5".to_owned(),
+            schema_version: 5,
             path: legacy.entries[0].destination.clone(),
             digest: legacy.entries[0].sha256.clone(),
             bytes: legacy.entries[0].bytes,

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -11515,6 +11515,19 @@ pub(crate) mod tests {
         let path = dir.path().join("edges.uuidx");
         assert_eq!(write_identity_records(&path, &records).unwrap(), 3);
         assert_eq!(fs::metadata(path).unwrap().len(), 2_097_137);
+        let edges = records.iter().map(|record| record.0).collect::<Vec<_>>();
+        let root = dir.path().join(INDEX_DIR);
+        fs::create_dir_all(&root).unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        let (_, _, _, planned) =
+            plan_uuid_membership_delta(&root, 0, 1, None, scratch.path(), &[], &edges, &[], &[])
+                .unwrap();
+        assert_eq!(planned.write_blocks, 3);
+        assert_eq!(planned.write_bytes, 2_097_137);
+        crate::generation::force_bump_topology_generation_for_test(dir.path()).unwrap();
+        let appended = append_uuid_membership_delta(dir.path(), 1, &[], &edges).unwrap();
+        assert_eq!(appended.write_blocks, 3);
+        assert_eq!(appended.write_bytes, 2_097_137);
     }
 
     #[test]

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -21,11 +21,14 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-const FORMAT_VERSION: u32 = 3;
+mod identity_codec;
+
+const FORMAT_VERSION: u32 = 5;
 const NODE_LOOKUP_RECORD_BYTES: u64 = 24;
-const IDENTITY_RECORD_BYTES: u64 = 32;
+const IDENTITY_RECORD_BYTES: u64 = 25;
 const NODE_LOOKUP_RECORD_WIDTH: usize = 24;
-const IDENTITY_RECORD_WIDTH: usize = 32;
+const IDENTITY_RECORD_WIDTH: usize = identity_codec::WIDTH;
+const CONSTRUCTION_IDENTITY_WIDTH: usize = 32;
 const BULK_IO_BYTES: usize = 1 << 20;
 // Persistent authenticated authority for UUID-to-surrogate resolution. Keeping
 // it in the immutable topology generation is what lets writer reopen avoid
@@ -1384,16 +1387,7 @@ fn authenticated_block(
         .map_err(storage_err)?;
     let mut bytes = vec![0_u8; block.len as usize];
     file.read_exact(&mut bytes).map_err(storage_err)?;
-    let key_width = if width == IDENTITY_RECORD_WIDTH {
-        16
-    } else {
-        8
-    };
-    if hex_sha256(&bytes) != block.sha256
-        || hex_sha256_key(&bytes[..key_width]) != block.first_key
-        || hex_sha256_key(&bytes[bytes.len() - width..bytes.len() - width + key_width])
-            != block.last_key
-    {
+    if !block_matches(&bytes, block, width) {
         return Err(storage_err("UUID probe block authentication failed"));
     }
     metrics.validation_scan_bytes = metrics
@@ -1421,18 +1415,7 @@ fn authenticated_probe_block(
     metrics.file_seeks = metrics.file_seeks.saturating_add(1);
     let mut bytes = vec![0_u8; block.len as usize];
     file.read_exact(&mut bytes).map_err(storage_err)?;
-    let key_width = match width {
-        IDENTITY_RECORD_WIDTH => 16,
-        NODE_LOOKUP_RECORD_WIDTH => 8,
-        _ => return Err(storage_err("unsupported UUID probe record width")),
-    };
-    if bytes.is_empty()
-        || !bytes.len().is_multiple_of(width)
-        || hex_sha256(&bytes) != block.sha256
-        || hex_sha256_key(&bytes[..key_width]) != block.first_key
-        || hex_sha256_key(&bytes[bytes.len() - width..bytes.len() - width + key_width])
-            != block.last_key
-    {
+    if !block_matches(&bytes, block, width) {
         return Err(storage_err("UUID probe block authentication failed"));
     }
     match kind {
@@ -1483,13 +1466,12 @@ fn batch_identity_states(
             ProbeFileKind::Identity,
             metrics,
         )?;
-        let mut record_index = 0_usize;
+        let mut remaining = bytes.as_slice();
+        let mut next = identity_codec::take(&mut remaining)?;
         for uuid in candidates {
-            while record_index < bytes.len() / IDENTITY_RECORD_WIDTH {
-                let start = record_index * IDENTITY_RECORD_WIDTH;
-                let record = &bytes[start..start + IDENTITY_RECORD_WIDTH];
+            while let Some(record) = next {
                 match record[..16].cmp(uuid.as_bytes()) {
-                    std::cmp::Ordering::Less => record_index += 1,
+                    std::cmp::Ordering::Less => next = identity_codec::take(&mut remaining)?,
                     std::cmp::Ordering::Greater => break,
                     std::cmp::Ordering::Equal => {
                         let record_kind = if matches!(record[16], 0 | 2) {
@@ -1503,11 +1485,11 @@ fn batch_identity_states(
                                 present: record_kind == expected_kind
                                     && matches!(record[16], 0 | 1),
                                 surrogate: u64::from_be_bytes(
-                                    record[24..32].try_into().expect("fixed record"),
+                                    record[17..25].try_into().expect("fixed record"),
                                 ),
                             },
                         );
-                        record_index += 1;
+                        next = identity_codec::take(&mut remaining)?;
                         break;
                     }
                 }
@@ -1605,20 +1587,24 @@ fn reject_retained_identity_collisions(
             groups.entry(index).or_default().push(item);
         }
     }
-    for (index, items) in groups {
+    for (index, mut items) in groups {
         let bytes = authenticated_block(
             &mut run.identities,
             &run.descriptor.identities.blocks[index],
             IDENTITY_RECORD_WIDTH,
             metrics,
         )?;
+        items.sort_unstable_by_key(|item| item.0);
+        let mut remaining = bytes.as_slice();
+        let mut next = identity_codec::take(&mut remaining)?;
         for (uuid, kind, surrogate) in items {
-            let found = block_record_index(&bytes, IDENTITY_RECORD_WIDTH, uuid.as_bytes())
-                .map(|at| &bytes[at * 32..at * 32 + 32]);
-            if let Some(record) = found {
+            while next.is_some_and(|record| record[..16] < uuid.as_bytes()[..]) {
+                next = identity_codec::take(&mut remaining)?;
+            }
+            if let Some(record) = next.filter(|record| record[..16] == uuid.as_bytes()[..]) {
                 let retained_kind = record[16];
                 let retained_surrogate =
-                    u64::from_be_bytes(record[24..32].try_into().expect("fixed"));
+                    u64::from_be_bytes(record[17..25].try_into().expect("fixed"));
                 let deletion_matches = ((*kind == 2 && retained_kind == 0)
                     || (*kind == 3 && retained_kind == 1))
                     && retained_surrogate == *surrogate;
@@ -2354,7 +2340,7 @@ impl UuidConstructionSnapshot {
                 .expect("one UUID head was selected");
             let record = heads[selected].as_ref().expect("selected head exists");
             let kind = record[16];
-            if !matches!(kind, 0..=3) || record[17..24].iter().any(|byte| *byte != 0) {
+            if !matches!(kind, 0..=3) {
                 return Err(storage_err(
                     "construction UUID identity record is malformed",
                 ));
@@ -2367,7 +2353,7 @@ impl UuidConstructionSnapshot {
                     } else {
                         UuidIndexKind::Edge
                     },
-                    surrogate: u64::from_be_bytes(record[24..32].try_into().expect("fixed")),
+                    surrogate: u64::from_be_bytes(record[17..25].try_into().expect("fixed")),
                 };
                 if identity.kind == UuidIndexKind::Node {
                     if identity.surrogate == 0 {
@@ -2442,7 +2428,7 @@ impl ConstructionRunCursor {
             if self.block_index == self.descriptor.blocks.len() {
                 self.finished = true;
                 if self.records != self.descriptor.count
-                    || self.bytes != self.descriptor.count.saturating_mul(self.width as u64)
+                    || self.bytes != record_length(&self.descriptor, self.width as u64)?
                     || hex_bytes(&self.digest.clone().finalize()) != self.descriptor.sha256
                 {
                     return Err(storage_err("construction UUID run authentication failed"));
@@ -2451,25 +2437,14 @@ impl ConstructionRunCursor {
             }
             let descriptor = &self.descriptor.blocks[self.block_index];
             if descriptor.offset != self.bytes
-                || descriptor.len as usize % self.width != 0
+                || descriptor.len as usize > BULK_IO_BYTES
                 || descriptor.len == 0
             {
                 return Err(storage_err("construction UUID block framing changed"));
             }
             self.block.resize(descriptor.len as usize, 0);
             self.file.read_exact(&mut self.block).map_err(storage_err)?;
-            let key_width = if self.width == IDENTITY_RECORD_WIDTH {
-                16
-            } else {
-                8
-            };
-            if hex_sha256(&self.block) != descriptor.sha256
-                || hex_sha256_key(&self.block[..key_width]) != descriptor.first_key
-                || hex_sha256_key(
-                    &self.block
-                        [self.block.len() - self.width..self.block.len() - self.width + key_width],
-                ) != descriptor.last_key
-            {
+            if !block_matches(&self.block, descriptor, self.width) {
                 return Err(storage_err("construction UUID block digest changed"));
             }
             self.digest.update(&self.block);
@@ -2478,9 +2453,18 @@ impl ConstructionRunCursor {
             self.block_index += 1;
             self.within = 0;
         }
-        let end = self.within + self.width;
-        let record = self.block[self.within..end].to_vec();
-        self.within = end;
+        let record = if self.width == IDENTITY_RECORD_WIDTH {
+            let mut remaining = &self.block[self.within..];
+            let record = identity_codec::take(&mut remaining)?
+                .ok_or_else(|| storage_err("missing identity record"))?;
+            self.within = self.block.len() - remaining.len();
+            record.to_vec()
+        } else {
+            let end = self.within + self.width;
+            let record = self.block[self.within..end].to_vec();
+            self.within = end;
+            record
+        };
         self.records = self.records.saturating_add(1);
         Ok(Some(record))
     }
@@ -2635,13 +2619,14 @@ impl AuthenticatedUuidIndexSnapshot {
             source_volume: identity.volume_serial,
             source_file_id: hex_bytes(&identity.file_id),
             target_path: format!("{INDEX_DIR}/{}", record.name),
-            bytes: record
-                .count
-                .saturating_mul(if record.name.starts_with("identities-") {
+            bytes: record_length(
+                record,
+                if record.name.starts_with("identities-") {
                     IDENTITY_RECORD_BYTES
                 } else {
                     NODE_LOOKUP_RECORD_BYTES
-                }),
+                },
+            )?,
             sha256: record.sha256.clone(),
             parent_manifest_sha256: self.manifest_sha256.clone(),
         })
@@ -2680,7 +2665,13 @@ impl AuthenticatedUuidIndexSnapshot {
             .iter()
             .fold(manifest_bytes, |total, run| {
                 total
-                    .saturating_add(run.identities.count.saturating_mul(IDENTITY_RECORD_BYTES))
+                    .saturating_add(
+                        run.identities
+                            .blocks
+                            .iter()
+                            .map(|block| u64::from(block.len))
+                            .sum::<u64>(),
+                    )
                     .saturating_add(
                         run.node_surrogates
                             .count
@@ -2724,14 +2715,14 @@ impl AuthenticatedUuidIndexSnapshot {
             .ok_or_else(|| storage_err("retained construction run is absent"))?;
         let mut file = self.open_retained_file(record)?;
         let identity = graphforge_filesystem::file_identity(&file).map_err(storage_err)?;
-        let expected_bytes =
-            record
-                .count
-                .saturating_mul(if record.name.starts_with("identities-") {
-                    IDENTITY_RECORD_BYTES
-                } else {
-                    NODE_LOOKUP_RECORD_BYTES
-                });
+        let expected_bytes = record_length(
+            record,
+            if record.name.starts_with("identities-") {
+                IDENTITY_RECORD_BYTES
+            } else {
+                NODE_LOOKUP_RECORD_BYTES
+            },
+        )?;
         file.seek(SeekFrom::Start(0)).map_err(storage_err)?;
         let mut digest = Sha256::new();
         let mut actual_bytes = 0_u64;
@@ -2792,7 +2783,10 @@ impl AuthenticatedUuidIndexSnapshot {
             let node_surrogates =
                 open_verified_at(&root, &descriptor.node_surrogates, NODE_LOOKUP_RECORD_BYTES)?;
             authenticated_bytes = authenticated_bytes
-                .saturating_add(descriptor.identities.count * IDENTITY_RECORD_BYTES)
+                .saturating_add(record_length(
+                    &descriptor.identities,
+                    IDENTITY_RECORD_BYTES,
+                )?)
                 .saturating_add(descriptor.node_surrogates.count * NODE_LOOKUP_RECORD_BYTES);
             authenticated_blocks = authenticated_blocks
                 .saturating_add(descriptor.identities.blocks.len() as u64)
@@ -2892,7 +2886,7 @@ impl AuthenticatedUuidIndexSnapshot {
                     .find(|entry| entry.relative_path == logical)
                     .ok_or_else(|| storage_err("compact UUID run is absent"))?;
                 if entry.content_sha256 != record.sha256
-                    || entry.byte_length != record.count.saturating_mul(width)
+                    || entry.byte_length != record_length(record, width)?
                 {
                     return Err(storage_err("compact UUID run authority changed"));
                 }
@@ -2931,7 +2925,10 @@ impl AuthenticatedUuidIndexSnapshot {
                 None,
             )?;
             authenticated_bytes = authenticated_bytes
-                .saturating_add(descriptor.identities.count * IDENTITY_RECORD_BYTES)
+                .saturating_add(record_length(
+                    &descriptor.identities,
+                    IDENTITY_RECORD_BYTES,
+                )?)
                 .saturating_add(descriptor.node_surrogates.count * NODE_LOOKUP_RECORD_BYTES);
             authenticated_blocks = authenticated_blocks
                 .saturating_add(descriptor.identities.blocks.len() as u64)
@@ -3148,7 +3145,10 @@ impl AuthenticatedUuidIndexSnapshot {
                     NODE_LOOKUP_RECORD_BYTES,
                 )?;
                 authenticated_bytes = authenticated_bytes
-                    .saturating_add(descriptor.identities.count * IDENTITY_RECORD_BYTES)
+                    .saturating_add(record_length(
+                        &descriptor.identities,
+                        IDENTITY_RECORD_BYTES,
+                    )?)
                     .saturating_add(descriptor.node_surrogates.count * NODE_LOOKUP_RECORD_BYTES);
                 next_runs.push(AuthenticatedRun {
                     identities_identity: graphforge_filesystem::file_identity(&identities)
@@ -3377,7 +3377,7 @@ fn encode_construction_index_inner(
         .open_child_file(std::ffi::OsStr::new(identities_name))
         .map_err(storage_err)?;
     let input_len = input.metadata().map_err(storage_err)?.len();
-    if input_len % IDENTITY_RECORD_BYTES != 0 {
+    if input_len % CONSTRUCTION_IDENTITY_WIDTH as u64 != 0 {
         return Err(storage_err("construction identity stream is truncated"));
     }
     let source_identity = graphforge_filesystem::file_identity(&input).map_err(storage_err)?;
@@ -3434,7 +3434,8 @@ fn encode_construction_index_inner(
     )
     .map_err(storage_err)?;
     crate::graph_construction::construction_failpoint("uuid_encode.after_temps");
-    let aligned_input_bytes = (BULK_IO_BYTES / IDENTITY_RECORD_WIDTH) * IDENTITY_RECORD_WIDTH;
+    let aligned_input_bytes =
+        (BULK_IO_BYTES / CONSTRUCTION_IDENTITY_WIDTH) * CONSTRUCTION_IDENTITY_WIDTH;
     let aligned_surrogate_bytes =
         (BULK_IO_BYTES / NODE_LOOKUP_RECORD_WIDTH) * NODE_LOOKUP_RECORD_WIDTH;
     let mut input_block = vec![0_u8; aligned_input_bytes];
@@ -3459,7 +3460,13 @@ fn encode_construction_index_inner(
             source_digest.update(&input_block[..count]);
             work.read_bytes = work.read_bytes.saturating_add(count as u64);
             work.read_operations = work.read_operations.saturating_add(1);
-            for record in input_block[..count].chunks_exact_mut(IDENTITY_RECORD_WIDTH) {
+            let mut packed_len = 0;
+            for source_offset in (0..count).step_by(CONSTRUCTION_IDENTITY_WIDTH) {
+                let record =
+                    &input_block[source_offset..source_offset + CONSTRUCTION_IDENTITY_WIDTH];
+                let mut packed = [0_u8; IDENTITY_RECORD_WIDTH];
+                packed[..17].copy_from_slice(&record[..17]);
+                packed[17..].copy_from_slice(&record[24..32]);
                 let uuid: [u8; 16] = record[..16].try_into().expect("fixed UUID");
                 if previous_uuid.is_some_and(|prior| prior >= uuid)
                     || record[17..24].iter().any(|byte| *byte != 0)
@@ -3494,18 +3501,20 @@ fn encode_construction_index_inner(
                         node_count = node_count.saturating_add(1);
                     }
                     1 => {
-                        // Construction assigns edge surrogates for topology; v3
-                        // edge membership deliberately stores zero.
-                        record[24..32].fill(0);
+                        // Edge surrogates belong to topology; membership stores only the UUID.
+                        packed[17..].fill(0);
                         edge_count = edge_count.saturating_add(1);
                     }
                     _ => return Err(storage_err("construction identity kind is invalid")),
                 }
+                let packed = identity_codec::encoded(&packed)?;
+                input_block[packed_len..packed_len + packed.len()].copy_from_slice(packed);
+                packed_len += packed.len();
             }
             identity_writer
-                .write_all(&input_block[..count])
+                .write_all(&input_block[..packed_len])
                 .map_err(storage_err)?;
-            work.write_bytes = work.write_bytes.saturating_add(count as u64);
+            work.write_bytes = work.write_bytes.saturating_add(packed_len as u64);
             work.write_operations = work.write_operations.saturating_add(1);
             remaining -= count as u64;
         }
@@ -3593,7 +3602,7 @@ fn encode_construction_index_inner(
         &index,
         &identity_temp,
         identity_identity,
-        "identities-v3",
+        "identities-v5",
         generation,
         IDENTITY_RECORD_WIDTH,
         &mut artifacts,
@@ -3603,7 +3612,7 @@ fn encode_construction_index_inner(
         &index,
         &surrogate_temp,
         surrogate_identity,
-        "node-surrogates-v3",
+        "node-surrogates-v5",
         generation,
         NODE_LOOKUP_RECORD_WIDTH,
         &mut artifacts,
@@ -3618,7 +3627,7 @@ fn encode_construction_index_inner(
     if parent_generation == 0 {
         let base_identity = install_empty_construction_run(
             &index,
-            "identities-v3-base",
+            "identities-v5-base",
             0,
             IDENTITY_RECORD_WIDTH,
             &mut artifacts,
@@ -3626,7 +3635,7 @@ fn encode_construction_index_inner(
         )?;
         let base_surrogate = install_empty_construction_run(
             &index,
-            "node-surrogates-v3-base",
+            "node-surrogates-v5-base",
             0,
             NODE_LOOKUP_RECORD_WIDTH,
             &mut artifacts,
@@ -3847,8 +3856,8 @@ fn cleanup_private_construction_index_with_allocation(
             && name_text != MANIFEST
             && !name_text.starts_with(".construction-")
             && !name_text.starts_with(".manifest.json-")
-            && !name_text.starts_with("identities-v3")
-            && !name_text.starts_with("node-surrogates-v3")
+            && !name_text.starts_with("identities-v5")
+            && !name_text.starts_with("node-surrogates-v5")
             && !v4_allowed.contains(name_text)
         {
             return Err(storage_err(
@@ -4266,7 +4275,7 @@ fn compact_construction_levels(
                 &left.identities,
                 &right.identities,
                 output_names,
-                &format!("identities-v3-l{}", level + 1),
+                &format!("identities-v5-l{}", level + 1),
                 generation,
                 IDENTITY_RECORD_WIDTH,
                 artifacts,
@@ -4280,7 +4289,7 @@ fn compact_construction_levels(
                 &left.node_surrogates,
                 &right.node_surrogates,
                 output_names,
-                &format!("node-surrogates-v3-l{}", level + 1),
+                &format!("node-surrogates-v5-l{}", level + 1),
                 generation,
                 NODE_LOOKUP_RECORD_WIDTH,
                 artifacts,
@@ -4529,15 +4538,23 @@ impl ConstructionBlockCursor {
         Ok(cursor)
     }
 
+    fn record_width(&self) -> usize {
+        if self.width == IDENTITY_RECORD_WIDTH && self.block[self.within + 16] == 1 {
+            identity_codec::EDGE_WIDTH
+        } else {
+            self.width
+        }
+    }
+
     fn current(&self) -> Option<&[u8]> {
-        (!self.finished).then(|| &self.block[self.within..self.within + self.width])
+        (!self.finished).then(|| &self.block[self.within..self.within + self.record_width()])
     }
 
     fn advance(&mut self) -> Result<(), GfError> {
         if self.finished {
             return Ok(());
         }
-        self.within += self.width;
+        self.within += self.record_width();
         self.records = self.records.saturating_add(1);
         if self.within == self.block.len() {
             self.fill()?;
@@ -4564,9 +4581,9 @@ impl ConstructionBlockCursor {
             );
         }
         let expected = &self.descriptor.blocks[self.block_index];
-        if expected.offset != self.records.saturating_mul(self.width as u64)
+        if expected.offset != self.read_bytes
             || expected.len == 0
-            || !(expected.len as usize).is_multiple_of(self.width)
+            || expected.len as usize > BULK_IO_BYTES
         {
             return Err(storage_err("construction merge block framing changed"));
         }
@@ -4574,18 +4591,7 @@ impl ConstructionBlockCursor {
         self.file.read_exact(&mut self.block).map_err(storage_err)?;
         self.read_bytes = self.read_bytes.saturating_add(self.block.len() as u64);
         self.read_operations = self.read_operations.saturating_add(1);
-        let key_width = if self.width == IDENTITY_RECORD_WIDTH {
-            16
-        } else {
-            8
-        };
-        if hex_sha256(&self.block) != expected.sha256
-            || hex_sha256_key(&self.block[..key_width]) != expected.first_key
-            || hex_sha256_key(
-                &self.block
-                    [self.block.len() - self.width..self.block.len() - self.width + key_width],
-            ) != expected.last_key
-        {
+        if !block_matches(&self.block, expected, self.width) {
             return Err(storage_err("construction merge source block changed"));
         }
         self.digest.update(&self.block);
@@ -4712,59 +4718,16 @@ fn describe_and_install_construction_run(
         .open_child_file(std::ffi::OsStr::new(temporary))
         .map_err(storage_err)?;
     let bytes = file.metadata().map_err(storage_err)?.len();
-    if bytes % width as u64 != 0 {
-        return Err(storage_err("construction index run is truncated"));
-    }
-    let block_bytes = (BULK_IO_BYTES / width) * width;
-    let key_width = if width == IDENTITY_RECORD_WIDTH {
-        16
-    } else {
-        8
-    };
     let mut file =
         graphforge_filesystem::FileCacheReleasingReader::new(file).map_err(storage_err)?;
-    let mut digest = Sha256::new();
-    let mut blocks = Vec::new();
-    let mut offset = 0_u64;
-    let mut buffer = vec![0_u8; block_bytes];
-    let described = (|| -> Result<(), GfError> {
-        loop {
-            let mut filled = 0;
-            while filled < buffer.len() {
-                let read = file.read(&mut buffer[filled..]).map_err(storage_err)?;
-                if read == 0 {
-                    break;
-                }
-                filled += read;
-                work.read_bytes = work.read_bytes.saturating_add(read as u64);
-                work.read_operations = work.read_operations.saturating_add(1);
-            }
-            if filled == 0 {
-                break;
-            }
-            if filled % width != 0 {
-                return Err(storage_err("construction index block framing changed"));
-            }
-            let block = &buffer[..filled];
-            digest.update(block);
-            blocks.push(BlockRecord {
-                offset,
-                len: u32::try_from(filled).map_err(storage_err)?,
-                first_key: hex_bytes(&block[..key_width]),
-                last_key: hex_bytes(&block[filled - width..filled - width + key_width]),
-                sha256: hex_sha256(block),
-            });
-            offset = offset.saturating_add(filled as u64);
-            if filled < buffer.len() {
-                break;
-            }
-        }
-        Ok(())
-    })();
+    let mut reads = (0_u64, 0_u64);
+    let described = describe_stream(&mut file, width, &mut reads);
+    work.read_bytes = work.read_bytes.saturating_add(reads.0);
+    work.read_operations = work.read_operations.saturating_add(reads.1);
     let released = file.finish().map_err(storage_err);
-    let read_cache_release = match (described, released) {
-        (Ok(()), Ok(released)) => released,
-        (Ok(()), Err(release)) => return Err(release),
+    let ((sha256, blocks, count), read_cache_release) = match (described, released) {
+        (Ok(described), Ok(released)) => (described, released),
+        (Ok(_), Err(release)) => return Err(release),
         (Err(primary), Ok(_)) => return Err(primary),
         (Err(primary), Err(release)) => {
             return Err(storage_err(format!(
@@ -4773,7 +4736,6 @@ fn describe_and_install_construction_run(
         }
     };
     merge_cache_release_evidence(&mut work.cache_release, read_cache_release);
-    let sha256 = hex_bytes(&digest.finalize());
     let name = format!("{prefix}-{generation}-{}.uuidx", &sha256[..16]);
     output
         .replace_child(
@@ -4791,7 +4753,7 @@ fn describe_and_install_construction_run(
     });
     Ok(FileRecord {
         name,
-        count: bytes / width as u64,
+        count,
         sha256,
         blocks,
     })
@@ -5417,7 +5379,7 @@ fn is_canonical_run_name(name: &str) -> bool {
         return false;
     };
     let is_v4 = is_canonical_v4_artifact_prefix(prefix);
-    ((prefix.starts_with("identities-v3") || prefix.starts_with("node-surrogates-v3")) || is_v4)
+    ((prefix.starts_with("identities-v5") || prefix.starts_with("node-surrogates-v5")) || is_v4)
         && digest.len() == 16
         && if is_v4 {
             digest
@@ -5915,7 +5877,7 @@ pub(crate) fn prepare_uuid_membership_delta(
         metrics,
         manifest,
         auxiliary: crate::AuxiliaryReceipt {
-            kind: "uuid-membership/v3".to_owned(),
+            kind: "uuid-membership/v5".to_owned(),
             schema_version: FORMAT_VERSION,
             path: format!("{INDEX_DIR}/{TOPOLOGY_RECEIPT}"),
             digest: hex_bytes(&digest),
@@ -6099,17 +6061,17 @@ fn plan_uuid_membership_delta(
 
     let identity_path = scratch.join("identities-l0.run");
     let surrogate_path = scratch.join("surrogates-l0.run");
-    write_identity_records(&identity_path, &identities)?;
-    write_surrogate_records(&surrogate_path, &surrogates)?;
+    let identity_write_blocks = write_identity_records(&identity_path, &identities)?;
+    let surrogate_write_blocks = write_surrogate_records(&surrogate_path, &surrogates)?;
     let identity_record = describe_run(
         &identity_path,
-        "identities-v3",
+        "identities-v5",
         generation,
         IDENTITY_RECORD_BYTES,
     )?;
     let surrogate_record = describe_run(
         &surrogate_path,
-        "node-surrogates-v3",
+        "node-surrogates-v5",
         generation,
         NODE_LOOKUP_RECORD_BYTES,
     )?;
@@ -6126,13 +6088,13 @@ fn plan_uuid_membership_delta(
         sync_uuid_file(&empty_surrogate)?;
         let base_identities = describe_run(
             &empty_identity_path,
-            "identities-v3-base",
+            "identities-v5-base",
             0,
             IDENTITY_RECORD_BYTES,
         )?;
         let base_surrogates = describe_run(
             &empty_surrogate_path,
-            "node-surrogates-v3-base",
+            "node-surrogates-v5-base",
             0,
             NODE_LOOKUP_RECORD_BYTES,
         )?;
@@ -6165,13 +6127,17 @@ fn plan_uuid_membership_delta(
     });
     let mut metrics = UuidIndexAppendMetrics {
         input_records: identities.len() as u64,
-        physical_bytes_written: identities.len() as u64 * IDENTITY_RECORD_BYTES
+        physical_bytes_written: identities
+            .iter()
+            .map(|(_, kind, _)| if *kind == 1 { 17_u64 } else { 25_u64 })
+            .sum::<u64>()
             + surrogates.len() as u64 * NODE_LOOKUP_RECORD_BYTES,
-        write_bytes: identities.len() as u64 * IDENTITY_RECORD_BYTES
+        write_bytes: identities
+            .iter()
+            .map(|(_, kind, _)| if *kind == 1 { 17_u64 } else { 25_u64 })
+            .sum::<u64>()
             + surrogates.len() as u64 * NODE_LOOKUP_RECORD_BYTES,
-        write_blocks: (identities.len() as u64 * IDENTITY_RECORD_BYTES)
-            .div_ceil(BULK_IO_BYTES as u64)
-            + (surrogates.len() as u64 * NODE_LOOKUP_RECORD_BYTES).div_ceil(BULK_IO_BYTES as u64),
+        write_blocks: identity_write_blocks + surrogate_write_blocks,
         peak_buffered_records: identities.len() + surrogates.len(),
         peak_buffered_bytes: identities.len() * 32 + surrogates.len() * 24,
         validation_random_seeks: 0,
@@ -6248,6 +6214,43 @@ fn plan_uuid_membership_delta(
     Ok((manifest, outputs, superseded, metrics))
 }
 
+fn record_length(record: &FileRecord, width: u64) -> Result<u64, GfError> {
+    if width == IDENTITY_RECORD_BYTES {
+        record.blocks.iter().try_fold(0_u64, |total, block| {
+            total
+                .checked_add(u64::from(block.len))
+                .ok_or_else(|| storage_err("record length overflow"))
+        })
+    } else {
+        record
+            .count
+            .checked_mul(width)
+            .ok_or_else(|| storage_err("record length overflow"))
+    }
+}
+
+fn block_layout(bytes: &[u8], width: usize) -> Result<(u64, &[u8], &[u8]), GfError> {
+    if width == IDENTITY_RECORD_WIDTH {
+        return identity_codec::layout(bytes);
+    }
+    if width != NODE_LOOKUP_RECORD_WIDTH || bytes.is_empty() || !bytes.len().is_multiple_of(width) {
+        return Err(storage_err("partial UUID run record"));
+    }
+    Ok((
+        (bytes.len() / width) as u64,
+        &bytes[..8],
+        &bytes[bytes.len() - width..bytes.len() - width + 8],
+    ))
+}
+
+fn block_matches(bytes: &[u8], block: &BlockRecord, width: usize) -> bool {
+    block_layout(bytes, width).is_ok_and(|(_, first, last)| {
+        hex_sha256(bytes) == block.sha256
+            && hex_sha256_key(first) == block.first_key
+            && hex_sha256_key(last) == block.last_key
+    })
+}
+
 fn open_verified_at(
     directory: &graphforge_filesystem::StableDirectory,
     record: &FileRecord,
@@ -6257,10 +6260,7 @@ fn open_verified_at(
         return Err(storage_err("manifest contains a non-local index filename"));
     }
     let mut file = open_uuid_child_file(directory, std::ffi::OsStr::new(&record.name))?;
-    let expected = record
-        .count
-        .checked_mul(record_bytes)
-        .ok_or_else(|| storage_err("record length overflow"))?;
+    let expected = record_length(record, record_bytes)?;
     if file.metadata().map_err(storage_err)?.len() != expected {
         return Err(storage_err("retained run authentication failed"));
     }
@@ -6277,6 +6277,7 @@ fn authenticate_file_blocks(
 ) -> Result<(), GfError> {
     validate_block_records(record, record_bytes)?;
     let mut whole = Sha256::new();
+    let mut count = 0_u64;
     for block in &record.blocks {
         file.seek(SeekFrom::Start(block.offset))
             .map_err(storage_err)?;
@@ -6284,18 +6285,12 @@ fn authenticate_file_blocks(
         file.read_exact(&mut bytes).map_err(storage_err)?;
         let width = usize::try_from(record_bytes)
             .map_err(|_| storage_err("record width does not fit address space"))?;
-        let key_width = if record_bytes == IDENTITY_RECORD_BYTES {
-            16
-        } else {
-            8
-        };
-        if hex_sha256(&bytes) != block.sha256
-            || hex_sha256_key(&bytes[..key_width]) != block.first_key
-            || hex_sha256_key(&bytes[bytes.len() - width..bytes.len() - width + key_width])
-                != block.last_key
-        {
+        if !block_matches(&bytes, block, width) {
             return Err(storage_err("UUID run block authentication failed"));
         }
+        count = count
+            .checked_add(block_layout(&bytes, width)?.0)
+            .ok_or_else(|| storage_err("record count overflow"))?;
         whole.update(&bytes);
         if let Some(metrics) = work.as_deref_mut() {
             metrics.validation_scan_bytes = metrics
@@ -6305,19 +6300,16 @@ fn authenticate_file_blocks(
         }
     }
     let digest = hex_bytes(&whole.finalize());
-    if digest != record.sha256 {
+    if digest != record.sha256 || count != record.count {
         return Err(storage_err("UUID run authentication failed"));
     }
     Ok(())
 }
 
 fn validate_block_records(record: &FileRecord, record_bytes: u64) -> Result<(), GfError> {
-    let expected = record
-        .count
-        .checked_mul(record_bytes)
-        .ok_or_else(|| storage_err("record length overflow"))?;
+    let expected = record_length(record, record_bytes)?;
     if expected == 0 {
-        if !record.blocks.is_empty() {
+        if record.count != 0 || !record.blocks.is_empty() {
             return Err(storage_err("empty UUID run has authenticated blocks"));
         }
         return Ok(());
@@ -6331,7 +6323,7 @@ fn validate_block_records(record: &FileRecord, record_bytes: u64) -> Result<(), 
     for block in &record.blocks {
         if block.offset != offset
             || block.len == 0
-            || u64::from(block.len) % record_bytes != 0
+            || (record_bytes != IDENTITY_RECORD_BYTES && u64::from(block.len) % record_bytes != 0)
             || block.len as usize > BULK_IO_BYTES
             || block.first_key.len() != key_hex_len
             || block.last_key.len() != key_hex_len
@@ -6342,7 +6334,10 @@ fn validate_block_records(record: &FileRecord, record_bytes: u64) -> Result<(), 
         }
         offset = offset.saturating_add(u64::from(block.len));
     }
-    if offset != expected
+    if (record_bytes == IDENTITY_RECORD_BYTES
+        && (expected < record.count.saturating_mul(17)
+            || expected > record.count.saturating_mul(25)))
+        || offset != expected
         || record
             .blocks
             .windows(2)
@@ -6360,57 +6355,104 @@ fn describe_run(
     width: u64,
 ) -> Result<FileRecord, GfError> {
     let length = path.metadata().map_err(storage_err)?.len();
-    if length % width != 0 {
+    if width != IDENTITY_RECORD_BYTES && length % width != 0 {
         return Err(storage_err("internal run has a partial index record"));
     }
-    let (sha256, blocks) = describe_blocks(&mut open_uuid_file(path)?, width)?;
+    let (sha256, blocks, count) = describe_blocks(&mut open_uuid_file(path)?, width)?;
     Ok(FileRecord {
         name: format!("{kind}-{generation}-{}.uuidx", &sha256[..16]),
-        count: length / width,
+        count,
         sha256,
         blocks,
     })
 }
 
-fn describe_blocks(file: &mut File, width: u64) -> Result<(String, Vec<BlockRecord>), GfError> {
-    let width = usize::try_from(width).map_err(storage_err)?;
-    let key_width = match width {
-        32 => 16,
-        24 => 8,
-        _ => return Err(storage_err("unsupported UUID run record width")),
-    };
-    let block_len = BULK_IO_BYTES / width * width;
+fn describe_blocks(
+    file: &mut File,
+    width: u64,
+) -> Result<(String, Vec<BlockRecord>, u64), GfError> {
+    describe_stream(
+        file,
+        usize::try_from(width).map_err(storage_err)?,
+        &mut (0, 0),
+    )
+}
+
+/// Read bounded physical windows while carrying at most one partial record.
+/// Published authentication blocks always end at a complete record boundary.
+fn describe_stream(
+    file: &mut impl Read,
+    width: usize,
+    reads: &mut (u64, u64),
+) -> Result<(String, Vec<BlockRecord>, u64), GfError> {
+    if !matches!(width, IDENTITY_RECORD_WIDTH | NODE_LOOKUP_RECORD_WIDTH) {
+        return Err(storage_err("unsupported UUID run record width"));
+    }
+    let mut buffer = vec![0_u8; BULK_IO_BYTES];
+    let mut carried = 0;
     let mut offset = 0_u64;
+    let mut count = 0_u64;
     let mut whole = Sha256::new();
     let mut blocks = Vec::new();
-    let mut bytes = vec![0_u8; block_len];
     loop {
-        let mut valid = 0;
-        while valid < bytes.len() {
-            let read = file.read(&mut bytes[valid..]).map_err(storage_err)?;
+        let mut filled = carried;
+        let mut eof = false;
+        while filled < buffer.len() {
+            let read = file.read(&mut buffer[filled..]).map_err(storage_err)?;
             if read == 0 {
+                eof = true;
                 break;
             }
-            valid += read;
+            filled += read;
+            reads.0 = reads.0.saturating_add(read as u64);
+            reads.1 = reads.1.saturating_add(1);
         }
-        if valid == 0 {
+        if filled == 0 {
             break;
         }
-        if valid % width != 0 {
+        let valid = if width == IDENTITY_RECORD_WIDTH {
+            let mut valid = 0;
+            while filled - valid >= identity_codec::EDGE_WIDTH {
+                let length = match buffer[valid + 16] {
+                    1 => identity_codec::EDGE_WIDTH,
+                    0 | 2 | 3 => IDENTITY_RECORD_WIDTH,
+                    _ => return Err(storage_err("identity record kind is invalid")),
+                };
+                if filled - valid < length {
+                    break;
+                }
+                valid += length;
+            }
+            valid
+        } else {
+            filled / width * width
+        };
+        if valid == 0 || (eof && valid != filled) {
             return Err(storage_err("internal run has a partial index record"));
         }
-        let slice = &bytes[..valid];
-        whole.update(slice);
+        let bytes = &buffer[..valid];
+        let (records, first, last) = block_layout(bytes, width)?;
+        whole.update(bytes);
         blocks.push(BlockRecord {
             offset,
             len: u32::try_from(valid).map_err(storage_err)?,
-            first_key: hex_sha256_key(&slice[..key_width]),
-            last_key: hex_sha256_key(&slice[valid - width..valid - width + key_width]),
-            sha256: hex_sha256(slice),
+            first_key: hex_sha256_key(first),
+            last_key: hex_sha256_key(last),
+            sha256: hex_sha256(bytes),
         });
-        offset = offset.saturating_add(valid as u64);
+        offset = offset
+            .checked_add(valid as u64)
+            .ok_or_else(|| storage_err("block offset overflow"))?;
+        count = count
+            .checked_add(records)
+            .ok_or_else(|| storage_err("record count overflow"))?;
+        carried = filled - valid;
+        buffer.copy_within(valid..filled, 0);
+        if eof {
+            break;
+        }
     }
-    Ok((hex_bytes(&whole.finalize()), blocks))
+    Ok((hex_bytes(&whole.finalize()), blocks, count))
 }
 
 fn hex_sha256_key(bytes: &[u8]) -> String {
@@ -6483,17 +6525,17 @@ fn compact_planned_levels(
         merge_surrogate_handles(surrogate_inputs, &surrogate_path, metrics)?;
         let identities = describe_run(
             &identity_path,
-            &format!("identities-v3-l{}", level + 1),
+            &format!("identities-v5-l{}", level + 1),
             right.last_generation,
             IDENTITY_RECORD_BYTES,
         )?;
         let node_surrogates = describe_run(
             &surrogate_path,
-            &format!("node-surrogates-v3-l{}", level + 1),
+            &format!("node-surrogates-v5-l{}", level + 1),
             right.last_generation,
             NODE_LOOKUP_RECORD_BYTES,
         )?;
-        let bytes = identities.count * IDENTITY_RECORD_BYTES
+        let bytes = record_length(&identities, IDENTITY_RECORD_BYTES)?
             + node_surrogates.count * NODE_LOOKUP_RECORD_BYTES;
         metrics.physical_bytes_written = metrics.physical_bytes_written.saturating_add(bytes);
         metrics.write_bytes = metrics.write_bytes.saturating_add(bytes);
@@ -6552,7 +6594,6 @@ struct VerifiedBlockReader {
     authenticated_bytes: u64,
     authenticated_blocks: u64,
     width: usize,
-    key_width: usize,
 }
 
 impl VerifiedBlockReader {
@@ -6568,11 +6609,6 @@ impl VerifiedBlockReader {
             authenticated_blocks: 0,
             width: usize::try_from(width)
                 .map_err(|_| storage_err("record width does not fit address space"))?,
-            key_width: if width == IDENTITY_RECORD_BYTES {
-                16
-            } else {
-                8
-            },
         })
     }
 }
@@ -6586,13 +6622,7 @@ impl Read for VerifiedBlockReader {
             self.file.seek(SeekFrom::Start(block.offset))?;
             self.bytes.resize(block.len as usize, 0);
             self.file.read_exact(&mut self.bytes)?;
-            if hex_sha256(&self.bytes) != block.sha256
-                || hex_sha256_key(&self.bytes[..self.key_width]) != block.first_key
-                || hex_sha256_key(
-                    &self.bytes[self.bytes.len() - self.width
-                        ..self.bytes.len() - self.width + self.key_width],
-                ) != block.last_key
-            {
+            if !block_matches(&self.bytes, block, self.width) {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     "UUID compaction block authentication failed",
@@ -6622,9 +6652,9 @@ fn merge_identity_handles(
         .into_iter()
         .map(|(file, record)| VerifiedBlockReader::new(file, &record, IDENTITY_RECORD_BYTES))
         .collect::<Result<Vec<_>, _>>()?;
-    let mut heap = BinaryHeap::<Reverse<([u8; 32], usize)>>::new();
+    let mut heap = BinaryHeap::<Reverse<([u8; IDENTITY_RECORD_WIDTH], usize)>>::new();
     for (index, reader) in readers.iter_mut().enumerate() {
-        if let Some(record) = read_exact_record::<32>(reader)? {
+        if let Some(record) = identity_codec::read(reader)? {
             heap.push(Reverse((record, index)));
         }
     }
@@ -6633,7 +6663,7 @@ fn merge_identity_handles(
     while let Some(Reverse((mut record, index))) = heap.pop() {
         let key: [u8; 16] = record[..16].try_into().expect("fixed");
         let mut newest = index;
-        if let Some(next) = read_exact_record::<32>(&mut readers[index])? {
+        if let Some(next) = identity_codec::read(&mut readers[index])? {
             heap.push(Reverse((next, index)));
         }
         while heap
@@ -6645,15 +6675,15 @@ fn merge_identity_handles(
                 record = candidate;
                 newest = source;
             }
-            if let Some(next) = read_exact_record::<32>(&mut readers[source])? {
+            if let Some(next) = identity_codec::read(&mut readers[source])? {
                 heap.push(Reverse((next, source)));
             }
         }
-        if block.len() + 32 > BULK_IO_BYTES {
+        if block.len() + IDENTITY_RECORD_WIDTH > BULK_IO_BYTES {
             out.write_all(&block).map_err(storage_err)?;
             block.clear();
         }
-        block.extend_from_slice(&record);
+        block.extend_from_slice(identity_codec::encoded(&record)?);
     }
     if !block.is_empty() {
         out.write_all(&block).map_err(storage_err)?;
@@ -6852,7 +6882,7 @@ fn append_uuid_membership_delta_with_tombstones(
                 &empty,
                 &root,
                 staging,
-                "identities-v3-base",
+                "identities-v5-base",
                 0,
                 IDENTITY_RECORD_BYTES,
             )?;
@@ -6860,7 +6890,7 @@ fn append_uuid_membership_delta_with_tombstones(
                 &empty,
                 &root,
                 staging,
-                "node-surrogates-v3-base",
+                "node-surrogates-v5-base",
                 0,
                 NODE_LOOKUP_RECORD_BYTES,
             )?;
@@ -6971,13 +7001,13 @@ fn append_uuid_membership_delta_with_tombstones(
         .map_err(storage_err)?;
     let identity_path = scratch.path().join("identities.run");
     let surrogate_path = scratch.path().join("surrogates.run");
-    write_identity_records(&identity_path, &identities)?;
-    write_surrogate_records(&surrogate_path, &surrogate_keys)?;
+    let identity_write_blocks = write_identity_records(&identity_path, &identities)?;
+    let surrogate_write_blocks = write_surrogate_records(&surrogate_path, &surrogate_keys)?;
     let identity_record = publish_data(
         &identity_path,
         &root,
         staging,
-        "identities-v3",
+        "identities-v5",
         generation,
         IDENTITY_RECORD_BYTES,
     )?;
@@ -6985,7 +7015,7 @@ fn append_uuid_membership_delta_with_tombstones(
         &surrogate_path,
         &root,
         staging,
-        "node-surrogates-v3",
+        "node-surrogates-v5",
         generation,
         NODE_LOOKUP_RECORD_BYTES,
     )?;
@@ -7003,13 +7033,16 @@ fn append_uuid_membership_delta_with_tombstones(
     });
     let mut metrics = UuidIndexAppendMetrics {
         input_records: identities.len() as u64,
-        physical_bytes_written: identities.len() as u64 * IDENTITY_RECORD_BYTES
+        physical_bytes_written: identities
+            .iter()
+            .map(|(_, kind, _)| if *kind == 1 { 17_u64 } else { 25_u64 })
+            .sum::<u64>()
             + surrogate_keys.len() as u64 * NODE_LOOKUP_RECORD_BYTES,
-        write_blocks: (identities.len() as u64 * IDENTITY_RECORD_BYTES)
-            .div_ceil(BULK_IO_BYTES as u64)
-            + (surrogate_keys.len() as u64 * NODE_LOOKUP_RECORD_BYTES)
-                .div_ceil(BULK_IO_BYTES as u64),
-        write_bytes: identities.len() as u64 * IDENTITY_RECORD_BYTES
+        write_blocks: identity_write_blocks + surrogate_write_blocks,
+        write_bytes: identities
+            .iter()
+            .map(|(_, kind, _)| if *kind == 1 { 17_u64 } else { 25_u64 })
+            .sum::<u64>()
             + surrogate_keys.len() as u64 * NODE_LOOKUP_RECORD_BYTES,
         peak_buffered_records: identities.len() + surrogate_keys.len(),
         peak_buffered_bytes: identities.len() * 32 + surrogate_keys.len() * 24,
@@ -7079,10 +7112,10 @@ fn reject_identity_collisions(
     let mut incoming_index = 0;
     let mut bytes = 0_u64;
     while incoming_index < incoming.len() {
-        let Some(record) = read_exact_record::<32>(&mut retained)? else {
+        let Some(record) = identity_codec::read(&mut retained)? else {
             break;
         };
-        bytes += IDENTITY_RECORD_BYTES;
+        bytes += identity_codec::encoded(&record)?.len() as u64;
         let retained_uuid = &record[..16];
         while incoming_index < incoming.len()
             && incoming[incoming_index].0.as_bytes().as_slice() < retained_uuid
@@ -7094,7 +7127,7 @@ fn reject_identity_collisions(
         {
             let incoming_record = incoming[incoming_index];
             let retained_kind = record[16];
-            let retained_surrogate = u64::from_be_bytes(record[24..32].try_into().expect("fixed"));
+            let retained_surrogate = u64::from_be_bytes(record[17..25].try_into().expect("fixed"));
             if matches!(incoming_record.1, 2 | 3)
                 && incoming_record.1 - 2 == retained_kind
                 && incoming_record.2 == retained_surrogate
@@ -7137,31 +7170,39 @@ fn reject_surrogate_collisions(
     Ok(bytes)
 }
 
-fn write_identity_records(path: &Path, records: &[(Uuid, u8, u64)]) -> Result<(), GfError> {
+fn write_identity_records(path: &Path, records: &[(Uuid, u8, u64)]) -> Result<u64, GfError> {
+    let mut blocks = 0;
     let mut bytes = Vec::with_capacity(BULK_IO_BYTES);
     let mut file = create_uuid_file(path)?;
     for (uuid, kind, surrogate) in records {
-        if bytes.len() + 32 > BULK_IO_BYTES {
+        let mut record = [0_u8; IDENTITY_RECORD_WIDTH];
+        record[..16].copy_from_slice(uuid.as_bytes());
+        record[16] = *kind;
+        record[17..].copy_from_slice(&surrogate.to_be_bytes());
+        let encoded = identity_codec::encoded(&record)?;
+        if bytes.len() + encoded.len() > BULK_IO_BYTES {
             file.write_all(&bytes).map_err(storage_err)?;
+            blocks += 1;
             bytes.clear();
         }
-        bytes.extend_from_slice(uuid.as_bytes());
-        bytes.push(*kind);
-        bytes.extend_from_slice(&[0; 7]);
-        bytes.extend_from_slice(&surrogate.to_be_bytes());
+        bytes.extend_from_slice(encoded);
     }
     if !bytes.is_empty() {
         file.write_all(&bytes).map_err(storage_err)?;
+        blocks += 1;
     }
-    sync_uuid_file(&file)
+    sync_uuid_file(&file)?;
+    Ok(blocks)
 }
 
-fn write_surrogate_records(path: &Path, records: &[(u64, Uuid)]) -> Result<(), GfError> {
+fn write_surrogate_records(path: &Path, records: &[(u64, Uuid)]) -> Result<u64, GfError> {
+    let mut blocks = 0;
     let mut bytes = Vec::with_capacity(BULK_IO_BYTES);
     let mut file = create_uuid_file(path)?;
     for (surrogate, uuid) in records {
         if bytes.len() + 24 > BULK_IO_BYTES {
             file.write_all(&bytes).map_err(storage_err)?;
+            blocks += 1;
             bytes.clear();
         }
         bytes.extend_from_slice(&surrogate.to_be_bytes());
@@ -7169,8 +7210,10 @@ fn write_surrogate_records(path: &Path, records: &[(u64, Uuid)]) -> Result<(), G
     }
     if !bytes.is_empty() {
         file.write_all(&bytes).map_err(storage_err)?;
+        blocks += 1;
     }
-    sync_uuid_file(&file)
+    sync_uuid_file(&file)?;
+    Ok(blocks)
 }
 
 #[cfg(test)]
@@ -7243,7 +7286,7 @@ fn compact_manifest_levels(
                 &identity_path,
                 root,
                 staging,
-                &format!("identities-v3-l{}", level + 1),
+                &format!("identities-v5-l{}", level + 1),
                 right.last_generation,
                 IDENTITY_RECORD_BYTES,
             )?;
@@ -7251,11 +7294,11 @@ fn compact_manifest_levels(
                 &surrogate_path,
                 root,
                 staging,
-                &format!("node-surrogates-v3-l{}", level + 1),
+                &format!("node-surrogates-v5-l{}", level + 1),
                 right.last_generation,
                 NODE_LOOKUP_RECORD_BYTES,
             )?;
-            let bytes = identities.count * IDENTITY_RECORD_BYTES
+            let bytes = record_length(&identities, IDENTITY_RECORD_BYTES)?
                 + node_surrogates.count * NODE_LOOKUP_RECORD_BYTES;
             metrics.physical_bytes_written = metrics.physical_bytes_written.saturating_add(bytes);
             metrics.write_bytes = metrics.write_bytes.saturating_add(bytes);
@@ -7285,7 +7328,7 @@ fn count_identity_states(path: &Path) -> Result<(u64, u64, u64, u64), GfError> {
     let mut reader =
         BufReader::with_capacity(BULK_IO_BYTES, File::open(path).map_err(storage_err)?);
     let mut counts = [0_u64; 4];
-    while let Some(record) = read_exact_record::<32>(&mut reader)? {
+    while let Some(record) = identity_codec::read(&mut reader)? {
         let kind = usize::from(record[16]);
         if kind >= counts.len() {
             return Err(storage_err("invalid compacted identity kind"));
@@ -7301,9 +7344,9 @@ fn merge_identity_v3(inputs: &[PathBuf], output: &Path) -> Result<(), GfError> {
         .iter()
         .map(|path| File::open(path).map(BufReader::new).map_err(storage_err))
         .collect::<Result<Vec<_>, _>>()?;
-    let mut heap = BinaryHeap::<Reverse<([u8; 32], usize)>>::new();
+    let mut heap = BinaryHeap::<Reverse<([u8; IDENTITY_RECORD_WIDTH], usize)>>::new();
     for (index, reader) in readers.iter_mut().enumerate() {
-        if let Some(record) = read_exact_record::<32>(reader)? {
+        if let Some(record) = identity_codec::read(reader)? {
             heap.push(Reverse((record, index)));
         }
     }
@@ -7312,7 +7355,7 @@ fn merge_identity_v3(inputs: &[PathBuf], output: &Path) -> Result<(), GfError> {
     while let Some(Reverse((mut record, index))) = heap.pop() {
         let uuid: [u8; 16] = record[..16].try_into().expect("fixed");
         let mut newest_index = index;
-        if let Some(next) = read_exact_record::<32>(&mut readers[index])? {
+        if let Some(next) = identity_codec::read(&mut readers[index])? {
             heap.push(Reverse((next, index)));
         }
         while heap
@@ -7324,15 +7367,15 @@ fn merge_identity_v3(inputs: &[PathBuf], output: &Path) -> Result<(), GfError> {
                 record = candidate;
                 newest_index = candidate_index;
             }
-            if let Some(next) = read_exact_record::<32>(&mut readers[candidate_index])? {
+            if let Some(next) = identity_codec::read(&mut readers[candidate_index])? {
                 heap.push(Reverse((next, candidate_index)));
             }
         }
-        if block.len() + 32 > BULK_IO_BYTES {
+        if block.len() + IDENTITY_RECORD_WIDTH > BULK_IO_BYTES {
             out.write_all(&block).map_err(storage_err)?;
             block.clear();
         }
-        block.extend_from_slice(&record);
+        block.extend_from_slice(identity_codec::encoded(&record)?);
     }
     if !block.is_empty() {
         out.write_all(&block).map_err(storage_err)?;
@@ -7400,16 +7443,16 @@ fn validate_run_contents(
     let mut deleted_node_count = 0_u64;
     let mut deleted_edge_count = 0_u64;
     for _ in 0..descriptor.identities.count {
-        let mut record = [0_u8; 32];
-        identities.read_exact(&mut record).map_err(storage_err)?;
+        let record = identity_codec::read(&mut identities)?
+            .ok_or_else(|| storage_err("identity run is truncated"))?;
         let uuid: [u8; 16] = record[..16].try_into().expect("fixed record");
-        if previous_uuid.is_some_and(|previous| previous >= uuid) || record[17..24] != [0_u8; 7] {
+        if previous_uuid.is_some_and(|previous| previous >= uuid) {
             return Err(storage_err(
                 "identity run is not canonical and strictly sorted",
             ));
         }
         previous_uuid = Some(uuid);
-        let surrogate = u64::from_be_bytes(record[24..32].try_into().expect("fixed record"));
+        let surrogate = u64::from_be_bytes(record[17..25].try_into().expect("fixed record"));
         match record[16] {
             0 if surrogate != 0 => node_count += 1,
             1 if surrogate == 0 => edge_count += 1,
@@ -7447,10 +7490,7 @@ fn open_verified(root: &Path, record: &FileRecord, record_bytes: u64) -> Result<
     }
     let path = root.join(&record.name);
     let mut file = File::open(&path).map_err(storage_err)?;
-    let expected_len = record
-        .count
-        .checked_mul(record_bytes)
-        .ok_or_else(|| storage_err("record length overflow"))?;
+    let expected_len = record_length(record, record_bytes)?;
     if file.metadata().map_err(storage_err)?.len() != expected_len {
         return Err(storage_err(format!(
             "length mismatch for {}",
@@ -9260,7 +9300,7 @@ fn migrate_uuid_membership_indexes(
                 &receipt_bytes,
             )?;
             Ok(Some(crate::AuxiliaryReceipt {
-                kind: "uuid-membership/v3".to_owned(),
+                kind: "uuid-membership/v5".to_owned(),
                 schema_version: FORMAT_VERSION,
                 path: format!("{INDEX_DIR}/{TOPOLOGY_RECEIPT}"),
                 digest: hex_sha256(&receipt_bytes),
@@ -9357,19 +9397,19 @@ fn stage_uuid_membership_rebuild_locked(
         &mut metrics,
     )?;
     reject_cross_kind_identities(&node_tmp, &edge_tmp)?;
-    let identity_tmp = scratch.path().join("identities-v3.run");
+    let identity_tmp = scratch.path().join("identities-v5.run");
     build_identity_run(&node_surrogates_tmp, &edge_tmp, &identity_tmp)?;
     let surrogate_tmp =
         build_surrogate_run(&node_surrogates_tmp, scratch.path(), limits, &mut metrics)?;
     let identities = describe_staged_data(
         &identity_tmp,
-        "identities-v3",
+        "identities-v5",
         generation,
         IDENTITY_RECORD_BYTES,
     )?;
     let node_surrogates = describe_staged_data(
         &surrogate_tmp,
-        "node-surrogates-v3",
+        "node-surrogates-v5",
         generation,
         NODE_LOOKUP_RECORD_BYTES,
     )?;
@@ -9466,14 +9506,14 @@ fn describe_staged_data(
     record_bytes: u64,
 ) -> Result<FileRecord, GfError> {
     let length = source.metadata().map_err(storage_err)?.len();
-    if length % record_bytes != 0 {
+    if record_bytes != IDENTITY_RECORD_BYTES && length % record_bytes != 0 {
         return Err(storage_err("internal run has a partial index record"));
     }
     let mut input = File::open(source).map_err(storage_err)?;
-    let (sha256, blocks) = describe_blocks(&mut input, record_bytes)?;
+    let (sha256, blocks, count) = describe_blocks(&mut input, record_bytes)?;
     Ok(FileRecord {
         name: format!("{kind}-{generation}-{}.uuidx", &sha256[..16]),
-        count: length / record_bytes,
+        count,
         sha256,
         blocks,
     })
@@ -9560,15 +9600,15 @@ fn build_identity_run(nodes: &Path, edges: &Path, output: &Path) -> Result<(), G
             edge = read_record(&mut edge_reader)?;
             (uuid, 0, 1_u8)
         };
-        let mut record = [0_u8; 32];
+        let mut record = [0_u8; IDENTITY_RECORD_WIDTH];
         record[..16].copy_from_slice(&uuid);
         record[16] = kind;
-        record[24..].copy_from_slice(&surrogate.to_be_bytes());
-        if block.len() + 32 > BULK_IO_BYTES {
+        record[17..].copy_from_slice(&surrogate.to_be_bytes());
+        if block.len() + IDENTITY_RECORD_WIDTH > BULK_IO_BYTES {
             out.write_all(&block).map_err(storage_err)?;
             block.clear();
         }
-        block.extend_from_slice(&record);
+        block.extend_from_slice(identity_codec::encoded(&record)?);
     }
     if !block.is_empty() {
         out.write_all(&block).map_err(storage_err)?;
@@ -10230,11 +10270,11 @@ fn publish_data(
     record_bytes: u64,
 ) -> Result<FileRecord, GfError> {
     let length = source.metadata().map_err(storage_err)?.len();
-    if length % record_bytes != 0 {
+    if record_bytes != IDENTITY_RECORD_BYTES && length % record_bytes != 0 {
         return Err(storage_err("internal run has a partial index record"));
     }
     let mut input = File::open(source).map_err(storage_err)?;
-    let (sha256, blocks) = describe_blocks(&mut input, record_bytes)?;
+    let (sha256, blocks, count) = describe_blocks(&mut input, record_bytes)?;
     let name = format!("{kind}-{generation}-{}.uuidx", &sha256[..16]);
     let directory = graphforge_filesystem::StableDirectory::open(root).map_err(storage_err)?;
     let target = std::ffi::OsStr::new(&name);
@@ -10276,7 +10316,7 @@ fn publish_data(
     }
     Ok(FileRecord {
         name,
-        count: length / record_bytes,
+        count,
         sha256,
         blocks,
     })
@@ -11467,12 +11507,23 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn packed_identity_write_count_tracks_whole_record_flush_boundaries() {
+        let dir = tempfile::tempdir().unwrap();
+        let records = (1..=123_361_u128)
+            .map(|id| (Uuid::from_u128(id), 1, 0))
+            .collect::<Vec<_>>();
+        let path = dir.path().join("edges.uuidx");
+        assert_eq!(write_identity_records(&path, &records).unwrap(), 3);
+        assert_eq!(fs::metadata(path).unwrap().len(), 2_097_137);
+    }
+
+    #[test]
     fn fixed_width_codecs_distinguish_clean_eof_from_partial_tail() {
         let mut clean = std::io::Cursor::new(Vec::<u8>::new());
-        assert_eq!(read_exact_record::<32>(&mut clean).unwrap(), None);
-        for length in 1..32 {
+        assert_eq!(identity_codec::read(&mut clean).unwrap(), None);
+        for length in 1..IDENTITY_RECORD_WIDTH {
             let mut partial = std::io::Cursor::new(vec![0_u8; length]);
-            assert!(read_exact_record::<32>(&mut partial).is_err());
+            assert!(identity_codec::read(&mut partial).is_err());
         }
         for length in 1..24 {
             let mut partial = std::io::Cursor::new(vec![0_u8; length]);
@@ -12566,8 +12617,8 @@ pub(crate) mod tests {
         let manifest: Manifest =
             serde_json::from_slice(&fs::read(root.join(MANIFEST)).unwrap()).unwrap();
         let live = root.join(&manifest.runs[0].identities.name);
-        let orphan_one = root.join("identities-v3-orphan-0000000000000001.uuidx");
-        let orphan_two = root.join("node-surrogates-v3-orphan-0000000000000002.uuidx");
+        let orphan_one = root.join("identities-v5-orphan-0000000000000001.uuidx");
+        let orphan_two = root.join("node-surrogates-v5-orphan-0000000000000002.uuidx");
         fs::copy(&live, &orphan_one).unwrap();
         fs::copy(&live, &orphan_two).unwrap();
 
@@ -12601,8 +12652,8 @@ pub(crate) mod tests {
             append_uuid_membership_delta(dir.path(), 2, &[(Uuid::from_u128(50_000), 50_000)], &[])
                 .unwrap();
         assert_eq!(metrics.validation_random_seeks, 0);
-        assert_eq!(metrics.validation_scan_bytes, 40_000 * (32 + 24));
-        assert_eq!(metrics.validation_scan_blocks, 3);
+        assert_eq!(metrics.validation_scan_bytes, 40_000 * (25 + 24));
+        assert_eq!(metrics.validation_scan_blocks, 2);
     }
 
     #[test]
@@ -12720,7 +12771,8 @@ pub(crate) mod tests {
         bytes[8..24].copy_from_slice(Uuid::from_u128(999).as_bytes());
         fs::write(&path, &bytes).unwrap();
         let mut file = File::open(&path).unwrap();
-        let (sha256, blocks) = describe_blocks(&mut file, NODE_LOOKUP_RECORD_BYTES).unwrap();
+        let (sha256, blocks, count) = describe_blocks(&mut file, NODE_LOOKUP_RECORD_BYTES).unwrap();
+        assert_eq!(count, run.node_surrogates.count);
         run.node_surrogates.sha256 = sha256;
         run.node_surrogates.blocks = blocks;
         fs::write(root.join(MANIFEST), serde_json::to_vec(&manifest).unwrap()).unwrap();

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -12803,6 +12803,56 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn packed_membership_rebuild_reopen_and_tombstone_preserve_full_width_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let nodes = [
+            Uuid::from_u128(2),
+            Uuid::from_u128(u128::MAX - 1),
+            Uuid::from_u128(u128::MAX),
+        ];
+        let ids = [u64::from(u32::MAX), u64::from(u32::MAX) + 1, u64::MAX];
+        write_node_parquet_with_ids(&dir.path().join("topology/nodes.parquet"), &nodes, &ids);
+        let edge = Uuid::from_u128(1);
+        write_uuid_parquet(
+            &dir.path().join("topology/edges/R.parquet"),
+            "edge_uuid",
+            &[edge],
+        );
+        rebuild_uuid_membership_indexes(
+            dir.path(),
+            UuidIndexBuildLimits {
+                scan_batch_rows: 1,
+                run_records: 1,
+                merge_fan_in: 2,
+            },
+        )
+        .unwrap();
+        let mut index = UuidMembershipIndex::open(dir.path()).unwrap();
+        assert_eq!(
+            index.lookup_node_surrogates(&nodes).unwrap().0,
+            ids.map(Some)
+        );
+        assert_eq!(index.probe(UuidIndexKind::Edge, &[edge]).unwrap().0, [true]);
+        drop(index);
+        crate::generation::force_bump_topology_generation_for_test(dir.path()).unwrap();
+        append_uuid_membership_delta_with_tombstones(
+            dir.path(),
+            1,
+            &[],
+            &[],
+            &[(nodes[2], u64::MAX)],
+            &[],
+        )
+        .unwrap();
+        let mut index = UuidMembershipIndex::open(dir.path()).unwrap();
+        assert_eq!(
+            index.lookup_node_surrogates(&nodes).unwrap().0,
+            [Some(ids[0]), Some(ids[1]), None]
+        );
+        assert_eq!(index.probe(UuidIndexKind::Edge, &[edge]).unwrap().0, [true]);
+    }
+
+    #[test]
     fn duplicate_and_zero_node_surrogates_fail_closed_across_bounded_runs() {
         let limits = UuidIndexBuildLimits {
             scan_batch_rows: 1,

--- a/crates/graphforge-storage/src/uuid_membership/identity_codec.rs
+++ b/crates/graphforge-storage/src/uuid_membership/identity_codec.rs
@@ -1,0 +1,154 @@
+//! Current permanent identity framing. Live edges omit their defined-zero
+//! membership surrogate; topology retains the canonical edge identifier.
+use std::io::Read;
+
+use graphforge_core::GfError;
+
+use super::storage_err;
+
+pub(super) const WIDTH: usize = 25;
+pub(super) const EDGE_WIDTH: usize = 17;
+pub(super) type Record = [u8; WIDTH];
+
+fn width(kind: u8) -> Result<usize, GfError> {
+    match kind {
+        1 => Ok(EDGE_WIDTH),
+        0 | 2 | 3 => Ok(WIDTH),
+        _ => Err(storage_err("identity record kind is invalid")),
+    }
+}
+
+pub(super) fn encoded(record: &Record) -> Result<&[u8], GfError> {
+    let length = width(record[16])?;
+    if length == EDGE_WIDTH && record[EDGE_WIDTH..].iter().any(|byte| *byte != 0) {
+        return Err(storage_err("live edge membership surrogate must be zero"));
+    }
+    Ok(&record[..length])
+}
+
+pub(super) fn read(reader: &mut impl Read) -> Result<Option<Record>, GfError> {
+    let mut record = [0_u8; WIDTH];
+    loop {
+        match reader.read(&mut record[..1]) {
+            Ok(0) => return Ok(None),
+            Ok(_) => break,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(storage_err(error)),
+        }
+    }
+    reader
+        .read_exact(&mut record[1..EDGE_WIDTH])
+        .map_err(storage_err)?;
+    let length = width(record[16])?;
+    reader
+        .read_exact(&mut record[EDGE_WIDTH..length])
+        .map_err(storage_err)?;
+    Ok(Some(record))
+}
+
+pub(super) fn take(bytes: &mut &[u8]) -> Result<Option<Record>, GfError> {
+    read(bytes)
+}
+
+/// Validate complete block framing and ordered UUID fences without allocation.
+pub(super) fn layout(bytes: &[u8]) -> Result<(u64, &[u8], &[u8]), GfError> {
+    let mut offset = 0;
+    let mut count = 0_u64;
+    let mut previous: Option<&[u8]> = None;
+    let mut last = 0;
+    while offset < bytes.len() {
+        let suffix = &bytes[offset..];
+        if suffix.len() < EDGE_WIDTH {
+            return Err(storage_err(
+                "partial identity record in authenticated block",
+            ));
+        }
+        let length = width(suffix[16])?;
+        if suffix.len() < length {
+            return Err(storage_err(
+                "partial identity record in authenticated block",
+            ));
+        }
+        let key = &suffix[..16];
+        if previous.is_some_and(|prior| prior >= key) {
+            return Err(storage_err("identity block UUIDs are not strictly ordered"));
+        }
+        previous = Some(key);
+        last = offset;
+        offset += length;
+        count += 1;
+    }
+    if count == 0 {
+        return Err(storage_err("empty identity block"));
+    }
+    Ok((count, &bytes[..16], &bytes[last..last + 16]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_width_nodes_and_tombstones_and_zero_edge_round_trip() {
+        for kind in 0..=3 {
+            for surrogate in [0, 1, u64::from(u32::MAX), u64::from(u32::MAX) + 1, u64::MAX] {
+                let mut record = [u8::MAX; WIDTH];
+                record[16] = kind;
+                record[17..].copy_from_slice(&surrogate.to_be_bytes());
+                if kind == 1 && surrogate != 0 {
+                    assert!(encoded(&record).is_err());
+                    continue;
+                }
+                let bytes = encoded(&record).unwrap();
+                assert_eq!(bytes.len(), if kind == 1 { EDGE_WIDTH } else { WIDTH });
+                assert_eq!(read(&mut &bytes[..]).unwrap(), Some(record));
+            }
+        }
+    }
+
+    #[test]
+    fn partial_records_unknown_kinds_and_cross_block_records_fail_closed() {
+        for kind in 0..=3 {
+            let mut record = [0_u8; WIDTH];
+            record[16] = kind;
+            let bytes = encoded(&record).unwrap();
+            for length in 1..bytes.len() {
+                assert!(read(&mut &bytes[..length]).is_err());
+                assert!(layout(&bytes[..length]).is_err());
+            }
+            assert_eq!(layout(bytes).unwrap().0, 1);
+        }
+        let mut invalid = [0_u8; WIDTH];
+        invalid[16] = 4;
+        assert!(encoded(&invalid).is_err());
+        assert!(read(&mut &invalid[..]).is_err());
+        assert!(layout(&invalid).is_err());
+        assert_eq!(read(&mut &[][..]).unwrap(), None);
+    }
+
+    #[test]
+    fn mixed_records_have_exact_budget_and_ordered_fences() {
+        let mut bytes = Vec::new();
+        for i in 0..69_634_u64 {
+            let mut record = [0_u8; WIDTH];
+            record[..16].copy_from_slice(&u128::from(i + 1).to_be_bytes());
+            record[16] = u8::from(i >= 4097);
+            if record[16] == 0 {
+                record[17..].copy_from_slice(&(i + 1).to_be_bytes());
+            }
+            bytes.extend_from_slice(encoded(&record).unwrap());
+        }
+        assert_eq!(bytes.len(), 1_216_554);
+        assert_eq!(layout(&bytes).unwrap().0, 69_634);
+        let mut input = bytes.as_slice();
+        for i in 0..69_634_u64 {
+            let record = take(&mut input).unwrap().unwrap();
+            assert_eq!(&record[..16], &(u128::from(i) + 1).to_be_bytes());
+            assert_eq!(
+                u64::from_be_bytes(record[17..].try_into().unwrap()),
+                if i < 4097 { i + 1 } else { 0 }
+            );
+        }
+        assert!(input.is_empty());
+    }
+}

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -147,8 +147,10 @@ manifest as reachability evidence.
 
 [Raw integrated measurements](../../development/evidence/packed-membership-1203.json)
 use source `d103c3cb0360e5a76a4b3cbbf60ce3c3cec14d60`, including the merged
-construction Zstd repair. The four permanent fixtures and full-width boundary
-test pass exact query/reopen/export/full-verify/clean-import checks.
+construction Zstd repair. Four permanent fixtures pass exact
+query/reopen/export/full-verify/clean-import checks. The additional boundary test
+verifies full-width encoding; separate production tests cover rebuild, reopen,
+probes and deletion at the ID boundary.
 
 For 4,097 nodes and 65,537 edges, membership payload falls from 2,228,288 to
 1,216,554 bytes: 487,438 bytes of reserved padding and 524,296 bytes of defined-zero

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -142,3 +142,36 @@ Orphan maintenance runs only from the union of selected authenticated v5 and v4
 authority. It removes an unreferenced single-link artifact by retained identity,
 defers linked or over-budget candidates, and never treats an untrusted sibling
 manifest as reachability evidence.
+
+## Packed membership evidence (#1203)
+
+[Raw integrated measurements](../../development/evidence/packed-membership-1203.json)
+use source `d103c3cb0360e5a76a4b3cbbf60ce3c3cec14d60`, including the merged
+construction Zstd repair. The four permanent fixtures and full-width boundary
+test pass exact query/reopen/export/full-verify/clean-import checks.
+
+For 4,097 nodes and 65,537 edges, membership payload falls from 2,228,288 to
+1,216,554 bytes: 487,438 bytes of reserved padding and 524,296 bytes of defined-zero
+live-edge fields. For 8,193 nodes it falls from 2,359,360 to 1,318,954 bytes.
+Node reverse-surrogate records remain 24 bytes and the ordinal facet keeps its
+independent current schema.
+
+| Fixture | After Parquet repair: permanent allocation | With packed membership |
+| --- | ---: | ---: |
+| Sequential | 4,112,384 | 3,096,576 |
+| Random | 7,585,792 | 6,541,312 |
+| Eight property routes, CSR built | 18,644,992 | 17,633,280 |
+| Heterogeneous properties | 13,086,720 | 12,075,008 |
+
+The serial integrated assessment took 391.33 seconds and peaked at 247,332 KiB
+RSS on the same ext4 host, versus 393.65 seconds and 270,208 KiB after the Parquet
+repair. These are whole-test measurements, including reads and portable copies;
+they do not establish an isolated codec CPU improvement. Raw process I/O is
+recorded separately from logical storage counters.
+
+Production-path regressions cover full-width rebuild/reopen/probes and a
+`u64::MAX` tombstone, current-format crash recovery, retained snapshots, framing
+corruption and bounded merge/probe work. The write-counter boundary test uses
+123,361 live edges: exactly 2,097,137 payload bytes and three whole-record writes,
+verified through both append paths. Dividing total bytes by 1 MiB would incorrectly
+report two writes.

--- a/docs/book/architecture/uuid-membership-index.md
+++ b/docs/book/architecture/uuid-membership-index.md
@@ -6,11 +6,27 @@ schema or digest.
 
 ## UUID membership facet
 
-`manifest.json` is the existing v3 authority for both node and edge UUID
+`manifest.json` is the current v5 authority for both node and edge UUID
 membership and node `UUID -> node_id` resolution. Existing endpoint-resolution,
-construction, and mutation consumers continue to authenticate this facet
-unchanged. Its immutable runs and `topology-receipt.json` remain reachable
-until the v3 manifest no longer selects them.
+construction, and mutation consumers authenticate this facet. Its immutable runs and `topology-receipt.json` remain reachable
+until the v5 manifest no longer selects them.
+
+
+Membership format 5 encodes UUID16 + kind1, followed by the full big-endian
+surrogate8 for nodes and tombstones (25 bytes). Live edges use 17 bytes because
+their membership surrogate is defined as zero; their canonical edge ID remains
+in topology. Nonzero live-edge membership surrogates are rejected. This removes
+seven reserved zero bytes per record and eight additional bytes per live edge.
+No UUID bits or meaningful surrogate bits are truncated.
+
+Authenticated blocks are at most 1 MiB and end on complete record boundaries.
+Readers validate kinds, record counts, UUID ordering, first/last fences and SHA;
+probes select blocks by their fences and merge-scan sorted requests. Byte counts
+come from authenticated block lengths, and write-call counters count actual
+whole-record flushes. Private construction input remains a separate 32-byte
+format, hashed before bounded in-place packing. The published manifest and
+receipt select format 5; unsupported prior membership formats are refused.
+There is no compatibility reader or migration requirement before v1.
 
 ## Node ordinal facet
 
@@ -25,18 +41,18 @@ mapping independently. Ordinal payloads are packed by contiguous node-ID range
 and carry fixed-size authenticated block fences.
 
 Discovery and authenticated open are separate operations. When the ordinal
-manifest is absent, discovery validates that current v3 authority is canonical
+manifest is absent, discovery validates that current v5 authority is canonical
 before returning `RebuildRequired`. When the ordinal path exists, discovery
 reports it as present without trusting its contents. Authenticated open then
 requires the ordinal digest selected by the project receipt. A malformed,
 substituted, or generation-mismatched ordinal facet fails closed and never
-falls back to v3.
+falls back to v5.
 
 The explicit rebuild API constructs v4 only from canonical topology and returns
 an aggregate `CanonicalTopology` disposition with generation, identity/range,
 artifact-byte, fixed-block, buffer, temporary-run, and fsync evidence. It never
-opens a v3 reverse run as migration input. Durable-rewrite recovery either
-retains the prior v3-only authority or completes the receipt-bound v4 facet;
+opens a v5 reverse run as migration input. Durable-rewrite recovery either
+retains the prior v5-only authority or completes the receipt-bound v4 facet;
 there is no mixed-version read state.
 
 `peak_temporary_bytes` is the total maximum coexisting rebuild scratch, not
@@ -70,17 +86,17 @@ requested/unique/found counts, selected ranges, logical bytes, coalesced calls,
 tombstones, and bounded-buffer charges. A typed failure can be reduced to
 sanitized failure evidence, including an authentication-failure count, without
 emitting UUIDs, paths, or record contents. Consumers must not reopen the index
-per chunk or substitute the v3 membership LSM.
+per chunk or substitute the v5 membership LSM.
 
-Orphan collection starts from the current authenticated v3 manifest and, when
+Orphan collection starts from the current authenticated v5 manifest and, when
 the ordinal facet exists, requires the opaque authority resolved from a pinned
 project generation before authenticating the v4 manifest and artifacts. It
 retains the union. Hashing an untrusted manifest or receipt is never treated as
 provenance for deciding reachability.
 
 Both facets are persistent graph authority, not `.graphforge-cache/` content.
-Construction and canonical v3-to-v4 publication are specified separately by
-#969.
+Construction and canonical ordinal-facet publication are specified separately by
+#969. The facet version numbers identify separate schemas, not an upgrade order.
 
 ### Incremental ordinal publication
 
@@ -96,7 +112,7 @@ Their descriptors are strictly generation-ordered; they are not required to be
 globally concatenation-sorted. The reader authenticates every run and compares
 the aggregate forward mapping commitment with the aggregate ordinal mapping
 commitment. Historical UUID and surrogate uniqueness is also proved by the
-coupled authenticated v3 participant in the same topology transaction.
+coupled authenticated v5 participant in the same topology transaction.
 
 The construction artifact remains an immutable base. Later forward artifacts
 close implicit contiguous generation intervals. Two adjacent equal-width delta
@@ -122,7 +138,7 @@ expected manifest, so retry never replays a graph mutation. A retained old read
 handle fails stale named-manifest revalidation after the switch; callers advance
 by opening the exact newly receipt-authorized generation.
 
-Orphan maintenance runs only from the union of selected authenticated v3 and v4
+Orphan maintenance runs only from the union of selected authenticated v5 and v4
 authority. It removes an unreferenced single-link artifact by retained identity,
 defers linked or over-budget candidates, and never treats an untrusted sibling
 manifest as reachability evidence.

--- a/docs/development/evidence/packed-membership-1203.json
+++ b/docs/development/evidence/packed-membership-1203.json
@@ -1,0 +1,865 @@
+{
+  "source_commit": "d103c3cb0360e5a76a4b3cbbf60ce3c3cec14d60",
+  "command": "/usr/bin/time -v /home/ubuntu/code/graphforge-target-1195/debug/deps/permanent_storage_budgets-c514423ca6fb68a2 --nocapture --test-threads=1",
+  "result": "5 passed; 0 failed; 391.31 seconds",
+  "process_resource_output": "\tCommand being timed: \"/home/ubuntu/code/graphforge-target-1195/debug/deps/permanent_storage_budgets-c514423ca6fb68a2 --nocapture --test-threads=1\"\n\tUser time (seconds): 352.21\n\tSystem time (seconds): 27.48\n\tPercent of CPU this job got: 97%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 6:31.33\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 247332\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 199150\n\tVoluntary context switches: 173345\n\tInvoluntary context switches: 3243\n\tSwaps: 0\n\tFile system inputs: 4612640\n\tFile system outputs: 3231536\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+  "fixtures": [
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 26972459598,
+      "edges": 65537,
+      "fixture": "heterogeneous_property_schemas",
+      "heterogeneous_schemas": true,
+      "identity_padding_experiment": {
+        "current_record_bytes": 1216554,
+        "defined_zero_edge_saved_bytes": 524296,
+        "identity_runs": 2,
+        "live_edge_records": 65537,
+        "previous_32_byte_baseline": 2228288,
+        "production_format_changed": true,
+        "records": 69634,
+        "reserved_padding_saved_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 544,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 974848,
+        "candidate_logical_bytes": 194598,
+        "candidate_objects": 238,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 3072000,
+        "source_manifest_objects": 750
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          170901470,
+          203487009,
+          203372907
+        ],
+        "encode_elapsed_ns": [
+          657191800,
+          824312086,
+          848801142
+        ],
+        "normalized_allocated_bytes_at_4096": [
+          9310208,
+          7467008,
+          7483392
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          8357272,
+          6398839,
+          6420637
+        ],
+        "production_parquet_allocated_bytes": 7467008,
+        "production_parquet_bytes": 6398839
+      },
+      "permanent": {
+        "allocated_bytes": 12075008,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 3104768,
+            "logical_bytes": 371612,
+            "logical_references": 758,
+            "physical_logical_bytes": 371612,
+            "physical_objects": 758
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 2265088,
+            "logical_bytes": 1877949,
+            "logical_references": 266,
+            "physical_logical_bytes": 1877949,
+            "physical_objects": 266
+          },
+          "topology_edges": {
+            "allocated_bytes": 5091328,
+            "logical_bytes": 4428564,
+            "logical_references": 257,
+            "physical_logical_bytes": 4428564,
+            "physical_objects": 257
+          },
+          "topology_nodes": {
+            "allocated_bytes": 102400,
+            "logical_bytes": 88869,
+            "logical_references": 5,
+            "physical_logical_bytes": 88869,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 1511424,
+            "logical_bytes": 1482397,
+            "logical_references": 12,
+            "physical_logical_bytes": 1482397,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 8249391,
+        "physical_logical_bytes": 8249391,
+        "physical_objects": 1295
+      },
+      "properties": true,
+      "random_ids": true,
+      "routes": 4,
+      "semantic_fingerprint": "5c704d8bf7e1851e1631e6f36bc37495f9d9d9e1e9b94950e84310b545824ec2",
+      "unindexed_allocated_bytes": 12075008,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 3104768,
+          "logical_bytes": 371612,
+          "logical_references": 758,
+          "physical_logical_bytes": 371612,
+          "physical_objects": 758
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 2265088,
+          "logical_bytes": 1877949,
+          "logical_references": 266,
+          "physical_logical_bytes": 1877949,
+          "physical_objects": 266
+        },
+        "topology_edges": {
+          "allocated_bytes": 5091328,
+          "logical_bytes": 4428564,
+          "logical_references": 257,
+          "physical_logical_bytes": 4428564,
+          "physical_objects": 257
+        },
+        "topology_nodes": {
+          "allocated_bytes": 102400,
+          "logical_bytes": 88869,
+          "logical_references": 5,
+          "physical_logical_bytes": 88869,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 1511424,
+          "logical_bytes": 1482397,
+          "logical_references": 12,
+          "physical_logical_bytes": 1482397,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": true,
+      "adjacency_codec_experiment": {
+        "decode_elapsed_ns": [
+          5246088,
+          109966333,
+          36960820
+        ],
+        "encode_elapsed_ns": [
+          3039176,
+          193323233,
+          109137928
+        ],
+        "estimated_allocated_bytes_at_4096": [
+          4972544,
+          2351104,
+          1363968
+        ],
+        "largest_decoded_batch_array_bytes": 3322008,
+        "normalized_bytes_none_lz4_zstd": [
+          4920564,
+          2320564,
+          1324020
+        ],
+        "production_format_changed": false,
+        "shards": 18,
+        "source_bytes": 4920564
+      },
+      "construction_elapsed_ns": 34641114448,
+      "edges": 65537,
+      "fixture": "random_properties_eight_routes",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 1216554,
+        "defined_zero_edge_saved_bytes": 524296,
+        "identity_runs": 2,
+        "live_edge_records": 65537,
+        "previous_32_byte_baseline": 2228288,
+        "production_format_changed": true,
+        "records": 69634,
+        "reserved_padding_saved_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 1080,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 1372160,
+        "candidate_logical_bytes": 359411,
+        "candidate_objects": 335,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 5967872,
+        "source_manifest_objects": 1457
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          326066616,
+          372188535,
+          374729110
+        ],
+        "encode_elapsed_ns": [
+          1089693084,
+          1323997663,
+          1350358584
+        ],
+        "normalized_allocated_bytes_at_4096": [
+          12939264,
+          10743808,
+          10747904
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          10231116,
+          7845372,
+          7861925
+        ],
+        "production_parquet_allocated_bytes": 10743808,
+        "production_parquet_bytes": 7845372
+      },
+      "permanent": {
+        "allocated_bytes": 17633280,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 5050368,
+            "logical_bytes": 4930822,
+            "logical_references": 37,
+            "physical_logical_bytes": 4930822,
+            "physical_objects": 37
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 335872,
+            "logical_bytes": 309543,
+            "logical_references": 8,
+            "physical_logical_bytes": 309543,
+            "physical_objects": 8
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 4337664,
+            "logical_bytes": 2576971,
+            "logical_references": 546,
+            "physical_logical_bytes": 2576971,
+            "physical_objects": 546
+          },
+          "topology_edges": {
+            "allocated_bytes": 6295552,
+            "logical_bytes": 5174833,
+            "logical_references": 513,
+            "physical_logical_bytes": 5174833,
+            "physical_objects": 513
+          },
+          "topology_nodes": {
+            "allocated_bytes": 102400,
+            "logical_bytes": 90021,
+            "logical_references": 5,
+            "physical_logical_bytes": 90021,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 1511424,
+            "logical_bytes": 1482397,
+            "logical_references": 12,
+            "physical_logical_bytes": 1482397,
+            "physical_objects": 12
+          }
+        },
+        "logical_bytes": 14564587,
+        "physical_logical_bytes": 14564587,
+        "physical_objects": 1121
+      },
+      "properties": true,
+      "random_ids": true,
+      "routes": 8,
+      "semantic_fingerprint": "1a4578d5b5d6c474b1fd9de5478fd2afe0f69e1456f3964d410bc6e0fd3e8b51",
+      "unindexed_allocated_bytes": 18247680,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 6000640,
+          "logical_bytes": 728070,
+          "logical_references": 1465,
+          "physical_logical_bytes": 728070,
+          "physical_objects": 1465
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 4337664,
+          "logical_bytes": 2576971,
+          "logical_references": 546,
+          "physical_logical_bytes": 2576971,
+          "physical_objects": 546
+        },
+        "topology_edges": {
+          "allocated_bytes": 6295552,
+          "logical_bytes": 5174833,
+          "logical_references": 513,
+          "physical_logical_bytes": 5174833,
+          "physical_objects": 513
+        },
+        "topology_nodes": {
+          "allocated_bytes": 102400,
+          "logical_bytes": 90021,
+          "logical_references": 5,
+          "physical_logical_bytes": 90021,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 1511424,
+          "logical_bytes": 1482397,
+          "logical_references": 12,
+          "physical_logical_bytes": 1482397,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 20284094999,
+      "edges": 65537,
+      "fixture": "random_single_route",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 1318954,
+        "defined_zero_edge_saved_bytes": 524296,
+        "identity_runs": 2,
+        "live_edge_records": 65537,
+        "previous_32_byte_baseline": 2359360,
+        "production_format_changed": true,
+        "records": 73730,
+        "reserved_padding_saved_bytes": 516110
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 90,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 122880,
+        "candidate_logical_bytes": 28602,
+        "candidate_objects": 30,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 495616,
+        "source_manifest_objects": 121
+      },
+      "nodes": 8193,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          50697163,
+          65744078,
+          66458133
+        ],
+        "encode_elapsed_ns": [
+          329807417,
+          413504532,
+          437969379
+        ],
+        "normalized_allocated_bytes_at_4096": [
+          5488640,
+          4145152,
+          4145152
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          5318519,
+          4015814,
+          4047391
+        ],
+        "production_parquet_allocated_bytes": 4145152,
+        "production_parquet_bytes": 4015814
+      },
+      "permanent": {
+        "allocated_bytes": 6541312,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 528384,
+            "logical_bytes": 62909,
+            "logical_references": 129,
+            "physical_logical_bytes": 62909,
+            "physical_objects": 129
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "topology_edges": {
+            "allocated_bytes": 3936256,
+            "logical_bytes": 3841869,
+            "logical_references": 65,
+            "physical_logical_bytes": 3841869,
+            "physical_objects": 65
+          },
+          "topology_nodes": {
+            "allocated_bytes": 200704,
+            "logical_bytes": 170753,
+            "logical_references": 9,
+            "physical_logical_bytes": 170753,
+            "physical_objects": 9
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 1875968,
+            "logical_bytes": 1847051,
+            "logical_references": 12,
+            "physical_logical_bytes": 1847051,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 5922582,
+        "physical_logical_bytes": 5922582,
+        "physical_objects": 212
+      },
+      "properties": false,
+      "random_ids": true,
+      "routes": 1,
+      "semantic_fingerprint": "6ce665fa15e02a8781492c112961d22d14fa79e33d0fd22bbedfc29958308030",
+      "unindexed_allocated_bytes": 6541312,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 528384,
+          "logical_bytes": 62909,
+          "logical_references": 129,
+          "physical_logical_bytes": 62909,
+          "physical_objects": 129
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 3936256,
+          "logical_bytes": 3841869,
+          "logical_references": 65,
+          "physical_logical_bytes": 3841869,
+          "physical_objects": 65
+        },
+        "topology_nodes": {
+          "allocated_bytes": 200704,
+          "logical_bytes": 170753,
+          "logical_references": 9,
+          "physical_logical_bytes": 170753,
+          "physical_objects": 9
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 1875968,
+          "logical_bytes": 1847051,
+          "logical_references": 12,
+          "physical_logical_bytes": 1847051,
+          "physical_objects": 9
+        }
+      }
+    },
+    {
+      "adjacency_built": false,
+      "adjacency_codec_experiment": null,
+      "construction_elapsed_ns": 18326227381,
+      "edges": 65537,
+      "fixture": "sequential_single_route",
+      "heterogeneous_schemas": false,
+      "identity_padding_experiment": {
+        "current_record_bytes": 1216554,
+        "defined_zero_edge_saved_bytes": 524296,
+        "identity_runs": 2,
+        "live_edge_records": 65537,
+        "previous_32_byte_baseline": 2228288,
+        "production_format_changed": true,
+        "records": 69634,
+        "reserved_padding_saved_bytes": 487438
+      },
+      "manifest_bucket_experiment": {
+        "authenticated_lookups_checked": 86,
+        "candidate_bucket_capacity": 8,
+        "candidate_estimated_allocated_bytes_at_4096": 131072,
+        "candidate_logical_bytes": 28378,
+        "candidate_objects": 32,
+        "production_format_changed": false,
+        "source_manifest_allocated_bytes": 462848,
+        "source_manifest_objects": 113
+      },
+      "nodes": 4097,
+      "parquet_experiment": {
+        "decode_elapsed_ns": [
+          44854979,
+          68777589,
+          67110477
+        ],
+        "encode_elapsed_ns": [
+          293439370,
+          373887029,
+          379350516
+        ],
+        "normalized_allocated_bytes_at_4096": [
+          5373952,
+          1097728,
+          1097728
+        ],
+        "normalized_bytes_uncompressed_zstd1_zstd3": [
+          5262627,
+          973925,
+          960425
+        ],
+        "production_parquet_allocated_bytes": 1097728,
+        "production_parquet_bytes": 973925
+      },
+      "permanent": {
+        "allocated_bytes": 3096576,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 495616,
+            "logical_bytes": 59995,
+            "logical_references": 121,
+            "physical_logical_bytes": 59995,
+            "physical_objects": 121
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "topology_edges": {
+            "allocated_bytes": 1052672,
+            "logical_bytes": 944705,
+            "logical_references": 65,
+            "physical_logical_bytes": 944705,
+            "physical_objects": 65
+          },
+          "topology_nodes": {
+            "allocated_bytes": 36864,
+            "logical_bytes": 26028,
+            "logical_references": 5,
+            "physical_logical_bytes": 26028,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 1511424,
+            "logical_bytes": 1482397,
+            "logical_references": 12,
+            "physical_logical_bytes": 1482397,
+            "physical_objects": 9
+          }
+        },
+        "logical_bytes": 2513125,
+        "physical_logical_bytes": 2513125,
+        "physical_objects": 200
+      },
+      "properties": false,
+      "random_ids": false,
+      "routes": 1,
+      "semantic_fingerprint": "57f3deaf6829d02e203e90a4c5c69f9e7b2949a647aa0a0ac82684550722b805",
+      "unindexed_allocated_bytes": 3096576,
+      "unindexed_categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 495616,
+          "logical_bytes": 59995,
+          "logical_references": 121,
+          "physical_logical_bytes": 59995,
+          "physical_objects": 121
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 1052672,
+          "logical_bytes": 944705,
+          "logical_references": 65,
+          "physical_logical_bytes": 944705,
+          "physical_objects": 65
+        },
+        "topology_nodes": {
+          "allocated_bytes": 36864,
+          "logical_bytes": 26028,
+          "logical_references": 5,
+          "physical_logical_bytes": 26028,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 1511424,
+          "logical_bytes": 1482397,
+          "logical_references": 12,
+          "physical_logical_bytes": 1482397,
+          "physical_objects": 9
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Permanent membership stored seven reserved zero bytes per identity and an unused zero surrogate for every live edge. Format 5 removes that padding: nodes and tombstones use 25 bytes; live edges use 17 bytes while canonical edge IDs remain in topology. Full UUIDs and meaningful u64 surrogates remain exact. The separate current ordinal facet retains its own schema.

Readers authenticate complete variable-length blocks, counts, ordering, fences and digests. Probes remain fence-selected merge scans. Construction hashes its separate 32-byte input before in-place packing. Both append paths report actual flush counts, including the 123,361-edge boundary requiring three writes rather than the misleading byte-ceiling estimate of two. No compatibility reader or migration is introduced.

For 4,097 nodes and 65,537 edges, membership payload falls from 2,228,288 to 1,216,554 bytes. Source-bound physical allocation and whole-test CPU/RSS/I/O evidence is committed. Four random/sequential/heterogeneous/property fixtures retain exact public queries, reopen, export/full verification and clean import; boundary tests separately verify full-width encoding and production rebuild/reopen/deletion through u64::MAX.

Validation: refreshed 56 membership tests, 99 construction tests and all 5 permanent-storage tests pass; 27 durable-rewrite tests and 26 delta/replay/compaction tests pass. Workspace clippy, formatting, make pre-push-fast and make gate-registry-check pass. Independent review found no remaining blocking findings. The extra storage --tests Clippy command fails on existing test lint debt, also reproduced on the base branch (192 lib-test errors); it is not claimed green. The earlier full-pre-push coverage-floor failure remains tracked by #360.

Closes #1203

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791596289&installation_model_id=20486&pr_number=1215&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1215&signature=f63366a570929f7971ef36f891d64d7d2c62c90ff63ef5268b53f9d6a56e1a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->