### PR TITLE
fix(storage): replace authenticated shared payloads during mutation

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -923,3 +923,53 @@ fn assess(f: Fixture) {
             "adjacency_codec_experiment":adjacency_experiment,"parquet_experiment":experiment,"identity_padding_experiment":identity_experiment,"manifest_bucket_experiment":manifest_experiment})
     );
 }
+
+#[test]
+fn public_mutation_replaces_shared_constructed_payloads() {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "shared_payload_mutation",
+        nodes: 33,
+        edges: 129,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: true,
+    };
+    let (mut nodes, edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let query =
+        "MATCH (n) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score ORDER BY n.node_uuid";
+    let expected = graph.execute(query).unwrap();
+    let old_stream = graph.execute_stream(query).unwrap();
+    graph
+        .execute("MATCH (n) WHERE n.score IS NOT NULL SET n.score = n.score + 1")
+        .unwrap();
+    for node in &mut nodes {
+        node.2 = node.2.map(|score| score + 1);
+    }
+    verify_graph(&graph, fixture, &nodes, &edges);
+    use futures::TryStreamExt as _;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let old_batches: Vec<RecordBatch> = runtime.block_on(old_stream.try_collect()).unwrap();
+    assert_eq!(
+        old_batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>(),
+        expected
+            .batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>()
+    );
+    drop(graph);
+    round_trip(root.path(), &source, fixture, &nodes, &edges);
+}

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -1492,14 +1492,52 @@ impl StableDirectory {
             Err(error) => return Err(error),
         };
         let result = if target_exists {
-            replace_file_platform(&self.file, temporary, target, Some(expected_temporary))
-                .map_err(|error| io::Error::other(error.to_string()))
+            replace_file_platform(
+                &self.file,
+                temporary,
+                target,
+                Some(expected_temporary),
+                None,
+            )
+            .map_err(|error| io::Error::other(error.to_string()))
         } else {
             install_new_file_platform(&self.file, temporary, target, Some(expected_temporary))
         };
         result?;
         self.revalidate_named()?;
         self.open_child_file(target).map(|_| ())
+    }
+
+    /// Atomically replace an authenticated prior child, which may share its inode
+    /// with immutable payloads or active snapshots. The source must be private.
+    /// Callers must authenticate the prior contents and serialize publishers;
+    /// this operation checks identity and never writes to the prior inode.
+    pub fn replace_authenticated_child(
+        &self,
+        temporary: &OsStr,
+        expected_temporary: FileIdentity,
+        target: &OsStr,
+        expected_target: FileIdentity,
+    ) -> io::Result<()> {
+        validate_child_name(temporary)?;
+        validate_child_name(target)?;
+        self.revalidate_named()?;
+        replace_file_platform(
+            &self.file,
+            temporary,
+            target,
+            Some(expected_temporary),
+            Some(expected_target),
+        )
+        .map_err(|error| io::Error::other(error.to_string()))?;
+        self.revalidate_named()?;
+        let installed = self.open_child_file(target)?;
+        if file_identity(&installed)? != expected_temporary || file_link_count(&installed)? != 1 {
+            return Err(io::Error::other(
+                "authenticated replacement identity changed",
+            ));
+        }
+        Ok(())
     }
 
     /// Atomically install a retained temporary child without replacing an
@@ -2265,7 +2303,7 @@ pub fn replace_file(
 ) -> Result<(), ReplaceFileError> {
     verify_single_component(source_name).map_err(ReplaceFileError::NotReplaced)?;
     verify_single_component(target_name).map_err(ReplaceFileError::NotReplaced)?;
-    replace_file_platform(directory, source_name, target_name, None)
+    replace_file_platform(directory, source_name, target_name, None, None)
 }
 
 /// Atomically install a new regular file without replacing an existing entry.
@@ -2391,6 +2429,7 @@ fn replace_file_platform(
     source_name: &OsStr,
     target_name: &OsStr,
     expected_source: Option<FileIdentity>,
+    expected_target: Option<FileIdentity>,
 ) -> Result<(), ReplaceFileError> {
     use rustix::fs::{AtFlags, Mode, OFlags, openat, renameat, statat};
 
@@ -2414,8 +2453,17 @@ fn replace_file_platform(
     .map_err(ReplaceFileError::NotReplaced)?;
     verify_regular_metadata(&source.metadata().map_err(ReplaceFileError::NotReplaced)?)
         .map_err(ReplaceFileError::NotReplaced)?;
-    verify_regular_metadata(&target.metadata().map_err(ReplaceFileError::NotReplaced)?)
-        .map_err(ReplaceFileError::NotReplaced)?;
+    let target_metadata = target.metadata().map_err(ReplaceFileError::NotReplaced)?;
+    if let Some(expected) = expected_target {
+        verify_space_usage_metadata(&target_metadata).map_err(ReplaceFileError::NotReplaced)?;
+        if unix_identity(&target).map_err(ReplaceFileError::NotReplaced)? != expected {
+            return Err(ReplaceFileError::NotReplaced(io::Error::other(
+                "rename target differs from the authenticated expected identity",
+            )));
+        }
+    } else {
+        verify_regular_metadata(&target_metadata).map_err(ReplaceFileError::NotReplaced)?;
+    }
     let source_identity = unix_identity(&source).map_err(ReplaceFileError::NotReplaced)?;
     if expected_source.is_some_and(|expected| expected != source_identity) {
         return Err(ReplaceFileError::NotReplaced(io::Error::other(
@@ -2589,8 +2637,15 @@ fn replace_file_platform(
     source_name: &OsStr,
     target_name: &OsStr,
     expected_source: Option<FileIdentity>,
+    expected_target: Option<FileIdentity>,
 ) -> Result<(), ReplaceFileError> {
-    windows::replace_file(directory, source_name, target_name, expected_source)
+    windows::replace_file(
+        directory,
+        source_name,
+        target_name,
+        expected_source,
+        expected_target,
+    )
 }
 
 #[cfg(windows)]
@@ -2616,6 +2671,7 @@ fn replace_file_platform(
     _source_name: &OsStr,
     _target_name: &OsStr,
     _expected_source: Option<FileIdentity>,
+    _expected_target: Option<FileIdentity>,
 ) -> Result<(), ReplaceFileError> {
     Err(ReplaceFileError::NotReplaced(io::Error::new(
         io::ErrorKind::Unsupported,
@@ -3018,6 +3074,7 @@ mod windows {
         source_name: &OsStr,
         target_name: &OsStr,
         expected_source: Option<FileIdentity>,
+        expected_target: Option<FileIdentity>,
     ) -> Result<(), ReplaceFileError> {
         let (_directory_guard, directory_path) =
             guarded_directory_path(directory).map_err(ReplaceFileError::NotReplaced)?;
@@ -3039,15 +3096,27 @@ mod windows {
         }
 
         let target = open_identity_handle(&target_path).map_err(ReplaceFileError::NotReplaced)?;
-        verify_open_regular(&target).map_err(ReplaceFileError::NotReplaced)?;
+        if expected_target.is_some() {
+            verify_space_usage_metadata(&target.metadata().map_err(ReplaceFileError::NotReplaced)?)
+                .map_err(ReplaceFileError::NotReplaced)?;
+        } else {
+            verify_open_regular(&target).map_err(ReplaceFileError::NotReplaced)?;
+        }
         let target_before = file_identity(&target).map_err(ReplaceFileError::NotReplaced)?;
-        if identity(&target_path).map_err(ReplaceFileError::NotReplaced)? != target_before {
+        if expected_target.is_some_and(|expected| expected != target_before)
+            || identity(&target_path).map_err(ReplaceFileError::NotReplaced)? != target_before
+        {
             return Err(ReplaceFileError::NotReplaced(io::Error::other(
                 "rename target identity changed during open",
             )));
         }
 
-        let result = rename_handle(&source, target_path.as_os_str(), true);
+        let result = rename_handle(
+            &source,
+            target_path.as_os_str(),
+            true,
+            expected_target.is_some(),
+        );
         let opened_source_after = file_identity(&source).ok();
         let opened_target_after = file_identity(&target).ok();
         let source_after = identity(&source_path).ok();
@@ -3114,7 +3183,7 @@ mod windows {
         }
 
         before_rename();
-        let result = rename_handle(&source, target_path.as_os_str(), false);
+        let result = rename_handle(&source, target_path.as_os_str(), false, false);
         let opened_after = file_identity(&source).ok();
         let source_after = identity(&source_path).ok();
         let target_after = identity(&target_path).ok();
@@ -3232,8 +3301,10 @@ mod windows {
         source: &File,
         target_path: &OsStr,
         replace_if_exists: bool,
+        authenticated_target: bool,
     ) -> io::Result<()> {
-        let mut rename = RenameInformation::new(target_path, replace_if_exists)?;
+        let mut rename =
+            RenameInformation::new(target_path, replace_if_exists, authenticated_target)?;
         // SAFETY: `rename` owns an aligned, initialized FILE_RENAME_INFO buffer
         // for the duration of the call. The absolute target path was resolved
         // from the retained directory handle, and the source was opened with
@@ -3267,7 +3338,11 @@ mod windows {
     }
 
     impl RenameInformation {
-        fn new(target_name: &OsStr, replace_if_exists: bool) -> io::Result<Self> {
+        fn new(
+            target_name: &OsStr,
+            replace_if_exists: bool,
+            authenticated_target: bool,
+        ) -> io::Result<Self> {
             let target = target_name.encode_wide().collect::<Vec<_>>();
             if target.is_empty() {
                 return Err(io::Error::new(
@@ -3303,8 +3378,10 @@ mod windows {
             // FileNameLength excludes the retained zero terminator.
             unsafe {
                 if replace_if_exists {
-                    (*information).Anonymous.Flags =
-                        FILE_RENAME_REPLACE_IF_EXISTS_FLAG | FILE_RENAME_POSIX_SEMANTICS_FLAG;
+                    (*information).Anonymous.Flags = FILE_RENAME_REPLACE_IF_EXISTS_FLAG | FILE_RENAME_POSIX_SEMANTICS_FLAG
+                        // FILE_RENAME_IGNORE_READONLY_ATTRIBUTE replaces the name
+                        // without changing attributes on the shared prior inode.
+                        | if authenticated_target { 0x40 } else { 0 };
                 } else {
                     (*information).Anonymous.ReplaceIfExists = false;
                 }
@@ -3774,7 +3851,7 @@ mod windows {
             let old_target = open_identity_handle(&target_path).unwrap();
             let old_target_identity = file_identity(&old_target).unwrap();
 
-            rename_handle(&source, target_path.as_os_str(), true).unwrap();
+            rename_handle(&source, target_path.as_os_str(), true, false).unwrap();
 
             assert_eq!(file_identity(&source).unwrap(), source_identity);
             assert_eq!(file_identity(&old_target).unwrap(), old_target_identity);
@@ -3787,7 +3864,7 @@ mod windows {
         fn rename_information_buffer_meets_win32_layout_contract() {
             let target_path = OsStr::new(r"C:\durability-probe\published");
             let target = target_path.encode_wide().collect::<Vec<_>>();
-            let mut rename = RenameInformation::new(target_path, false).unwrap();
+            let mut rename = RenameInformation::new(target_path, false, false).unwrap();
             let information = rename.as_mut_ptr();
 
             assert_eq!(
@@ -3811,7 +3888,7 @@ mod windows {
                 assert_eq!(*file_name.add(target.len()), 0);
             }
 
-            let mut replacement = RenameInformation::new(target_path, true).unwrap();
+            let mut replacement = RenameInformation::new(target_path, true, false).unwrap();
             // SAFETY: `replacement` owns a live initialized buffer.
             unsafe {
                 assert_eq!(
@@ -4182,6 +4259,18 @@ mod tests {
             "replace-target" => {
                 stable.replace_child(OsStr::new("regular"), regular_identity, OsStr::new("fifo"))
             }
+            "authenticated-source" => stable.replace_authenticated_child(
+                OsStr::new("fifo"),
+                fifo_identity,
+                OsStr::new("regular"),
+                regular_identity,
+            ),
+            "authenticated-target" => stable.replace_authenticated_child(
+                OsStr::new("regular"),
+                regular_identity,
+                OsStr::new("fifo"),
+                fifo_identity,
+            ),
             "native-replace-source" => replace_file(
                 &directory_handle(&root),
                 OsStr::new("fifo"),
@@ -4222,6 +4311,8 @@ mod tests {
             "native-replace-source",
             "native-replace-target",
             "native-install-source",
+            "authenticated-source",
+            "authenticated-target",
         ] {
             let root = tempfile::tempdir().unwrap();
             std::fs::write(root.path().join("regular"), b"regular").unwrap();
@@ -4672,6 +4763,136 @@ mod tests {
                 .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
                 .open(&path)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn authenticated_replacement_preserves_shared_payload_and_open_snapshot() {
+        use std::io::Read as _;
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        std::fs::write(root.path().join("target"), b"old payload").unwrap();
+        std::fs::hard_link(root.path().join("target"), root.path().join("cas")).unwrap();
+        std::fs::write(root.path().join("temporary"), b"new payload").unwrap();
+        let mut permissions = std::fs::metadata(root.path().join("cas"))
+            .unwrap()
+            .permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(root.path().join("cas"), permissions).unwrap();
+        let mut snapshot = stable.open_child_file(OsStr::new("target")).unwrap();
+        let prior = file_identity(&snapshot).unwrap();
+        let staged = path_identity(&root.path().join("temporary")).unwrap();
+        assert!(
+            stable
+                .replace_child(OsStr::new("temporary"), staged, OsStr::new("target"))
+                .is_err()
+        );
+        stable
+            .replace_authenticated_child(
+                OsStr::new("temporary"),
+                staged,
+                OsStr::new("target"),
+                prior,
+            )
+            .unwrap();
+        stable.sync().unwrap();
+        let mut old = Vec::new();
+        snapshot.read_to_end(&mut old).unwrap();
+        assert_eq!(old, b"old payload");
+        assert_eq!(
+            std::fs::read(root.path().join("cas")).unwrap(),
+            b"old payload"
+        );
+        assert_eq!(path_identity(&root.path().join("cas")).unwrap(), prior);
+        assert_eq!(
+            std::fs::read(root.path().join("target")).unwrap(),
+            b"new payload"
+        );
+        assert_eq!(path_identity(&root.path().join("target")).unwrap(), staged);
+        assert!(!root.path().join("temporary").exists());
+        assert!(
+            std::fs::metadata(root.path().join("cas"))
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authenticated_replacement_rejects_symlinks_and_directories() {
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        std::fs::write(root.path().join("regular"), b"payload").unwrap();
+        std::os::unix::fs::symlink("regular", root.path().join("symlink")).unwrap();
+        std::fs::create_dir(root.path().join("directory")).unwrap();
+        let regular = path_identity(&root.path().join("regular")).unwrap();
+        for name in ["symlink", "directory"] {
+            let invalid = path_identity(&root.path().join(name)).unwrap();
+            assert!(
+                stable
+                    .replace_authenticated_child(
+                        OsStr::new(name),
+                        invalid,
+                        OsStr::new("regular"),
+                        regular
+                    )
+                    .is_err()
+            );
+            assert!(
+                stable
+                    .replace_authenticated_child(
+                        OsStr::new("regular"),
+                        regular,
+                        OsStr::new(name),
+                        invalid
+                    )
+                    .is_err()
+            );
+        }
+        assert_eq!(
+            std::fs::read(root.path().join("regular")).unwrap(),
+            b"payload"
+        );
+    }
+
+    #[test]
+    fn authenticated_replacement_rejects_substitution_and_shared_source() {
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        std::fs::write(root.path().join("target"), b"old").unwrap();
+        std::fs::write(root.path().join("temporary"), b"new").unwrap();
+        std::fs::write(root.path().join("other"), b"other").unwrap();
+        let prior = path_identity(&root.path().join("target")).unwrap();
+        let staged = path_identity(&root.path().join("temporary")).unwrap();
+        let other = path_identity(&root.path().join("other")).unwrap();
+        for (source, target) in [(other, prior), (staged, other)] {
+            assert!(
+                stable
+                    .replace_authenticated_child(
+                        OsStr::new("temporary"),
+                        source,
+                        OsStr::new("target"),
+                        target
+                    )
+                    .is_err()
+            );
+        }
+        std::fs::hard_link(root.path().join("temporary"), root.path().join("alias")).unwrap();
+        assert!(
+            stable
+                .replace_authenticated_child(
+                    OsStr::new("temporary"),
+                    staged,
+                    OsStr::new("target"),
+                    prior
+                )
+                .is_err()
+        );
+        assert_eq!(std::fs::read(root.path().join("target")).unwrap(), b"old");
+        assert_eq!(
+            std::fs::read(root.path().join("temporary")).unwrap(),
+            b"new"
         );
     }
 

--- a/crates/graphforge-filesystem/src/lib.rs
+++ b/crates/graphforge-filesystem/src/lib.rs
@@ -4779,7 +4779,9 @@ mod tests {
             .permissions();
         permissions.set_readonly(true);
         std::fs::set_permissions(root.path().join("cas"), permissions).unwrap();
-        let mut snapshot = stable.open_child_file(OsStr::new("target")).unwrap();
+        // Match Parquet readers: File::open shares deletion on Windows.
+        // Retained authentication capabilities intentionally deny deletion.
+        let mut snapshot = File::open(root.path().join("target")).unwrap();
         let prior = file_identity(&snapshot).unwrap();
         let staged = path_identity(&root.path().join("temporary")).unwrap();
         assert!(
@@ -4816,6 +4818,45 @@ mod tests {
                 .permissions()
                 .readonly()
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn authenticated_replacement_respects_retained_authentication_guard() {
+        let root = tempfile::tempdir().unwrap();
+        let stable = StableDirectory::open(root.path()).unwrap();
+        std::fs::write(root.path().join("target"), b"old").unwrap();
+        std::fs::hard_link(root.path().join("target"), root.path().join("cas")).unwrap();
+        std::fs::write(root.path().join("temporary"), b"new").unwrap();
+        let guard = stable.open_child_file(OsStr::new("target")).unwrap();
+        let prior = file_identity(&guard).unwrap();
+        let staged = path_identity(&root.path().join("temporary")).unwrap();
+        assert!(
+            stable
+                .replace_authenticated_child(
+                    OsStr::new("temporary"),
+                    staged,
+                    OsStr::new("target"),
+                    prior
+                )
+                .is_err()
+        );
+        assert_eq!(std::fs::read(root.path().join("target")).unwrap(), b"old");
+        assert_eq!(
+            std::fs::read(root.path().join("temporary")).unwrap(),
+            b"new"
+        );
+        drop(guard);
+        stable
+            .replace_authenticated_child(
+                OsStr::new("temporary"),
+                staged,
+                OsStr::new("target"),
+                prior,
+            )
+            .unwrap();
+        assert_eq!(std::fs::read(root.path().join("target")).unwrap(), b"new");
+        assert_eq!(std::fs::read(root.path().join("cas")).unwrap(), b"old");
     }
 
     #[cfg(unix)]

--- a/crates/graphforge-storage/src/durable_rewrite.rs
+++ b/crates/graphforge-storage/src/durable_rewrite.rs
@@ -453,7 +453,8 @@ fn install(root_path: &Path, root: &StableDirectory, entry: &Entry) -> Result<()
     match parent.open_child_file(&temporary) {
         Ok(temp) => {
             authenticate_staged_file(&temp, entry)?;
-            authenticate_prior_destination(&parent, &target, entry.prior_destination.as_ref())?;
+            let prior =
+                authenticate_prior_destination(&parent, &target, entry.prior_destination.as_ref())?;
             let expected = graphforge_filesystem::file_identity(&temp).map_err(storage)?;
             drop(temp);
             let authority = if entry.destination == crate::route_component::TABLE_FILE {
@@ -465,9 +466,13 @@ fn install(root_path: &Path, root: &StableDirectory, entry: &Entry) -> Result<()
             } else {
                 "graph data"
             };
-            parent
-                .replace_child(&temporary, expected, &target)
-                .map_err(|error| storage(format!("rewrite {authority} install: {error}")))?;
+            match prior {
+                Some(prior) => {
+                    parent.replace_authenticated_child(&temporary, expected, &target, prior)
+                }
+                None => parent.install_child(&temporary, expected, &target),
+            }
+            .map_err(|error| storage(format!("rewrite {authority} install: {error}")))?;
             parent.sync().map_err(storage)?;
             authenticate_installed_destination(&parent, &target, entry)?;
         }
@@ -498,9 +503,9 @@ fn authenticate_prior_destination(
     parent: &StableDirectory,
     target: &std::ffi::OsStr,
     prior: Option<&AuthenticatedFile>,
-) -> Result<(), GfError> {
+) -> Result<Option<FileIdentity>, GfError> {
     match (parent.open_child_file(target), prior) {
-        (Err(error), None) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        (Err(error), None) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         (Ok(file), Some(prior)) => {
             let identity = graphforge_filesystem::file_identity(&file).map_err(storage)?;
             if (identity.volume_serial, hex(&identity.file_id))
@@ -509,7 +514,7 @@ fn authenticate_prior_destination(
             {
                 return Err(storage("rewrite destination changed after intent"));
             }
-            Ok(())
+            Ok(Some(identity))
         }
         (Err(error), Some(_)) if error.kind() == std::io::ErrorKind::NotFound => {
             Err(storage("rewrite destination disappeared after intent"))
@@ -1817,9 +1822,38 @@ mod tests {
             ("rewrite.before_generation_authority", true),
             ("rewrite.after_generation_authority", true),
         ];
-        for (phase, committed) in phases {
-            let root = TempDir::new().unwrap();
-            let status = std::process::Command::new(std::env::current_exe().unwrap())
+        for shared in [false, true] {
+            for (phase, committed) in phases {
+                let root = TempDir::new().unwrap();
+                let mut old_payloads = Vec::new();
+                if shared {
+                    for (index, relative) in destinations.iter().enumerate() {
+                        let path = root.path().join(relative);
+                        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                        let schema =
+                            Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+                        let batch = RecordBatch::try_new(
+                            Arc::clone(&schema),
+                            vec![Arc::new(Int64Array::from(vec![-1_i64]))],
+                        )
+                        .unwrap();
+                        let mut writer = parquet::arrow::ArrowWriter::try_new(
+                            File::create(&path).unwrap(),
+                            schema,
+                            None,
+                        )
+                        .unwrap();
+                        writer.write(&batch).unwrap();
+                        writer.close().unwrap();
+                        let alias = root.path().join(format!("cas-{index}"));
+                        std::fs::hard_link(&path, &alias).unwrap();
+                        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+                        permissions.set_readonly(true);
+                        std::fs::set_permissions(&path, permissions).unwrap();
+                        old_payloads.push((alias, std::fs::read(&path).unwrap()));
+                    }
+                }
+                let status = std::process::Command::new(std::env::current_exe().unwrap())
                 .arg("--exact")
                 .arg("durable_rewrite::tests::subprocess_crash_matrix_preserves_generation_last_and_reopens_idempotently")
                 .arg("--nocapture")
@@ -1828,52 +1862,81 @@ mod tests {
                 .env("GRAPHFORGE_PROJECT_FAILPOINT", phase)
                 .status()
                 .unwrap();
-            assert_eq!(
-                status.code(),
-                Some(crate::project_failpoint::exit_code()),
-                "{phase}"
-            );
-
-            let first = crate::generation::read_topology_generation(root.path()).unwrap();
-            crate::staging::remove_stale_temps(root.path()).unwrap();
-            let second = crate::generation::read_topology_generation(root.path()).unwrap();
-            assert_eq!(
-                (first, second),
-                if committed { (1, 1) } else { (0, 0) },
-                "{phase}"
-            );
-            for (index, relative) in destinations.iter().enumerate() {
-                let path = root.path().join(relative);
-                assert_eq!(path.exists(), committed, "{phase}: {relative}");
-                if committed {
-                    let mut reader =
-                        ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
-                            .unwrap()
-                            .build()
-                            .unwrap();
-                    let batch = reader.next().unwrap().unwrap();
-                    let values = batch
-                        .column(0)
-                        .as_any()
-                        .downcast_ref::<Int64Array>()
-                        .unwrap();
-                    assert_eq!(
-                        values.value(0),
-                        i64::try_from(index).unwrap() + 10,
-                        "{phase}: {relative}"
-                    );
-                    assert!(reader.next().is_none(), "{phase}: duplicate payload");
-                }
-            }
-            assert!(!root.path().join(JOURNAL).exists(), "{phase}");
-            for relative in ["topology", "properties", "edge_properties"] {
-                assert!(
-                    std::fs::read_dir(root.path().join(relative))
-                        .unwrap()
-                        .filter_map(Result::ok)
-                        .all(|entry| !entry.file_name().to_string_lossy().ends_with(".tmp")),
-                    "{phase}: temp cleanup"
+                assert_eq!(
+                    status.code(),
+                    Some(crate::project_failpoint::exit_code()),
+                    "{phase}"
                 );
+
+                let first = crate::generation::read_topology_generation(root.path()).unwrap();
+                crate::staging::remove_stale_temps(root.path()).unwrap();
+                let second = crate::generation::read_topology_generation(root.path()).unwrap();
+                assert_eq!(
+                    (first, second),
+                    if committed { (1, 1) } else { (0, 0) },
+                    "{phase}"
+                );
+                for (index, relative) in destinations.iter().enumerate() {
+                    let path = root.path().join(relative);
+                    assert_eq!(path.exists(), committed || shared, "{phase}: {relative}");
+                    if committed {
+                        let mut reader =
+                            ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
+                                .unwrap()
+                                .build()
+                                .unwrap();
+                        let batch = reader.next().unwrap().unwrap();
+                        let values = batch
+                            .column(0)
+                            .as_any()
+                            .downcast_ref::<Int64Array>()
+                            .unwrap();
+                        assert_eq!(
+                            values.value(0),
+                            i64::try_from(index).unwrap() + 10,
+                            "{phase}: {relative}"
+                        );
+                        assert!(reader.next().is_none(), "{phase}: duplicate payload");
+                    }
+                }
+                for (alias, bytes) in old_payloads {
+                    assert!(std::fs::metadata(&alias).unwrap().permissions().readonly());
+                    assert_eq!(
+                        std::fs::read(alias).unwrap(),
+                        bytes,
+                        "{phase}: shared payload changed"
+                    );
+                }
+                if shared && !committed {
+                    for relative in destinations {
+                        let reader = ParquetRecordBatchReaderBuilder::try_new(
+                            File::open(root.path().join(relative)).unwrap(),
+                        )
+                        .unwrap()
+                        .build()
+                        .unwrap();
+                        let batch = reader.into_iter().next().unwrap().unwrap();
+                        assert_eq!(
+                            batch
+                                .column(0)
+                                .as_any()
+                                .downcast_ref::<Int64Array>()
+                                .unwrap()
+                                .value(0),
+                            -1
+                        );
+                    }
+                }
+                assert!(!root.path().join(JOURNAL).exists(), "{phase}");
+                for relative in ["topology", "properties", "edge_properties"] {
+                    assert!(
+                        std::fs::read_dir(root.path().join(relative))
+                            .unwrap()
+                            .filter_map(Result::ok)
+                            .all(|entry| !entry.file_name().to_string_lossy().ends_with(".tmp")),
+                        "{phase}: temp cleanup"
+                    );
+                }
             }
         }
     }

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -453,7 +453,9 @@ A hydrated destination may be a read-only hardlink to a published CAS payload.
 After authenticating its prior identity and contents, the rewrite uses an
 explicit shared-destination replacement capability. The temporary source must
 remain a private single-link regular file; the replacement checks both expected
-identities and preserves the old inode, bytes, attributes, and open snapshots.
+identities and preserves the old inode, bytes, attributes, and ordinary query
+readers. Windows retained authentication guards still deny deletion and must
+be released before replacement; their sharing protections remain unchanged.
 On Windows this path alone uses `FILE_RENAME_IGNORE_READONLY_ATTRIBUTE`; it
 never clears attributes shared with CAS aliases. An absent prior destination
 uses no-replace installation. Ordinary filesystem replacement stays strict.

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -449,6 +449,15 @@ intent. Paths must be canonical descendants; substitution, traversal,
 duplicate names, and cross-root state fail closed, while the named rewrite lock
 also requires one link.
 
+A hydrated destination may be a read-only hardlink to a published CAS payload.
+After authenticating its prior identity and contents, the rewrite uses an
+explicit shared-destination replacement capability. The temporary source must
+remain a private single-link regular file; the replacement checks both expected
+identities and preserves the old inode, bytes, attributes, and open snapshots.
+On Windows this path alone uses `FILE_RENAME_IGNORE_READONLY_ATTRIBUTE`; it
+never clears attributes shared with CAS aliases. An absent prior destination
+uses no-replace installation. Ordinary filesystem replacement stays strict.
+
 The intent is bounded to 16,384 entries and 8 MiB. Its sole generation-authority
 entry is `topology/generation.json`, whose JSON is bounded to 4 KiB and must
 encode the exact next topology/search pair. Data files are installed and


### PR DESCRIPTION
Public property mutation after resumable construction failed because durable replacement rejected graph payloads hardlinked from CAS. Carry the authenticated prior identity into a narrow atomic replacement capability, keep staged sources private, and preserve the old payload inode and active snapshots. Missing destinations use no-replace installation; ordinary replacement retains its strict link checks.

Windows authenticated replacement additionally permits a read-only destination without clearing its shared attributes. Tests cover exact public mutation/reopen/export/verify/clean-import results, an unpolled old query stream, read-only aliases, substituted identities, hardlinked sources, symlinks/FIFOs/directories, and shared-destination crash recovery across intent/install/generation boundaries.

Validation: 36 filesystem tests; 27 durable-rewrite tests; 99 construction tests; 10 delta compaction tests; 6 public resumable-construction tests; focused public mutation/portable round-trip regression. Workspace Clippy, formatting, `make pre-push-fast`, and `make gate-registry-check` pass. Refreshed public mutation, durable-rewrite, Clippy and fast checks against main after #1215. Native Windows execution is required CI evidence. Full local coverage remains the previously documented #360 baseline limitation, not claimed green.

Closes #1216. Unblocks the production publishing-path assessment in #1213; no encoding defaults or compatibility machinery change here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791597592&installation_model_id=20486&pr_number=1217&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1217&signature=24dbf665409fdd3b68ecb5d36f8c10ee14da3d11b0129a61e2304d5cb4405b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->