### PR TITLE
fix(storage): preserve exploratory and qualified routes through replay

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -2002,11 +2002,16 @@ fn assert_exploratory_edge_windows(source: &Path, expected_files: usize, expecte
     let mut rows = 0;
     for entry in entries {
         let path = graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap();
-        let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
-            .unwrap()
-            .with_batch_size(7)
-            .build()
-            .unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap()).unwrap();
+        assert!(builder.metadata().file_metadata().num_rows() <= 1024);
+        assert!(
+            builder
+                .metadata()
+                .row_groups()
+                .iter()
+                .all(|group| group.num_rows() <= 1024)
+        );
+        let reader = builder.with_batch_size(7).build().unwrap();
         for batch in reader {
             let batch = batch.unwrap();
             assert!(batch.num_rows() <= 7);
@@ -2076,11 +2081,36 @@ fn exploratory_construction_groups_bounded_windows_by_physical_route() {
         assert_eq!(evidence.prior_topology_rows_decoded, 0);
         assert!(evidence.encode_application_read_bytes > 0);
         assert!(evidence.encode_application_write_bytes > 0);
-        assert!(evidence.total_application_read_bytes().unwrap() <= evidence.write_bytes * 80);
+        assert!(
+            evidence.peak_batch_bytes <= GraphConstructionBudgets::default().max_batch_bytes as u64
+        );
+        assert!(evidence.peak_batch_bytes <= 128 * 1024);
+        assert!(evidence.peak_accounted_live_bytes <= 4 * 1024 * 1024);
+        assert!(evidence.encode_application_read_bytes <= 1536 * 1024);
+        assert!(evidence.encode_application_write_bytes <= 512 * 1024);
+        assert!(evidence.total_application_read_bytes().unwrap() <= 16 * 1024 * 1024);
+        assert!(evidence.canonical_output_bytes <= 256 * 1024);
+        assert!(evidence.staged_and_retained_disk_bytes <= 640 * 1024);
+        assert!(evidence.storage_transient_peak_total_allocated_bytes <= 2 * 1024 * 1024);
     }
+    let measured = |e: &graphforge_api::GraphConstructionEvidence| {
+        json!({
+            "input_rows": e.input_rows,
+            "canonical_output_bytes": e.canonical_output_bytes,
+            "encode_read_bytes": e.encode_application_read_bytes,
+            "encode_write_bytes": e.encode_application_write_bytes,
+            "total_read_bytes": e.total_application_read_bytes().unwrap(),
+            "staged_and_retained_disk_bytes": e.staged_and_retained_disk_bytes,
+            "peak_batch_rows": e.peak_batch_rows,
+            "peak_batch_bytes": e.peak_batch_bytes,
+            "peak_accounted_live_bytes": e.peak_accounted_live_bytes,
+            "peak_merge_temporary_bytes": e.peak_merge_temporary_bytes,
+            "temporary_allocation_peak_bytes": e.storage_transient_peak_total_allocated_bytes,
+        })
+    };
     println!(
         "PHYSICAL_ROUTE_WINDOW_RESOURCES {}",
-        json!({"parent":parent_evidence,"child":child_evidence})
+        json!({"parent":measured(&parent_evidence),"child":measured(&child_evidence)})
     );
     let graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
@@ -2202,18 +2232,18 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
     let source = root.path().join("source");
     let fixture = Fixture {
         name: "mixed_semantic_routes",
-        nodes: 66,
+        nodes: 33,
         edges: 258,
-        routes: 2,
+        routes: 1,
         identifiers: Identifiers::Random,
         properties: false,
         adjacency: false,
         heterogeneous: false,
     };
-    let (nodes, mut edges) = rows(fixture);
+    let (mut nodes, mut edges) = rows(fixture);
     construct(&source, fixture, &nodes, &edges[..129]);
     let ontology = root.path().join("routes.yaml");
-    std::fs::write(&ontology, "ontology_id: mixed\nversion: \"1\"\nentity_types:\n  - name: Node0\n    abstract: false\n  - name: Node1\n    abstract: false\nrelation_types:\n  - name: NEW_TYPED\n    src: Node0\n    dst: Node1\nproperties:\n  - owner: Node0\n    name: score\n    type: int64\n    nullable: true\n").unwrap();
+    std::fs::write(&ontology, "ontology_id: https://example.test/mixed\nversion: \"1\"\nentity_types:\n  - name: NewNode\n    abstract: false\nrelation_types:\n  - name: NEW_TYPED\n    src: NewNode\n    dst: NewNode\nproperties:\n  - owner: NewNode\n    name: score\n    type: int64\n    nullable: true\n").unwrap();
     let mut graph = GraphForge::new(source.to_str()).unwrap();
     graph
         .adopt_ontology(AdoptOntologyRequest {
@@ -2226,10 +2256,58 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
         })
         .unwrap();
     drop(graph);
-    for edge in &mut edges[129..] {
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    let candidate = graph.workspace_ontology_composition().unwrap().unwrap();
+    let request = graphforge_api::CompositionChangeRequest {
+        context: WriteContext {
+            operation_uuid: OperationId(Uuid::now_v7()),
+            actor_uuid: None,
+        },
+        expected_project_generation_uuid: graphforge_storage::resolve_project_generation(&source)
+            .unwrap()
+            .generation_uuid(),
+        expected_composition_fingerprint: Some(candidate.composition_fingerprint.clone()),
+        candidate,
+        data_disposition: graphforge_api::CompositionDataDisposition::RequireConforming,
+    };
+    let preview = graph
+        .preview_ontology_composition_change(&request, None)
+        .unwrap();
+    assert!(preview.diagnostics.is_empty(), "{:?}", preview.diagnostics);
+    graph
+        .publish_ontology_composition_change(&request, &preview, None)
+        .unwrap();
+    drop(graph);
+    let child_nodes = (0..33)
+        .map(|row| (id(3, row, true), "NewNode".to_owned(), None))
+        .collect::<Vec<_>>();
+    let changed_node = child_nodes[0].0;
+    for (row, edge) in edges[129..].iter_mut().enumerate() {
         edge.3 = "NEW_TYPED".into();
+        edge.1 = child_nodes[row % child_nodes.len()].0;
+        edge.2 = child_nodes[(row + 1) % child_nodes.len()].0;
     }
-    construct(&source, fixture, &[], &edges[129..]);
+    construct(&source, fixture, &child_nodes, &edges[129..]);
+    nodes.extend(child_nodes.into_iter().map(|mut node| {
+        node.1 = "mixed:entity:NewNode".into();
+        node
+    }));
+    let current = graphforge_storage::resolve_project_generation(&source).unwrap();
+    let bindings = graphforge_storage::semantic_storage_bindings(&current)
+        .unwrap()
+        .unwrap();
+    let relation = bindings
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.route_kind == graphforge_storage::SemanticRouteKind::Relation
+                && binding.symbol.local_id == "NEW_TYPED"
+        })
+        .unwrap();
+    assert_eq!(relation.symbol.display(), "mixed:relation:NEW_TYPED");
+    for edge in &mut edges[129..] {
+        edge.3.clone_from(&relation.route);
+    }
     let graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     let schemas = |source: &Path| {
@@ -2281,7 +2359,7 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
                 actor_uuid: None,
             },
             graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
-                node_uuid: nodes[0].0,
+                node_uuid: changed_node,
                 property: "score".into(),
                 value: PropValue::Int(123),
             }],
@@ -2303,6 +2381,8 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
         )
         .unwrap();
     assert_eq!(before, schemas(&source));
+    drop(graph);
+    let graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     let score_query = "MATCH (n) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score";
     let expected_score = graph.execute(score_query).unwrap();
@@ -2314,7 +2394,7 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
             .sum::<usize>(),
         1
     );
-    assert_eq!(uuid_at(&expected_score.batches[0], 0, 0), nodes[0].0);
+    assert_eq!(uuid_at(&expected_score.batches[0], 0, 0), changed_node);
     assert_eq!(int_at(&expected_score.batches[0], 1, 0), Some(123));
     drop(graph);
     round_trip(root.path(), &source, fixture, &nodes, &edges);
@@ -2335,4 +2415,70 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
                 .collect::<Vec<_>>()
         );
     }
+}
+
+#[test]
+fn exploratory_coalesced_routes_reject_oversized_encoding_before_publication() {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "long_routes",
+        nodes: 2,
+        edges: 64,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: false,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (nodes, mut edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &[]);
+    let before = graphforge_storage::resolve_project_generation(&source).unwrap();
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let mut session = graph
+        .begin_graph_construction(GraphConstructionBudgets {
+            max_batch_rows: 64,
+            max_batch_bytes: 16 * 1024,
+            max_run_records: 256,
+            merge_fan_in: 2,
+            ..Default::default()
+        })
+        .unwrap();
+    for (row, edge) in edges.iter_mut().enumerate() {
+        edge.3 = format!("R{}_{}", row % 2, "x".repeat(197));
+    }
+    for (chunk, rows) in edges.chunks(4).enumerate() {
+        let batch = RecordBatch::try_new(
+            CONSTRUCTION_EDGE_SCHEMA.clone(),
+            vec![
+                uuids(rows.iter().map(|row| row.0)),
+                Arc::new(StringArray::from_iter_values(
+                    rows.iter().map(|row| row.3.as_str()),
+                )),
+                uuids(rows.iter().map(|row| row.1)),
+                uuids(rows.iter().map(|row| row.2)),
+            ],
+        )
+        .unwrap();
+        session
+            .append_edges(&format!("edges-{chunk}"), &batch)
+            .unwrap();
+    }
+    let error = session.seal_and_publish().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("decoded canonical batch exceeds encoding budget"),
+        "{error}"
+    );
+    let after = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert_eq!(before.generation_uuid(), after.generation_uuid());
+    assert_eq!(
+        before.graph_files_inventory().unwrap(),
+        after.graph_files_inventory().unwrap()
+    );
+    drop(session);
+    drop(graph);
+    let reopened = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&reopened, fixture, &nodes, &[]);
 }

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -97,7 +97,12 @@ fn uuids(ids: impl Iterator<Item = Uuid>) -> ArrayRef {
     Arc::new(FixedSizeBinaryArray::try_from_iter(ids.map(|id| *id.as_bytes())).unwrap())
 }
 
-fn construct(path: &Path, f: Fixture, nodes: &[Node], edges: &[Edge]) {
+fn construct(
+    path: &Path,
+    f: Fixture,
+    nodes: &[Node],
+    edges: &[Edge],
+) -> graphforge_api::GraphConstructionEvidence {
     let graph = GraphForge::new(path.to_str()).unwrap();
     let mut session = graph
         .begin_graph_construction(GraphConstructionBudgets {
@@ -158,6 +163,7 @@ fn construct(path: &Path, f: Fixture, nodes: &[Node], edges: &[Edge]) {
             .unwrap();
     }
     session.seal_and_publish().unwrap();
+    session.progress().evidence.clone()
 }
 
 fn uuid_at(batch: &RecordBatch, column: usize, row: usize) -> Uuid {
@@ -2031,7 +2037,7 @@ fn exploratory_construction_groups_bounded_windows_by_physical_route() {
     let fixture = Fixture {
         name: "physical_route_windows",
         nodes: 66,
-        edges: 258,
+        edges: 4097,
         routes: 2,
         identifiers: Identifiers::Random,
         properties: true,
@@ -2039,15 +2045,15 @@ fn exploratory_construction_groups_bounded_windows_by_physical_route() {
         heterogeneous: true,
     };
     let (nodes, edges) = rows(fixture);
-    construct(&source, fixture, &nodes, &edges[..129]);
-    assert_exploratory_edge_windows(&source, 1, 129);
+    let parent_evidence = construct(&source, fixture, &nodes, &edges[..2048]);
+    assert_exploratory_edge_windows(&source, 2, 2048);
     let parent = graphforge_storage::resolve_project_generation(&source)
         .unwrap()
         .graph_files_inventory()
         .unwrap()
         .unwrap();
-    construct(&source, fixture, &[], &edges[129..]);
-    assert_exploratory_edge_windows(&source, 2, 258);
+    let child_evidence = construct(&source, fixture, &[], &edges[2048..]);
+    assert_exploratory_edge_windows(&source, 5, 4097);
     let child = graphforge_storage::resolve_project_generation(&source)
         .unwrap()
         .graph_files_inventory()
@@ -2063,6 +2069,19 @@ fn exploratory_construction_groups_bounded_windows_by_physical_route() {
             "parent edge payloads remain byte-identical"
         );
     }
+    for evidence in [&parent_evidence, &child_evidence] {
+        assert!(evidence.peak_batch_rows <= 1024);
+        assert!(evidence.peak_run_records <= 4096);
+        assert!(evidence.peak_merge_inputs <= 2);
+        assert_eq!(evidence.prior_topology_rows_decoded, 0);
+        assert!(evidence.encode_application_read_bytes > 0);
+        assert!(evidence.encode_application_write_bytes > 0);
+        assert!(evidence.total_application_read_bytes().unwrap() <= evidence.write_bytes * 80);
+    }
+    println!(
+        "PHYSICAL_ROUTE_WINDOW_RESOURCES {}",
+        json!({"parent":parent_evidence,"child":child_evidence})
+    );
     let graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     drop(graph);
@@ -2080,7 +2099,7 @@ fn exploratory_parent_construction_replays_and_compacts_exact_routes() {
     let fixture = Fixture {
         name: "publishing_policy",
         nodes: 66,
-        edges: 258,
+        edges: 4097,
         routes: 2,
         identifiers: Identifiers::Random,
         properties: true,
@@ -2088,8 +2107,8 @@ fn exploratory_parent_construction_replays_and_compacts_exact_routes() {
         heterogeneous: true,
     };
     let (mut nodes, edges) = rows(fixture);
-    construct(&source, fixture, &nodes, &edges[..129]);
-    construct(&source, fixture, &[], &edges[129..]);
+    construct(&source, fixture, &nodes, &edges[..2048]);
+    construct(&source, fixture, &[], &edges[2048..]);
     let graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     drop(graph);
@@ -2098,6 +2117,11 @@ fn exploratory_parent_construction_replays_and_compacts_exact_routes() {
         CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
     };
     let graph = GraphForge::new(source.to_str()).unwrap();
+    let snapshot_query = "MATCH (n) RETURN n.node_uuid, n.score ORDER BY n.node_uuid";
+    let expected_snapshot = graph.execute(snapshot_query).unwrap();
+    let (old_stream, _, _snapshot_guard) = graph
+        .execute_stream_owned(snapshot_query, &Default::default())
+        .unwrap();
     graph
         .publish_composite_transaction(CompositeTransactionRequest {
             contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
@@ -2131,8 +2155,184 @@ fn exploratory_parent_construction_replays_and_compacts_exact_routes() {
             None,
         )
         .unwrap();
+    use futures::TryStreamExt as _;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let old_batches: Vec<RecordBatch> = runtime.block_on(old_stream.try_collect()).unwrap();
+    assert_eq!(
+        old_batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>(),
+        expected_snapshot
+            .batches
+            .iter()
+            .map(|batch| batch.columns())
+            .collect::<Vec<_>>()
+    );
+    drop(graph);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    graph
+        .execute("MATCH (n) WHERE n.score IS NOT NULL SET n.score = n.score + 1")
+        .unwrap();
+    for node in &mut nodes {
+        node.2 = node.2.map(|score| score + 1);
+    }
+    verify_graph(&graph, fixture, &nodes, &edges);
     drop(graph);
     let portable = root.path().join("compaction-portable");
     std::fs::create_dir(&portable).unwrap();
     round_trip(&portable, &source, fixture, &nodes, &edges);
+}
+
+#[test]
+fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
+    use graphforge_api::{
+        AdoptOntologyRequest, COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation,
+        CompositeKnowledgeParticipants, CompositeTransactionRequest, OntologyMode, PropValue,
+        WriteContext,
+    };
+    use graphforge_storage::{
+        GraphDeltaCompactionLimits, GraphDeltaCompactionRequest, ProjectRetentionLimits,
+        ProjectRetentionPolicy,
+    };
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "mixed_semantic_routes",
+        nodes: 66,
+        edges: 258,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: false,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (nodes, mut edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges[..129]);
+    let ontology = root.path().join("routes.yaml");
+    std::fs::write(&ontology, "ontology_id: mixed\nversion: \"1\"\nentity_types:\n  - name: Node0\n    abstract: false\n  - name: Node1\n    abstract: false\nrelation_types:\n  - name: NEW_TYPED\n    src: Node0\n    dst: Node1\nproperties:\n  - owner: Node0\n    name: score\n    type: int64\n    nullable: true\n").unwrap();
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    graph
+        .adopt_ontology(AdoptOntologyRequest {
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            path: ontology,
+            mode: OntologyMode::Advisory,
+        })
+        .unwrap();
+    drop(graph);
+    for edge in &mut edges[129..] {
+        edge.3 = "NEW_TYPED".into();
+    }
+    construct(&source, fixture, &[], &edges[129..]);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let schemas = |source: &Path| {
+        let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+        let generation_owned = selected.declared_graph_files_inventory().unwrap().is_some();
+        let inventory = selected.graph_files_inventory().unwrap().unwrap();
+        let mut schemas = BTreeMap::new();
+        for entry in inventory
+            .files
+            .iter()
+            .filter(|entry| entry.relative_path.starts_with("topology/edges/"))
+        {
+            let path = if generation_owned {
+                selected.graph_tree_root().join(&entry.relative_path)
+            } else {
+                graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap()
+            };
+            let reader =
+                ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap()).unwrap();
+            let schema = reader.schema().clone();
+            let key = if schema.index_of("rel_type_name").is_ok() {
+                "exploratory".to_owned()
+            } else {
+                let route = schema
+                    .metadata()
+                    .get(graphforge_storage::SEMANTIC_ROUTE_METADATA_KEY)
+                    .unwrap();
+                assert!(
+                    schema
+                        .metadata()
+                        .contains_key(graphforge_storage::SEMANTIC_COMPOSITION_METADATA_KEY)
+                );
+                route.clone()
+            };
+            if let Some(previous) = schemas.insert(key, schema.clone()) {
+                assert_eq!(previous, schema);
+            }
+        }
+        assert_eq!(schemas.len(), 2);
+        assert!(schemas.contains_key("exploratory"));
+        schemas
+    };
+    let before = schemas(&source);
+    graph
+        .publish_composite_transaction(CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
+                node_uuid: nodes[0].0,
+                property: "score".into(),
+                value: PropValue::Int(123),
+            }],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        })
+        .unwrap();
+    graph
+        .compact_graph_delta(
+            &GraphDeltaCompactionRequest {
+                transaction_uuid: Uuid::now_v7(),
+                generation_uuid: Uuid::now_v7(),
+                through_run_sequence: None,
+                limits: GraphDeltaCompactionLimits::default(),
+                cleanup_after_commit: false,
+                cleanup_policy: ProjectRetentionPolicy::default(),
+                cleanup_limits: ProjectRetentionLimits::default(),
+            },
+            None,
+        )
+        .unwrap();
+    assert_eq!(before, schemas(&source));
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let score_query = "MATCH (n) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score";
+    let expected_score = graph.execute(score_query).unwrap();
+    assert_eq!(
+        expected_score
+            .batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>(),
+        1
+    );
+    assert_eq!(uuid_at(&expected_score.batches[0], 0, 0), nodes[0].0);
+    assert_eq!(int_at(&expected_score.batches[0], 1, 0), Some(123));
+    drop(graph);
+    round_trip(root.path(), &source, fixture, &nodes, &edges);
+    for path in [&source, &root.path().join("imported")] {
+        let reopened = GraphForge::new(path.to_str()).unwrap();
+        assert_eq!(
+            reopened
+                .execute(score_query)
+                .unwrap()
+                .batches
+                .iter()
+                .map(|batch| batch.columns())
+                .collect::<Vec<_>>(),
+            expected_score
+                .batches
+                .iter()
+                .map(|batch| batch.columns())
+                .collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -2351,21 +2351,34 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
         schemas
     };
     let before = schemas(&source);
-    graph
-        .publish_composite_transaction(CompositeTransactionRequest {
-            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
-            context: WriteContext {
-                operation_uuid: OperationId(Uuid::now_v7()),
-                actor_uuid: None,
-            },
-            graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
-                node_uuid: changed_node,
-                property: "score".into(),
-                value: PropValue::Int(123),
-            }],
-            knowledge: CompositeKnowledgeParticipants::default(),
-        })
-        .unwrap();
+    // First write establishes qualified schema authority; the next is real GFDR.
+    for score in [122, 123] {
+        graph
+            .publish_composite_transaction(CompositeTransactionRequest {
+                contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                context: WriteContext {
+                    operation_uuid: OperationId(Uuid::now_v7()),
+                    actor_uuid: None,
+                },
+                graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
+                    node_uuid: changed_node,
+                    property: "score".into(),
+                    value: PropValue::Int(score),
+                }],
+                knowledge: CompositeKnowledgeParticipants::default(),
+            })
+            .unwrap();
+    }
+    let delta = graphforge_storage::resolve_project_generation(&source).unwrap();
+    assert_eq!(
+        graphforge_storage::list_delta_runs(
+            &delta.graph_files_inventory().unwrap().unwrap(),
+            Default::default()
+        )
+        .unwrap()
+        .len(),
+        1
+    );
     graph
         .compact_graph_delta(
             &GraphDeltaCompactionRequest {
@@ -2384,7 +2397,8 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
     drop(graph);
     let graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
-    let score_query = "MATCH (n) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score";
+    let score_query =
+        "MATCH (n:`mixed:NewNode`) WHERE n.score IS NOT NULL RETURN n.node_uuid, n.score";
     let expected_score = graph.execute(score_query).unwrap();
     assert_eq!(
         expected_score

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -1978,3 +1978,161 @@ fn composite_qualified_create_then_set_preserves_node_and_edge_owners() {
             .collect::<Vec<_>>()
     );
 }
+
+fn assert_exploratory_edge_windows(source: &Path, expected_files: usize, expected_rows: usize) {
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let inventory = selected.graph_files_inventory().unwrap().unwrap();
+    let entries = inventory
+        .files
+        .iter()
+        .filter(|entry| entry.relative_path.starts_with("topology/edges/"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        entries.len(),
+        expected_files,
+        "one fragment per physical route and bounded window"
+    );
+    let mut previous = 0_u64;
+    let mut rows = 0;
+    for entry in entries {
+        let path = graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
+            .unwrap()
+            .with_batch_size(7)
+            .build()
+            .unwrap();
+        for batch in reader {
+            let batch = batch.unwrap();
+            assert!(batch.num_rows() <= 7);
+            assert!(batch.column_by_name("rel_type_name").is_some());
+            let ids = batch
+                .column_by_name("edge_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow::array::UInt64Array>()
+                .unwrap();
+            for id in ids.values() {
+                assert!(
+                    *id > previous,
+                    "physical fragments must concatenate in strict surrogate order"
+                );
+                previous = *id;
+                rows += 1;
+            }
+        }
+    }
+    assert_eq!(rows, expected_rows);
+}
+
+#[test]
+fn exploratory_construction_groups_bounded_windows_by_physical_route() {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "physical_route_windows",
+        nodes: 66,
+        edges: 258,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: true,
+    };
+    let (nodes, edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges[..129]);
+    assert_exploratory_edge_windows(&source, 1, 129);
+    let parent = graphforge_storage::resolve_project_generation(&source)
+        .unwrap()
+        .graph_files_inventory()
+        .unwrap()
+        .unwrap();
+    construct(&source, fixture, &[], &edges[129..]);
+    assert_exploratory_edge_windows(&source, 2, 258);
+    let child = graphforge_storage::resolve_project_generation(&source)
+        .unwrap()
+        .graph_files_inventory()
+        .unwrap()
+        .unwrap();
+    for entry in parent
+        .files
+        .iter()
+        .filter(|entry| entry.relative_path.starts_with("topology/edges/"))
+    {
+        assert!(
+            child.files.contains(entry),
+            "parent edge payloads remain byte-identical"
+        );
+    }
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    drop(graph);
+    round_trip(root.path(), &source, fixture, &nodes, &edges);
+}
+
+#[test]
+fn exploratory_parent_construction_replays_and_compacts_exact_routes() {
+    use graphforge_storage::{
+        GraphDeltaCompactionLimits, GraphDeltaCompactionRequest, ProjectRetentionLimits,
+        ProjectRetentionPolicy,
+    };
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "publishing_policy",
+        nodes: 66,
+        edges: 258,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: true,
+    };
+    let (mut nodes, edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges[..129]);
+    construct(&source, fixture, &[], &edges[129..]);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    drop(graph);
+    use graphforge_api::{
+        COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation,
+        CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
+    };
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    graph
+        .publish_composite_transaction(CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![CompositeGraphMutation::SetNodeProperty {
+                node_uuid: nodes[0].0,
+                property: "score".into(),
+                value: PropValue::Int(123),
+            }],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        })
+        .unwrap();
+    drop(graph);
+    nodes[0].2 = Some(123);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    graph
+        .compact_graph_delta(
+            &GraphDeltaCompactionRequest {
+                transaction_uuid: Uuid::from_u128(121305),
+                generation_uuid: Uuid::from_u128(121306),
+                through_run_sequence: None,
+                limits: GraphDeltaCompactionLimits::default(),
+                cleanup_after_commit: false,
+                cleanup_policy: ProjectRetentionPolicy::default(),
+                cleanup_limits: ProjectRetentionLimits::default(),
+            },
+            None,
+        )
+        .unwrap();
+    drop(graph);
+    let portable = root.path().join("compaction-portable");
+    std::fs::create_dir(&portable).unwrap();
+    round_trip(&portable, &source, fixture, &nodes, &edges);
+}

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -1593,8 +1593,11 @@ fn encode_edges(
                 shape.runtime_catalog_now_micros,
             )?;
             account_batch(&canonical, budgets, evidence)?;
-            for (route, output_indexes) in groups {
-                let mut selected = select_rows(&canonical, &output_indexes)?;
+            // Canonical ordering belongs to the physical route. Several
+            // logical exploratory relationships can share that route.
+            let mut physical_groups = BTreeMap::<(String, bool, bool), Vec<u32>>::new();
+            let mut logical_routes = vec![""; canonical.num_rows()];
+            for (route, output_indexes) in &groups {
                 let runtime_route = if ontology_mode == OntologyMode::Exploratory {
                     "_exploratory"
                 } else {
@@ -1605,32 +1608,57 @@ fn encode_edges(
                     semantic_bindings,
                     SymbolKind::Relation,
                     SemanticRouteKind::Relation,
-                    &route,
+                    route,
                     runtime_route,
                 )?;
-                let topology_route =
-                    if owner.symbol.is_none() && ontology_mode == OntologyMode::Exploratory {
-                        let routes = StringArray::from(vec![route.as_str(); selected.num_rows()]);
-                        let mut columns = selected.columns().to_vec();
-                        columns.push(Arc::new(routes));
-                        selected = RecordBatch::try_new(
-                            crate::schemas::EXPLORATORY_EDGE_SCHEMA.clone(),
-                            columns,
-                        )
-                        .map_err(storage)?;
-                        "_exploratory"
-                    } else {
-                        owner.topology_route.as_str()
-                    };
-                if owner.symbol.is_some() {
+                let exploratory =
+                    owner.symbol.is_none() && ontology_mode == OntologyMode::Exploratory;
+                let topology_route = if exploratory {
+                    "_exploratory"
+                } else {
+                    owner.topology_route.as_str()
+                };
+                if exploratory {
+                    for index in output_indexes {
+                        logical_routes[*index as usize] = route;
+                    }
+                }
+                physical_groups
+                    .entry((
+                        topology_route.to_owned(),
+                        owner.symbol.is_some(),
+                        exploratory,
+                    ))
+                    .or_default()
+                    .extend(output_indexes);
+            }
+            for ((topology_route, qualified, exploratory), mut output_indexes) in physical_groups {
+                output_indexes.sort_unstable();
+                let mut selected = select_rows(&canonical, &output_indexes)?;
+                if exploratory {
+                    let routes = StringArray::from_iter_values(
+                        output_indexes
+                            .iter()
+                            .map(|index| logical_routes[*index as usize]),
+                    );
+                    let mut columns = selected.columns().to_vec();
+                    columns.push(Arc::new(routes));
+                    selected = RecordBatch::try_new(
+                        crate::schemas::EXPLORATORY_EDGE_SCHEMA.clone(),
+                        columns,
+                    )
+                    .map_err(storage)?;
+                }
+                if qualified {
                     selected = with_route_metadata_batch(
                         &selected,
-                        topology_route,
+                        &topology_route,
                         semantic_context
                             .expect("qualified owner has context")
                             .fingerprint(),
                     )?;
                 }
+                account_batch(&selected, budgets, evidence)?;
                 let ids = selected
                     .column_by_name("edge_id")
                     .and_then(|array| array.as_any().downcast_ref::<UInt64Array>())
@@ -1639,7 +1667,7 @@ fn encode_edges(
                 let last = ids.value(ids.len() - 1);
                 let path = format!(
                     "topology/edges/{}/{first:020}-{last:020}.parquet",
-                    encoded_route_component(route_table, topology_route)?
+                    encoded_route_component(route_table, &topology_route)?
                 );
                 artifacts.push(write_parquet(
                     output,

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -383,6 +383,10 @@ impl AuthenticatedPropertyInventory {
             .collect()
     }
 
+    pub(crate) fn has_edge_route(&self, route: &str) -> bool {
+        self.edge_routes.contains_key(route)
+    }
+
     pub(crate) fn edge_rewrite_files(&self) -> impl Iterator<Item = (&str, &Path, &str)> {
         self.edge_routes.iter().flat_map(|(route, files)| {
             files.iter().map(move |file| {

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -717,12 +717,13 @@ fn stream_replay_edges(
         .into_iter()
         .map(|(route, _)| route)
         .collect::<std::collections::BTreeSet<_>>();
+    let exploratory = relations.contains("_exploratory");
     relations.extend(
         overlay
             .edges
             .values()
             .filter_map(Option::as_ref)
-            .map(|edge| edge.rel_type.clone()),
+            .map(|edge| replay_edge_physical_route(edge, inventory, exploratory).to_owned()),
     );
     let relation_authority_bytes = relations.iter().fold(0_usize, |sum, relation| {
         sum.saturating_add(64).saturating_add(relation.len())
@@ -734,10 +735,25 @@ fn stream_replay_edges(
         let mut existing_overlay = HashSet::new();
         let mut base_max = 0_u64;
         let mut base_rows = 0_usize;
+        let mut output_schema: Option<SchemaRef> = None;
+        let mut maximum_row_bytes = 128_usize;
+        let expected_schema = if relation == "_exploratory" {
+            crate::schemas::EXPLORATORY_EDGE_SCHEMA.clone()
+        } else {
+            TYPED_EDGE_SCHEMA.clone()
+        };
         for (_, source_path) in &source_paths {
             let input = fs::File::open(source_path).map_err(|error| io_err(&error))?;
-            let reader = ParquetRecordBatchReaderBuilder::try_new(input)
-                .map_err(pq_err)?
+            let builder = ParquetRecordBatchReaderBuilder::try_new(input).map_err(pq_err)?;
+            if builder.schema().fields() != expected_schema.fields()
+                || output_schema
+                    .as_ref()
+                    .is_some_and(|schema| schema != builder.schema())
+            {
+                return Err(pq_err("canonical edge route schemas differ"));
+            }
+            output_schema = Some(builder.schema().clone());
+            let reader = builder
                 .with_batch_size(limits.max_batch_rows)
                 .build()
                 .map_err(pq_err)?;
@@ -763,6 +779,19 @@ fn stream_replay_edges(
                             "GF_UNSUPPORTED_PROJECT_FORMAT: retained edge references deleted node",
                         ));
                     }
+                    if relation == "_exploratory" {
+                        let types = batch
+                            .column_by_name("rel_type_name")
+                            .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+                            .ok_or_else(|| {
+                                pq_err("canonical exploratory relationship is incompatible")
+                            })?;
+                        if types.is_null(row) || types.value(row).is_empty() {
+                            return Err(pq_err("canonical exploratory relationship is absent"));
+                        }
+                        maximum_row_bytes =
+                            maximum_row_bytes.max(128_usize.saturating_add(types.value(row).len()));
+                    }
                     let id = ids.value(row);
                     if id <= base_max {
                         return Err(pq_err("canonical edge_id order is not strictly increasing"));
@@ -783,10 +812,22 @@ fn stream_replay_edges(
                 }
             }
         }
+        let output_schema = output_schema.unwrap_or(expected_schema);
+        if relation == "_exploratory" {
+            maximum_row_bytes = maximum_row_bytes.max(
+                overlay
+                    .edges
+                    .values()
+                    .filter_map(Option::as_ref)
+                    .map(|edge| 128_usize.saturating_add(edge.rel_type.len()))
+                    .max()
+                    .unwrap_or(128),
+            );
+        }
         let mut new_ids = HashSet::new();
         for (uuid, row) in &overlay.edges {
             if let Some(row) = row
-                && row.rel_type == relation
+                && replay_edge_physical_route(row, inventory, exploratory) == relation
                 && !existing_overlay.contains(uuid.as_str())
                 && (row.edge_id <= base_max || !new_ids.insert(row.edge_id))
             {
@@ -797,9 +838,9 @@ fn stream_replay_edges(
         }
         let maximum_edge_rows = base_rows.saturating_add(overlay.edges.len());
         let edge_writer_reservation = replay_writer_reservation(
-            TYPED_EDGE_SCHEMA.as_ref(),
+            output_schema.as_ref(),
             maximum_edge_rows,
-            128,
+            maximum_row_bytes,
             limits.max_batch_rows,
         )?;
         let route_authority_bytes = existing_overlay
@@ -825,7 +866,7 @@ fn stream_replay_edges(
         let output = fs::File::create(&target_path).map_err(|error| io_err(&error))?;
         let mut writer = parquet::arrow::ArrowWriter::try_new(
             output,
-            TYPED_EDGE_SCHEMA.clone(),
+            output_schema.clone(),
             Some(replay_writer_properties(limits.max_batch_rows)),
         )
         .map_err(pq_err)?;
@@ -848,9 +889,17 @@ fn stream_replay_edges(
                 for row in 0..batch.num_rows() {
                     let uuid = canonical_uuid(uuids.value(row), "edge_uuid")?;
                     match overlay.edges.get(&uuid) {
-                        Some(Some(replacement)) if replacement.rel_type == relation => writer
-                            .write(&replay_edge_batch(&[replacement])?)
-                            .map_err(pq_err)?,
+                        Some(Some(replacement))
+                            if replay_edge_physical_route(replacement, inventory, exploratory)
+                                == relation =>
+                        {
+                            writer
+                                .write(&replay_edge_batch_with_schema(
+                                    &[replacement],
+                                    &output_schema,
+                                )?)
+                                .map_err(pq_err)?;
+                        }
                         Some(_) => {}
                         None => writer.write(&batch.slice(row, 1)).map_err(pq_err)?,
                     }
@@ -861,14 +910,17 @@ fn stream_replay_edges(
             .edges
             .iter()
             .filter(|(uuid, row)| {
-                row.as_ref().is_some_and(|edge| edge.rel_type == relation)
-                    && !existing_overlay.contains(uuid.as_str())
+                row.as_ref().is_some_and(|edge| {
+                    replay_edge_physical_route(edge, inventory, exploratory) == relation
+                }) && !existing_overlay.contains(uuid.as_str())
             })
             .filter_map(|(_, row)| row.as_ref())
             .collect();
         appended.sort_by_key(|edge| edge.edge_id);
         for chunk in appended.chunks(limits.max_batch_rows) {
-            writer.write(&replay_edge_batch(chunk)?).map_err(pq_err)?;
+            writer
+                .write(&replay_edge_batch_with_schema(chunk, &output_schema)?)
+                .map_err(pq_err)?;
             writer.flush().map_err(pq_err)?;
         }
         writer.close().map_err(pq_err)?;
@@ -895,6 +947,32 @@ fn canonical_uuid(bytes: &[u8], field: &str) -> Result<String, GfError> {
     uuid::Uuid::from_slice(bytes)
         .map(|value| value.hyphenated().to_string())
         .map_err(|error| pq_err(format!("canonical {field} is invalid: {error}")))
+}
+
+fn replay_edge_physical_route<'a>(
+    edge: &'a crate::graph_delta_journal::ReplayEdgeRow,
+    inventory: &crate::AuthenticatedPropertyInventory,
+    exploratory: bool,
+) -> &'a str {
+    if exploratory && !inventory.has_edge_route(&edge.rel_type) {
+        "_exploratory"
+    } else {
+        &edge.rel_type
+    }
+}
+
+fn replay_edge_batch_with_schema(
+    rows: &[&crate::graph_delta_journal::ReplayEdgeRow],
+    schema: &SchemaRef,
+) -> Result<RecordBatch, GfError> {
+    let typed = replay_edge_batch(rows)?;
+    let mut columns = typed.columns().to_vec();
+    if schema.index_of("rel_type_name").is_ok() {
+        columns.push(Arc::new(StringArray::from_iter_values(
+            rows.iter().map(|edge| edge.rel_type.as_str()),
+        )));
+    }
+    RecordBatch::try_new(Arc::clone(schema), columns).map_err(pq_err)
 }
 
 fn replay_edge_batch(
@@ -6491,6 +6569,127 @@ mod tests {
                 "weight"
             ),
             None
+        );
+    }
+
+    #[test]
+    fn exploratory_replay_preserves_routes_and_full_width_ids_for_edge_changes() {
+        use crate::graph_delta_journal::{GraphDeltaJournalLimits, ReplayEdgeRow, ReplayOverlay};
+        let base = TempDir::new().unwrap();
+        let left = new_v7();
+        let right = new_v7();
+        let first = new_v7();
+        let deleted = new_v7();
+        let added = new_v7();
+        let left_id = u64::MAX - 2;
+        let right_id = u64::MAX - 1;
+        let first_id = u64::from(u32::MAX) - 1;
+        let mut writer = GraphWriter::open_at(base.path(), OntologyMode::Exploratory, TS).unwrap();
+        writer.next_node_id = left_id;
+        writer.next_edge_id = first_id;
+        writer
+            .create_node(left, EntityTypeId::decode(0).unwrap())
+            .unwrap();
+        writer
+            .create_node(right, EntityTypeId::decode(0).unwrap())
+            .unwrap();
+        writer.create_edge(first, "KNOWS", &left, &right).unwrap();
+        writer.create_edge(deleted, "LIKES", &left, &right).unwrap();
+        writer.flush().unwrap();
+        let original = crate::graph_delta_journal::load_base_state(base.path()).unwrap();
+        let edge = |uuid: Uuid, id, rel_type: &str, reversed| ReplayEdgeRow {
+            edge_uuid: uuid.to_string(),
+            edge_id: id,
+            rel_type: rel_type.into(),
+            src_uuid: if reversed { right } else { left }.to_string(),
+            dst_uuid: if reversed { left } else { right }.to_string(),
+            src_id: if reversed { right_id } else { left_id },
+            dst_id: if reversed { left_id } else { right_id },
+            created_at_micros: TS,
+        };
+        let mut overlay = ReplayOverlay::default();
+        overlay.edges.insert(
+            first.to_string(),
+            Some(edge(first, first_id, "LIKES", true)),
+        );
+        overlay.edges.insert(deleted.to_string(), None);
+        overlay.edges.insert(
+            added.to_string(),
+            Some(edge(added, first_id + 2, "KNOWS", false)),
+        );
+        let apply = |source: &Path, overlay: &ReplayOverlay| -> Result<TempDir, GfError> {
+            let target = TempDir::new().unwrap();
+            let (inventory, _) = crate::capture_graph_files(source)?;
+            crate::graph_files::materialize_graph_tree(source, &inventory, target.path())?;
+            write_replay_overlay_streaming(
+                source,
+                &inventory,
+                target.path(),
+                overlay,
+                GraphDeltaJournalLimits {
+                    max_batch_rows: 1,
+                    max_replay_memory_bytes: 2 * 1024 * 1024,
+                    ..Default::default()
+                },
+            )?;
+            Ok(target)
+        };
+        let target = apply(base.path(), &overlay).unwrap();
+        let actual = crate::graph_delta_journal::load_base_state(target.path()).unwrap();
+        assert_eq!(actual.node_ids, original.node_ids);
+        assert_eq!(actual.node_ids[&left.to_string()], left_id);
+        assert_eq!(actual.node_ids[&right.to_string()], right_id);
+        assert_eq!(
+            actual.edge_ids[&first.to_string()],
+            (first_id, right_id, left_id)
+        );
+        assert_eq!(
+            actual.edge_ids[&added.to_string()],
+            (first_id + 2, left_id, right_id)
+        );
+        assert_eq!(
+            actual.edges[&first.to_string()],
+            (right.to_string(), left.to_string(), "LIKES".into())
+        );
+        assert_eq!(
+            actual.edges[&added.to_string()],
+            (left.to_string(), right.to_string(), "KNOWS".into())
+        );
+        assert!(!actual.edges.contains_key(&deleted.to_string()));
+        let again = apply(target.path(), &ReplayOverlay::default()).unwrap();
+        assert_eq!(
+            crate::graph_delta_journal::load_base_state(again.path()).unwrap(),
+            actual
+        );
+        assert_eq!(
+            crate::graph_delta_journal::load_base_state(base.path()).unwrap(),
+            original
+        );
+        let mut changed = overlay.clone();
+        changed
+            .edges
+            .get_mut(&first.to_string())
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .edge_id += 1;
+        assert!(
+            apply(base.path(), &changed)
+                .unwrap_err()
+                .to_string()
+                .contains("edge surrogate changed")
+        );
+        let duplicate = new_v7();
+        let mut duplicated = overlay;
+        duplicated.edges.insert(
+            duplicate.to_string(),
+            Some(edge(duplicate, first_id + 2, "LIKES", false)),
+        );
+        assert!(
+            apply(base.path(), &duplicated)
+                .unwrap_err()
+                .to_string()
+                .contains("new edge surrogate is not monotonic")
         );
     }
 

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -314,3 +314,65 @@ fails filesystem admission before its hostile-file assertions. Required Bazel
 PR CI remains the merge authority. Composite topology creation on an already
 constructed CAS parent still exposes the UUID authority defect tracked in
 #1221; no authentication check was relaxed to admit that operation.
+
+## Exploratory construction and replay layout (#1218)
+
+Source `13699caebd45a97e2da2cbb4575a91be1fe9f9e9` coalesces logical
+relationship groups into their physical route inside each existing bounded
+construction ID window. Previously two exploratory logical types produced
+individually sorted fragments with overlapping ID ranges in `_exploratory`;
+replay correctly rejected their concatenation. The encoder now sorts only the
+selected window's indexes and preserves each row's relationship name. It does
+not introduce a full-graph sort or a compatibility reader.
+
+Replay retains the authenticated source schema for both node and edge output,
+including qualified route/composition metadata. Exploratory rows retain the
+physical `rel_type_name` column; typed rows retain their physical route. Resource
+charges include variable relationship names. Full-width IDs, UUIDs, endpoints,
+replacement identity, duplicate rejection and strict cross-fragment ordering
+remain enforced. Encoding defaults are unchanged here; replay compression is
+still the policy repair in #1213.
+
+Four public fixtures cover retained-parent construction with 66 nodes and 4,097
+random-ID edges across two logical relationships, property delta publication,
+actual compaction, active snapshots, subsequent mutation, exact query, reopen,
+export, full verification and clean import. The mixed fixture contains 33
+exploratory and 33 qualified nodes, with 129 edges in each domain. It establishes
+qualified property authority, publishes a second update, asserts exactly one
+GFDR run, compacts, and checks both physical edge schemas and the exact value
+123 through reopen and portable import. A separate long-route fixture admits
+small input chunks but rejects the oversized coalesced Arrow batch before
+publication, preserving CURRENT and the exact parent graph.
+
+The retained-parent fixture has two first-generation edge fragments and three
+additional child fragments, each at most 1,024 rows. The reader check uses
+seven-row batches and verifies strictly increasing IDs across fragments.
+Deterministic ceilings and observed counters are:
+
+| Counter | Ceiling | Parent | Child |
+| --- | ---: | ---: | ---: |
+| Peak Arrow batch bytes | 131,072 | 103,396 | 103,396 |
+| Accounted live bytes | 4,194,304 | 2,805,218 | 2,805,232 |
+| Temporary allocated peak bytes | 2,097,152 | 1,224,704 | 1,302,528 |
+| Encode read bytes | 1,572,864 | 927,188 | 1,042,455 |
+| Encode write bytes | 524,288 | 302,218 | 363,917 |
+| Total construction read bytes | 16,777,216 | 5,827,068 | 7,319,877 |
+| Canonical output bytes | 262,144 | 160,479 | 189,915 |
+| Staged plus retained logical bytes | 655,360 | 479,256 | 476,148 |
+
+Batch rows stay at most 1,024, run bytes at most 4,096, merge fan-in at most two,
+and prior topology payload decoding is zero. These counters describe the
+construction subsystem. Retained logical groups and the selected physical
+Arrow batch coexist inside the bounded window; the Arrow counter alone is not
+a whole-process RSS measurement. The full public fixture process takes 14.86 s
+elapsed (10.57 s user, 2.77 s system), peaks at 146,584 KiB RSS, and records
+148,784 input / 84,416 output kernel blocks of 512 bytes. Startup, query, replay,
+portable verification and import are included. Raw syscall I/O and commands are
+in [`exploratory-replay-1218.json`](../../development/evidence/exploratory-replay-1218.json).
+
+Validation: four public regressions, 99 construction tests, 23 replay-focused
+tests, ten delta/compaction tests, production workspace Clippy, fast pre-push,
+formatting and gate-registry checks pass. Independent review verifies the
+retained #1224 property-generation repair and real mixed GFDR coverage. #1221
+still owns unsupported topology-journal authority and constructed-parent
+composite topology mutation; this repair does not broaden that support.

--- a/docs/development/evidence/exploratory-replay-1218.json
+++ b/docs/development/evidence/exploratory-replay-1218.json
@@ -1,0 +1,109 @@
+{
+  "issue": 1218,
+  "source_commit": "13699caebd45a97e2da2cbb4575a91be1fe9f9e9",
+  "base_commit": "2b63f4c957596fee342b33fa11e3cf6a6f2f99b3",
+  "deterministic_ceilings": {
+    "batch_rows": 1024,
+    "run_bytes": 4096,
+    "merge_fan_in": 2,
+    "prior_topology_decode_bytes": 0,
+    "peak_batch_bytes": 131072,
+    "peak_accounted_live_bytes": 4194304,
+    "temporary_allocation_peak_bytes": 2097152,
+    "encode_read_bytes": 1572864,
+    "encode_write_bytes": 524288,
+    "total_read_bytes": 16777216,
+    "canonical_output_bytes": 262144,
+    "staged_and_retained_disk_bytes": 655360
+  },
+  "construction_counters": {
+    "child": {
+      "canonical_output_bytes": 189915,
+      "encode_read_bytes": 1042455,
+      "encode_write_bytes": 363917,
+      "input_rows": 2049,
+      "peak_accounted_live_bytes": 2805232,
+      "peak_batch_bytes": 103396,
+      "peak_batch_rows": 1024,
+      "peak_merge_temporary_bytes": 802816,
+      "staged_and_retained_disk_bytes": 476148,
+      "temporary_allocation_peak_bytes": 1302528,
+      "total_read_bytes": 7319877
+    },
+    "parent": {
+      "canonical_output_bytes": 160479,
+      "encode_read_bytes": 927188,
+      "encode_write_bytes": 302218,
+      "input_rows": 2114,
+      "peak_accounted_live_bytes": 2805218,
+      "peak_batch_bytes": 103396,
+      "peak_batch_rows": 1024,
+      "peak_merge_temporary_bytes": 729088,
+      "staged_and_retained_disk_bytes": 479256,
+      "temporary_allocation_peak_bytes": 1224704,
+      "total_read_bytes": 5827068
+    }
+  },
+  "runtime": {
+    "elapsed_seconds": 14.86,
+    "user_seconds": 10.57,
+    "system_seconds": 2.77,
+    "peak_rss_kib": 146584,
+    "filesystem_input_512_byte_blocks": 148784,
+    "filesystem_output_512_byte_blocks": 84416,
+    "exit_status": 0
+  },
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 66324,
+        "bytes": 151277668
+      },
+      "pread64": {
+        "calls": 16796,
+        "bytes": 8114399
+      },
+      "write": {
+        "calls": 6029,
+        "bytes": 27923873
+      },
+      "fsync": {
+        "calls": 10288,
+        "bytes": 0
+      },
+      "copy_file_range": {
+        "calls": 580,
+        "bytes": 4093666
+      }
+    },
+    "read_bytes": 163485733,
+    "write_bytes": 32017539,
+    "errors": []
+  },
+  "trace_elapsed_seconds": 55.29,
+  "validation": {
+    "public_exploratory_passed": 4,
+    "public_qualified_ownership_passed": 5,
+    "construction_passed": 99,
+    "replay_passed": 23,
+    "delta_compaction_passed": 10,
+    "workspace_clippy": "passed",
+    "fast_pre_push": "passed",
+    "gate_registry": "passed",
+    "independent_review": "no blocking findings"
+  },
+  "commands": {
+    "public": "cargo test -p graphforge-api --test permanent_storage_budgets exploratory_ -- --nocapture",
+    "construction": "cargo test -p graphforge-storage --lib graph_construction",
+    "replay": "cargo test -p graphforge-storage --lib replay",
+    "delta": "cargo test -p graphforge-storage --lib graph_delta",
+    "runtime": "/usr/bin/time -v <prebuilt permanent_storage_budgets binary> exploratory_ --nocapture --test-threads=1",
+    "trace": "strace -f -qq -e trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync <same binary/filter>"
+  },
+  "limitations": [
+    "Construction counters do not measure whole-process RSS or all query/replay/import temporary allocation.",
+    "Logical groups and selected Arrow batch coexist only inside the existing bounded ID window.",
+    "Kernel I/O is cache dependent. Separate syscall trace includes startup, query, verification, import and test output.",
+    "No encoding defaults or unsupported topology-journal authority changed; #1213/#1221 retain those scopes."
+  ]
+}


### PR DESCRIPTION
Construction emitted overlapping edge-ID ranges when multiple logical exploratory relationships shared one physical route. Replay rejected the otherwise valid fragments and also wrote exploratory/qualified input through a schema that lost route information.

Coalesce logical groups inside each existing bounded construction ID window, sort that window by edge ID, and preserve per-row relationship names. Replay retains the authenticated node/edge schema and qualified metadata, with variable relationship names included in memory charges. Duplicate and changed surrogate IDs still fail; no compatibility reader, encoding-policy change or full-graph sort is introduced.

Validation:
- Four public regressions cover retained-parent construction, property GFDR, real compaction, active snapshots, subsequent mutation, exact queries, reopen, export/full verification/clean import, and oversized coalesced-batch rejection before publication. Mixed exploratory/qualified coverage asserts a real delta run and exact schema/value preservation.
- 99 construction tests, 23 replay tests, 10 delta/compaction tests, and all five merged qualified-ownership public fixtures pass. Workspace Clippy, formatting, fast pre-push and gate-registry checks pass. Independent review found no blockers.
- Fixed regression ceilings: 1,024 batch rows, 4 KiB runs, merge fan-in two, 128 KiB Arrow batch, 4 MiB accounted live memory, 2 MiB temporary allocation peak, 1.5 MiB encode reads and 512 KiB encode writes per fixture phase. Exact observed counters and separate CPU/RSS/syscall evidence are in `exploratory-replay-1218.json` and the permanent-storage assessment. These construction counters are not whole-process resource ceilings.

Encoding policy remains #1213; broader topology-journal and constructed-parent composite topology authority remains #1221.

Closes #1218

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791612405&installation_model_id=20486&pr_number=1226&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1226&signature=a19ac9744481fa8ba89fe614c24dc6e9060fe20afab8b5a341011a5c164138c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->