### PR TITLE
fix(api): preserve CAS ownership in workspace publication and preflight

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -2616,14 +2616,21 @@ fn load_runtime_catalog(dir: &std::path::Path) -> Result<RuntimeCatalog, GfError
 
 /// Read and decode every batch of `runtime_catalog.parquet` into a [`RuntimeCatalog`].
 fn read_runtime_catalog(path: &std::path::Path) -> Result<RuntimeCatalog, GfError> {
-    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-
     let file = std::fs::File::open(path).map_err(|e| {
         GfError::Storage(format!(
             "failed to open runtime catalog {}: {e}",
             path.display()
         ))
     })?;
+    decode_runtime_catalog(file, path)
+}
+
+fn decode_runtime_catalog<T: parquet::file::reader::ChunkReader + 'static>(
+    file: T,
+    path: &std::path::Path,
+) -> Result<RuntimeCatalog, GfError> {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
     let reader = ParquetRecordBatchReaderBuilder::try_new(file)
         .map_err(|e| {
             GfError::Storage(format!("malformed runtime catalog {}: {e}", path.display()))

--- a/crates/graphforge-api/src/ontology_composition_lifecycle.rs
+++ b/crates/graphforge-api/src/ontology_composition_lifecycle.rs
@@ -811,7 +811,26 @@ fn runtime_symbols(
     cancellation: Option<&CancellationToken>,
 ) -> Result<(BTreeSet<String>, bool), GfError> {
     let current = graph.generation_for_read()?;
-    let persisted = crate::load_runtime_catalog(&current.graph_tree_root())?;
+    let persisted = if current.declared_graph_files_inventory()?.is_some() {
+        crate::load_runtime_catalog(&current.graph_tree_root())?
+    } else if let Some(inventory) = current.graph_files_inventory()? {
+        if let Some(entry) = inventory
+            .files
+            .iter()
+            .find(|entry| entry.relative_path == "topology/runtime_catalog.parquet")
+        {
+            let file = graphforge_storage::open_graph_object_by_digest(
+                current.container_root(),
+                &entry.content_sha256,
+                entry.byte_length,
+            )?;
+            crate::decode_runtime_catalog(file, std::path::Path::new(&entry.relative_path))?
+        } else {
+            crate::RuntimeCatalog::new()
+        }
+    } else {
+        crate::load_runtime_catalog(&current.graph_tree_root())?
+    };
     let live = graph
         .runtime_catalog
         .lock()

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -341,7 +341,7 @@ fn publish_workspace_records_inner(
             "project generation changed before ontology publication".into(),
         ));
     }
-    let carries_graph_tree = parent
+    let has_graph_files = parent
         .participant_snapshot(
             graphforge_storage::GRAPH_CAPABILITY_ID,
             graphforge_storage::GRAPH_FILES_FAMILY,
@@ -404,9 +404,16 @@ fn publish_workspace_records_inner(
             .collect(),
         participants,
     };
+    let generation_owned = parent.declared_graph_files_inventory()?.is_some();
+    let publication_lease =
+        if candidate_graph_root.is_none() && has_graph_files && !generation_owned {
+            Some(graphforge_storage::begin_graph_object_publication(&root)?)
+        } else {
+            None
+        };
     let selected_graph_root = candidate_graph_root
         .map(std::path::Path::to_path_buf)
-        .or_else(|| carries_graph_tree.then(|| parent.graph_tree_root()));
+        .or_else(|| generation_owned.then(|| parent.graph_tree_root()));
     let receipt = match graphforge_storage::stage_project_generation_with_graph_tree_mode(
         &root,
         &request,
@@ -430,7 +437,11 @@ fn publish_workspace_records_inner(
             if let Some(token) = cancellation {
                 token.checkpoint()?;
             }
-            validated.publish()?
+            if let Some(lease) = &publication_lease {
+                validated.publish_with_graph_objects(lease)?
+            } else {
+                validated.publish()?
+            }
         }
     };
     *graph

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -1273,3 +1273,178 @@ fn cas_delta_preparation_reuses_payloads_with_bounded_private_allocation() {
         );
     }
 }
+
+#[test]
+fn workspace_publication_preserves_constructed_cas_payloads() {
+    use graphforge_api::{AdoptOntologyRequest, ClearOntologyRequest, OntologyMode, WriteContext};
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "workspace_cas",
+        nodes: 33,
+        edges: 258,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: false,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (mut nodes, mut edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges[..129]);
+    let selected = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert!(selected.declared_graph_files_inventory().unwrap().is_none());
+    let before = selected.graph_files_inventory().unwrap().unwrap();
+    let identities = before
+        .files
+        .iter()
+        .map(|entry| {
+            let file = File::open(
+                graphforge_storage::graph_object_path(&source, &entry.content_sha256).unwrap(),
+            )
+            .unwrap();
+            (
+                entry.relative_path.clone(),
+                graphforge_filesystem::file_identity(&file).unwrap(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let ontology = root.path().join("routes.yaml");
+    std::fs::write(&ontology, "ontology_id: https://example.test/mixed\nversion: \"1\"\nentity_types:\n  - name: NewNode\n    abstract: false\nrelation_types:\n  - name: NEW_TYPED\n    src: NewNode\n    dst: NewNode\n").unwrap();
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    let context = WriteContext {
+        operation_uuid: OperationId(Uuid::now_v7()),
+        actor_uuid: None,
+    };
+    let request = AdoptOntologyRequest {
+        context,
+        path: ontology,
+        mode: OntologyMode::Advisory,
+    };
+    graph.adopt_ontology(request.clone()).unwrap();
+    let adopted = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert!(adopted.declared_graph_files_inventory().unwrap().is_none());
+    assert_eq!(before, adopted.graph_files_inventory().unwrap().unwrap());
+    for entry in &before.files {
+        let file = File::open(
+            graphforge_storage::graph_object_path(&source, &entry.content_sha256).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            identities[&entry.relative_path],
+            graphforge_filesystem::file_identity(&file).unwrap()
+        );
+    }
+    assert_eq!(selected.capabilities(), adopted.capabilities());
+    for participant in selected
+        .participant_snapshots()
+        .unwrap()
+        .into_iter()
+        .filter(|participant| participant.capability_id != "workspace")
+    {
+        assert_eq!(
+            adopted
+                .participant_snapshot(&participant.capability_id, &participant.record_family_id)
+                .unwrap()
+                .unwrap()
+                .bytes,
+            participant.bytes
+        );
+    }
+    graph.adopt_ontology(request.clone()).unwrap();
+    assert_eq!(
+        adopted.generation_uuid(),
+        graphforge_storage::resolve_project_generation(&source)
+            .unwrap()
+            .generation_uuid()
+    );
+    verify_graph(&graph, fixture, &nodes, &edges[..129]);
+    graph
+        .clear_ontology(ClearOntologyRequest {
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+        })
+        .unwrap();
+    drop(graph);
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges[..129]);
+    let mut readopt = request;
+    readopt.context.operation_uuid = OperationId(Uuid::now_v7());
+    graph.adopt_ontology(readopt).unwrap();
+    drop(graph);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    assert_eq!(graph.ontology_mode(), OntologyMode::Advisory);
+    verify_graph(&graph, fixture, &nodes, &edges[..129]);
+    drop(graph);
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    let candidate = graph.workspace_ontology_composition().unwrap().unwrap();
+    let request = graphforge_api::CompositionChangeRequest {
+        context: WriteContext {
+            operation_uuid: OperationId(Uuid::now_v7()),
+            actor_uuid: None,
+        },
+        expected_project_generation_uuid: graphforge_storage::resolve_project_generation(&source)
+            .unwrap()
+            .generation_uuid(),
+        expected_composition_fingerprint: Some(candidate.composition_fingerprint.clone()),
+        candidate,
+        data_disposition: graphforge_api::CompositionDataDisposition::RequireConforming,
+    };
+    let preview = graph
+        .preview_ontology_composition_change(&request, None)
+        .unwrap();
+    assert!(preview.diagnostics.is_empty(), "{:?}", preview.diagnostics);
+    graph
+        .publish_ontology_composition_change(&request, &preview, None)
+        .unwrap();
+    drop(graph);
+    let child_nodes = (0..33)
+        .map(|row| (id(3, row, true), "NewNode".to_owned(), None))
+        .collect::<Vec<_>>();
+    for (row, edge) in edges[129..].iter_mut().enumerate() {
+        edge.3 = "NEW_TYPED".into();
+        edge.1 = child_nodes[row % child_nodes.len()].0;
+        edge.2 = child_nodes[(row + 1) % child_nodes.len()].0;
+    }
+    construct(&source, fixture, &child_nodes, &edges[129..]);
+    nodes.extend(child_nodes.into_iter().map(|mut node| {
+        node.1 = "mixed:entity:NewNode".into();
+        node
+    }));
+    let current = graphforge_storage::resolve_project_generation(&source).unwrap();
+    let bindings = graphforge_storage::semantic_storage_bindings(&current)
+        .unwrap()
+        .unwrap();
+    let relation = bindings
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.route_kind == graphforge_storage::SemanticRouteKind::Relation
+                && binding.symbol.local_id == "NEW_TYPED"
+        })
+        .unwrap();
+    assert_eq!(relation.symbol.display(), "mixed:relation:NEW_TYPED");
+    // The unqualified relationship projection exposes the stored route. Bind
+    // it independently to the declared qualified symbol, not a query result.
+    for edge in &mut edges[129..] {
+        edge.3.clone_from(&relation.route);
+    }
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    graph
+        .set_graph_directedness(
+            &WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            Some(graphforge_storage::GraphDirectedness::Directed),
+        )
+        .unwrap();
+    drop(graph);
+    round_trip(root.path(), &source, fixture, &nodes, &edges);
+    println!(
+        "WORKSPACE_CAS_REUSE {}",
+        json!({"retained_files":before.files.len(),"retained_bytes":before.total_byte_length,"reencoded_graph_payload_bytes":0})
+    );
+}

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -3082,7 +3082,7 @@ pub fn read_graph_object_by_digest(
 }
 
 /// Open and stream-authenticate one immutable CAS object without allocating its payload.
-pub(crate) struct AuthenticatedGraphObject {
+pub struct AuthenticatedGraphObject {
     file: File,
     authenticated_length: u64,
     _cas: std::sync::Arc<ReadOnlyCasRoot>,
@@ -3275,7 +3275,12 @@ impl ChunkReader for AuthenticatedGraphObject {
     }
 }
 
-pub(crate) fn open_graph_object_by_digest(
+/// Retain and stream-authenticate the exact immutable object selected by a graph manifest.
+/// The returned Parquet reader keeps its CAS read lease and file descriptor alive.
+///
+/// # Errors
+/// Rejects changed ownership, length or digest and reports filesystem failures.
+pub fn open_graph_object_by_digest(
     root: &Path,
     digest: &str,
     expected_length: u64,

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -106,22 +106,22 @@ pub use graph_manifest::{
     reason = "private CAS construction is consumed by the staged #932 integration"
 )]
 mod graph_object_store;
+#[cfg(not(any(test, feature = "test-support")))]
+pub(crate) use graph_object_store::graph_object_path;
+#[cfg(any(test, feature = "test-support"))]
+pub use graph_object_store::graph_object_path;
 pub use graph_object_store::{
-    GRAPH_OBJECT_IO_BUFFER_BYTES, GraphObjectIoTotals, GraphPublicationIo,
-    materialize_graph_objects,
+    AuthenticatedGraphObject, GRAPH_OBJECT_IO_BUFFER_BYTES, GraphObjectIoTotals,
+    GraphObjectPublicationLease, GraphPublicationIo, begin_graph_object_publication,
+    materialize_graph_objects, open_graph_object_by_digest,
 };
 #[cfg(any(test, feature = "test-support"))]
 pub use graph_object_store::{
     GraphManifestState, append_graph_files_v2, install_graph_object_bytes, read_graph_object,
 };
 pub(crate) use graph_object_store::{
-    GraphObjectPublicationLease, graph_object_publication_is_live, read_graph_object_by_digest,
-    verify_graph_object,
+    graph_object_publication_is_live, read_graph_object_by_digest, verify_graph_object,
 };
-#[cfg(not(any(test, feature = "test-support")))]
-pub(crate) use graph_object_store::{begin_graph_object_publication, graph_object_path};
-#[cfg(any(test, feature = "test-support"))]
-pub use graph_object_store::{begin_graph_object_publication, graph_object_path};
 
 pub mod semantic_bindings;
 pub use semantic_bindings::{

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -210,3 +210,45 @@ syscall byte counts are different quantities. Compilation is excluded. Reproduce
 with the prebuilt `permanent_storage_budgets` binary and
 `cas_ --nocapture --test-threads=1`, using native-root `TMPDIR`; run `/usr/bin/time -v`
 separately from `strace -f -e trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync`.
+
+## Workspace publication ownership (#1222)
+
+Source `47505945dcdcf4711aa6710ac192b2616e20558a` fixes two CAS ownership
+assumptions in workspace operations: publication now selects a generation tree
+only for a generation-owned graph participant, and composition preflight reads
+the manifest-selected CAS runtime catalog. CAS publication retains its lease
+through CURRENT. Catalog decoding uses the existing authenticated file reader
+with a fixed 1 MiB authentication buffer and a retained read lease; it does not
+allocate a whole encoded-catalog copy or materialize the graph.
+
+The public fixture constructs 33 nodes and 129 exploratory edges, adopts a
+URI-identified Advisory ontology with disjoint new names, retries adoption,
+clears and re-adopts before any qualified bindings exist, and reopens. It then
+uses public composition preview/publication to establish bindings, constructs
+33 new qualified nodes and 129 edges, updates graph directedness, and proves
+exact query results through export, full verification and clean import.
+The original 18 graph files (20,842 bytes) retain their inventory entries and
+inode identities across adoption; no original graph payload is re-encoded.
+The test independently binds the stored relation route to its qualified symbol.
+
+| Measurement | Result |
+| --- | ---: |
+| Prebuilt public test elapsed / user / system | 2.03 / 1.12 / 0.61 s |
+| Peak process RSS | 129,120 KiB |
+| Syscall read / write bytes | 10,162,546 / 1,396,254 |
+| Kernel input / output blocks (512 bytes) | 14,360 / 8,048 |
+| Successful fsync calls in separate trace | 2,259 |
+
+The separate trace takes 11.65 s with instrumentation. Process I/O includes
+startup, verification, import and test output; kernel I/O is cache-dependent.
+These measurements do not establish portable CPU/RSS or temporary-disk peak
+budgets. Encoding-policy resource assessment remains #1213. The focused public
+test, 53 ontology-related API tests, production workspace Clippy, fast pre-push
+and gate-registry checks pass. Commands and raw measurements are in
+[`workspace-cas-ownership-1222.json`](../../development/evidence/workspace-cas-ownership-1222.json).
+
+Same-name ontology promotion changes graph and ordinal authorities after
+workspace publication, and clearing authority for retained typed data can
+leave semantic bindings without their composition. Both are recorded under
+#1221 with public reproducers. This ownership-only repair does not claim those
+complete graph-contract failures are resolved.

--- a/docs/development/evidence/workspace-cas-ownership-1222.json
+++ b/docs/development/evidence/workspace-cas-ownership-1222.json
@@ -1,0 +1,82 @@
+{
+  "issue": 1222,
+  "source_commit": "47505945dcdcf4711aa6710ac192b2616e20558a",
+  "base_commit": "cddc04c30312ba4e064337882600384997974b76",
+  "fixture": {
+    "parent_nodes": 33,
+    "parent_edges": 129,
+    "child_nodes": 33,
+    "child_edges": 129,
+    "identifiers": "deterministic random UUIDs",
+    "ontology_id": "https://example.test/mixed",
+    "mode": "Advisory",
+    "retained_name_promotion": false
+  },
+  "deterministic_evidence": {
+    "retained_graph_files": 18,
+    "retained_graph_bytes": 20842,
+    "adoption_reencoded_graph_payload_bytes": 0,
+    "payload_inode_identities_preserved": true,
+    "graph_inventory_preserved": true,
+    "non_workspace_participants_preserved": true,
+    "capabilities_preserved": true,
+    "adoption_retry_same_generation": true,
+    "catalog_authentication_buffer_bytes": 1048576
+  },
+  "runtime": {
+    "elapsed_seconds": 2.03,
+    "user_seconds": 1.12,
+    "system_seconds": 0.61,
+    "peak_rss_kib": 129120,
+    "filesystem_input_512_byte_blocks": 14360,
+    "filesystem_output_512_byte_blocks": 8048,
+    "exit_status": 0
+  },
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 16239,
+        "bytes": 10159186
+      },
+      "pread64": {
+        "calls": 4,
+        "bytes": 3360
+      },
+      "write": {
+        "calls": 1415,
+        "bytes": 1396254
+      },
+      "fsync": {
+        "calls": 2259,
+        "bytes": 0
+      }
+    },
+    "read_bytes": 10162546,
+    "write_bytes": 1396254,
+    "errors": []
+  },
+  "trace_elapsed_seconds": 11.65,
+  "commands": {
+    "public": "cargo test -p graphforge-api --test permanent_storage_budgets workspace_publication_preserves_constructed_cas_payloads -- --exact --nocapture",
+    "ontology": "cargo test -p graphforge-api --lib ontology",
+    "clippy": "cargo clippy --workspace -- -D warnings",
+    "runtime": "/usr/bin/time -v <prebuilt permanent_storage_budgets binary> workspace_publication_preserves_constructed_cas_payloads --exact --nocapture --test-threads=1",
+    "trace": "strace -f -qq -e trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync <same prebuilt binary and filter>"
+  },
+  "validation": {
+    "public_tests_passed": 1,
+    "ontology_tests_passed": 53,
+    "ontology_elapsed_seconds": 0.71,
+    "clippy": "passed, 42.49 seconds",
+    "pre_push_fast": "passed",
+    "gate_registry": "passed, 14 tests"
+  },
+  "limits": [
+    "Zero re-encoding is asserted for adoption of the existing graph, not subsequent new qualified construction.",
+    "Runtime measurements exclude compilation. Trace timing includes instrumentation and is not normal runtime.",
+    "Syscall bytes cover all process descriptors, including startup, query, portable verification and test output; they are not physical device traffic. Kernel filesystem blocks depend on cache state.",
+    "The existing reader authenticates with a fixed 1 MiB buffer; Parquet decoding and runtime-catalog materialization retain their existing costs. No whole encoded-catalog Vec or full graph materialization is added.",
+    "This is a bounded ownership repair measurement, not a cross-platform CPU/RSS or temporary-disk peak budget. Full encoding-policy tradeoffs remain in #1213.",
+    "Same-name ontology promotion and clearing authority for retained typed data remain explicit #1221 contract failures; this evidence does not claim those operations are fixed."
+  ]
+}


### PR DESCRIPTION
Workspace publication after CAS construction passed a generation-tree path for an object-backed participant, and composition preflight read an empty catalog from that nonexistent tree. Select the declared ownership, retain the CAS publication lease through CURRENT, and decode the authenticated CAS catalog through the existing streaming reader.

The public regression preserves all 18 original payload identities and inventory entries through non-promoting ontology adoption/retry/reopen, establishes semantic bindings through public composition publication, adds qualified child data, and verifies exact queries through export/full verification/clean import. No encoding default changes. Same-name promotion and removing authority from retained typed data remain explicitly tracked under #1221.

Validation: public regression; 53 ontology-related API tests; `cargo clippy --workspace -- -D warnings`; `make pre-push-fast`; `make gate-registry-check`; final formatting and diff checks. Prebuilt fixture: 2.03 s, 129,120 KiB RSS; separate syscall trace and measurement limitations are recorded in the evidence JSON. Required CI remains the merge gate.

Closes #1222

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791606111&installation_model_id=20486&pr_number=1223&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1223&signature=c0e13aaf86b1f51a0e69facd9c3f2c9c6c3060d264b3a1f7ddb3346977629bd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->