### PR TITLE
fix(api): preserve composite property ownership across publishing paths

### DIFF
--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -26,10 +26,226 @@ use crate::composite_transaction::{CompositeGraphMutation, CompositeTransactionR
 use crate::composite_validation::{CompositeOntologySnapshot, CompositeValidationSnapshot};
 use crate::construction::prop_literal;
 
+/// Physical property owners resolved during the existing authenticated topology scan.
+/// Only requested identities are retained; both publication backends use this plan.
+#[derive(Default)]
+struct CompositePropertyRoutes {
+    nodes: BTreeMap<Uuid, String>,
+    edges: BTreeMap<Uuid, String>,
+    requires_canonical: bool,
+    created_node_types: HashMap<Uuid, graphforge_value::EntityTypeId>,
+}
+
+impl CompositePropertyRoutes {
+    fn node(&self, uuid: &Uuid) -> Result<String, GfError> {
+        self.nodes
+            .get(uuid)
+            .cloned()
+            .ok_or_else(|| GfError::Validation("composite node property owner is absent".into()))
+    }
+
+    fn edge(&self, uuid: &Uuid) -> Result<String, GfError> {
+        self.edges
+            .get(uuid)
+            .cloned()
+            .ok_or_else(|| GfError::Validation("composite edge property owner is absent".into()))
+    }
+}
+
+fn composite_node_property_owner(
+    graph: &GraphForge,
+    primary: graphforge_value::PrimaryEntityTypeId,
+) -> Result<String, GfError> {
+    let Some(id) = primary.label().and_then(|id| id.tagged().ontology_id()) else {
+        return Ok("_untyped".to_owned());
+    };
+    let bindings = graph
+        .semantic_storage_bindings
+        .lock()
+        .expect("semantic storage binding lock poisoned");
+    if let Some(bindings) = bindings.as_ref() {
+        if let Some(owner) = bindings.bindings.iter().find(|binding| {
+            binding.route_kind == graphforge_storage::SemanticRouteKind::Entity
+                && binding.storage_id == id.0
+        }) {
+            return Ok(owner.route.clone());
+        }
+        return Err(GfError::Storage(
+            "composite node property owner is absent from semantic authority".into(),
+        ));
+    }
+    graph
+        .ontology
+        .as_ref()
+        .and_then(|ontology| ontology.entity_type_name(id))
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            GfError::Storage(
+                "composite node property owner is absent from ontology authority".into(),
+            )
+        })
+}
+
+fn composite_created_owner(
+    graph: &GraphForge,
+    kind: graphforge_ontology::SymbolKind,
+    name: &str,
+) -> Result<Option<(u32, String)>, GfError> {
+    let Some(context) = graph.default_composition_snapshot() else {
+        return Ok(None);
+    };
+    let (symbol, _) = context.resolve(kind, name).map_err(|error| {
+        GfError::Validation(format!(
+            "composite owner resolution failed: {:?}",
+            error.code
+        ))
+    })?;
+    let graphforge_ir::SymbolBinding::Qualified(symbol) = symbol else {
+        return Ok(None);
+    };
+    let route_kind = if kind == graphforge_ontology::SymbolKind::Entity {
+        graphforge_storage::SemanticRouteKind::Entity
+    } else {
+        graphforge_storage::SemanticRouteKind::Relation
+    };
+    graph
+        .semantic_storage_bindings
+        .lock()
+        .expect("semantic storage binding lock poisoned")
+        .as_ref()
+        .and_then(|bindings| {
+            bindings
+                .bindings
+                .iter()
+                .find(|binding| binding.route_kind == route_kind && binding.symbol == symbol)
+        })
+        .map(|binding| (binding.storage_id, binding.route.clone()))
+        .ok_or_else(|| {
+            GfError::Validation("composite owner lacks a generation storage binding".into())
+        })
+        .map(Some)
+}
+
+fn validate_composite_property_owner(
+    graph: &GraphForge,
+    route: &str,
+    edge: bool,
+    property: &str,
+) -> Result<(), GfError> {
+    if !route.starts_with("s-") {
+        return Ok(());
+    }
+    let context = graph.default_composition_snapshot().ok_or_else(|| {
+        GfError::Validation("composite semantic property lacks composition authority".into())
+    })?;
+    let bindings = graph
+        .semantic_storage_bindings
+        .lock()
+        .expect("semantic storage binding lock poisoned");
+    let kind = if edge {
+        graphforge_storage::SemanticRouteKind::Relation
+    } else {
+        graphforge_storage::SemanticRouteKind::Entity
+    };
+    let owner = bindings
+        .as_ref()
+        .and_then(|bindings| {
+            bindings
+                .bindings
+                .iter()
+                .find(|binding| binding.route_kind == kind && binding.route == route)
+        })
+        .ok_or_else(|| {
+            GfError::Validation("composite property owner lacks semantic authority".into())
+        })?;
+    context
+        .resolve_owned_property(
+            owner.symbol.kind,
+            &owner.symbol.ambiguity_candidate(),
+            property,
+        )
+        .map_err(|error| {
+            GfError::Validation(format!(
+                "composite property owner rejected: {:?}",
+                error.code
+            ))
+        })?;
+    Ok(())
+}
+
+fn validate_composite_property_routes(
+    graph: &GraphForge,
+    request: &CompositeTransactionRequest,
+    routes: &CompositePropertyRoutes,
+) -> Result<(), GfError> {
+    for mutation in &request.graph_mutations {
+        match mutation {
+            CompositeGraphMutation::SetNodeProperty {
+                node_uuid,
+                property,
+                ..
+            }
+            | CompositeGraphMutation::RemoveNodeProperty {
+                node_uuid,
+                property,
+            } => {
+                validate_composite_property_owner(
+                    graph,
+                    &routes.node(node_uuid)?,
+                    false,
+                    property,
+                )?;
+            }
+            CompositeGraphMutation::SetEdgeProperty {
+                edge_uuid,
+                property,
+                ..
+            }
+            | CompositeGraphMutation::RemoveEdgeProperty {
+                edge_uuid,
+                property,
+            } => {
+                validate_composite_property_owner(graph, &routes.edge(edge_uuid)?, true, property)?;
+            }
+            CompositeGraphMutation::CreateNode {
+                node_uuid,
+                properties,
+                ..
+            } => {
+                for property in properties.keys() {
+                    validate_composite_property_owner(
+                        graph,
+                        &routes.node(node_uuid)?,
+                        false,
+                        property,
+                    )?;
+                }
+            }
+            CompositeGraphMutation::CreateEdge {
+                edge_uuid,
+                properties,
+                ..
+            } => {
+                for property in properties.keys() {
+                    validate_composite_property_owner(
+                        graph,
+                        &routes.edge(edge_uuid)?,
+                        true,
+                        property,
+                    )?;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 fn eligible_delta_operations(
     request: &CompositeTransactionRequest,
+    routes: &CompositePropertyRoutes,
 ) -> Result<Option<Vec<graphforge_storage::GraphDeltaOp>>, GfError> {
-    if request.graph_mutations.is_empty() {
+    if request.graph_mutations.is_empty() || routes.requires_canonical {
         return Ok(None);
     }
     let mut operations = Vec::with_capacity(request.graph_mutations.len());
@@ -43,7 +259,7 @@ fn eligible_delta_operations(
                 graphforge_storage::GraphDeltaOpKind::SetNodeProperty,
                 graphforge_storage::GraphDeltaPayload::SetNodeProperty {
                     node_uuid: node_uuid.hyphenated().to_string(),
-                    property_stem: "_untyped".into(),
+                    property_stem: routes.node(node_uuid)?,
                     key: property.clone(),
                     value: graphforge_storage::encode_graph_delta_value(&prop_literal(value)?)?,
                 },
@@ -55,7 +271,7 @@ fn eligible_delta_operations(
                 graphforge_storage::GraphDeltaOpKind::RemoveNodeProperty,
                 graphforge_storage::GraphDeltaPayload::RemoveNodeProperty {
                     node_uuid: node_uuid.hyphenated().to_string(),
-                    property_stem: "_untyped".into(),
+                    property_stem: routes.node(node_uuid)?,
                     key: property.clone(),
                 },
             ),
@@ -67,7 +283,7 @@ fn eligible_delta_operations(
                 graphforge_storage::GraphDeltaOpKind::SetEdgeProperty,
                 graphforge_storage::GraphDeltaPayload::SetEdgeProperty {
                     edge_uuid: edge_uuid.hyphenated().to_string(),
-                    property_stem: "_untyped".into(),
+                    property_stem: routes.edge(edge_uuid)?,
                     key: property.clone(),
                     value: graphforge_storage::encode_graph_delta_value(&prop_literal(value)?)?,
                 },
@@ -79,7 +295,7 @@ fn eligible_delta_operations(
                 graphforge_storage::GraphDeltaOpKind::RemoveEdgeProperty,
                 graphforge_storage::GraphDeltaPayload::RemoveEdgeProperty {
                     edge_uuid: edge_uuid.hyphenated().to_string(),
-                    property_stem: "_untyped".into(),
+                    property_stem: routes.edge(edge_uuid)?,
                     key: property.clone(),
                 },
             ),
@@ -195,10 +411,7 @@ impl GraphForge {
                 reconciled = true;
             }
 
-            if optimistic && baseline.is_none() {
-                baseline = Some(capture_rebase_baseline(self, &request, &parent)?);
-            }
-            let snapshot = build_validation_snapshot(self, &parent)?;
+            let (snapshot, routes) = build_validation_snapshot(self, &parent, &request)?;
             let receipt =
                 authorize_composite_transaction(&request, &snapshot, None).map_err(|error| {
                     if (reconciled || rebases > 0) && error.code() == "GF_IDENTITY_CONFLICT" {
@@ -208,6 +421,10 @@ impl GraphForge {
                     }
                 })?;
             require_capabilities(&parent, &request)?;
+            validate_composite_property_routes(self, &request, &routes)?;
+            if optimistic && baseline.is_none() {
+                baseline = Some(capture_rebase_baseline(self, &request, &parent, &routes)?);
+            }
 
             match self.publish_composite_attempt(
                 &request,
@@ -216,6 +433,7 @@ impl GraphForge {
                 content_fingerprint,
                 generation_uuid,
                 optimistic,
+                &routes,
             ) {
                 Ok(batch) => return Ok(batch),
                 Err(error) if optimistic && error.code() == "GF_WRITE_CONFLICT" => {
@@ -254,8 +472,10 @@ impl GraphForge {
     ) -> Result<RecordBatch, GfError> {
         let root = self.resolved_generation.container_root();
         let parent = graphforge_storage::resolve_project_generation(root)?;
-        let snapshot = build_validation_snapshot(self, &parent)?;
-        authorize_composite_transaction(request, &snapshot, None)
+        let (snapshot, routes) = build_validation_snapshot(self, &parent, request)?;
+        let receipt = authorize_composite_transaction(request, &snapshot, None)?;
+        validate_composite_property_routes(self, request, &routes)?;
+        Ok(receipt)
     }
 
     #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
@@ -267,6 +487,7 @@ impl GraphForge {
         content_fingerprint: [u8; 32],
         generation_uuid: Uuid,
         optimistic: bool,
+        routes: &CompositePropertyRoutes,
     ) -> Result<RecordBatch, GfError> {
         let root = self.resolved_generation.container_root();
         let expected_parent = parent.generation_uuid();
@@ -286,7 +507,7 @@ impl GraphForge {
             let delta_operations = if optimistic {
                 None
             } else {
-                eligible_delta_operations(request)?
+                eligible_delta_operations(request, routes)?
             };
             let property_inventory =
                 crate::property_inventory_for_hydrated_generation(parent, &self.dir)?;
@@ -296,6 +517,7 @@ impl GraphForge {
                 &mut next_catalog,
                 recorded_at,
                 property_inventory.as_ref(),
+                routes,
             )?;
             if self.path.is_some() {
                 crate::persist_runtime_catalog(&self.dir, &next_catalog)?;
@@ -318,9 +540,20 @@ impl GraphForge {
             } else {
                 None
             };
-            let graph = match prepared_delta.as_ref() {
-                Some(prepared) => prepared.files_participant.clone(),
-                None => graphforge_storage::capture_graph_files(&self.dir)?.1,
+            let mut canonical_lease = None;
+            let graph = if let Some(prepared) = prepared_delta.as_ref() {
+                prepared.files_participant.clone()
+            } else {
+                let (inventory, participant) = graphforge_storage::capture_graph_files(&self.dir)?;
+                if routes.requires_canonical {
+                    let (participant, lease) = graphforge_storage::prepare_graph_files_replacement(
+                        parent, &self.dir, &inventory,
+                    )?;
+                    canonical_lease = lease;
+                    participant
+                } else {
+                    participant
+                }
             };
             let participants = assemble_composite_participants(self, parent, request, graph)?;
             let capabilities = parent
@@ -342,22 +575,20 @@ impl GraphForge {
                     root,
                     &publication,
                     content_fingerprint,
-                    prepared_delta
-                        .as_ref()
-                        .map_or(Some(self.dir.as_path()), |prepared| {
-                            prepared.graph_tree_source()
-                        }),
+                    prepared_delta.as_ref().map_or_else(
+                        || canonical_lease.is_none().then_some(self.dir.as_path()),
+                        |prepared| prepared.graph_tree_source(),
+                    ),
                     self.lifecycle_mode,
                 )?
             } else {
                 graphforge_storage::stage_project_generation_with_graph_tree_mode(
                     root,
                     &publication,
-                    prepared_delta
-                        .as_ref()
-                        .map_or(Some(self.dir.as_path()), |prepared| {
-                            prepared.graph_tree_source()
-                        }),
+                    prepared_delta.as_ref().map_or_else(
+                        || canonical_lease.is_none().then_some(self.dir.as_path()),
+                        |prepared| prepared.graph_tree_source(),
+                    ),
                     self.lifecycle_mode,
                 )?
             };
@@ -380,7 +611,10 @@ impl GraphForge {
                     )?;
                     match &prepared_delta {
                         Some(prepared) => prepared.publish(validated)?,
-                        None => validated.publish()?,
+                        None => match &canonical_lease {
+                            Some(lease) => validated.publish_with_graph_objects(lease)?,
+                            None => validated.publish()?,
+                        },
                     }
                 }
             };
@@ -522,6 +756,7 @@ fn capture_rebase_baseline(
     graph: &GraphForge,
     request: &CompositeTransactionRequest,
     generation: &ResolvedProjectGeneration,
+    routes: &CompositePropertyRoutes,
 ) -> Result<RebaseBaseline, GfError> {
     let created_nodes = request
         .graph_mutations
@@ -555,7 +790,14 @@ fn capture_rebase_baseline(
                 property,
             } if !created_nodes.contains(node_uuid) => {
                 baseline.node_targets.insert(*node_uuid);
-                capture_rebase_field(graph, &mut baseline, *node_uuid, property, false)?;
+                capture_rebase_field(
+                    graph,
+                    &mut baseline,
+                    *node_uuid,
+                    property,
+                    false,
+                    &routes.node(node_uuid)?,
+                )?;
             }
             CompositeGraphMutation::SetEdgeProperty {
                 edge_uuid,
@@ -567,7 +809,14 @@ fn capture_rebase_baseline(
                 property,
             } if !created_edges.contains(edge_uuid) => {
                 baseline.edge_targets.insert(*edge_uuid);
-                capture_rebase_field(graph, &mut baseline, *edge_uuid, property, true)?;
+                capture_rebase_field(
+                    graph,
+                    &mut baseline,
+                    *edge_uuid,
+                    property,
+                    true,
+                    &routes.edge(edge_uuid)?,
+                )?;
             }
             CompositeGraphMutation::DeleteNode { .. }
             | CompositeGraphMutation::DeleteEdge { .. } => baseline.non_mergeable = true,
@@ -583,6 +832,7 @@ fn capture_rebase_field(
     uuid: Uuid,
     property: &str,
     is_edge: bool,
+    route: &str,
 ) -> Result<(), GfError> {
     let kind = if is_edge {
         graphforge_storage::PropertyRouteKind::Edge
@@ -593,7 +843,7 @@ fn capture_rebase_field(
     let (rows, _) = graphforge_storage::read_authenticated_property_snapshots_for_inventory(
         &inventory,
         kind,
-        "_untyped",
+        route,
         &BTreeSet::from([uuid.into_bytes()]),
     )?;
     let properties = rows
@@ -625,7 +875,7 @@ fn ensure_rebase_compatible(
             "concurrent operation changed project capabilities or workspace configuration",
         ));
     }
-    let snapshot = build_validation_snapshot(graph, latest)?;
+    let (snapshot, routes) = build_validation_snapshot(graph, latest, request)?;
     if !baseline.node_targets.is_subset(&snapshot.nodes)
         || !baseline.edge_targets.is_subset(&snapshot.edges)
     {
@@ -633,7 +883,7 @@ fn ensure_rebase_compatible(
             "concurrent operation removed a graph mutation target",
         ));
     }
-    let current = capture_rebase_baseline(graph, request, latest)?;
+    let current = capture_rebase_baseline(graph, request, latest, &routes)?;
     if current.fields != baseline.fields {
         return Err(write_conflict(
             "concurrent operation changed a requested graph property",
@@ -748,7 +998,32 @@ fn require_capabilities(
 fn build_validation_snapshot(
     graph: &GraphForge,
     parent: &ResolvedProjectGeneration,
-) -> Result<CompositeValidationSnapshot, GfError> {
+    request: &CompositeTransactionRequest,
+) -> Result<(CompositeValidationSnapshot, CompositePropertyRoutes), GfError> {
+    let mut routes = CompositePropertyRoutes::default();
+    let node_targets = request
+        .graph_mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+            CompositeGraphMutation::SetNodeProperty { node_uuid, .. }
+            | CompositeGraphMutation::RemoveNodeProperty { node_uuid, .. } => Some(*node_uuid),
+            _ => None,
+        })
+        .collect::<BTreeSet<_>>();
+    let edge_targets = request
+        .graph_mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+            CompositeGraphMutation::SetEdgeProperty { edge_uuid, .. }
+            | CompositeGraphMutation::RemoveEdgeProperty { edge_uuid, .. } => Some(*edge_uuid),
+            _ => None,
+        })
+        .collect::<BTreeSet<_>>();
+    let mode = graph
+        .default_composition_snapshot()
+        .map_or(graph.ontology_mode, |context| {
+            GraphForge::composition_execution_mode(&context)
+        });
     let mut snapshot = CompositeValidationSnapshot {
         ontology: CompositeOntologySnapshot {
             mode: graph.ontology_mode,
@@ -783,11 +1058,36 @@ fn build_validation_snapshot(
             .ok_or_else(|| GfError::Storage("node_uuid column has unexpected type".into()))?;
         for row in 0..uuids.len() {
             if !uuids.is_null(row) {
-                snapshot
-                    .nodes
-                    .insert(Uuid::from_slice(uuids.value(row)).map_err(|_| {
-                        GfError::Storage("persisted node UUID is malformed".into())
-                    })?);
+                let uuid = Uuid::from_slice(uuids.value(row))
+                    .map_err(|_| GfError::Storage("persisted node UUID is malformed".into()))?;
+                snapshot.nodes.insert(uuid);
+                if node_targets.contains(&uuid) {
+                    let primary = batch
+                        .column_by_name("type_id")
+                        .and_then(|column| {
+                            column.as_any().downcast_ref::<arrow::array::UInt32Array>()
+                        })
+                        .ok_or_else(|| {
+                            GfError::Storage("composite node primary identity is absent".into())
+                        })?;
+                    if primary.is_null(row) {
+                        return Err(GfError::Storage(
+                            "composite node primary identity is null".into(),
+                        ));
+                    }
+                    let primary = graphforge_value::PrimaryEntityTypeId::decode(primary.value(row))
+                        .map_err(|error| GfError::Storage(error.to_string()))?;
+                    let route = if mode == OntologyMode::Exploratory {
+                        "_untyped".to_owned()
+                    } else {
+                        composite_node_property_owner(graph, primary)?
+                    };
+                    if routes.nodes.insert(uuid, route).is_some() {
+                        return Err(GfError::Storage(
+                            "composite node property owner is duplicated".into(),
+                        ));
+                    }
+                }
             }
         }
     }
@@ -807,11 +1107,33 @@ fn build_validation_snapshot(
             .ok_or_else(|| GfError::Storage("edge_uuid column has unexpected type".into()))?;
         for row in 0..uuids.len() {
             if !uuids.is_null(row) {
-                snapshot
-                    .edges
-                    .insert(Uuid::from_slice(uuids.value(row)).map_err(|_| {
-                        GfError::Storage("persisted edge UUID is malformed".into())
-                    })?);
+                let uuid = Uuid::from_slice(uuids.value(row))
+                    .map_err(|_| GfError::Storage("persisted edge UUID is malformed".into()))?;
+                snapshot.edges.insert(uuid);
+                if edge_targets.contains(&uuid) {
+                    let owners = batch
+                        .column_by_name("rel_type_name")
+                        .and_then(|column| {
+                            column.as_any().downcast_ref::<arrow::array::StringArray>()
+                        })
+                        .ok_or_else(|| {
+                            GfError::Storage("composite edge property owner is absent".into())
+                        })?;
+                    if owners.is_null(row) || owners.value(row).is_empty() {
+                        return Err(GfError::Storage(
+                            "composite edge property owner is empty".into(),
+                        ));
+                    }
+                    if routes
+                        .edges
+                        .insert(uuid, owners.value(row).to_owned())
+                        .is_some()
+                    {
+                        return Err(GfError::Storage(
+                            "composite edge property owner is duplicated".into(),
+                        ));
+                    }
+                }
             }
         }
     }
@@ -892,7 +1214,78 @@ fn build_validation_snapshot(
         let runs = crate::algorithm_runs::read_ledger(parent)?;
         snapshot.algorithm_runs = runs.runs.iter().map(|row| row.run_uuid).collect();
     }
-    Ok(snapshot)
+    for mutation in &request.graph_mutations {
+        match mutation {
+            CompositeGraphMutation::CreateNode {
+                node_uuid, label, ..
+            } => {
+                let semantic =
+                    composite_created_owner(graph, graphforge_ontology::SymbolKind::Entity, label)?;
+                let declared = semantic
+                    .as_ref()
+                    .map(|(id, _)| graphforge_core::TypeId(*id))
+                    .or_else(|| {
+                        graph
+                            .ontology
+                            .as_ref()
+                            .and_then(|ontology| ontology.entity_type_id(label))
+                    });
+                let route = if let Some((_, route)) = semantic {
+                    route
+                } else if declared.is_some() && mode != OntologyMode::Exploratory {
+                    label.clone()
+                } else {
+                    "_untyped".to_owned()
+                };
+                if let Some(id) = declared {
+                    routes.created_node_types.insert(
+                        *node_uuid,
+                        graphforge_value::EntityTypeId::ontology(id)
+                            .map_err(|error| GfError::Validation(error.to_string()))?,
+                    );
+                    snapshot.ontology.entity_types.insert(label.clone());
+                }
+                routes.nodes.insert(*node_uuid, route);
+            }
+            CompositeGraphMutation::CreateEdge {
+                edge_uuid,
+                rel_type,
+                ..
+            } => {
+                let semantic = composite_created_owner(
+                    graph,
+                    graphforge_ontology::SymbolKind::Relation,
+                    rel_type,
+                )?;
+                let route = if let Some((_, route)) = semantic {
+                    snapshot.ontology.relation_types.insert(rel_type.clone());
+                    route
+                } else {
+                    rel_type.clone()
+                };
+                routes.edges.insert(*edge_uuid, route);
+            }
+            _ => {}
+        }
+    }
+    // A GFDR run has no schema-metadata authority of its own. Publish a first
+    // qualified property fragment canonically so later replay can inherit its
+    // authenticated semantic schema from the base inventory.
+    let property_inventory = graph.property_inventory_for_session();
+    for (kind, owners) in [
+        (graphforge_storage::PropertyRouteKind::Node, &routes.nodes),
+        (graphforge_storage::PropertyRouteKind::Edge, &routes.edges),
+    ] {
+        for route in owners.values().filter(|route| route.starts_with("s-")) {
+            if !property_inventory
+                .routes(kind)
+                .any(|existing| existing == route)
+            {
+                routes.requires_canonical = true;
+            }
+        }
+    }
+    Ok((snapshot, routes))
 }
 
 fn register_existing_endpoints(
@@ -924,12 +1317,18 @@ fn apply_graph_mutations(
     catalog: &mut RuntimeCatalog,
     recorded_at: i64,
     inventory: &graphforge_storage::AuthenticatedPropertyInventory,
+    routes: &CompositePropertyRoutes,
 ) -> Result<(), GfError> {
     if request.graph_mutations.is_empty() {
         return Ok(());
     }
     let mut writer =
-        graphforge_storage::GraphWriter::open_at(&graph.dir, graph.ontology_mode, recorded_at)?;
+        graphforge_storage::GraphWriter::open_at(&graph.dir, graph.ontology_mode, recorded_at)?
+            .with_semantic_composition_fingerprint(
+                graph
+                    .default_composition_snapshot()
+                    .map(|context| context.fingerprint().to_owned()),
+            );
     let endpoints = request
         .graph_mutations
         .iter()
@@ -968,13 +1367,8 @@ fn apply_graph_mutations(
             node_uuid, label, ..
         } = mutation
         {
-            let type_id = match graph
-                .ontology
-                .as_ref()
-                .and_then(|ontology| ontology.entity_type_id(label))
-            {
-                Some(id) => graphforge_value::EntityTypeId::ontology(id)
-                    .map_err(|error| graphforge_core::GfError::Validation(error.to_string()))?,
+            let type_id = match routes.created_node_types.get(node_uuid) {
+                Some(id) => *id,
                 None => graphforge_value::EntityTypeId::runtime(catalog.intern_label(label)?),
             };
             writer.create_node(*node_uuid, type_id)?;
@@ -996,10 +1390,7 @@ fn apply_graph_mutations(
                             Ok((name.clone(), prop_literal(value)?))
                         })
                         .collect::<Result<HashMap<_, _>, GfError>>()?;
-                    let property_route = match graph.ontology_mode {
-                        OntologyMode::Advisory | OntologyMode::Strict => label.clone(),
-                        OntologyMode::Exploratory => "_untyped".to_owned(),
-                    };
+                    let property_route = routes.node(node_uuid)?;
                     node_sets
                         .entry(property_route)
                         .or_default()
@@ -1014,7 +1405,12 @@ fn apply_graph_mutations(
                 properties,
             } => {
                 catalog.intern_relation_type(rel_type)?;
-                writer.create_edge(*edge_uuid, rel_type, source_uuid, target_uuid)?;
+                writer.create_edge(
+                    *edge_uuid,
+                    &routes.edge(edge_uuid)?,
+                    source_uuid,
+                    target_uuid,
+                )?;
                 if !properties.is_empty() {
                     let props = properties
                         .iter()
@@ -1024,7 +1420,7 @@ fn apply_graph_mutations(
                         })
                         .collect::<Result<HashMap<_, _>, GfError>>()?;
                     edge_sets
-                        .entry(rel_type.clone())
+                        .entry(routes.edge(edge_uuid)?)
                         .or_default()
                         .insert(edge_uuid.into_bytes(), props);
                 }
@@ -1037,7 +1433,7 @@ fn apply_graph_mutations(
                 catalog.intern_property(property, None)?;
                 let literal = prop_literal(value)?;
                 node_sets
-                    .entry("_untyped".into())
+                    .entry(routes.node(node_uuid)?)
                     .or_default()
                     .entry(node_uuid.into_bytes())
                     .or_default()
@@ -1051,7 +1447,7 @@ fn apply_graph_mutations(
                 catalog.intern_property(property, None)?;
                 let literal = prop_literal(value)?;
                 edge_sets
-                    .entry("_untyped".into())
+                    .entry(routes.edge(edge_uuid)?)
                     .or_default()
                     .entry(edge_uuid.into_bytes())
                     .or_default()
@@ -1062,7 +1458,7 @@ fn apply_graph_mutations(
                 property,
             } => {
                 node_removes
-                    .entry("_untyped".into())
+                    .entry(routes.node(node_uuid)?)
                     .or_default()
                     .entry(node_uuid.into_bytes())
                     .or_default()
@@ -1073,7 +1469,7 @@ fn apply_graph_mutations(
                 property,
             } => {
                 edge_removes
-                    .entry("_untyped".into())
+                    .entry(routes.edge(edge_uuid)?)
                     .or_default()
                     .entry(edge_uuid.into_bytes())
                     .or_default()
@@ -1818,6 +2214,12 @@ mod tests {
             &mut catalog,
             1,
             inventory.as_ref(),
+            &CompositePropertyRoutes {
+                nodes: BTreeMap::from([(Uuid::from_u128(231), "_untyped".into())]),
+                edges: BTreeMap::new(),
+                requires_canonical: false,
+                created_node_types: HashMap::new(),
+            },
         )
         .unwrap_err();
 

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -807,8 +807,8 @@ impl GraphForge {
             load_workspace_ontology(&resolved_generation)?;
         let (dir, workspace, graph_open_evidence) =
             hydrate_graph_workspace(&resolved_generation, read_only)?;
-        let property_inventory =
-            property_inventory_for_hydrated_generation(&resolved_generation, &dir)?;
+        let (property_inventory, hydrated_inventory) =
+            property_and_graph_inventory_for_hydrated_generation(&resolved_generation, &dir)?;
         let ordinal_identities = ordinal_identity_resolver(&resolved_generation, &dir)?;
 
         let runtime_catalog = load_runtime_catalog(&dir)?;
@@ -834,8 +834,7 @@ impl GraphForge {
                 )
             })?;
             bindings.validate_against(context.composition())?;
-            let inventory = resolved_generation.graph_files_inventory()?;
-            bindings.validate_physical_routes_with_inventory(&dir, inventory.as_ref())?;
+            bindings.validate_physical_routes_with_inventory(&dir, Some(&hydrated_inventory))?;
         }
         let default_composition_context =
             match (default_composition_context, &semantic_storage_bindings) {
@@ -1014,11 +1013,7 @@ impl GraphForge {
         &self,
         generation: &ResolvedProjectGeneration,
     ) -> Result<(), GfError> {
-        let replacement = Arc::new(
-            graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(
-                generation,
-            )?,
-        );
+        let replacement = property_inventory_for_hydrated_generation(generation, &self.dir)?;
         let ordinal_replacement = ordinal_identity_handle(generation, &self.dir)?;
         let adjacency_replacement = Arc::new(adjacency_provider_for_graph(
             &self.dir,
@@ -2761,6 +2756,23 @@ fn property_inventory_for_hydrated_generation(
     generation: &ResolvedProjectGeneration,
     hydrated_root: &Path,
 ) -> Result<Arc<graphforge_storage::AuthenticatedPropertyInventory>, GfError> {
+    property_and_graph_inventory_for_hydrated_generation(generation, hydrated_root)
+        .map(|(properties, _)| properties)
+}
+
+// Hydration authenticates the published base and journal before deriving this
+// private inventory. Both property and semantic validation must use that same
+// effective graph, rather than compare replay output with the unchanged base.
+fn property_and_graph_inventory_for_hydrated_generation(
+    generation: &ResolvedProjectGeneration,
+    hydrated_root: &Path,
+) -> Result<
+    (
+        Arc<graphforge_storage::AuthenticatedPropertyInventory>,
+        graphforge_storage::GraphFilesInventory,
+    ),
+    GfError,
+> {
     let inventory = generation.graph_files_inventory()?;
     let has_deltas = match inventory.as_ref() {
         Some(inventory) => !graphforge_storage::list_delta_runs(
@@ -2772,17 +2784,25 @@ fn property_inventory_for_hydrated_generation(
     };
     // Snapshot-only generations have no graph-files inventory; hydration has
     // authenticated their snapshot payload into this private workspace.
-    let admitted = if has_deltas || inventory.is_none() {
-        let (materialized, _) = graphforge_storage::capture_graph_files(hydrated_root)?;
-        graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
-            generation,
-            hydrated_root,
-            materialized,
-        )?
-    } else {
-        graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(generation)?
+    let (admitted, effective) = match inventory {
+        Some(inventory) if !has_deltas => (
+            graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(
+                generation,
+            )?,
+            inventory,
+        ),
+        _ => {
+            let (materialized, _) = graphforge_storage::capture_graph_files(hydrated_root)?;
+            let admitted =
+                graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
+                    generation,
+                    hydrated_root,
+                    materialized.clone(),
+                )?;
+            (admitted, materialized)
+        }
     };
-    Ok(Arc::new(admitted))
+    Ok((Arc::new(admitted), effective))
 }
 
 fn ordinal_identity_handle(

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -1934,4 +1934,47 @@ fn composite_qualified_create_then_set_preserves_node_and_edge_owners() {
     assert_eq!(int_at(&result.batches[0], 0, 0), Some(3));
     assert_eq!(int_at(&result.batches[0], 1, 0), None);
     assert_eq!(int_at(&result.batches[0], 2, 0), Some(2));
+    let current = graphforge_storage::resolve_project_generation(&source).unwrap();
+    let bindings = graphforge_storage::semantic_storage_bindings(&current)
+        .unwrap()
+        .unwrap();
+    let relation = bindings
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.route_kind == graphforge_storage::SemanticRouteKind::Relation
+                && binding.symbol.local_id == "NEW_TYPED"
+        })
+        .unwrap();
+    let fixture = Fixture {
+        name: "qualified_composite_edge",
+        nodes: 2,
+        edges: 1,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: false,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let nodes = [
+        (a, "mixed:entity:NewNode".into(), None),
+        (b, "mixed:entity:NewNode".into(), None),
+    ];
+    let edges = [(edge, a, b, relation.route.clone(), None, None)];
+    drop(graph);
+    round_trip(root.path(), &source, fixture, &nodes, &edges);
+    let imported = GraphForge::new(root.path().join("imported").to_str()).unwrap();
+    let imported_result = imported.execute("MATCH (a:`mixed:NewNode`)-[r:`mixed:NEW_TYPED`]->(b:`mixed:NewNode`) RETURN a.score, r.weight, b.score").unwrap();
+    assert_eq!(
+        imported_result
+            .batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>(),
+        result
+            .batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>()
+    );
 }

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -1448,3 +1448,441 @@ fn workspace_publication_preserves_constructed_cas_payloads() {
         json!({"retained_files":before.files.len(),"retained_bytes":before.total_byte_length,"reencoded_graph_payload_bytes":0})
     );
 }
+
+#[test]
+fn composite_qualified_property_publishing_preserves_values() {
+    exercise_qualified_property_publication(true, 33);
+}
+
+#[test]
+fn composite_qualified_undeclared_property_is_rejected_before_publication() {
+    exercise_qualified_property_publication(false, 33);
+}
+
+#[test]
+fn composite_qualified_property_large_base_reuses_topology() {
+    exercise_qualified_property_publication(true, 4097);
+}
+
+fn exercise_qualified_property_publication(declared_property: bool, node_count: usize) {
+    use graphforge_api::{
+        COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation,
+        CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
+    };
+    use graphforge_storage::{
+        GraphDeltaCompactionLimits, GraphDeltaCompactionRequest, ProjectRetentionLimits,
+        ProjectRetentionPolicy,
+    };
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "mixed_semantic_routes",
+        nodes: 0,
+        edges: 0,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: false,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (mut nodes, mut edges) = rows(fixture);
+    drop(GraphForge::new(source.to_str()).unwrap());
+    configure_composite_ontology(root.path(), &source, declared_property);
+    let child_nodes = (0..node_count)
+        .map(|row| (id(3, row, true), "NewNode".to_owned(), None))
+        .collect::<Vec<_>>();
+    let changed_node = child_nodes[0].0;
+    for (row, edge) in edges[..].iter_mut().enumerate() {
+        edge.3 = "NEW_TYPED".into();
+        edge.1 = child_nodes[row % child_nodes.len()].0;
+        edge.2 = child_nodes[(row + 1) % child_nodes.len()].0;
+    }
+    construct(&source, fixture, &child_nodes, &edges[..]);
+    nodes.extend(child_nodes.into_iter().map(|mut node| {
+        node.1 = "mixed:entity:NewNode".into();
+        node
+    }));
+    let current = graphforge_storage::resolve_project_generation(&source).unwrap();
+    let bindings = graphforge_storage::semantic_storage_bindings(&current)
+        .unwrap()
+        .unwrap();
+    let relation = bindings
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.route_kind == graphforge_storage::SemanticRouteKind::Relation
+                && binding.symbol.local_id == "NEW_TYPED"
+        })
+        .unwrap();
+    assert_eq!(relation.symbol.display(), "mixed:relation:NEW_TYPED");
+    for edge in &mut edges[..] {
+        edge.3.clone_from(&relation.route);
+    }
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let base = current.graph_files_inventory().unwrap().unwrap();
+    assert!(current.declared_graph_files_inventory().unwrap().is_none());
+    let publication = graph.publish_composite_transaction(CompositeTransactionRequest {
+        contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+        context: WriteContext {
+            operation_uuid: OperationId(Uuid::now_v7()),
+            actor_uuid: None,
+        },
+        graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
+            node_uuid: changed_node,
+            property: "score".into(),
+            value: PropValue::Int(123),
+        }],
+        knowledge: CompositeKnowledgeParticipants::default(),
+    });
+    if !declared_property {
+        let error = publication.unwrap_err();
+        assert!(error.to_string().contains("WrongOwnerProperty"), "{error}");
+        let unchanged = graphforge_storage::resolve_project_generation(&source).unwrap();
+        assert_eq!(current.generation_uuid(), unchanged.generation_uuid());
+        assert_eq!(base, unchanged.graph_files_inventory().unwrap().unwrap());
+        verify_graph(&graph, fixture, &nodes, &edges);
+        return;
+    }
+    publication.unwrap();
+    let first = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert!(
+        first.declared_graph_files_inventory().unwrap().is_none(),
+        "first property authority must retain CAS ownership"
+    );
+    let first_inventory = first.graph_files_inventory().unwrap().unwrap();
+    for entry in base.files.iter().filter(|entry| {
+        entry.relative_path.starts_with("topology/")
+            && entry.relative_path.ends_with(".parquet")
+            && entry.relative_path != "topology/runtime_catalog.parquet"
+    }) {
+        assert!(
+            first_inventory.files.contains(entry),
+            "property publication must reuse unchanged topology: {}",
+            entry.relative_path
+        );
+    }
+    assert!(
+        graphforge_storage::list_delta_runs(&first_inventory, Default::default())
+            .unwrap()
+            .is_empty()
+    );
+    let changed_payload_bytes: u64 = first_inventory
+        .files
+        .iter()
+        .filter(|entry| entry.relative_path.ends_with(".parquet") && !base.files.contains(entry))
+        .map(|entry| entry.byte_length)
+        .sum();
+    assert!(
+        changed_payload_bytes <= 64 * 1024,
+        "one property must not copy or reencode the base: {changed_payload_bytes}"
+    );
+    println!(
+        "COMPOSITE_OWNER_BUDGET {}",
+        json!({
+            "nodes": node_count, "base_bytes": base.total_byte_length,
+            "first_property_changed_parquet_bytes": changed_payload_bytes,
+            "unchanged_topology_reencoded_bytes": 0
+        })
+    );
+    let immediate = graph
+        .execute("MATCH (n:`mixed:NewNode`) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score")
+        .unwrap();
+    assert_eq!(
+        immediate
+            .batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>(),
+        1,
+        "qualified property must be visible immediately"
+    );
+    assert_eq!(uuid_at(&immediate.batches[0], 0, 0), changed_node);
+    assert_eq!(int_at(&immediate.batches[0], 1, 0), Some(123));
+    let snapshot_query =
+        "MATCH (n:`mixed:NewNode`) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score";
+    let (snapshot, _, _snapshot_guard) = graph
+        .execute_stream_owned(snapshot_query, &Default::default())
+        .unwrap();
+    graph
+        .publish_composite_transaction(CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
+                node_uuid: changed_node,
+                property: "score".into(),
+                value: PropValue::Int(124),
+            }],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        })
+        .unwrap();
+    let delta = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert_eq!(
+        graphforge_storage::list_delta_runs(
+            &delta.graph_files_inventory().unwrap().unwrap(),
+            Default::default()
+        )
+        .unwrap()
+        .len(),
+        1
+    );
+    let latest = graph.execute(snapshot_query).unwrap();
+    assert_eq!(int_at(&latest.batches[0], 1, 0), Some(124));
+    graph
+        .compact_graph_delta(
+            &GraphDeltaCompactionRequest {
+                transaction_uuid: Uuid::now_v7(),
+                generation_uuid: Uuid::now_v7(),
+                through_run_sequence: None,
+                limits: GraphDeltaCompactionLimits::default(),
+                cleanup_after_commit: false,
+                cleanup_policy: ProjectRetentionPolicy::default(),
+                cleanup_limits: ProjectRetentionLimits::default(),
+            },
+            None,
+        )
+        .unwrap();
+    use futures::TryStreamExt as _;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let old: Vec<RecordBatch> = runtime.block_on(snapshot.try_collect()).unwrap();
+    assert_eq!(
+        old.iter().map(|batch| batch.columns()).collect::<Vec<_>>(),
+        immediate
+            .batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>()
+    );
+    drop(graph);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let score_query =
+        "MATCH (n:`mixed:NewNode`) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score";
+    let expected_score = graph.execute(score_query).unwrap();
+    assert_eq!(
+        expected_score
+            .batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>(),
+        1
+    );
+    assert_eq!(uuid_at(&expected_score.batches[0], 0, 0), changed_node);
+    assert_eq!(int_at(&expected_score.batches[0], 1, 0), Some(124));
+    drop(graph);
+    round_trip(root.path(), &source, fixture, &nodes, &edges);
+    for path in [&source, &root.path().join("imported")] {
+        let reopened = GraphForge::new(path.to_str()).unwrap();
+        assert_eq!(
+            reopened
+                .execute(score_query)
+                .unwrap()
+                .batches
+                .iter()
+                .map(|batch| batch.columns())
+                .collect::<Vec<_>>(),
+            expected_score
+                .batches
+                .iter()
+                .map(|batch| batch.columns())
+                .collect::<Vec<_>>()
+        );
+        reopened
+            .publish_composite_transaction(CompositeTransactionRequest {
+                contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                context: WriteContext {
+                    operation_uuid: OperationId(Uuid::now_v7()),
+                    actor_uuid: None,
+                },
+                graph_mutations: vec![CompositeGraphMutation::RemoveNodeProperty {
+                    node_uuid: changed_node,
+                    property: "score".into(),
+                }],
+                knowledge: CompositeKnowledgeParticipants::default(),
+            })
+            .unwrap();
+        assert_eq!(
+            reopened
+                .execute(score_query)
+                .unwrap()
+                .batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            0
+        );
+        drop(reopened);
+        let removed = GraphForge::new(path.to_str()).unwrap();
+        assert_eq!(
+            removed
+                .execute(score_query)
+                .unwrap()
+                .batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            0
+        );
+    }
+}
+
+fn configure_composite_ontology(root: &Path, source: &Path, declared_property: bool) {
+    use graphforge_api::{AdoptOntologyRequest, OntologyMode, WriteContext};
+    let ontology = root.join("routes.yaml");
+    let mut ontology_yaml = "ontology_id: https://example.test/mixed\nversion: \"1\"\nentity_types:\n  - name: NewNode\n    abstract: false\nrelation_types:\n  - name: NEW_TYPED\n    src: NewNode\n    dst: NewNode\n".to_owned();
+    if declared_property {
+        ontology_yaml.push_str("properties:\n  - owner: NewNode\n    name: score\n    type: int64\n    nullable: true\n  - owner: NEW_TYPED\n    name: weight\n    type: int64\n    nullable: true\n");
+    }
+    std::fs::write(&ontology, ontology_yaml).unwrap();
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    graph
+        .adopt_ontology(AdoptOntologyRequest {
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            path: ontology,
+            mode: OntologyMode::Advisory,
+        })
+        .unwrap();
+    drop(graph);
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    let candidate = graph.workspace_ontology_composition().unwrap().unwrap();
+    let request = graphforge_api::CompositionChangeRequest {
+        context: WriteContext {
+            operation_uuid: OperationId(Uuid::now_v7()),
+            actor_uuid: None,
+        },
+        expected_project_generation_uuid: graphforge_storage::resolve_project_generation(source)
+            .unwrap()
+            .generation_uuid(),
+        expected_composition_fingerprint: Some(candidate.composition_fingerprint.clone()),
+        candidate,
+        data_disposition: graphforge_api::CompositionDataDisposition::RequireConforming,
+    };
+    let preview = graph
+        .preview_ontology_composition_change(&request, None)
+        .unwrap();
+    assert!(preview.diagnostics.is_empty(), "{:?}", preview.diagnostics);
+    graph
+        .publish_ontology_composition_change(&request, &preview, None)
+        .unwrap();
+    drop(graph);
+}
+
+#[test]
+fn composite_qualified_create_then_set_preserves_node_and_edge_owners() {
+    use graphforge_api::{
+        COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation as Mutation,
+        CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
+    };
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    drop(GraphForge::new(source.to_str()).unwrap());
+    configure_composite_ontology(root.path(), &source, true);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let a = Uuid::now_v7();
+    let b = Uuid::now_v7();
+    let edge = Uuid::now_v7();
+    graph
+        .publish_composite_transaction(CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![
+                Mutation::CreateNode {
+                    node_uuid: a,
+                    label: "mixed:NewNode".into(),
+                    properties: [("score".into(), PropValue::Int(1))].into(),
+                },
+                Mutation::CreateNode {
+                    node_uuid: b,
+                    label: "mixed:NewNode".into(),
+                    properties: [("score".into(), PropValue::Int(2))].into(),
+                },
+                Mutation::CreateEdge {
+                    edge_uuid: edge,
+                    rel_type: "mixed:NEW_TYPED".into(),
+                    source_uuid: a,
+                    target_uuid: b,
+                    properties: [("weight".into(), PropValue::Int(1))].into(),
+                },
+                Mutation::SetNodeProperty {
+                    node_uuid: a,
+                    property: "score".into(),
+                    value: PropValue::Int(3),
+                },
+                Mutation::SetEdgeProperty {
+                    edge_uuid: edge,
+                    property: "weight".into(),
+                    value: PropValue::Int(4),
+                },
+            ],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        })
+        .unwrap();
+    drop(graph);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let result = graph.execute("MATCH (a:`mixed:NewNode`)-[r:`mixed:NEW_TYPED`]->(b:`mixed:NewNode`) RETURN a.node_uuid, b.node_uuid, a.score, r.weight, b.score").unwrap();
+    assert_eq!(
+        result
+            .batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>(),
+        1
+    );
+    let batch = &result.batches[0];
+    assert_eq!(uuid_at(batch, 0, 0), a);
+    assert_eq!(uuid_at(batch, 1, 0), b);
+    assert_eq!(int_at(batch, 2, 0), Some(3));
+    assert_eq!(int_at(batch, 3, 0), Some(4));
+    assert_eq!(int_at(batch, 4, 0), Some(2));
+    drop(graph);
+    // Optimistic publication exercises the canonical lifecycle independently
+    // of the typed-edge GFDR schema repair tracked in #1218.
+    let graph = GraphForge::new_with_options(
+        source.to_str(),
+        graphforge_api::GraphForgeOptions {
+            write_mode: graphforge_api::ProjectWriteMode::OptimisticMultiWriter,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    graph
+        .publish_composite_transaction(CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![Mutation::RemoveEdgeProperty {
+                edge_uuid: edge,
+                property: "weight".into(),
+            }],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        })
+        .unwrap();
+    drop(graph);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let result = graph.execute("MATCH (a:`mixed:NewNode`)-[r:`mixed:NEW_TYPED`]->(b:`mixed:NewNode`) RETURN a.score, r.weight, b.score").unwrap();
+    assert_eq!(
+        result
+            .batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>(),
+        1
+    );
+    assert_eq!(int_at(&result.batches[0], 0, 0), Some(3));
+    assert_eq!(int_at(&result.batches[0], 1, 0), None);
+    assert_eq!(int_at(&result.batches[0], 2, 0), Some(2));
+}

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -1451,20 +1451,29 @@ fn workspace_publication_preserves_constructed_cas_payloads() {
 
 #[test]
 fn composite_qualified_property_publishing_preserves_values() {
-    exercise_qualified_property_publication(true, 33);
+    exercise_qualified_property_publication(true, 33, false);
 }
 
 #[test]
 fn composite_qualified_undeclared_property_is_rejected_before_publication() {
-    exercise_qualified_property_publication(false, 33);
+    exercise_qualified_property_publication(false, 33, false);
 }
 
 #[test]
 fn composite_qualified_property_large_base_reuses_topology() {
-    exercise_qualified_property_publication(true, 4097);
+    exercise_qualified_property_publication(true, 4097, false);
 }
 
-fn exercise_qualified_property_publication(declared_property: bool, node_count: usize) {
+#[test]
+fn composite_qualified_mixed_graph_canonical_properties_preserve_values() {
+    exercise_qualified_property_publication(true, 33, true);
+}
+
+fn exercise_qualified_property_publication(
+    declared_property: bool,
+    node_count: usize,
+    mixed: bool,
+) {
     use graphforge_api::{
         COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation,
         CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
@@ -1477,8 +1486,8 @@ fn exercise_qualified_property_publication(declared_property: bool, node_count: 
     let source = root.path().join("source");
     let fixture = Fixture {
         name: "mixed_semantic_routes",
-        nodes: 0,
-        edges: 0,
+        nodes: if mixed { 33 } else { 0 },
+        edges: if mixed { 129 } else { 0 },
         routes: 1,
         identifiers: Identifiers::Random,
         properties: false,
@@ -1487,17 +1496,24 @@ fn exercise_qualified_property_publication(declared_property: bool, node_count: 
     };
     let (mut nodes, mut edges) = rows(fixture);
     drop(GraphForge::new(source.to_str()).unwrap());
+    if mixed {
+        construct(&source, fixture, &nodes, &edges);
+    }
     configure_composite_ontology(root.path(), &source, declared_property);
     let child_nodes = (0..node_count)
         .map(|row| (id(3, row, true), "NewNode".to_owned(), None))
         .collect::<Vec<_>>();
     let changed_node = child_nodes[0].0;
-    for (row, edge) in edges[..].iter_mut().enumerate() {
+    let parent_edges = edges.len();
+    let mut child_edges = edges.clone();
+    for (row, edge) in child_edges.iter_mut().enumerate() {
+        edge.0 = id(4, row, true);
         edge.3 = "NEW_TYPED".into();
         edge.1 = child_nodes[row % child_nodes.len()].0;
         edge.2 = child_nodes[(row + 1) % child_nodes.len()].0;
     }
-    construct(&source, fixture, &child_nodes, &edges[..]);
+    construct(&source, fixture, &child_nodes, &child_edges);
+    edges.extend(child_edges);
     nodes.extend(child_nodes.into_iter().map(|mut node| {
         node.1 = "mixed:entity:NewNode".into();
         node
@@ -1515,10 +1531,18 @@ fn exercise_qualified_property_publication(declared_property: bool, node_count: 
         })
         .unwrap();
     assert_eq!(relation.symbol.display(), "mixed:relation:NEW_TYPED");
-    for edge in &mut edges[..] {
+    for edge in &mut edges[parent_edges..] {
         edge.3.clone_from(&relation.route);
     }
-    let graph = GraphForge::new(source.to_str()).unwrap();
+    let options = graphforge_api::GraphForgeOptions {
+        write_mode: if mixed {
+            graphforge_api::ProjectWriteMode::OptimisticMultiWriter
+        } else {
+            graphforge_api::ProjectWriteMode::SingleWriter
+        },
+        ..Default::default()
+    };
+    let graph = GraphForge::new_with_options(source.to_str(), options).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     let base = current.graph_files_inventory().unwrap().unwrap();
     assert!(current.declared_graph_files_inventory().unwrap().is_none());
@@ -1627,24 +1651,38 @@ fn exercise_qualified_property_publication(declared_property: bool, node_count: 
         )
         .unwrap()
         .len(),
-        1
+        usize::from(!mixed)
     );
     let latest = graph.execute(snapshot_query).unwrap();
     assert_eq!(int_at(&latest.batches[0], 1, 0), Some(124));
-    graph
-        .compact_graph_delta(
-            &GraphDeltaCompactionRequest {
-                transaction_uuid: Uuid::now_v7(),
-                generation_uuid: Uuid::now_v7(),
-                through_run_sequence: None,
-                limits: GraphDeltaCompactionLimits::default(),
-                cleanup_after_commit: false,
-                cleanup_policy: ProjectRetentionPolicy::default(),
-                cleanup_limits: ProjectRetentionLimits::default(),
-            },
-            None,
-        )
-        .unwrap();
+    let compaction = graph.compact_graph_delta(
+        &GraphDeltaCompactionRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            through_run_sequence: None,
+            limits: GraphDeltaCompactionLimits::default(),
+            cleanup_after_commit: false,
+            cleanup_policy: ProjectRetentionPolicy::default(),
+            cleanup_limits: ProjectRetentionLimits::default(),
+        },
+        None,
+    );
+    if mixed {
+        assert!(
+            compaction
+                .unwrap_err()
+                .to_string()
+                .contains("requires at least one verified run")
+        );
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .generation_uuid(),
+            delta.generation_uuid()
+        );
+    } else {
+        compaction.unwrap();
+    }
     use futures::TryStreamExt as _;
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -1678,7 +1716,18 @@ fn exercise_qualified_property_publication(declared_property: bool, node_count: 
     drop(graph);
     round_trip(root.path(), &source, fixture, &nodes, &edges);
     for path in [&source, &root.path().join("imported")] {
-        let reopened = GraphForge::new(path.to_str()).unwrap();
+        let reopened = GraphForge::new_with_options(
+            path.to_str(),
+            graphforge_api::GraphForgeOptions {
+                write_mode: if mixed {
+                    graphforge_api::ProjectWriteMode::OptimisticMultiWriter
+                } else {
+                    graphforge_api::ProjectWriteMode::SingleWriter
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
         assert_eq!(
             reopened
                 .execute(score_query)

--- a/crates/graphforge-storage/src/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/src/graph_delta_compaction.rs
@@ -338,7 +338,7 @@ fn compact_graph_delta_after_prepare(
 
     let inventory = &prepared.materialized_inventory;
     let (files_participant, publication_lease) =
-        compaction_graph_participant(&parent, staging.path(), inventory)?;
+        crate::prepare_graph_files_replacement(&parent, staging.path(), inventory)?;
     let generation_request = crate::graph_delta_journal::generation_with_replaced_graph(
         &parent,
         request.transaction_uuid,
@@ -400,40 +400,6 @@ fn compact_graph_delta_after_prepare(
     );
     report.output_bytes = output_bytes;
     Ok(report)
-}
-
-fn compaction_graph_participant(
-    parent: &crate::ResolvedProjectGeneration,
-    workspace: &Path,
-    inventory: &GraphFilesInventory,
-) -> Result<
-    (
-        crate::ProjectParticipant,
-        Option<crate::GraphObjectPublicationLease>,
-    ),
-    GfError,
-> {
-    let mut files_participant = crate::graph_files::inventory_participant(
-        crate::graph_files::encode_inventory(inventory)?,
-        inventory.file_count,
-    )?;
-    let publication_lease = match parent.declared_graph_files_participant()? {
-        Some(crate::GraphFilesParticipant::V2(root)) => {
-            let lease = crate::begin_graph_object_publication(parent.container_root())?;
-            let (mut state, _) = crate::graph_object_store::GraphManifestState::open(
-                &lease,
-                root,
-                crate::GraphManifestLimits::default(),
-            )?;
-            let (root, _) = crate::graph_object_store::replace_replayed_graph_files(
-                &lease, workspace, &mut state, inventory,
-            )?;
-            files_participant = crate::graph_files::graph_files_root_participant(&root)?;
-            Some(lease)
-        }
-        _ => None,
-    };
-    Ok((files_participant, publication_lease))
 }
 
 /// Inspect whether CURRENT triggers compaction under `policy`.

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -1240,6 +1240,46 @@ pub fn append_graph_files_v2(
     )
 }
 
+/// Prepare an authenticated canonical candidate while preserving its parent ownership.
+/// CAS parents reuse unchanged objects; generation-owned parents retain their
+/// existing graph-tree publication path. Keep the returned lease through CURRENT.
+///
+/// # Errors
+/// Rejects invalid inventories, route authority, or object publication failures.
+pub fn prepare_graph_files_replacement(
+    parent: &crate::ResolvedProjectGeneration,
+    workspace: &Path,
+    inventory: &GraphFilesInventory,
+) -> Result<
+    (
+        crate::ProjectParticipant,
+        Option<crate::GraphObjectPublicationLease>,
+    ),
+    GfError,
+> {
+    let mut files_participant = crate::graph_files::inventory_participant(
+        crate::graph_files::encode_inventory(inventory)?,
+        inventory.file_count,
+    )?;
+    let publication_lease = match parent.declared_graph_files_participant()? {
+        Some(crate::GraphFilesParticipant::V2(root)) => {
+            let lease = crate::begin_graph_object_publication(parent.container_root())?;
+            let (mut state, _) = crate::graph_object_store::GraphManifestState::open(
+                &lease,
+                root,
+                crate::GraphManifestLimits::default(),
+            )?;
+            let (root, _) = crate::graph_object_store::replace_replayed_graph_files(
+                &lease, workspace, &mut state, inventory,
+            )?;
+            files_participant = crate::graph_files::graph_files_root_participant(&root)?;
+            Some(lease)
+        }
+        _ => None,
+    };
+    Ok((files_participant, publication_lease))
+}
+
 /// Publish a private replay candidate using its authenticated route contract.
 pub(crate) fn replace_replayed_graph_files(
     lease: &GraphObjectPublicationLease,

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -113,7 +113,7 @@ pub use graph_object_store::graph_object_path;
 pub use graph_object_store::{
     AuthenticatedGraphObject, GRAPH_OBJECT_IO_BUFFER_BYTES, GraphObjectIoTotals,
     GraphObjectPublicationLease, GraphPublicationIo, begin_graph_object_publication,
-    materialize_graph_objects, open_graph_object_by_digest,
+    materialize_graph_objects, open_graph_object_by_digest, prepare_graph_files_replacement,
 };
 #[cfg(any(test, feature = "test-support"))]
 pub use graph_object_store::{

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1537,11 +1537,14 @@ impl ValidatedProjectGeneration {
         }
         let manifest_sha256 = make_generation_durable(staged)?;
         if let Some(lease) = graph_object_lease {
-            verify_optional_graph_tree_with_lease(
-                &staged.generation_root,
-                &staged.participants,
-                lease,
-            )?;
+            // Durability promotes optimistic attempts before the final CAS
+            // closure check. Authenticate the installed generation, not its
+            // former private attempt path.
+            let durable_root = staged
+                .root
+                .join(GENERATIONS_DIR)
+                .join(staged.generation_uuid.hyphenated().to_string());
+            verify_optional_graph_tree_with_lease(&durable_root, &staged.participants, lease)?;
             lease.revalidate_for_root(staged.parent.container_root())?;
         }
         replace_current(

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -632,6 +632,7 @@ impl AuthenticatedPropertyInventory {
         entries: Vec<crate::GraphFileEntry>,
     ) -> Result<Self, GfError> {
         let mut admitted = Self::from_entries_at_root(root, entries)?;
+        admitted.seed_semantic_property_schemas(generation)?;
         admitted.generation_lease = Some(generation.clone());
         Ok(admitted)
     }
@@ -643,6 +644,7 @@ impl AuthenticatedPropertyInventory {
         inventory: crate::GraphFilesInventory,
     ) -> Result<Self, GfError> {
         let mut admitted = Self::from_inventory_at_root(root, inventory, None)?;
+        admitted.seed_semantic_property_schemas(generation)?;
         admitted.generation_lease = Some(generation.clone());
         Ok(admitted)
     }
@@ -791,6 +793,7 @@ impl AuthenticatedPropertyInventory {
                 Ok::<Self, GfError>(admitted)
             }
         }?;
+        admitted.seed_semantic_property_schemas(generation)?;
         admitted.generation_lease = Some(generation.clone());
         Ok(admitted)
     }
@@ -932,6 +935,39 @@ impl AuthenticatedPropertyInventory {
             #[cfg(test)]
             mutation_barrier: Mutex::new(None),
         })
+    }
+
+    // A declared owner may not have a property payload yet. Its authenticated
+    // binding still owns the metadata of the first fragment we publish.
+    fn seed_semantic_property_schemas(
+        &mut self,
+        generation: &crate::ResolvedProjectGeneration,
+    ) -> Result<(), GfError> {
+        let Some(bindings) = crate::semantic_storage_bindings(generation)? else {
+            return Ok(());
+        };
+        for binding in &bindings.bindings {
+            let kind = match binding.route_kind {
+                crate::SemanticRouteKind::NodeProperty => PropertyRouteKind::Node,
+                crate::SemanticRouteKind::EdgeProperty => PropertyRouteKind::Edge,
+                _ => continue,
+            };
+            self.schemas
+                .entry((kind, binding.route.clone()))
+                .or_insert_with(|| {
+                    let schema = arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+                        kind.uuid_field(),
+                        arrow::datatypes::DataType::FixedSizeBinary(16),
+                        false,
+                    )]);
+                    Arc::new(crate::schemas::with_semantic_route_metadata(
+                        &schema,
+                        &binding.route,
+                        &bindings.composition_fingerprint,
+                    ))
+                });
+        }
+        Ok(())
     }
 
     /// Canonical logical schema authenticated across every fragment in a route.

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -325,7 +325,17 @@ pub(crate) fn write_replay_overlay_streaming(
         true,
         &mut target_routes,
     )?;
-    replace_private_replay_route_table(target, &target_routes)
+    let node_properties_changed =
+        !overlay.node_properties.is_empty() || overlay.nodes.values().any(Option::is_none);
+    let properties_changed = node_properties_changed
+        || !overlay.edge_properties.is_empty()
+        || overlay.edges.values().any(Option::is_none);
+    replace_private_replay_route_table(
+        target,
+        &target_routes,
+        properties_changed,
+        node_properties_changed,
+    )
 }
 
 fn stream_replay_nodes(
@@ -1369,6 +1379,8 @@ fn stream_replay_property_route_with_table(
 fn replace_private_replay_route_table(
     target: &Path,
     table: &crate::route_component::RouteTable,
+    properties_changed: bool,
+    node_properties_changed: bool,
 ) -> Result<(), GfError> {
     let mut batch = RewriteBatch::new();
     batch.stage_named_control_bytes(
@@ -1376,7 +1388,17 @@ fn replace_private_replay_route_table(
         &table.encode(64 * 1024 * 1024)?,
         "semantic-routes.json.",
     )?;
-    crate::durable_rewrite::commit(batch, target, false, false, false, None)?;
+    // Replayed fragments advance their route generation. Publish the matching
+    // property high-water mark and invalidate node-property search state, so
+    // the next ordinary mutation cannot reuse an existing fragment generation.
+    crate::durable_rewrite::commit(
+        batch,
+        target,
+        false,
+        node_properties_changed,
+        properties_changed,
+        None,
+    )?;
     crate::capture_graph_files(target)?;
     Ok(())
 }
@@ -1395,7 +1417,7 @@ fn stream_replay_property_route(
     stream_replay_property_route_with_table(
         target, inventory, overlay, limits, edge, route, &mut table,
     )?;
-    replace_private_replay_route_table(target, &table)
+    replace_private_replay_route_table(target, &table, true, !edge)
 }
 
 type ReplayPropertyOperations =
@@ -6242,6 +6264,89 @@ mod tests {
     fn test_inventory(dir: &Path) -> crate::AuthenticatedPropertyInventory {
         let (files, _) = crate::capture_graph_files(dir).unwrap();
         crate::AuthenticatedPropertyInventory::from_inventory_at_root(dir, files, None).unwrap()
+    }
+
+    #[test]
+    fn replay_advances_property_authority_across_unequal_route_generations() {
+        let dir = TempDir::new().unwrap();
+        let a = new_v7();
+        let b = new_v7();
+        let mut writer = GraphWriter::open_at(dir.path(), OntologyMode::Strict, TS).unwrap();
+        for (uuid, route) in [(a, "Person"), (b, "Company")] {
+            writer
+                .create_node(uuid, EntityTypeId::decode(1).unwrap())
+                .unwrap();
+            writer
+                .set_properties(
+                    &uuid,
+                    Some(route),
+                    HashMap::from([("score".into(), IrLiteral::Int(1))]),
+                )
+                .unwrap();
+        }
+        writer.flush().unwrap();
+        for value in [2, 3] {
+            set_node_properties(
+                dir.path(),
+                "Person",
+                &HashMap::from([(
+                    to_bytes(&a),
+                    HashMap::from([("score".into(), IrLiteral::Int(value))]),
+                )]),
+            )
+            .unwrap();
+        }
+        let property_before = crate::generation::read_property_generation(dir.path()).unwrap();
+        let search_before = crate::generation::read_search_generation(dir.path()).unwrap();
+        let mut overlay = crate::graph_delta_journal::ReplayOverlay::default();
+        for (uuid, route, value) in [(a, "Person", 4), (b, "Company", 5)] {
+            overlay.node_properties.insert(
+                (uuid.to_string(), route.into(), "score".into()),
+                Some(IrLiteral::Int(value)),
+            );
+        }
+        let (inventory, _) = crate::capture_graph_files(dir.path()).unwrap();
+        let target = TempDir::new().unwrap();
+        for file in &inventory.files {
+            let destination = target.path().join(&file.relative_path);
+            fs::create_dir_all(destination.parent().unwrap()).unwrap();
+            fs::copy(dir.path().join(&file.relative_path), destination).unwrap();
+        }
+        write_replay_overlay_streaming(
+            dir.path(),
+            &inventory,
+            target.path(),
+            &overlay,
+            Default::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            crate::generation::read_property_generation(target.path()).unwrap(),
+            property_before + 1
+        );
+        assert_eq!(
+            crate::generation::read_search_generation(target.path()).unwrap(),
+            search_before + 1
+        );
+        for (uuid, route, value) in [(a, "Person", 4), (b, "Company", 5)] {
+            assert_eq!(
+                read_node_props(target.path(), route)[&to_bytes(&uuid)]["score"],
+                IrLiteral::Int(value)
+            );
+            set_node_properties(
+                target.path(),
+                route,
+                &HashMap::from([(
+                    to_bytes(&uuid),
+                    HashMap::from([("score".into(), IrLiteral::Int(value + 10))]),
+                )]),
+            )
+            .unwrap();
+            assert_eq!(
+                read_node_props(target.path(), route)[&to_bytes(&uuid)]["score"],
+                IrLiteral::Int(value + 10)
+            );
+        }
     }
 
     #[test]

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -252,3 +252,65 @@ workspace publication, and clearing authority for retained typed data can
 leave semantic bindings without their composition. Both are recorded under
 #1221 with public reproducers. This ownership-only repair does not claim those
 complete graph-contract failures are resolved.
+
+## Composite property ownership (#1224)
+
+Composite property operations now resolve physical owners during the existing
+validation scan. Nodes use their immutable primary identity, as ordinary Cypher
+mutation does; runtime nodes use `_untyped`, and qualified nodes use the retained
+semantic binding. Edges use the authenticated physical relation route (including
+logical relation names in exploratory storage). Same-request creates resolve the
+same qualified identities. Both canonical staging and GFDR encoding consume this
+operation plan, including optimistic conflict baselines. Qualified properties
+must resolve against their declared owner before publication; a missing or wrong
+owner never silently selects `_untyped`.
+
+A first write to an absent qualified property route uses canonical staging:
+GFDR carries values but cannot establish the route's semantic schema authority.
+The property inventory seeds that authority from authenticated property bindings,
+without decorating an existing malformed fragment. Canonical CAS replacement
+reuses the existing compaction object-difference helper and holds its publication
+lease through CURRENT. Later supported property updates use GFDR. Hydrated
+property and semantic validation share the authenticated materialized inventory;
+replay advances property/search counters so subsequent ordinary mutations cannot
+reuse a fragment generation. Optimistic CAS publication authenticates the final
+installed directory after promotion, before CURRENT.
+
+Five public fixtures at source `df3a707d` cover declared-property refusal,
+qualified create-then-set for nodes and edges, edge removal through portable
+import, qualified node GFDR/compaction at 33 and 4,097 nodes, and a mixed graph
+with 33 exploratory plus 33 qualified nodes and 129 edges of each kind through
+canonical optimistic publication. Exact values, active snapshots, reopen,
+export, full verification, clean import and later removals are checked. The
+mixed canonical fixture has no GFDR run and explicitly checks compaction refusal
+without changing CURRENT; actual mixed-edge GFDR compaction remains #1218's
+integration test. These are distinct proofs, not interchangeable substitutes.
+
+The first property write changes 4,393 Parquet bytes on both node-only sizes,
+and 4,494 bytes on the mixed graph. Each fixture enforces a 64 KiB changed-Parquet
+budget and exact reuse of unchanged topology payload inventory entries. No
+encoding defaults change in this repair. The owner maps retain only requested
+identities and same-request creates, and use existing binding/catalog authority.
+The existing validation snapshot still reads complete topology batches and
+retains full identity sets; this repair adds no second topology scan, but the
+whole transaction is **not** request-sized. Hydration, canonical staging,
+manifest capture, portable verification and import also retain their existing
+I/O and temporary-workspace costs. The changed-Parquet ceiling is not a bound on
+those costs, native codec memory, peak RSS or total temporary disk. Their
+cross-path admission and encoding-policy budgets remain #1213.
+
+The five prebuilt fixtures take 12.51 s elapsed (8.70 s user, 2.62 s system),
+with peak RSS 139,224 KiB and kernel input/output of 126,224/53,288 blocks of
+512 bytes on the admitted native ext4 host. These are source-bound observations,
+not portable resource ceilings; the separate syscall trace includes startup,
+query, verification, import and test output. Raw evidence and commands are in
+[`composite-property-ownership-1224.json`](../../development/evidence/composite-property-ownership-1224.json).
+
+Validation includes 734 API unit tests, 45 publication tests, the unequal-route
+property generation regression, production workspace Clippy and fast pre-push.
+The storage-wide run passed 1,074 tests with two existing ignored tests; its one
+failure is an unchanged test hard-coding `/tmp`, which is tmpfs on this host and
+fails filesystem admission before its hostile-file assertions. Required Bazel
+PR CI remains the merge authority. Composite topology creation on an already
+constructed CAS parent still exposes the UUID authority defect tracked in
+#1221; no authentication check was relaxed to admit that operation.

--- a/docs/development/evidence/composite-property-ownership-1224.json
+++ b/docs/development/evidence/composite-property-ownership-1224.json
@@ -1,0 +1,97 @@
+{
+  "issue": 1224,
+  "source_commit": "df3a707de2bc3d8ec1979b56b60e3e059758cef1",
+  "base_commit": "cba602dc81665824b7eb4dd2b8757a024b2eb3d3",
+  "deterministic_budgets": {
+    "changed_parquet_bytes_limit": 65536,
+    "unchanged_topology_reencoded_bytes": 0,
+    "fixtures": [
+      {
+        "qualified_nodes": 33,
+        "base_bytes": 11620,
+        "changed_parquet_bytes": 4393
+      },
+      {
+        "qualified_nodes": 4097,
+        "base_bytes": 457292,
+        "changed_parquet_bytes": 4393
+      },
+      {
+        "runtime_nodes": 33,
+        "qualified_nodes": 33,
+        "runtime_edges": 129,
+        "qualified_edges": 129,
+        "base_bytes": 40573,
+        "changed_parquet_bytes": 4494
+      }
+    ]
+  },
+  "runtime": {
+    "elapsed_seconds": 12.51,
+    "user_seconds": 8.7,
+    "system_seconds": 2.62,
+    "peak_rss_kib": 139224,
+    "filesystem_input_512_byte_blocks": 126224,
+    "filesystem_output_512_byte_blocks": 53288,
+    "exit_status": 0
+  },
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 79263,
+        "bytes": 141358267
+      },
+      "pread64": {
+        "calls": 11411,
+        "bytes": 3919887
+      },
+      "write": {
+        "calls": 4495,
+        "bytes": 11802976
+      },
+      "fsync": {
+        "calls": 9671,
+        "bytes": 0
+      },
+      "copy_file_range": {
+        "calls": 1250,
+        "bytes": 3575055
+      }
+    },
+    "read_bytes": 148853209,
+    "write_bytes": 15378031,
+    "errors": []
+  },
+  "trace_elapsed_seconds": 51.97,
+  "commands": {
+    "public": "cargo test -p graphforge-api --test permanent_storage_budgets composite_qualified_ -- --nocapture",
+    "api": "cargo test -p graphforge-api --lib",
+    "storage": "cargo test -p graphforge-storage --lib",
+    "publication": "cargo test -p graphforge-storage --lib project_publication::tests",
+    "generation_regression": "cargo test -p graphforge-storage --lib replay_advances_property_authority_across_unequal_route_generations",
+    "clippy": "cargo clippy --workspace -- -D warnings",
+    "runtime": "/usr/bin/time -v <prebuilt permanent_storage_budgets binary> composite_qualified_ --nocapture --test-threads=1",
+    "trace": "strace -f -qq -e trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync <same binary/filter>"
+  },
+  "validation": {
+    "public_passed": 5,
+    "api_unit_passed": 734,
+    "publication_passed": 45,
+    "unequal_route_generations_passed": 1,
+    "storage_unit_passed": 1074,
+    "storage_unit_ignored_existing": 2,
+    "storage_unit_failed": 1,
+    "storage_failure": "Unchanged wave9_participant_inventory_rejects_links_and_special_files hard-codes /tmp; host /tmp is tmpfs; admission rejects before hostile-file assertion.",
+    "workspace_clippy": "passed",
+    "pre_push_fast": "passed",
+    "gate_registry": "passed"
+  },
+  "limitations": [
+    "Owner maps retain requested identities; existing full-topology validation and full identity sets remain. No new second topology scan.",
+    "Changed Parquet bytes do not bound whole-process I/O, peak temporary allocation, native codec memory or RSS; #1213 owns composed budgets.",
+    "Mixed fixture proves canonical optimistic values and no-run compaction refusal. #1218 owns mixed-edge GFDR compaction integration.",
+    "Existing constructed-parent composite topology mutation UUID authority defect remains #1221.",
+    "No permanent encoding settings changed.",
+    "Runtime and syscall runs are separate; syscall totals include startup, query, portable verification/import and test output. Kernel I/O is cache dependent."
+  ]
+}


### PR DESCRIPTION
Composite property updates on qualified entities succeeded but wrote to `_untyped`, making values invisible to the correctly bound query. Resolve physical property owners once from authenticated identities/bindings and share that plan between canonical staging, GFDR encoding, same-request creates and optimistic conflict baselines. Reject undeclared qualified properties before publication.

First qualified property writes establish semantic schema authority through canonical CAS staging; later supported property updates use GFDR. Refresh property/semantic inventories from authenticated replay output, advance replay property/search counters, and authenticate the installed directory after optimistic CAS promotion. Reuse the existing compaction CAS replacement helper without changing encoding defaults.

Validation:
- Five public fixtures prove exact node/edge values and removals, active snapshots, reopen, export/full verification/clean import, and subsequent mutation. Node-only fixtures exercise actual GFDR compaction; the mixed exploratory/qualified fixture exercises canonical optimistic publication. Mixed-edge GFDR integration remains in the dependent #1218 repair.
- 734 API unit tests, 45 publication tests, and the unequal-route property-generation regression pass. Storage-wide: 1,074 pass, two existing ignores, one unchanged test fails because it hard-codes `/tmp` (tmpfs here), rejected by filesystem admission before its assertions.
- Workspace Clippy, formatting, fast pre-push and gate-registry checks pass. Independent review verified ownership and the promoted-directory correction.
- At 33/4,097 qualified nodes, first property publication changes 4,393 Parquet bytes; the mixed fixture changes 4,494 bytes. Tests enforce a 64 KiB ceiling and exact reuse of unchanged topology payloads. Source-bound CPU/RSS/I/O evidence and limitations are documented in `permanent-storage-assessment.md` and `composite-property-ownership-1224.json`. Existing full-topology validation remains; these figures are not global memory or temporary-disk ceilings.

No compatibility or migration machinery. Constructed-parent topology UUID authority remains the separate #1221 concern.

Closes #1224

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791610823&installation_model_id=20486&pr_number=1225&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1225&signature=c5fdd163549d338212592374783e6540f59032f9a6a9719bc1cfe396aa9be343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->