### PR TITLE
fix(storage): preserve CAS ownership through delta publication and compaction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1002,6 +1002,13 @@ jobs:
             graph_object_store::tests::publication_and_gc_lifecycles_are_mutually_exclusive \
             -- --exact --nocapture
 
+      - name: Verify CAS-backed runtime catalog replacement on Windows
+        shell: bash
+        run: >-
+          cargo test -p graphforge-storage --lib
+          runtime_entity_labels::tests::catalog_persistence_replaces_read_only_cas_aliases
+          -- --exact --nocapture
+
       - name: Verify mapped routes and portable lifecycle on Windows
         shell: bash
         run: |
@@ -1111,6 +1118,12 @@ jobs:
       - name: Run macOS exact filesystem primitive tests
         run: >-
           cargo test -p graphforge-filesystem --lib --no-fail-fast
+
+      - name: Verify CAS-backed runtime catalog replacement on macOS
+        run: >-
+          cargo test -p graphforge-storage --lib
+          runtime_entity_labels::tests::catalog_persistence_replaces_read_only_cas_aliases
+          -- --exact --nocapture
 
       - name: Verify mapped routes and portable lifecycle on macOS
         shell: bash

--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -282,26 +282,12 @@ impl GraphForge {
         let recorded_at = (self.clock.lock().expect("clock lock poisoned"))()?;
 
         let publication = (|| -> Result<RecordBatch, GfError> {
-            // Select the storage route from explicit typed input before the
-            // private workspace is mutated. Capacity exhaustion deliberately
-            // falls back to canonical full-Parquet publication.
-            let prepared_delta =
-                if !optimistic && let Some(operations) = eligible_delta_operations(request)? {
-                    let delta_request = graphforge_storage::GraphDeltaPublishRequest {
-                        transaction_uuid,
-                        generation_uuid,
-                        run_uuid: graphforge_core::uuid::composite_delta_run(&transaction_uuid),
-                        operations,
-                        limits: graphforge_storage::GraphDeltaJournalLimits::default(),
-                    };
-                    match graphforge_storage::prepare_graph_delta(parent, &delta_request) {
-                        Ok(prepared) => Some(prepared),
-                        Err(error) if error.code() == "GF_RESOURCE_LIMIT" => None,
-                        Err(error) => return Err(error),
-                    }
-                } else {
-                    None
-                };
+            // Admit the typed delta operation shape before mutating the workspace.
+            let delta_operations = if optimistic {
+                None
+            } else {
+                eligible_delta_operations(request)?
+            };
             let property_inventory =
                 crate::property_inventory_for_hydrated_generation(parent, &self.dir)?;
             apply_graph_mutations(
@@ -314,6 +300,24 @@ impl GraphForge {
             if self.path.is_some() {
                 crate::persist_runtime_catalog(&self.dir, &next_catalog)?;
             }
+            let prepared_delta = if let Some(operations) = delta_operations {
+                let delta_request = graphforge_storage::GraphDeltaPublishRequest {
+                    transaction_uuid,
+                    generation_uuid,
+                    run_uuid: graphforge_core::uuid::composite_delta_run(&transaction_uuid),
+                    operations,
+                    limits: graphforge_storage::GraphDeltaJournalLimits::default(),
+                };
+                match graphforge_storage::graph_delta_journal::prepare_graph_delta_with_runtime_catalog(
+                    parent, &delta_request, &next_catalog,
+                ) {
+                    Ok(prepared) => Some(prepared),
+                    Err(error) if error.code() == "GF_RESOURCE_LIMIT" => None,
+                    Err(error) => return Err(error),
+                }
+            } else {
+                None
+            };
             let graph = match prepared_delta.as_ref() {
                 Some(prepared) => prepared.files_participant.clone(),
                 None => graphforge_storage::capture_graph_files(&self.dir)?.1,
@@ -338,31 +342,34 @@ impl GraphForge {
                     root,
                     &publication,
                     content_fingerprint,
-                    Some(
-                        prepared_delta
-                            .as_ref()
-                            .map_or(self.dir.as_path(), |prepared| prepared.graph_tree_root()),
-                    ),
+                    prepared_delta
+                        .as_ref()
+                        .map_or(Some(self.dir.as_path()), |prepared| {
+                            prepared.graph_tree_source()
+                        }),
                     self.lifecycle_mode,
                 )?
             } else {
                 graphforge_storage::stage_project_generation_with_graph_tree_mode(
                     root,
                     &publication,
-                    Some(
-                        prepared_delta
-                            .as_ref()
-                            .map_or(self.dir.as_path(), |prepared| prepared.graph_tree_root()),
-                    ),
+                    prepared_delta
+                        .as_ref()
+                        .map_or(Some(self.dir.as_path()), |prepared| {
+                            prepared.graph_tree_source()
+                        }),
                     self.lifecycle_mode,
                 )?
             };
+            if let Some(prepared) = &prepared_delta {
+                prepared.revalidate_for_publish()?;
+            }
             #[cfg(test)]
             optimistic_publish_barrier_for_test(optimistic);
             let outcome = match staged {
                 ProjectStageOutcome::AlreadyPublished(published) => published,
-                ProjectStageOutcome::Staged(staged) => staged
-                    .validate(
+                ProjectStageOutcome::Staged(staged) => {
+                    let validated = staged.validate(
                         |_| Ok(()),
                         |actual_parent, _| {
                             if actual_parent.generation_uuid() != expected_parent {
@@ -370,8 +377,12 @@ impl GraphForge {
                             }
                             Ok(())
                         },
-                    )?
-                    .publish()?,
+                    )?;
+                    match &prepared_delta {
+                        Some(prepared) => prepared.publish(validated)?,
+                        None => validated.publish()?,
+                    }
+                }
             };
             if outcome.generation_uuid != generation_uuid {
                 return Err(GfError::Validation(
@@ -2158,10 +2169,23 @@ mod tests {
                 .len(),
             1
         );
+        let expected_catalog = graph.runtime_catalog.lock().unwrap().to_record_batch();
+        let persisted_catalog = crate::read_runtime_catalog(
+            &published
+                .graph_tree_root()
+                .join("topology/runtime_catalog.parquet"),
+        )
+        .unwrap()
+        .to_record_batch();
+        assert_eq!(
+            persisted_catalog, expected_catalog,
+            "the newly observed nickname must be published in the runtime catalog"
+        );
         for entry in parent_graph.files.iter().filter(|entry| {
-            std::path::Path::new(&entry.relative_path)
-                .extension()
-                .is_some_and(|extension| extension == "parquet")
+            entry.relative_path != "topology/runtime_catalog.parquet"
+                && std::path::Path::new(&entry.relative_path)
+                    .extension()
+                    .is_some_and(|extension| extension == "parquet")
         }) {
             assert!(published_graph.files.iter().any(|candidate| {
                 candidate.relative_path == entry.relative_path

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3513,28 +3513,7 @@ fn shape_stream(
 /// `GraphForge::new(path)` reloads the types/properties observed this session
 /// (#725). Best-effort directory creation; surfaces I/O / Parquet errors.
 fn persist_runtime_catalog(dir: &std::path::Path, rc: &RuntimeCatalog) -> Result<(), GfError> {
-    use parquet::arrow::ArrowWriter;
-
-    let topology = dir.join("topology");
-    std::fs::create_dir_all(&topology)
-        .map_err(|e| GfError::Storage(format!("failed to create {}: {e}", topology.display())))?;
-    let batch = rc.to_record_batch();
-    let path = topology.join("runtime_catalog.parquet");
-    let file = std::fs::File::create(&path)
-        .map_err(|e| GfError::Storage(format!("failed to write {}: {e}", path.display())))?;
-    let mut writer = ArrowWriter::try_new(file, batch.schema(), None)
-        .map_err(|e| GfError::Storage(e.to_string()))?;
-    writer
-        .write(&batch)
-        .map_err(|e| GfError::Storage(e.to_string()))?;
-    writer
-        .close()
-        .map_err(|e| GfError::Storage(e.to_string()))?;
-    // Persisting observed runtime entity labels implies the tagged plan/storage
-    // encoding (#702). Mark the project so reopen does not treat ontology type
-    // zero as an unmarked legacy collision with the first advisory label.
-    graphforge_storage::write_runtime_entity_label_encoding_marker(dir)?;
-    Ok(())
+    graphforge_storage::runtime_entity_labels::persist_runtime_catalog(dir, rc)
 }
 
 /// Build the schema-level metadata attached to every public result.

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -973,3 +973,303 @@ fn public_mutation_replaces_shared_constructed_payloads() {
     drop(graph);
     round_trip(root.path(), &source, fixture, &nodes, &edges);
 }
+
+#[test]
+fn cas_construction_composite_mutation_and_compaction_preserve_values() {
+    use graphforge_storage::{
+        GraphDeltaCompactionLimits, GraphDeltaCompactionRequest, ProjectRetentionLimits,
+        ProjectRetentionPolicy,
+    };
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "publishing_policy",
+        nodes: 66,
+        edges: 0,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: true,
+    };
+    let (mut nodes, edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let initial = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert!(initial.declared_graph_files_inventory().unwrap().is_none());
+    let base = initial.graph_files_inventory().unwrap().unwrap();
+
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    drop(graph);
+    use graphforge_api::{
+        COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation,
+        CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
+    };
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let snapshot_query =
+        "MATCH (n) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score ORDER BY n.node_uuid";
+    let expected_snapshot = graph.execute(snapshot_query).unwrap();
+    let old_stream = graph.execute_stream(snapshot_query).unwrap();
+    graph
+        .publish_composite_transaction(CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
+                node_uuid: nodes[0].0,
+                property: "score".into(),
+                value: PropValue::Int(123),
+            }],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        })
+        .unwrap();
+    use futures::TryStreamExt as _;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let old_batches: Vec<RecordBatch> = runtime.block_on(old_stream.try_collect()).unwrap();
+    assert_eq!(
+        old_batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>(),
+        expected_snapshot
+            .batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>()
+    );
+    drop(graph);
+    nodes[0].2 = Some(123);
+    let delta = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert!(delta.declared_graph_files_inventory().unwrap().is_none());
+    let delta_inventory = delta.graph_files_inventory().unwrap().unwrap();
+    for entry in base
+        .files
+        .iter()
+        .filter(|entry| entry.relative_path != "topology/runtime_catalog.parquet")
+    {
+        assert!(
+            delta_inventory.files.contains(entry),
+            "delta must preserve base entry {}",
+            entry.relative_path
+        );
+    }
+    assert_eq!(delta_inventory.file_count, base.file_count + 1);
+    let participants = delta
+        .participant_snapshots()
+        .unwrap()
+        .into_iter()
+        .filter(|entry| !(entry.capability_id == "graph" && entry.record_family_id == "files"))
+        .collect::<Vec<_>>();
+
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let request = GraphDeltaCompactionRequest {
+        transaction_uuid: Uuid::from_u128(121305),
+        generation_uuid: Uuid::from_u128(121306),
+        through_run_sequence: None,
+        limits: GraphDeltaCompactionLimits::default(),
+        cleanup_after_commit: false,
+        cleanup_policy: ProjectRetentionPolicy::default(),
+        cleanup_limits: ProjectRetentionLimits::default(),
+    };
+    let cancelled = graphforge_api::CancellationToken::new();
+    cancelled.cancel();
+    assert!(
+        graph
+            .compact_graph_delta(&request, Some(&cancelled))
+            .is_err()
+    );
+    assert_eq!(
+        graphforge_storage::resolve_project_generation(&source)
+            .unwrap()
+            .generation_uuid(),
+        delta.generation_uuid()
+    );
+    let preview = graph
+        .preview_graph_delta_compaction(&request, None)
+        .unwrap();
+    assert!(preview.dry_run);
+    let compacted_report = graph.compact_graph_delta(&request, None).unwrap();
+    assert_eq!(
+        preview.state_fingerprint,
+        compacted_report.state_fingerprint
+    );
+    let repeated = graph.compact_graph_delta(&request, None).unwrap();
+    let replayed_receipt = repeated.publication.unwrap();
+    let committed_receipt = compacted_report.publication.unwrap();
+    assert!(replayed_receipt.idempotent_replay);
+    assert!(!committed_receipt.idempotent_replay);
+    assert_eq!(
+        replayed_receipt.transaction_uuid,
+        committed_receipt.transaction_uuid
+    );
+    assert_eq!(
+        replayed_receipt.generation_uuid,
+        committed_receipt.generation_uuid
+    );
+    assert_eq!(
+        replayed_receipt.generation_manifest_sha256,
+        committed_receipt.generation_manifest_sha256
+    );
+    drop(graph);
+    let compacted = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert!(
+        compacted
+            .declared_graph_files_inventory()
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(compacted.capabilities(), delta.capabilities());
+    assert_eq!(
+        compacted
+            .participant_snapshots()
+            .unwrap()
+            .into_iter()
+            .filter(|entry| !(entry.capability_id == "graph" && entry.record_family_id == "files"))
+            .collect::<Vec<_>>(),
+        participants
+    );
+    assert!(
+        graphforge_storage::list_delta_runs(
+            &compacted.graph_files_inventory().unwrap().unwrap(),
+            graphforge_storage::GraphDeltaJournalLimits::default(),
+        )
+        .unwrap()
+        .is_empty()
+    );
+    let portable = root.path().join("compaction-portable");
+    std::fs::create_dir(&portable).unwrap();
+    round_trip(&portable, &source, fixture, &nodes, &edges);
+}
+
+#[test]
+fn cas_delta_preparation_reuses_payloads_with_bounded_private_allocation() {
+    use graphforge_storage::{
+        GraphDeltaJournalLimits, GraphDeltaOp, GraphDeltaOpKind, GraphDeltaPayload,
+        GraphDeltaPublishRequest,
+    };
+    for node_count in [33, 4097] {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let fixture = Fixture {
+            name: "cas_delta_allocation",
+            nodes: node_count,
+            edges: 0,
+            routes: 1,
+            identifiers: Identifiers::Random,
+            properties: true,
+            adjacency: false,
+            heterogeneous: false,
+        };
+        let (nodes, edges) = rows(fixture);
+        construct(&source, fixture, &nodes, &edges);
+        let parent = graphforge_storage::resolve_project_generation(&source).unwrap();
+        let base = parent.graph_files_inventory().unwrap().unwrap();
+        let request = GraphDeltaPublishRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            run_uuid: Uuid::now_v7(),
+            operations: vec![GraphDeltaOp {
+                operation_uuid: Uuid::now_v7(),
+                kind: GraphDeltaOpKind::SetNodeProperty,
+                payload: GraphDeltaPayload::SetNodeProperty {
+                    node_uuid: nodes[0].0.to_string(),
+                    property_stem: "_untyped".into(),
+                    key: "score".into(),
+                    value: graphforge_storage::encode_graph_delta_value(
+                        &graphforge_ir::IrLiteral::Int(123),
+                    )
+                    .unwrap(),
+                },
+            }],
+            limits: GraphDeltaJournalLimits {
+                max_batch_rows: 7,
+                max_replay_memory_bytes: 2 * 1024 * 1024,
+                ..GraphDeltaJournalLimits::default()
+            },
+        };
+        let prepared = graphforge_storage::prepare_graph_delta(&parent, &request).unwrap();
+        assert!(prepared.graph_tree_source().is_none());
+        assert!(prepared.preserved_base_parquet_digests);
+        assert_eq!(prepared.unchanged_base_files, base.file_count);
+        let mut shared_bytes = 0_u64;
+        let mut private_allocated = 0_u64;
+        for entry in &base.files {
+            let object = File::open(
+                graphforge_storage::graph_object_path(&source, &entry.content_sha256).unwrap(),
+            )
+            .unwrap();
+            let private =
+                File::open(prepared.graph_tree_root().join(&entry.relative_path)).unwrap();
+            assert_eq!(private.metadata().unwrap().len(), entry.byte_length);
+            if graphforge_filesystem::file_identity(&object).unwrap()
+                == graphforge_filesystem::file_identity(&private).unwrap()
+            {
+                shared_bytes += entry.byte_length;
+            } else {
+                private_allocated += graphforge_filesystem::file_space_usage(&private)
+                    .unwrap()
+                    .allocated_bytes;
+            }
+            if entry.relative_path.starts_with("topology/nodes/")
+                || entry.relative_path.starts_with("properties/")
+            {
+                assert_eq!(
+                    graphforge_filesystem::file_identity(&object).unwrap(),
+                    graphforge_filesystem::file_identity(&private).unwrap(),
+                    "{} must reuse its CAS payload",
+                    entry.relative_path
+                );
+            }
+        }
+        let run = File::open(
+            prepared
+                .graph_tree_root()
+                .join(graphforge_storage::delta_run_relative_path(1)),
+        )
+        .unwrap();
+        private_allocated += graphforge_filesystem::file_space_usage(&run)
+            .unwrap()
+            .allocated_bytes;
+        assert!(shared_bytes > 0);
+        assert!(
+            private_allocated <= 256 * 1024,
+            "private control/run allocation must stay bounded: {private_allocated}"
+        );
+        assert!(run.metadata().unwrap().len() <= 4096);
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .generation_uuid(),
+            parent.generation_uuid()
+        );
+        assert_eq!(parent.graph_files_inventory().unwrap().unwrap(), base);
+        drop(run);
+        drop(prepared);
+        let receipt = graphforge_storage::publish_graph_delta(&source, &request).unwrap();
+        assert!(receipt.preserved_base_parquet_digests);
+        assert_eq!(receipt.unchanged_base_files, base.file_count);
+        let repeated = graphforge_storage::publish_graph_delta(&source, &request).unwrap();
+        assert!(repeated.publication.idempotent_replay);
+        assert_eq!(repeated.state_fingerprint, receipt.state_fingerprint);
+        let mut conflict = request.clone();
+        conflict.generation_uuid = Uuid::now_v7();
+        assert!(graphforge_storage::publish_graph_delta(&source, &conflict).is_err());
+        let selected = graphforge_storage::resolve_project_generation(&source).unwrap();
+        assert_eq!(selected.generation_uuid(), request.generation_uuid);
+        assert!(selected.declared_graph_files_inventory().unwrap().is_none());
+        let graph = GraphForge::new(source.to_str()).unwrap();
+        let mut expected_nodes = nodes.clone();
+        expected_nodes[0].2 = Some(123);
+        verify_graph(&graph, fixture, &expected_nodes, &edges);
+        println!(
+            "CAS_DELTA_ALLOCATION {}",
+            json!({"nodes":node_count,"base_bytes":base.total_byte_length,"shared_bytes":shared_bytes,"private_control_and_run_allocated_bytes":private_allocated,"replay_batch_rows":7,"replay_logical_memory_limit_bytes":2*1024*1024})
+        );
+    }
+}

--- a/crates/graphforge-storage/src/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/src/graph_delta_compaction.rs
@@ -21,14 +21,17 @@ use crate::graph_delta_journal::{
 };
 use crate::graph_files::{GraphFilesInventory, capture_graph_files, verify_graph_tree};
 use crate::project_generation::resolve_project_generation;
+#[cfg(test)]
+use crate::project_publication::{ProjectCapability, ProjectGenerationRequest};
 use crate::project_publication::{
-    ProjectCapability, ProjectGenerationRequest, ProjectPublicationReceipt, ProjectStageOutcome,
-    published_project_transaction, stage_project_generation_from_admitted_parent,
+    ProjectPublicationReceipt, ProjectStageOutcome, published_project_transaction,
+    stage_project_generation_from_admitted_parent,
 };
 use crate::project_retention::{
     ProjectCleanupReport, ProjectRetentionLimits, ProjectRetentionPolicy,
     execute_project_cleanup_with_mode,
 };
+#[cfg(test)]
 use crate::{GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, empty_workspace_participants};
 
 /// Default peak logical memory budget for one compaction invocation.
@@ -325,59 +328,58 @@ fn compact_graph_delta_after_prepare(
     let prepared = prepare_compaction(root, &parent, request, cancel)?;
     check_cancel(cancel)?;
 
-    let staging = tempfile::tempdir().map_err(|error| {
-        GfError::Storage(format!(
-            "create graph delta compaction staging directory: {error}"
-        ))
-    })?;
-    materialize_compacted_workspace(staging.path(), &prepared, &limits, cancel)?;
+    // Replay already owns a complete private candidate. Publish that candidate
+    // directly instead of copying the entire compacted graph a second time.
+    let staging = &prepared.materialized;
     let output_bytes = directory_byte_size(staging.path())?;
     if output_bytes > limits.max_disk_bytes {
         return Err(resource_limit("compaction staged disk bytes"));
     }
 
-    let (inventory, files_participant) = capture_graph_files(staging.path())?;
-    let mut participants = empty_workspace_participants()?;
-    participants.insert(0, files_participant);
-    let generation_request = ProjectGenerationRequest {
-        transaction_uuid: request.transaction_uuid,
-        generation_uuid: request.generation_uuid,
-        capabilities: vec![
-            ProjectCapability {
-                capability_id: GRAPH_CAPABILITY_ID.into(),
-                capability_version: GRAPH_CAPABILITY_VERSION,
-            },
-            ProjectCapability {
-                capability_id: "workspace".into(),
-                capability_version: 1,
-            },
-        ],
-        participants,
-    };
+    let inventory = &prepared.materialized_inventory;
+    let (files_participant, publication_lease) =
+        compaction_graph_participant(&parent, staging.path(), inventory)?;
+    let generation_request = crate::graph_delta_journal::generation_with_replaced_graph(
+        &parent,
+        request.transaction_uuid,
+        request.generation_uuid,
+        files_participant,
+    )?;
 
     check_cancel(cancel)?;
     before_stage(root)?;
+    if let Some(lease) = &publication_lease {
+        lease.revalidate_for_publish()?;
+    }
     let publication = match stage_project_generation_from_admitted_parent(
         admission,
         parent,
         &generation_request,
-        Some(staging.path()),
+        publication_lease.is_none().then(|| staging.path()),
         None,
     )? {
         ProjectStageOutcome::Staged(staged) => {
             // Pre-publication verification authenticates the exact bounded
             // materialization planned above without rebuilding whole-graph maps.
-            verify_graph_tree(staging.path(), &inventory)?;
-            if inventory_state_fingerprint(&inventory) != prepared.expected_fingerprint {
+            verify_graph_tree(staging.path(), inventory)?;
+            if inventory_state_fingerprint(inventory) != prepared.expected_fingerprint {
                 return Err(corrupt(
                     "compacted generation fingerprint mismatch before CURRENT",
                 ));
             }
-            staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()?
+            let validated = staged.validate(|_| Ok(()), |_, _| Ok(()))?;
+            match &publication_lease {
+                Some(lease) => validated
+                    .publish_with_graph_objects_cancellable(lease, &mut || {
+                        cancel.is_some_and(|flag| flag.load(Ordering::Relaxed))
+                    })?,
+                None => validated.publish()?,
+            }
         }
         ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
     };
 
+    drop(publication_lease);
     let cleanup = if request.cleanup_after_commit {
         Some(execute_project_cleanup_with_mode(
             root,
@@ -398,6 +400,40 @@ fn compact_graph_delta_after_prepare(
     );
     report.output_bytes = output_bytes;
     Ok(report)
+}
+
+fn compaction_graph_participant(
+    parent: &crate::ResolvedProjectGeneration,
+    workspace: &Path,
+    inventory: &GraphFilesInventory,
+) -> Result<
+    (
+        crate::ProjectParticipant,
+        Option<crate::GraphObjectPublicationLease>,
+    ),
+    GfError,
+> {
+    let mut files_participant = crate::graph_files::inventory_participant(
+        crate::graph_files::encode_inventory(inventory)?,
+        inventory.file_count,
+    )?;
+    let publication_lease = match parent.declared_graph_files_participant()? {
+        Some(crate::GraphFilesParticipant::V2(root)) => {
+            let lease = crate::begin_graph_object_publication(parent.container_root())?;
+            let (mut state, _) = crate::graph_object_store::GraphManifestState::open(
+                &lease,
+                root,
+                crate::GraphManifestLimits::default(),
+            )?;
+            let (root, _) = crate::graph_object_store::replace_replayed_graph_files(
+                &lease, workspace, &mut state, inventory,
+            )?;
+            files_participant = crate::graph_files::graph_files_root_participant(&root)?;
+            Some(lease)
+        }
+        _ => None,
+    };
+    Ok((files_participant, publication_lease))
 }
 
 /// Inspect whether CURRENT triggers compaction under `policy`.
@@ -434,15 +470,13 @@ pub fn graph_delta_compaction_status_with_mode(
     )?;
     admission.revalidate_identity()?;
     let resolved = resolve_project_generation(admission.root())?;
-    let inventory = resolved
-        .graph_files_inventory()?
-        .ok_or_else(|| validation("CURRENT generation lacks graph/files inventory"))?;
     let materialized = tempfile::tempdir().map_err(|error| {
         GfError::Storage(format!("create bounded compaction status view: {error}"))
     })?;
+    let source = crate::graph_delta_journal::DeltaReplaySource::open(&resolved)?;
     let (_, evidence) = crate::graph_delta_journal::materialize_replayed_graph_tree(
-        &resolved.graph_tree_root(),
-        &inventory,
+        source.root(),
+        &source.inventory,
         materialized.path(),
         limits,
     )?;
@@ -502,13 +536,11 @@ fn prepare_compaction(
     let limits = request.limits.validate()?;
     check_cancel(cancel)?;
 
-    let parent_inventory = parent
-        .graph_files_inventory()?
-        .ok_or_else(|| validation("parent generation lacks graph/files inventory"))?;
-    let parent_tree = parent.graph_tree_root();
-    verify_graph_tree(&parent_tree, &parent_inventory)?;
+    let source = crate::graph_delta_journal::DeltaReplaySource::open(parent)?;
+    let parent_tree = source.root();
+    let parent_inventory = &source.inventory;
 
-    let runs = load_verified_delta_runs(&parent_tree, &parent_inventory, limits.journal)?;
+    let runs = load_verified_delta_runs(parent_tree, parent_inventory, limits.journal)?;
     let input_runs = runs.len() as u64;
     if input_runs == 0 {
         return Err(validation(
@@ -545,8 +577,8 @@ fn prepare_compaction(
         ))
     })?;
     let (_, replay) = crate::graph_delta_journal::materialize_replayed_graph_tree(
-        &parent_tree,
-        &parent_inventory,
+        parent_tree,
+        parent_inventory,
         materialized.path(),
         limits.journal,
     )?;
@@ -583,21 +615,6 @@ fn prepare_compaction(
         materialized,
         materialized_inventory,
     })
-}
-
-fn materialize_compacted_workspace(
-    workspace: &Path,
-    prepared: &PreparedCompaction,
-    _limits: &GraphDeltaCompactionLimits,
-    cancel: Option<&AtomicBool>,
-) -> Result<(), GfError> {
-    check_cancel(cancel)?;
-    crate::graph_files::materialize_graph_tree(
-        prepared.materialized.path(),
-        &prepared.materialized_inventory,
-        workspace,
-    )?;
-    Ok(())
 }
 
 fn inventory_state_fingerprint(inventory: &GraphFilesInventory) -> [u8; 32] {
@@ -694,9 +711,10 @@ fn replay_compaction_receipt(
     let materialized = tempfile::tempdir().map_err(|error| {
         GfError::Storage(format!("create bounded compaction receipt view: {error}"))
     })?;
+    let source = crate::graph_delta_journal::DeltaReplaySource::open(&resolved)?;
     let (_, evidence) = crate::graph_delta_journal::materialize_replayed_graph_tree(
-        &resolved.graph_tree_root(),
-        &inventory,
+        source.root(),
+        &source.inventory,
         materialized.path(),
         request.limits.journal,
     )?;

--- a/crates/graphforge-storage/src/graph_delta_journal.rs
+++ b/crates/graphforge-storage/src/graph_delta_journal.rs
@@ -7,7 +7,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use arrow::array::{
     Array, FixedSizeBinaryArray, ListArray, StringArray, TimestampMicrosecondArray, UInt32Array,
@@ -28,6 +28,7 @@ use crate::project_publication::{
     ProjectCapability, ProjectGenerationRequest, ProjectPublicationReceipt, ProjectStageOutcome,
     published_project_transaction, stage_project_generation_from_admitted_parent,
 };
+#[cfg(test)]
 use crate::{GRAPH_CAPABILITY_ID, GRAPH_CAPABILITY_VERSION, empty_workspace_participants};
 
 /// Run file format identity implemented by this release.
@@ -638,6 +639,7 @@ pub struct GraphDeltaPublicationReceipt {
 /// complete project generation. Preparation never stages or publishes CURRENT.
 pub struct PreparedGraphDelta {
     workspace: tempfile::TempDir,
+    publication_lease: Option<crate::GraphObjectPublicationLease>,
     /// Authenticated `graph/files` participant for the prepared tree.
     pub files_participant: crate::ProjectParticipant,
     /// Sequence assigned to the appended run.
@@ -655,6 +657,36 @@ impl PreparedGraphDelta {
     #[must_use]
     pub fn graph_tree_root(&self) -> &Path {
         self.workspace.path()
+    }
+
+    /// Select the owning tree only when the participant declares that ownership.
+    #[must_use]
+    pub fn graph_tree_source(&self) -> Option<&Path> {
+        self.publication_lease
+            .is_none()
+            .then(|| self.workspace.path())
+    }
+
+    /// Revalidate the retained CAS publication capability before CURRENT changes.
+    pub fn revalidate_for_publish(&self) -> Result<(), GfError> {
+        if let Some(lease) = &self.publication_lease {
+            lease.revalidate_for_publish()?;
+        }
+        Ok(())
+    }
+
+    /// Publish a validated candidate with its declared ownership capability.
+    ///
+    /// # Errors
+    /// Propagates publication and retained-CAS authentication errors.
+    pub fn publish(
+        &self,
+        validated: crate::ValidatedProjectGeneration,
+    ) -> Result<ProjectPublicationReceipt, GfError> {
+        match &self.publication_lease {
+            Some(lease) => validated.publish_with_graph_objects(lease),
+            None => validated.publish(),
+        }
     }
 }
 
@@ -1286,6 +1318,110 @@ fn bounded_materialized_fingerprint(
     Ok(hasher.finalize().into())
 }
 
+/// An authenticated input for the existing path-based replay implementation.
+/// CAS payloads are linked into a private workspace; the selected generation
+/// remains the authority and retains its ownership throughout publication.
+pub(crate) struct DeltaReplaySource {
+    root: PathBuf,
+    pub(crate) inventory: GraphFilesInventory,
+    workspace: Option<tempfile::TempDir>,
+}
+
+pub(crate) fn generation_with_replaced_graph(
+    parent: &crate::ResolvedProjectGeneration,
+    transaction_uuid: Uuid,
+    generation_uuid: Uuid,
+    graph: crate::ProjectParticipant,
+) -> Result<ProjectGenerationRequest, GfError> {
+    let mut participants = parent
+        .participant_snapshots()?
+        .into_iter()
+        .filter(|snapshot| {
+            snapshot.capability_id != crate::GRAPH_CAPABILITY_ID
+                || snapshot.record_family_id != crate::GRAPH_FILES_FAMILY
+        })
+        .map(|snapshot| {
+            let encoding = match snapshot.encoding.as_str() {
+                "parquet" => crate::ProjectParticipantEncoding::Parquet,
+                "arrow" => crate::ProjectParticipantEncoding::Arrow,
+                "json" => crate::ProjectParticipantEncoding::Json,
+                _ => return Err(corrupt("parent participant encoding is unsupported")),
+            };
+            Ok(crate::ProjectParticipant {
+                capability_id: snapshot.capability_id,
+                capability_version: snapshot.capability_version,
+                record_family_id: snapshot.record_family_id,
+                record_version: snapshot.record_version,
+                encoding,
+                schema_fingerprint: snapshot.schema_fingerprint,
+                row_count: snapshot.row_count,
+                bytes: snapshot.bytes,
+            })
+        })
+        .collect::<Result<Vec<_>, GfError>>()?;
+    participants.push(graph);
+    Ok(ProjectGenerationRequest {
+        transaction_uuid,
+        generation_uuid,
+        capabilities: parent
+            .capabilities()
+            .into_iter()
+            .map(|capability| ProjectCapability {
+                capability_id: capability.capability_id,
+                capability_version: capability.capability_version,
+            })
+            .collect(),
+        participants,
+    })
+}
+
+impl DeltaReplaySource {
+    pub(crate) fn open(parent: &crate::ResolvedProjectGeneration) -> Result<Self, GfError> {
+        let inventory = parent
+            .graph_files_inventory()?
+            .ok_or_else(|| validation("parent generation lacks graph/files inventory"))?;
+        match parent.declared_graph_files_participant()? {
+            Some(crate::GraphFilesParticipant::V1(_)) => Ok(Self {
+                root: parent.graph_tree_root(),
+                inventory,
+                workspace: None,
+            }),
+            Some(crate::GraphFilesParticipant::V2(_)) => {
+                let workspace = tempfile::tempdir().map_err(|error| {
+                    GfError::Storage(format!("create authenticated delta input: {error}"))
+                })?;
+                crate::materialize_graph_objects(
+                    parent.container_root(),
+                    &inventory,
+                    workspace.path(),
+                )?;
+                let (inventory, _) = capture_graph_files(workspace.path())?;
+                Ok(Self {
+                    root: workspace.path().to_owned(),
+                    inventory,
+                    workspace: Some(workspace),
+                })
+            }
+            None => Err(validation("parent generation lacks graph/files inventory")),
+        }
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn into_workspace(self) -> Result<tempfile::TempDir, GfError> {
+        if let Some(workspace) = self.workspace {
+            return Ok(workspace);
+        }
+        let workspace = tempfile::tempdir().map_err(|error| {
+            GfError::Storage(format!("create graph delta staging directory: {error}"))
+        })?;
+        crate::graph_files::materialize_graph_tree(&self.root, &self.inventory, workspace.path())?;
+        Ok(workspace)
+    }
+}
+
 /// Prepare one owning base-plus-run graph tree without staging or publishing it.
 ///
 /// # Errors
@@ -1294,6 +1430,26 @@ fn bounded_materialized_fingerprint(
 pub fn prepare_graph_delta(
     parent: &crate::ResolvedProjectGeneration,
     request: &GraphDeltaPublishRequest,
+) -> Result<PreparedGraphDelta, GfError> {
+    prepare_graph_delta_inner(parent, request, None)
+}
+
+/// Prepare a delta together with runtime names observed by the owning facade.
+///
+/// # Errors
+/// Returns authentication, encoding, idempotency, and resource-limit errors.
+pub fn prepare_graph_delta_with_runtime_catalog(
+    parent: &crate::ResolvedProjectGeneration,
+    request: &GraphDeltaPublishRequest,
+    catalog: &graphforge_ir::RuntimeCatalog,
+) -> Result<PreparedGraphDelta, GfError> {
+    prepare_graph_delta_inner(parent, request, Some(catalog))
+}
+
+fn prepare_graph_delta_inner(
+    parent: &crate::ResolvedProjectGeneration,
+    request: &GraphDeltaPublishRequest,
+    catalog: Option<&graphforge_ir::RuntimeCatalog>,
 ) -> Result<PreparedGraphDelta, GfError> {
     for op in &request.operations {
         if op.payload.expected_kind() != op.kind {
@@ -1305,9 +1461,10 @@ pub fn prepare_graph_delta(
     let parent_inventory = parent
         .graph_files_inventory()?
         .ok_or_else(|| validation("parent generation lacks graph/files inventory"))?;
-    let parent_tree = parent.graph_tree_root();
-    verify_graph_tree(&parent_tree, &parent_inventory)?;
-    let parent_runs = load_verified_delta_runs(&parent_tree, &parent_inventory, request.limits)?;
+    let source = DeltaReplaySource::open(parent)?;
+    let parent_tree = source.root();
+    let source_inventory = &source.inventory;
+    let parent_runs = load_verified_delta_runs(parent_tree, source_inventory, request.limits)?;
     let committed_ops = parent_runs
         .iter()
         .flat_map(|run| run.records.iter())
@@ -1334,34 +1491,12 @@ pub fn prepare_graph_delta(
         &request.operations,
         request.limits,
     )?;
-    let workspace = tempfile::tempdir().map_err(|error| {
-        GfError::Storage(format!("create graph delta staging directory: {error}"))
-    })?;
-    for entry in &parent_inventory.files {
-        let source = crate::graph_files::resolve_v1_inventory_entry(&parent_tree, entry)?;
-        let relative = crate::graph_files::canonical_inventory_relative_path(&entry.relative_path)?;
-        let destination = workspace.path().join(relative);
-        if let Some(parent_dir) = destination.parent() {
-            fs::create_dir_all(parent_dir)
-                .map_err(|error| storage("create delta staging parent", parent_dir, error))?;
-        }
-        fs::copy(&source, &destination)
-            .map_err(|error| storage("copy parent graph file", &source, error))?;
+    let workspace = source.into_workspace()?;
+    write_prepared_run(workspace.path(), next_sequence, &run_bytes)?;
+    if let Some(catalog) = catalog {
+        crate::runtime_entity_labels::persist_runtime_catalog(workspace.path(), catalog)?;
     }
-    let new_path = workspace
-        .path()
-        .join(delta_run_relative_path(next_sequence));
-    if let Some(parent_dir) = new_path.parent() {
-        fs::create_dir_all(parent_dir)
-            .map_err(|error| storage("create deltas directory", parent_dir, error))?;
-    }
-    let mut file =
-        File::create(&new_path).map_err(|error| storage("create delta run", &new_path, error))?;
-    file.write_all(&run_bytes)
-        .map_err(|error| storage("write delta run", &new_path, error))?;
-    file.sync_all()
-        .map_err(|error| storage("flush delta run", &new_path, error))?;
-    let (inventory, files_participant) = capture_graph_files(workspace.path())?;
+    let (inventory, mut files_participant) = capture_graph_files(workspace.path())?;
     let unchanged_base_files = count_preserved_base_files(&parent_inventory, &inventory)?;
     let parent_base_count = count_base_files(&parent_inventory)?;
     let preserved_base_parquet_digests = base_parquet_digests_preserved(
@@ -1372,14 +1507,62 @@ pub fn prepare_graph_delta(
     )?;
     let state_fingerprint =
         bounded_materialized_fingerprint(workspace.path(), &inventory, request.limits)?;
+    let publication_lease = match parent.declared_graph_files_participant()? {
+        Some(crate::GraphFilesParticipant::V2(root)) => {
+            let lease = crate::begin_graph_object_publication(parent.container_root())?;
+            let (mut state, _) = crate::graph_object_store::GraphManifestState::open(
+                &lease,
+                root,
+                crate::GraphManifestLimits::default(),
+            )?;
+            let mut sealed = vec![PathBuf::from(delta_run_relative_path(next_sequence))];
+            if catalog.is_some() {
+                sealed.extend([
+                    PathBuf::from("topology/runtime_catalog.parquet"),
+                    PathBuf::from("topology/runtime_entity_label_encoding.json"),
+                ]);
+            }
+            let (root, _) = crate::graph_object_store::append_replayed_graph_files(
+                &lease,
+                workspace.path(),
+                &mut state,
+                &inventory,
+                &sealed,
+                &[],
+            )?;
+            files_participant = crate::graph_files::graph_files_root_participant(&root)?;
+            Some(lease)
+        }
+        _ => None,
+    };
     Ok(PreparedGraphDelta {
         workspace,
+        publication_lease,
         files_participant,
         run_sequence: next_sequence,
         preserved_base_parquet_digests,
         unchanged_base_files,
         state_fingerprint,
     })
+}
+
+fn write_prepared_run(
+    workspace: &Path,
+    next_sequence: u64,
+    run_bytes: &[u8],
+) -> Result<(), GfError> {
+    let new_path = workspace.join(delta_run_relative_path(next_sequence));
+    if let Some(parent_dir) = new_path.parent() {
+        fs::create_dir_all(parent_dir)
+            .map_err(|error| storage("create deltas directory", parent_dir, error))?;
+    }
+    let mut file =
+        File::create(&new_path).map_err(|error| storage("create delta run", &new_path, error))?;
+    file.write_all(run_bytes)
+        .map_err(|error| storage("write delta run", &new_path, error))?;
+    file.sync_all()
+        .map_err(|error| storage("flush delta run", &new_path, error))?;
+    Ok(())
 }
 
 /// Publish one small-write generation that preserves unchanged base Parquet.
@@ -1446,11 +1629,9 @@ fn publish_graph_delta_after_prepare(
         let inventory = resolved
             .graph_files_inventory()?
             .ok_or_else(|| corrupt("published generation missing graph inventory"))?;
-        let state_fingerprint = bounded_materialized_fingerprint(
-            &resolved.graph_tree_root(),
-            &inventory,
-            request.limits,
-        )?;
+        let source = DeltaReplaySource::open(&resolved)?;
+        let state_fingerprint =
+            bounded_materialized_fingerprint(source.root(), &source.inventory, request.limits)?;
         let run_sequence = list_delta_runs(&inventory, request.limits)?.len() as u64;
         return Ok(GraphDeltaPublicationReceipt {
             publication,
@@ -1468,33 +1649,23 @@ fn publish_graph_delta_after_prepare(
     let parent = resolve_project_generation(container_root)?;
     let prepared = prepare_graph_delta(&parent, request)?;
 
-    let mut participants = empty_workspace_participants()?;
-    participants.insert(0, prepared.files_participant.clone());
-    let generation_request = ProjectGenerationRequest {
-        transaction_uuid: request.transaction_uuid,
-        generation_uuid: request.generation_uuid,
-        capabilities: vec![
-            ProjectCapability {
-                capability_id: GRAPH_CAPABILITY_ID.into(),
-                capability_version: GRAPH_CAPABILITY_VERSION,
-            },
-            ProjectCapability {
-                capability_id: "workspace".into(),
-                capability_version: 1,
-            },
-        ],
-        participants,
-    };
+    let generation_request = generation_with_replaced_graph(
+        &parent,
+        request.transaction_uuid,
+        request.generation_uuid,
+        prepared.files_participant.clone(),
+    )?;
     before_stage(container_root)?;
+    prepared.revalidate_for_publish()?;
     let publication = match stage_project_generation_from_admitted_parent(
         admission,
         parent,
         &generation_request,
-        Some(prepared.graph_tree_root()),
+        prepared.graph_tree_source(),
         None,
     )? {
         ProjectStageOutcome::Staged(staged) => {
-            staged.validate(|_| Ok(()), |_, _| Ok(()))?.publish()?
+            prepared.publish(staged.validate(|_| Ok(()), |_, _| Ok(()))?)?
         }
         ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
     };

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1240,6 +1240,64 @@ pub fn append_graph_files_v2(
     )
 }
 
+/// Publish a private replay candidate using its authenticated route contract.
+pub(crate) fn replace_replayed_graph_files(
+    lease: &GraphObjectPublicationLease,
+    workspace: &Path,
+    state: &mut GraphManifestState,
+    inventory: &GraphFilesInventory,
+) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    let changed = inventory
+        .files
+        .iter()
+        .filter(|entry| {
+            state.entries.get(&entry.relative_path).is_none_or(|old| {
+                old.content_sha256 != entry.content_sha256 || old.byte_length != entry.byte_length
+            })
+        })
+        .map(|entry| PathBuf::from(&entry.relative_path))
+        .collect::<Vec<_>>();
+    let tombstones = state
+        .entries
+        .keys()
+        .filter(|path| {
+            inventory
+                .files
+                .binary_search_by(|entry| entry.relative_path.cmp(path))
+                .is_err()
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    append_replayed_graph_files(lease, workspace, state, inventory, &changed, &tombstones)
+}
+
+/// Append selected replay outputs without changing their authenticated route contract.
+pub(crate) fn append_replayed_graph_files(
+    lease: &GraphObjectPublicationLease,
+    workspace: &Path,
+    state: &mut GraphManifestState,
+    inventory: &GraphFilesInventory,
+    sealed_paths: &[PathBuf],
+    tombstones: &[String],
+) -> Result<(GraphFilesRootV2, GraphFilesAppendEvidence), GfError> {
+    let routes = crate::route_component::authenticate_manifest_routes(
+        inventory.format_version,
+        &inventory.files,
+        |entry| {
+            crate::graph_files::read_route_table_counted(workspace, entry).map(|(bytes, _)| bytes)
+        },
+    )?;
+    append_graph_files_v2_inner(
+        lease,
+        workspace,
+        state,
+        sealed_paths,
+        None,
+        tombstones,
+        routes.as_ref(),
+    )
+}
+
 /// Seal a verified mapped import into a fresh CAS root, checking exact table closure.
 pub(crate) fn append_mapped_import_graph_files(
     lease: &GraphObjectPublicationLease,

--- a/crates/graphforge-storage/src/runtime_entity_labels.rs
+++ b/crates/graphforge-storage/src/runtime_entity_labels.rs
@@ -574,6 +574,75 @@ pub fn runtime_entity_plan_id_is_disjoint_from_ontology(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn catalog_persistence_replaces_read_only_cas_aliases() {
+        use std::fs::{self, File};
+        let source = tempfile::tempdir().unwrap();
+        let mut writer = crate::GraphWriter::open_at(
+            source.path(),
+            graphforge_core::OntologyMode::Exploratory,
+            1,
+        )
+        .unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        let mut catalog = graphforge_ir::RuntimeCatalog::new();
+        catalog.intern_property("before", None).unwrap();
+        super::persist_runtime_catalog(source.path(), &catalog).unwrap();
+        let (inventory, _) = crate::capture_graph_files(source.path()).unwrap();
+        let objects = tempfile::tempdir().unwrap();
+        for entry in &inventory.files {
+            let bytes = fs::read(source.path().join(&entry.relative_path)).unwrap();
+            let (digest, _) = crate::install_graph_object_bytes(objects.path(), &bytes).unwrap();
+            assert_eq!(digest, entry.content_sha256);
+        }
+        let workspace = tempfile::tempdir().unwrap();
+        crate::materialize_graph_objects(objects.path(), &inventory, workspace.path()).unwrap();
+        let controls = [
+            "topology/runtime_catalog.parquet",
+            "topology/runtime_entity_label_encoding.json",
+        ];
+        for path in controls {
+            let file = File::open(workspace.path().join(path)).unwrap();
+            assert!(file.metadata().unwrap().permissions().readonly());
+            assert_eq!(graphforge_filesystem::file_link_count(&file).unwrap(), 2);
+        }
+        catalog.intern_property("after", None).unwrap();
+        super::persist_runtime_catalog(workspace.path(), &catalog).unwrap();
+        for path in controls {
+            let entry = inventory
+                .files
+                .iter()
+                .find(|entry| entry.relative_path == path)
+                .unwrap();
+            let object = crate::graph_object_path(objects.path(), &entry.content_sha256).unwrap();
+            assert_eq!(
+                fs::read(&object).unwrap(),
+                fs::read(source.path().join(path)).unwrap()
+            );
+            assert!(fs::metadata(&object).unwrap().permissions().readonly());
+            let private = File::open(workspace.path().join(path)).unwrap();
+            assert_eq!(graphforge_filesystem::file_link_count(&private).unwrap(), 1);
+            assert_ne!(
+                graphforge_filesystem::file_identity(&private).unwrap(),
+                graphforge_filesystem::file_identity(&File::open(object).unwrap()).unwrap()
+            );
+        }
+        let batches = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+            File::open(workspace.path().join(controls[0])).unwrap(),
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+        assert_eq!(batches, vec![catalog.to_record_batch()]);
+        assert_eq!(
+            fs::read(workspace.path().join(controls[1])).unwrap(),
+            super::runtime_entity_label_encoding_bytes().unwrap()
+        );
+    }
     use super::*;
     use crate::schemas::TOPOLOGY_NODES_SCHEMA;
     use arrow::array::{

--- a/crates/graphforge-storage/src/runtime_entity_labels.rs
+++ b/crates/graphforge-storage/src/runtime_entity_labels.rs
@@ -98,6 +98,33 @@ pub fn write_runtime_entity_label_encoding_marker(dir: &Path) -> Result<(), GfEr
     Ok(())
 }
 
+/// Persist observed runtime names by replacing the private workspace alias.
+/// A catalog hydrated from CAS must never be truncated in place.
+///
+/// # Errors
+/// Propagates Parquet encoding, authenticated replacement, and durability errors.
+pub fn persist_runtime_catalog(dir: &Path, catalog: &RuntimeCatalog) -> Result<(), GfError> {
+    let topology = dir.join("topology");
+    std::fs::create_dir_all(&topology).map_err(|error| storage_err(error.to_string()))?;
+    let batch = catalog.to_record_batch();
+    let temporary = tempfile::NamedTempFile::new_in(&topology)
+        .map_err(|error| storage_err(error.to_string()))?;
+    let mut writer =
+        parquet::arrow::ArrowWriter::try_new(temporary.as_file(), batch.schema(), None)
+            .map_err(|error| storage_err(error.to_string()))?;
+    writer
+        .write(&batch)
+        .map_err(|error| storage_err(error.to_string()))?;
+    writer
+        .close()
+        .map_err(|error| storage_err(error.to_string()))?;
+    let mut staged = crate::RewriteBatch::new();
+    staged.stage_file(&topology.join("runtime_catalog.parquet"), temporary.path())?;
+    staged.stage_bytes(&encoding_path(dir), &runtime_entity_label_encoding_bytes()?)?;
+    crate::generation::commit_topology_aware(staged, dir)?;
+    Ok(())
+}
+
 /// Shared marker bytes for reconciliation and authenticated construction artifacts.
 pub(crate) fn runtime_entity_label_encoding_bytes() -> Result<Vec<u8>, GfError> {
     let marker = EncodingMarker {

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -155,3 +155,55 @@ phase. The test verifies both measured phase peaks when they tie, no increase
 against the compressed retained control, strict reduction against the frozen
 pre-compression control, and the original strict retained-allocation reduction.
 Compression does not retroactively remove a historical shaping peak.
+
+## Delta and compaction ownership repair (#1219)
+
+Construction publishes mapped CAS roots. Delta preparation and compaction had
+assumed generation-owned graph directories, so direct construction → composite
+property mutation failed before replay. Current production emits both ownership
+forms. The repair resolves the declared authority, authenticates CAS payloads,
+and links immutable inputs into a private workspace. A delta seals its new run
+into the shared manifest. Compaction seals changed files and removes delta-run
+entries while retaining unchanged objects, capabilities and other participants.
+Publication retains its CAS lease through CURRENT and releases it before cleanup.
+
+Runtime catalog persistence now replaces the private alias through the existing
+durable rewrite protocol. Catalog and label-encoding marker commit together.
+Composite deltas include observed runtime names in their candidate; introducing
+a property can legitimately change the catalog digest. Node/property payloads
+remain byte-identical when appending a delta. The catalog writer retains its
+previous Parquet defaults; shared encoding policy remains #1213.
+
+[Measured ownership evidence](../../development/evidence/cas-delta-ownership-1219.json)
+uses runtime source `36bc94505baef9125ad254c4b707aac2383ea090`. Two compiled API
+regressions pass public construction, composite and direct storage publication,
+reopen/query, cancellation before publication, active query snapshots,
+idempotent retries, compaction, export, full verify and clean import. Node-only
+fixtures isolate ownership from the multi-relationship replay repair in #1218.
+The existing delta/compaction integration suites also pass (26 tests), alongside
+10 unit/crash tests, 19 composite tests and 30 bulk-construction tests.
+
+| Nodes | Base logical bytes | Reused payload bytes | Private controls + run allocated |
+| ---: | ---: | ---: | ---: |
+| 33 | 14,018 | 11,460 | 24,576 |
+| 4,097 | 545,130 | 379,901 | 188,416 |
+
+Both allocation fixtures assert identical CAS/private file identities for node
+and property payloads, unchanged parent inventories, a run no larger than 4 KiB,
+and private control/run allocation no larger than 256 KiB. They use seven-row
+batches and the existing 2 MiB logical replay limit. Mutable membership controls
+still require private copies, so their allocation grows with the fixture.
+These are scoped preparation budgets, not total temporary-disk or process-memory
+bounds. Fingerprinting still materializes a replay view; compaction now publishes
+its existing private replay output without making a second complete staging copy.
+
+The untraced serial binary took 5.38 seconds (4.10 user, 0.98 system), with
+142,932 KiB peak RSS. Kernel filesystem accounting reported 54,064 input and
+28,672 output blocks of 512 bytes. A separate syscall trace counted 60,252,083
+returned read bytes and 10,211,682 returned write bytes, including startup,
+authentication, both fixtures, queries and the portable round trip. These are
+observations, not portable CPU/I/O thresholds; cache-dependent physical I/O and
+syscall byte counts are different quantities. Compilation is excluded. Reproduce
+with the prebuilt `permanent_storage_budgets` binary and
+`cas_ --nocapture --test-threads=1`, using native-root `TMPDIR`; run `/usr/bin/time -v`
+separately from `strace -f -e trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync`.

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -181,7 +181,10 @@ reopen/query, cancellation before publication, active query snapshots,
 idempotent retries, compaction, export, full verify and clean import. Node-only
 fixtures isolate ownership from the multi-relationship replay repair in #1218.
 The existing delta/compaction integration suites also pass (26 tests), alongside
-10 unit/crash tests, 19 composite tests and 30 bulk-construction tests.
+10 unit/crash tests, 19 composite tests and 30 bulk-construction tests. A focused
+storage test installs real CAS catalog/marker objects and verifies that durable
+persistence replaces both private aliases while preserving the original objects;
+the Windows and macOS native CI lanes run this exact test.
 
 | Nodes | Base logical bytes | Reused payload bytes | Private controls + run allocated |
 | ---: | ---: | ---: | ---: |

--- a/docs/development/evidence/cas-delta-ownership-1219.json
+++ b/docs/development/evidence/cas-delta-ownership-1219.json
@@ -1,0 +1,89 @@
+{
+  "issue": 1219,
+  "runtime_source_commit": "36bc94505baef9125ad254c4b707aac2383ea090",
+  "base_main_commit": "4a03ead3ca449409840a950eb02b5495436e43bf",
+  "host": "OVHC-AGENCY",
+  "kernel": "7.0.0-30-generic",
+  "filesystem": "process-root ext4, 4096-byte allocation blocks",
+  "rust": "1.96.0",
+  "arrow_parquet": "58.4.0",
+  "test_filter": "cas_ --nocapture --test-threads=1",
+  "scope": "Two compiled API integration tests: node-only public construction/composite/reopen/compaction/portable round trip and direct delta preparation/publication/retry at 33 and 4097 nodes. Compilation excluded.",
+  "runtime": {
+    "elapsed_seconds": 5.38,
+    "user_cpu_seconds": 4.1,
+    "system_cpu_seconds": 0.98,
+    "peak_rss_kib": 142932,
+    "filesystem_input_blocks_512": 54064,
+    "filesystem_output_blocks_512": 28672,
+    "exit_status": 0
+  },
+  "allocation_fixtures": [
+    {
+      "base_bytes": 14018,
+      "nodes": 33,
+      "private_control_and_run_allocated_bytes": 24576,
+      "replay_batch_rows": 7,
+      "replay_logical_memory_limit_bytes": 2097152,
+      "shared_bytes": 11460
+    },
+    {
+      "base_bytes": 545130,
+      "nodes": 4097,
+      "private_control_and_run_allocated_bytes": 188416,
+      "replay_batch_rows": 7,
+      "replay_logical_memory_limit_bytes": 2097152,
+      "shared_bytes": 379901
+    }
+  ],
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 23719,
+        "bytes": 52242032,
+        "errors": 0
+      },
+      "pread64": {
+        "calls": 9160,
+        "bytes": 5676030,
+        "errors": 0
+      },
+      "write": {
+        "calls": 1618,
+        "bytes": 7877661,
+        "errors": 0
+      },
+      "fsync": {
+        "calls": 3731,
+        "bytes": 0,
+        "errors": 0
+      },
+      "copy_file_range": {
+        "calls": 456,
+        "bytes": 2334021,
+        "errors": 0
+      }
+    },
+    "returned_read_bytes": 60252083,
+    "returned_write_bytes": 10211682
+  },
+  "measurement_notes": [
+    "Syscall I/O is a separate strace run (20.51 seconds including instrumentation). read/pread64/readv/preadv and copy_file_range/sendfile successful returned lengths count as reads; write/pwrite64/writev/pwritev and copy_file_range/sendfile count as writes. Includes all process file descriptors, startup, authentication, queries, export, verify, import and test output; not physical device traffic.",
+    "RSS and CPU come from untraced /usr/bin/time -v over the prebuilt test binary; filesystem blocks are kernel-accounted I/O and depend on cache state.",
+    "Private allocation sums prepared base files whose physical identities differ from their CAS objects plus the new run. Node/property payloads must retain identical file identities. Does not include transient fingerprint replay output, generation metadata, CAS manifest objects or directory allocation.",
+    "The 2 MiB bound is the existing logical replay admission limit, not a bound on total process RSS or native codec contexts.",
+    "Deterministic budgets: private controls/run <=262144 bytes for each fixture; one run <=4096 bytes; seven-row replay batches with existing 2097152-byte logical memory limit; exact immutable node/property inode reuse and parent inventory preservation."
+  ],
+  "validation": {
+    "api_cas_tests": 2,
+    "api_composite_tests": 19,
+    "api_bulk_construction_tests": 30,
+    "storage_delta_compaction_integration_tests": 10,
+    "storage_delta_journal_integration_tests": 16,
+    "storage_delta_unit_and_crash_tests": 10,
+    "api_resumable_surface_tests": 1,
+    "workspace_clippy": "passed",
+    "pre_push_fast": "passed",
+    "gate_registry": "passed"
+  }
+}

--- a/docs/development/evidence/cas-delta-ownership-1219.json
+++ b/docs/development/evidence/cas-delta-ownership-1219.json
@@ -84,6 +84,11 @@
     "api_resumable_surface_tests": 1,
     "workspace_clippy": "passed",
     "pre_push_fast": "passed",
-    "gate_registry": "passed"
+    "gate_registry": "passed",
+    "storage_catalog_cas_alias_test": 1,
+    "native_catalog_test_lanes": [
+      "Windows graphforge-storage Locks",
+      "macOS graphforge-storage Durability"
+    ]
   }
 }


### PR DESCRIPTION
Direct composite mutation after construction failed because delta preparation and compaction assumed a generation-owned graph directory. Resolve the selected ownership, preserve mapped CAS roots and immutable payload reuse, and retain the CAS publication lease through CURRENT. Compaction preserves complete participants and publishes its existing private replay output without a second staging copy.

Persist runtime catalog and label marker through authenticated durable replacement, and include observed runtime names in the delta candidate. The Parquet writer retains its existing encoding defaults; broader policy work stays in #1213 and multi-relationship replay repair in #1218.

Validation:
- Two public CAS regressions: construction → composite/direct delta → reopen/query → compaction → export/full verify/clean import; cancellation, old streams, retries, complete participants and physical payload reuse.
- 26 delta/compaction integration tests, 10 unit/crash tests, 19 composite tests, 30 bulk-construction tests and the public resumable-construction surface test pass.
- A real CAS catalog/marker alias regression passes locally and is explicitly selected in Windows and macOS native CI.
- Workspace Clippy, formatting, pre-push-fast and gate-registry checks pass. Independent review findings were verified and fixed.
- Measured compiled serial tests: 5.38 seconds, 142,932 KiB peak RSS. Private controls/run allocate 24,576/188,416 bytes at 33/4,097 nodes, bounded at 256 KiB; node/property payloads retain CAS file identities. Raw CPU, syscall I/O and scope limitations are recorded in `docs/development/evidence/cas-delta-ownership-1219.json`.

Closes #1219.
