### PR TITLE
fix(storage): preserve authenticated UUID ownership in CAS mutation workspaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1015,6 +1015,8 @@ jobs:
           route_status=0
           cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib uuid_membership::tests::readonly_shared_runs_preserve_uuid_snapshot_authentication -- --exact --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib graph_object_store::tests::materialization_gives_mutable_uuid_controls_private_single_link_inodes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib graph_files::tests::graph_file_copy_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib project_portable_v2_export::tests::canonical_source_path_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib project_portable_v2_import::tests::authenticated_cleanup_releases_handles_before_removal -- --nocapture || route_status=1
@@ -1131,6 +1133,8 @@ jobs:
           route_status=0
           cargo test -p graphforge-storage --lib route_component::tests:: -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib uuid_membership::tests::owned_manifest_ -- --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib uuid_membership::tests::readonly_shared_runs_preserve_uuid_snapshot_authentication -- --exact --nocapture || route_status=1
+          cargo test -p graphforge-storage --lib graph_object_store::tests::materialization_gives_mutable_uuid_controls_private_single_link_inodes -- --exact --nocapture || route_status=1
           cargo test -p graphforge-storage --lib graph_files::tests::graph_file_copy_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib project_portable_v2_export::tests::canonical_source_path_ -- --nocapture || route_status=1
           cargo test -p graphforge-storage --lib project_portable_v2_import::tests::authenticated_cleanup_releases_handles_before_removal -- --nocapture || route_status=1

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -3906,14 +3906,20 @@ mod tests {
             .execute("MATCH (n:Person) RETURN n.name AS name")
             .expect("ordinary query over compact-root generation");
         assert_eq!(result.stats.rows_produced, 1);
-        // Mutable route authority owns a private copy; immutable payloads stay shared.
-        assert_eq!(reopened.graph_open_evidence().files_copied, 1);
-        assert_eq!(
-            reopened.graph_open_evidence().bytes_copied,
-            std::fs::metadata(reopened.dir.join("semantic-routes.json"))
-                .unwrap()
-                .len()
-        );
+        // Mutable route and UUID controls are private; immutable payloads stay shared.
+        let controls = [
+            "semantic-routes.json",
+            "topology/uuid-membership/manifest.json",
+            "topology/uuid-membership/topology-receipt.json",
+        ];
+        assert_eq!(reopened.graph_open_evidence().files_copied, 3);
+        let mut control_bytes = 0;
+        for relative in controls {
+            let file = std::fs::File::open(reopened.dir.join(relative)).unwrap();
+            assert_eq!(graphforge_filesystem::file_link_count(&file).unwrap(), 1);
+            control_bytes += file.metadata().unwrap().len();
+        }
+        assert_eq!(reopened.graph_open_evidence().bytes_copied, control_bytes);
         assert!(reopened.graph_open_evidence().files_reused > 0);
         assert!(!reopened.dir.join("files").exists());
         assert!(reopened.dir.join("topology").is_dir());

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -1833,13 +1833,35 @@ fn configure_composite_ontology(root: &Path, source: &Path, declared_property: b
 
 #[test]
 fn composite_qualified_create_then_set_preserves_node_and_edge_owners() {
+    exercise_qualified_create_then_set(0);
+}
+
+fn exercise_qualified_create_then_set(constructed_nodes: usize) {
     use graphforge_api::{
         COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation as Mutation,
         CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
     };
     let root = tempfile::tempdir().unwrap();
     let source = root.path().join("source");
-    drop(GraphForge::new(source.to_str()).unwrap());
+    let fixture = Fixture {
+        name: "qualified_composite_edge",
+        nodes: constructed_nodes,
+        edges: 129,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: false,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (mut nodes, mut edges) = if constructed_nodes == 0 {
+        drop(GraphForge::new(source.to_str()).unwrap());
+        (Vec::new(), Vec::new())
+    } else {
+        let (nodes, edges) = rows(fixture);
+        construct(&source, fixture, &nodes, &edges);
+        (nodes, edges)
+    };
+    let prior_objects = cas_uuid_parent_objects(&source);
     configure_composite_ontology(root.path(), &source, true);
     let graph = GraphForge::new(source.to_str()).unwrap();
     let a = Uuid::now_v7();
@@ -1952,21 +1974,12 @@ fn composite_qualified_create_then_set_preserves_node_and_edge_owners() {
                 && binding.symbol.local_id == "NEW_TYPED"
         })
         .unwrap();
-    let fixture = Fixture {
-        name: "qualified_composite_edge",
-        nodes: 2,
-        edges: 1,
-        routes: 1,
-        identifiers: Identifiers::Random,
-        properties: false,
-        adjacency: false,
-        heterogeneous: false,
-    };
-    let nodes = [
+    nodes.extend([
         (a, "mixed:entity:NewNode".into(), None),
         (b, "mixed:entity:NewNode".into(), None),
-    ];
-    let edges = [(edge, a, b, relation.route.clone(), None, None)];
+    ]);
+    edges.push((edge, a, b, relation.route.clone(), None, None));
+    cas_uuid_assert_parent_objects(&source, &prior_objects);
     drop(graph);
     round_trip(root.path(), &source, fixture, &nodes, &edges);
     let imported = GraphForge::new(root.path().join("imported").to_str()).unwrap();
@@ -2946,5 +2959,356 @@ fn permanent_codec_pairs_cover_wide_nullable_and_full_width_values() {
             }
         }
         println!("PERMANENT_CODEC_PAIRS {result}");
+    }
+}
+
+type CasUuidParentObjects = Vec<(
+    graphforge_storage::GraphFileEntry,
+    graphforge_filesystem::FileIdentity,
+)>;
+
+fn cas_uuid_parent_objects(source: &Path) -> CasUuidParentObjects {
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let Some(inventory) = selected.graph_files_inventory().unwrap() else {
+        return Vec::new();
+    };
+    if selected.declared_graph_files_inventory().unwrap().is_some() {
+        return Vec::new();
+    }
+    inventory
+        .files
+        .into_iter()
+        .map(|entry| {
+            let file = File::open(
+                graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap(),
+            )
+            .unwrap();
+            let identity = graphforge_filesystem::file_identity(&file).unwrap();
+            (entry, identity)
+        })
+        .collect()
+}
+
+fn cas_uuid_assert_parent_objects(source: &Path, objects: &CasUuidParentObjects) {
+    for (entry, identity) in objects {
+        let path = graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap();
+        let file = File::open(&path).unwrap();
+        assert_eq!(
+            graphforge_filesystem::file_identity(&file).unwrap(),
+            *identity
+        );
+        assert!(file.metadata().unwrap().permissions().readonly());
+        assert_eq!(
+            digest_hex(&std::fs::read(path).unwrap()),
+            entry.content_sha256
+        );
+    }
+}
+
+fn cas_uuid_node_surrogates(source: &Path) -> BTreeMap<Uuid, u64> {
+    use arrow::array::UInt64Array;
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let inventory = selected.graph_files_inventory().unwrap().unwrap();
+    let owned = selected.declared_graph_files_inventory().unwrap().is_some();
+    let mut ids = BTreeMap::new();
+    for entry in inventory.files.iter().filter(|entry| {
+        (entry.relative_path == "topology/nodes.parquet"
+            || entry.relative_path.starts_with("topology/nodes/"))
+            && entry.relative_path.ends_with(".parquet")
+    }) {
+        let path = if owned {
+            selected.graph_tree_root().join(&entry.relative_path)
+        } else {
+            graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap()
+        };
+        for batch in ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
+            .unwrap()
+            .build()
+            .unwrap()
+        {
+            let batch = batch.unwrap();
+            let uuids = batch
+                .column_by_name("node_uuid")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
+            let values = batch
+                .column_by_name("node_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .unwrap();
+            for row in 0..batch.num_rows() {
+                assert!(
+                    ids.insert(
+                        Uuid::from_slice(uuids.value(row)).unwrap(),
+                        values.value(row)
+                    )
+                    .is_none()
+                );
+            }
+        }
+    }
+    ids
+}
+
+fn cas_uuid_hydration_budget(root: &Path, source: &Path) {
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let inventory = selected.graph_files_inventory().unwrap().unwrap();
+    let owner = tempfile::tempdir_in(root).unwrap();
+    let workspace = owner.path().join("hydration-probe");
+    let evidence =
+        graphforge_storage::materialize_graph_objects(source, &inventory, &workspace).unwrap();
+    let mut control_bytes = 0;
+    let mut control_allocated = 0;
+    let mut shared_run_bytes = 0;
+    for entry in inventory
+        .files
+        .iter()
+        .filter(|entry| entry.relative_path.starts_with("topology/uuid-membership/"))
+    {
+        let name = Path::new(&entry.relative_path)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let file = File::open(workspace.join(&entry.relative_path)).unwrap();
+        let object = File::open(
+            graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap(),
+        )
+        .unwrap();
+        if matches!(name, "manifest.json" | "topology-receipt.json") {
+            assert_eq!(graphforge_filesystem::file_link_count(&file).unwrap(), 1);
+            assert_ne!(
+                graphforge_filesystem::file_identity(&file).unwrap(),
+                graphforge_filesystem::file_identity(&object).unwrap()
+            );
+            control_bytes += entry.byte_length;
+            control_allocated += graphforge_filesystem::file_space_usage(&file)
+                .unwrap()
+                .allocated_bytes;
+        } else if name.starts_with("identities-v5") || name.starts_with("node-surrogates-v5") {
+            assert!(file.metadata().unwrap().permissions().readonly());
+            assert_eq!(
+                graphforge_filesystem::file_identity(&file).unwrap(),
+                graphforge_filesystem::file_identity(&object).unwrap()
+            );
+            shared_run_bytes += entry.byte_length;
+        }
+    }
+    assert!(control_bytes > 0 && shared_run_bytes > 0);
+    assert!(
+        control_bytes <= 2 * 1024,
+        "mutable control copy I/O: {control_bytes}"
+    );
+    assert!(
+        evidence.application_write_bytes <= 192 * 1024,
+        "all private hydration writes: {}",
+        evidence.application_write_bytes
+    );
+    assert_eq!(graphforge_storage::GRAPH_OBJECT_IO_BUFFER_BYTES, 64 * 1024);
+    assert!(
+        control_allocated <= 8 * 1024,
+        "two mutable controls: {control_allocated}"
+    );
+    println!(
+        "CAS_UUID_HYDRATION {}",
+        json!({"control_bytes":control_bytes,"control_allocated_bytes":control_allocated,"shared_immutable_run_bytes":shared_run_bytes,"materialization":format!("{evidence:?}")})
+    );
+}
+
+#[test]
+fn cas_uuid_canonical_create_after_construction_preserves_authorities() {
+    for node_count in [33, 4097] {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let fixture = Fixture {
+            name: "cas_uuid_mutation",
+            nodes: node_count,
+            edges: 129,
+            routes: 1,
+            identifiers: Identifiers::Random,
+            properties: true,
+            adjacency: false,
+            heterogeneous: false,
+        };
+        let (mut nodes, edges) = rows(fixture);
+        construct(&source, fixture, &nodes, &edges);
+        let prior_objects = cas_uuid_parent_objects(&source);
+        assert!(!prior_objects.is_empty());
+        cas_uuid_hydration_budget(root.path(), &source);
+        let base_ids = cas_uuid_node_surrogates(&source);
+        let mut high_water = *base_ids.values().max().unwrap();
+        let graph = GraphForge::new(source.to_str()).unwrap();
+        let snapshot_query = "MATCH (n) RETURN n.node_uuid, n.score ORDER BY n.node_uuid";
+        let expected = graph.execute(snapshot_query).unwrap();
+        let old_stream = graph.execute_stream(snapshot_query).unwrap();
+        for step in 0..9 {
+            let score = 9_000_000 + step;
+            let result = graph
+                .execute(&format!(
+                    "CREATE (n:Node0 {{score: {score}}}) RETURN n.node_uuid"
+                ))
+                .unwrap();
+            let uuid = uuid_at(&result.batches[0], 0, 0);
+            let ids = cas_uuid_node_surrogates(&source);
+            assert!(ids[&uuid] > high_water);
+            high_water = ids[&uuid];
+            for (uuid, id) in &base_ids {
+                assert_eq!(ids[uuid], *id);
+            }
+            nodes.push((uuid, "Node0".into(), Some(score)));
+        }
+        graph
+            .execute("MATCH (n:Node0 {score: 9000000}) DELETE n")
+            .unwrap();
+        nodes.retain(|node| node.2 != Some(9_000_000));
+        let result = graph
+            .execute("CREATE (n:Node0 {score: 9000100}) RETURN n.node_uuid")
+            .unwrap();
+        let uuid = uuid_at(&result.batches[0], 0, 0);
+        assert!(cas_uuid_node_surrogates(&source)[&uuid] > high_water);
+        nodes.push((uuid, "Node0".into(), Some(9_000_100)));
+        verify_graph(&graph, fixture, &nodes, &edges);
+        use futures::TryStreamExt as _;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let batches: Vec<RecordBatch> = runtime.block_on(old_stream.try_collect()).unwrap();
+        // Each query has its own query_id schema metadata. Compare the exact
+        // fields and ordered values independently of execution batch boundaries.
+        let actual = arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
+        let expected =
+            arrow::compute::concat_batches(&expected.batches[0].schema(), &expected.batches)
+                .unwrap();
+        assert_eq!(actual.schema().fields(), expected.schema().fields());
+        assert_eq!(actual.columns(), expected.columns());
+        cas_uuid_assert_parent_objects(&source, &prior_objects);
+        drop(graph);
+        round_trip(root.path(), &source, fixture, &nodes, &edges);
+    }
+}
+
+#[test]
+fn cas_uuid_composite_create_after_construction_preserves_authorities() {
+    exercise_qualified_create_then_set(33);
+    exercise_qualified_create_then_set(4097);
+}
+
+#[test]
+fn cas_uuid_publication_fault_child() {
+    let Ok(source) = std::env::var("GF_CAS_UUID_FAULT_ROOT") else {
+        return;
+    };
+    let hook = std::env::var("GRAPHFORGE_PROJECT_FAILPOINT").unwrap();
+    let graph = GraphForge::new(Some(&source)).unwrap();
+    let result = graph.execute("CREATE (n:Node0 {score: 9000000}) RETURN n.node_uuid");
+    assert!(
+        hook.ends_with(".error"),
+        "crash hook was not reached: {hook}: {result:?}"
+    );
+    // A returned error after the private durable intent is reconciled by the
+    // UUID transaction's authenticated roll-forward, then published normally.
+    let reconciled = hook == "rewrite.after_durable_intent.error";
+    if reconciled {
+        result.unwrap();
+    } else {
+        let error = result.unwrap_err();
+        assert_eq!(error.code(), "GF_PUBLICATION_FAILED", "{hook}: {error}");
+    }
+    let count = if reconciled || hook == "project.after_current_replace.error" {
+        34
+    } else {
+        33
+    };
+    assert_eq!(graph.node_count("Node0").unwrap(), count);
+}
+
+#[test]
+fn cas_uuid_publication_faults_recover_and_allow_retry() {
+    for boundary in [
+        "rewrite.before_intent",
+        "rewrite.after_durable_intent",
+        "project.before_current_replace",
+        "project.after_current_replace",
+    ] {
+        for returned_error in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let source = root.path().join("source");
+            let fixture = Fixture {
+                name: "cas_uuid_recovery",
+                nodes: 33,
+                edges: 129,
+                routes: 1,
+                identifiers: Identifiers::Random,
+                properties: true,
+                adjacency: false,
+                heterogeneous: false,
+            };
+            let (mut nodes, edges) = rows(fixture);
+            construct(&source, fixture, &nodes, &edges);
+            let prior_objects = cas_uuid_parent_objects(&source);
+            let before = graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .generation_uuid();
+            let hook = format!("{boundary}{}", if returned_error { ".error" } else { "" });
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "cas_uuid_publication_fault_child", "--nocapture"])
+                .env("GF_CAS_UUID_FAULT_ROOT", &source)
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINTS",
+                    "graphforge-internal-subprocess-v1",
+                )
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", &hook)
+                .output()
+                .unwrap();
+            assert_eq!(
+                output.status.code(),
+                Some(if returned_error { 0 } else { 86 }),
+                "{hook}: {} {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let graph = GraphForge::new(source.to_str()).unwrap();
+            let after = graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .generation_uuid();
+            let published = boundary == "project.after_current_replace"
+                || (returned_error && boundary == "rewrite.after_durable_intent");
+            assert_eq!(before != after, published, "{hook}");
+            let result = graph
+                .execute("MATCH (n:Node0 {score: 9000000}) RETURN n.node_uuid")
+                .unwrap();
+            assert_eq!(
+                result
+                    .batches
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                usize::from(published)
+            );
+            if published {
+                nodes.push((
+                    uuid_at(&result.batches[0], 0, 0),
+                    "Node0".into(),
+                    Some(9_000_000),
+                ));
+            }
+            verify_graph(&graph, fixture, &nodes, &edges);
+            let result = graph
+                .execute("CREATE (n:Node0 {score: 9000001}) RETURN n.node_uuid")
+                .unwrap();
+            nodes.push((
+                uuid_at(&result.batches[0], 0, 0),
+                "Node0".into(),
+                Some(9_000_001),
+            ));
+            verify_graph(&graph, fixture, &nodes, &edges);
+            cas_uuid_assert_parent_objects(&source, &prior_objects);
+            drop(graph);
+            round_trip(root.path(), &source, fixture, &nodes, &edges);
+        }
     }
 }

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -3596,6 +3596,24 @@ fn run_integrated_certification_config(
     );
     let committed_generation = graphforge_storage::resolve_project_generation(&source)
         .expect("resolve committed ingest generation");
+    let committed_inventory = committed_generation
+        .graph_files_inventory()
+        .expect("committed inventory")
+        .expect("constructed graph inventory");
+    let manifest_bytes = committed_inventory
+        .files
+        .iter()
+        .find(|entry| entry.relative_path == "topology/uuid-membership/manifest.json")
+        .expect("constructed UUID manifest")
+        .byte_length;
+    // Fresh construction has no topology-mutation receipt yet. If present,
+    // its authenticated bytes are also copied privately during hydration.
+    let receipt_bytes = committed_inventory
+        .files
+        .iter()
+        .find(|entry| entry.relative_path == "topology/uuid-membership/topology-receipt.json")
+        .map_or(0, |entry| entry.byte_length);
+    let hydration_uuid_control_bytes = manifest_bytes + receipt_bytes;
     journal.replace_project_owner("source_project", &committed_generation);
     journal.pass("ingest", phase, Some(input_fingerprint));
 
@@ -4109,6 +4127,7 @@ fn run_integrated_certification_config(
             "clean_import": imported_storage,
             "construction": construction_storage,
             "application_io_phases": construction_phases,
+            "hydration_uuid_control_bytes": hydration_uuid_control_bytes,
             "workspace_current_allocated_bytes": workspace_current_allocated_bytes,
             "workspace_peak_allocated_bytes": workspace_peak_allocated_bytes,
             "workspace_components": workspace_components,
@@ -4371,6 +4390,7 @@ struct LifecycleLinearityObservation {
     cas_publication_io: graphforge_storage::GraphPublicationIo,
     encode_fsync_components: [u64; 4],
     hydration_files_copied: u64,
+    hydration_uuid_control_bytes: u64,
     hydration_file_fsync_operations: u64,
     hydration_directory_fsync_operations: u64,
     shape_read_component_calls: [u64; 6],
@@ -4688,6 +4708,9 @@ fn lifecycle_linearity_observation(evidence: &Value) -> LifecycleLinearityObserv
             .expect("native CAS component evidence"),
         encode_fsync_components,
         hydration_files_copied,
+        hydration_uuid_control_bytes: evidence["storage"]["hydration_uuid_control_bytes"]
+            .as_u64()
+            .expect("authenticated UUID control bytes"),
         hydration_file_fsync_operations,
         hydration_directory_fsync_operations,
         shape_read_component_calls,
@@ -5889,13 +5912,32 @@ fn validate_lifecycle_metric_policies_for_axis(
                     validate_affine_metric(&name, values, denominators)?;
                 }
                 PhaseMetricPolicy::NodeBearingBytes => {
-                    // Only private ordinal-V4 files are copied during this
-                    // fresh hydration; other immutable objects are hardlinked.
-                    // The controlled edge axis retains the identical node map.
+                    // Hydration copies private ordinal-V4 data plus mutable v5
+                    // controls. Control JSON gains count digits along either
+                    // axis; subtract its exact authenticated inventory bytes,
+                    // then retain the fixed-node-map bound on the edge axis.
+                    let mut ordinal_values = values;
+                    for (rung, observation) in observations.iter().enumerate() {
+                        let controls = observation.hydration_uuid_control_bytes;
+                        if controls == 0 || controls > 2 * 1024 {
+                            return Err(format!(
+                                "{name} UUID control bytes exceed fixture bounds: {controls}"
+                            ));
+                        }
+                        ordinal_values[rung] =
+                            values[rung].checked_sub(controls).ok_or_else(|| {
+                                format!("{name} omits authenticated UUID control copies")
+                            })?;
+                    }
                     if matches!(axis, LinearityAxis::Nodes) {
-                        validate_affine_metric(&name, values, denominators)?;
+                        validate_affine_metric(&name, ordinal_values, denominators)?;
                     } else {
-                        validate_fixed_protocol_metric(&name, values, values[0], values[0])?;
+                        validate_fixed_protocol_metric(
+                            &name,
+                            ordinal_values,
+                            ordinal_values[0],
+                            ordinal_values[0],
+                        )?;
                     }
                 }
                 PhaseMetricPolicy::BufferedCalls {
@@ -6428,6 +6470,7 @@ fn synthetic_linearity_observations_for_axis(
             },
             encode_fsync_components: [10, 5, 8, 20],
             hydration_files_copied: 19,
+            hydration_uuid_control_bytes: 100,
             hydration_file_fsync_operations: 19,
             hydration_directory_fsync_operations: 19,
             shape_read_component_calls: [factor, 0, 0, 0, 0, 0],
@@ -6852,6 +6895,35 @@ fn controlled_fixture_policies_reject_coherent_zero_and_excess_work() {
                 .unwrap()[1] = 0;
         }
         assert!(validate_lifecycle_metric_policies_for_axis(axis, &omitted_copies).is_err());
+    }
+}
+
+#[test]
+fn lifecycle_hydration_policy_accounts_exact_uuid_controls() {
+    let mut observations = synthetic_linearity_observations_for_axis(LinearityAxis::Edges);
+    for (rung, observation) in observations.iter_mut().enumerate() {
+        observation.hydration_uuid_control_bytes += rung as u64;
+        observation
+            .phases
+            .get_mut("hydration_verification")
+            .unwrap()[1] += rung as u64;
+    }
+    validate_lifecycle_metric_policies_for_axis(LinearityAxis::Edges, &observations)
+        .expect("exact control bytes may grow while ordinal copies remain fixed");
+    let mut unaccounted = observations.clone();
+    unaccounted[2]
+        .phases
+        .get_mut("hydration_verification")
+        .unwrap()[1] += 1;
+    assert!(
+        validate_lifecycle_metric_policies_for_axis(LinearityAxis::Edges, &unaccounted).is_err()
+    );
+    for controls in [0, 2 * 1024 + 1, u64::MAX] {
+        let mut invalid = observations.clone();
+        invalid[2].hydration_uuid_control_bytes = controls;
+        assert!(
+            validate_lifecycle_metric_policies_for_axis(LinearityAxis::Edges, &invalid).is_err()
+        );
     }
 }
 

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -2492,7 +2492,11 @@ fn requires_single_link_materialization(relative_path: &str) -> bool {
     !name.contains('/')
         && (matches!(
             name,
-            "ordinal-v4-manifest.json" | "ordinal-v4-receipt.json" | "ordinal-v4.lock"
+            "manifest.json"
+                | "topology-receipt.json"
+                | "ordinal-v4-manifest.json"
+                | "ordinal-v4-receipt.json"
+                | "ordinal-v4.lock"
         ) || (!name.starts_with(".v4-")
             && crate::uuid_membership::is_exact_private_v4_name(name)))
 }
@@ -2506,7 +2510,7 @@ fn copy_single_link_materialized_object(
     entry: &crate::GraphFileEntry,
 ) -> Result<MaterializeIoEvidence, GfError> {
     let temporary_name = std::ffi::OsString::from(format!(
-        ".ordinal-v4-materialize-{}.tmp",
+        ".graph-control-materialize-{}.tmp",
         Uuid::new_v4().simple()
     ));
     let input = source
@@ -5126,9 +5130,17 @@ mod tests {
     }
 
     #[test]
-    fn materialization_gives_v4_ordinal_authority_private_single_link_inodes() {
+    fn materialization_gives_mutable_uuid_controls_private_single_link_inodes() {
         let root = tempfile::tempdir().unwrap();
         let files = [
+            (
+                "topology/uuid-membership/manifest.json",
+                &b"v5 manifest"[..],
+            ),
+            (
+                "topology/uuid-membership/topology-receipt.json",
+                &b"v5 receipt"[..],
+            ),
             ("topology/uuid-membership/ordinal-v4.lock", &b""[..]),
             (
                 "topology/uuid-membership/ordinal-v4-manifest.json",

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -2570,6 +2570,20 @@ pub(crate) struct ConstructionReferenceAuthenticationWork {
     pub(crate) referenced_payload_bytes: u64,
 }
 
+// Immutable authenticated runs may be shared by a hydrated CAS workspace.
+// Mutable manifests/receipts and private construction artifacts retain their
+// strict single-link rules. Digest/block and named-inode checks remain separate.
+fn retained_run_has_safe_links(file: &File) -> Result<bool, GfError> {
+    let links = graphforge_filesystem::file_link_count(file).map_err(storage_err)?;
+    Ok(links == 1
+        || links > 1
+            && file
+                .metadata()
+                .map_err(storage_err)?
+                .permissions()
+                .readonly())
+}
+
 impl AuthenticatedUuidIndexSnapshot {
     fn open_retained_file(&self, record: &FileRecord) -> Result<File, GfError> {
         let (held, expected) = self
@@ -2588,8 +2602,8 @@ impl AuthenticatedUuidIndexSnapshot {
         let mut file = held.try_clone().map_err(storage_err)?;
         let identity_changed =
             graphforge_filesystem::file_identity(&file).map_err(storage_err)? != expected;
-        let path_native_link_changed = self.cas_source_paths.is_none()
-            && graphforge_filesystem::file_link_count(&file).map_err(storage_err)? != 1;
+        let path_native_link_changed =
+            self.cas_source_paths.is_none() && !retained_run_has_safe_links(&file)?;
         if identity_changed || path_native_link_changed {
             return Err(storage_err("retained UUID run identity changed"));
         }
@@ -3071,7 +3085,7 @@ impl AuthenticatedUuidIndexSnapshot {
             ] {
                 let named = open_uuid_child_file(&self.root, std::ffi::OsStr::new(&record.name))?;
                 if graphforge_filesystem::file_identity(&named).map_err(storage_err)? != identity
-                    || graphforge_filesystem::file_link_count(&named).map_err(storage_err)? != 1
+                    || !retained_run_has_safe_links(&named)?
                 {
                     return Err(storage_err("UUID retained run identity changed"));
                 }
@@ -12234,6 +12248,127 @@ pub(crate) mod tests {
             index.lookup_node_surrogates(&[first, second]).unwrap().0,
             [Some(1), Some(2)]
         );
+    }
+
+    #[test]
+    fn readonly_shared_runs_preserve_uuid_snapshot_authentication() {
+        for scenario in [
+            "valid",
+            "writable",
+            "made_writable",
+            "tampered",
+            "replaced",
+            "manifest_link",
+        ] {
+            let source = tempfile::tempdir().unwrap();
+            let aliases = tempfile::tempdir().unwrap();
+            let nodes = [(Uuid::from_u128(1), 1), (Uuid::from_u128(2), u64::MAX - 1)];
+            crate::generation::force_bump_topology_generation_for_test(source.path()).unwrap();
+            append_uuid_membership_delta(source.path(), 1, &nodes, &[]).unwrap();
+            let root = source.path().join(INDEX_DIR);
+            let mut snapshot =
+                AuthenticatedUuidIndexSnapshot::open_at_generation(source.path(), 1).unwrap();
+            let records = snapshot
+                .manifest
+                .runs
+                .iter()
+                .flat_map(|run| [run.identities.clone(), run.node_surrogates.clone()])
+                .collect::<Vec<_>>();
+            let record = records
+                .iter()
+                .find(|record| record.name.starts_with("identities-v5") && record.count > 0)
+                .unwrap();
+            let original_permissions = fs::metadata(root.join(&record.name)).unwrap().permissions();
+            for record in &records {
+                let path = root.join(&record.name);
+                fs::hard_link(&path, aliases.path().join(&record.name)).unwrap();
+                if scenario != "writable" {
+                    let mut permissions = fs::metadata(&path).unwrap().permissions();
+                    permissions.set_readonly(true);
+                    fs::set_permissions(&path, permissions).unwrap();
+                }
+            }
+            match scenario {
+                "valid" => {
+                    snapshot.revalidate().unwrap();
+                    snapshot.open_retained_file(record).unwrap();
+                    let (values, _) = snapshot
+                        .lookup_node_surrogates(&[nodes[0].0, nodes[1].0])
+                        .unwrap();
+                    assert_eq!(values, [Some(1), Some(u64::MAX - 1)]);
+                }
+                "writable" => {
+                    assert!(snapshot.revalidate().is_err());
+                    assert!(snapshot.open_retained_file(record).is_err());
+                }
+                "made_writable" => {
+                    snapshot.revalidate().unwrap();
+                    fs::set_permissions(
+                        aliases.path().join(&record.name),
+                        original_permissions.clone(),
+                    )
+                    .unwrap();
+                    assert!(snapshot.revalidate().is_err());
+                    assert!(snapshot.open_retained_file(record).is_err());
+                }
+                "tampered" => {
+                    let alias = aliases.path().join(&record.name);
+                    fs::set_permissions(&alias, original_permissions.clone()).unwrap();
+                    let mut writer = fs::OpenOptions::new().write(true).open(&alias).unwrap();
+                    writer.write_all(&[0xff]).unwrap();
+                    writer.sync_all().unwrap();
+                    drop(writer);
+                    let mut permissions = original_permissions.clone();
+                    permissions.set_readonly(true);
+                    fs::set_permissions(&alias, permissions).unwrap();
+                    // Metadata and inode still match. The retained read must
+                    // authenticate bytes, not trust readonly status alone.
+                    snapshot.revalidate().unwrap();
+                    let error = snapshot.lookup_node_surrogates(&[nodes[0].0]).unwrap_err();
+                    assert!(
+                        error.to_string().contains("block authentication"),
+                        "{error}"
+                    );
+                    assert!(
+                        AuthenticatedUuidIndexSnapshot::open_at_generation(source.path(), 1)
+                            .is_err()
+                    );
+                }
+                "replaced" => {
+                    let path = root.join(&record.name);
+                    let bytes = fs::read(&path).unwrap();
+                    let replacement = fs::rename(&path, root.join("held-original"));
+                    #[cfg(windows)]
+                    {
+                        // Stable retained handles intentionally omit
+                        // FILE_SHARE_DELETE: Windows prevents replacement.
+                        assert!(replacement.is_err());
+                        assert_eq!(fs::read(&path).unwrap(), bytes);
+                        snapshot.revalidate().unwrap();
+                    }
+                    #[cfg(not(windows))]
+                    {
+                        replacement.unwrap();
+                        fs::write(&path, bytes).unwrap();
+                        assert!(snapshot.revalidate().is_err());
+                    }
+                }
+                "manifest_link" => {
+                    fs::hard_link(root.join(MANIFEST), aliases.path().join(MANIFEST)).unwrap();
+                    assert!(snapshot.revalidate().is_err());
+                }
+                _ => unreachable!(),
+            }
+            // Restore this test's owned aliases so Windows cleanup can remove
+            // readonly files; production never mutates shared run permissions.
+            for record in &records {
+                fs::set_permissions(
+                    aliases.path().join(&record.name),
+                    original_permissions.clone(),
+                )
+                .unwrap();
+            }
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/uuid_membership.rs
+++ b/crates/graphforge-storage/src/uuid_membership.rs
@@ -12264,12 +12264,17 @@ pub(crate) mod tests {
             let aliases = tempfile::tempdir().unwrap();
             let nodes = [(Uuid::from_u128(1), 1), (Uuid::from_u128(2), u64::MAX - 1)];
             crate::generation::force_bump_topology_generation_for_test(source.path()).unwrap();
-            append_uuid_membership_delta(source.path(), 1, &nodes, &[]).unwrap();
+            write_node_parquet_with_ids(
+                &source.path().join("topology/nodes.parquet"),
+                &nodes.map(|(uuid, _)| uuid),
+                &nodes.map(|(_, surrogate)| surrogate),
+            );
+            rebuild_uuid_membership_indexes(source.path(), UuidIndexBuildLimits::default())
+                .unwrap();
             let root = source.path().join(INDEX_DIR);
-            let mut snapshot =
-                AuthenticatedUuidIndexSnapshot::open_at_generation(source.path(), 1).unwrap();
-            let records = snapshot
-                .manifest
+            let manifest: Manifest =
+                serde_json::from_slice(&fs::read(root.join(MANIFEST)).unwrap()).unwrap();
+            let records = manifest
                 .runs
                 .iter()
                 .flat_map(|run| [run.identities.clone(), run.node_surrogates.clone()])
@@ -12288,6 +12293,14 @@ pub(crate) mod tests {
                     fs::set_permissions(&path, permissions).unwrap();
                 }
             }
+            if scenario == "manifest_link" {
+                fs::hard_link(root.join(MANIFEST), aliases.path().join(MANIFEST)).unwrap();
+            }
+            // Match hydration: establish aliases before retaining immutable
+            // handles. Windows prevents adding links through held handles that
+            // intentionally deny DELETE sharing.
+            let mut snapshot =
+                AuthenticatedUuidIndexSnapshot::open_at_generation(source.path(), 1).unwrap();
             match scenario {
                 "valid" => {
                     snapshot.revalidate().unwrap();
@@ -12354,7 +12367,6 @@ pub(crate) mod tests {
                     }
                 }
                 "manifest_link" => {
-                    fs::hard_link(root.join(MANIFEST), aliases.path().join(MANIFEST)).unwrap();
                     assert!(snapshot.revalidate().is_err());
                 }
                 _ => unreachable!(),

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -546,3 +546,74 @@ workspace Clippy, formatting, fast pre-push and gate-registry checks passed.
 The full local storage aggregate passed 1,081 tests with two existing ignores;
 one unchanged test hardcodes `/tmp`, where this host's tmpfs fails filesystem
 admission. Required native Bazel CI remains the merge gate.
+
+## CAS UUID mutation ownership (#1228)
+
+The integrated publishing-contract census reproduced ordinary and qualified
+CREATE failures on a constructed CAS parent. Hydration shared the mutable v5
+UUID manifest and receipt, but mutation planning correctly required private
+control-file ownership. Those two controls now use the existing authenticated,
+bounded private-copy path. Immutable identity and surrogate runs remain shared;
+retained reads accept extra links only while readonly, with unchanged named-file
+identity, manifest digest/generation and full-run/per-block authentication.
+Private construction ownership guards remain single-link. No encoding changes,
+compatibility format or generic writer abstraction are introduced.
+
+Public regressions exercise flat 33-node and sharded 4,097-node exploratory
+parents with 129 edges. Nine successive CREATEs, DELETE and another CREATE
+preserve prior UUID/surrogate mappings and never reuse the deleted surrogate.
+Qualified node/edge creation and property changes retain the constructed parent
+and semantic owners. Both paths check exact query values, reopen, export, full
+portable verification and clean import. An active pre-mutation stream retains
+its exact ordered values; all original CAS inode identities and digests remain
+unchanged. Adversarial tests reject writable shared runs, readonly-to-writable
+transitions, mutated blocks and extra manifest aliases. Unix replacement fails
+retained identity checks; Windows retained handles prevent replacement itself.
+
+Eight subprocess cases cover process exit and returned errors before private
+intent, after durable intent, before CURRENT and after CURRENT. A returned error
+after durable UUID intent is authenticated and rolled forward before normal
+publication; a process exit there leaves the selected parent intact. Tests
+assert these distinct outcomes, reopen exact selected data, perform another
+mutation and complete a portable round trip. Existing storage tests continue to
+cover cancellation and unfinished private artifact cleanup.
+
+The public hydration fixtures cap the two mutable controls at 2 KiB logical and
+8 KiB allocated, all private hydration writes at 192 KiB, and the existing copy
+buffer at 64 KiB. Immutable UUID payloads must have the original readonly CAS
+inode: zero payload copying or reencoding. The buffer is reused serially across
+files; control file size changes copy I/O and disk use, not this buffer size.
+These are fixture/component bounds, not a whole-process RSS guarantee. Existing
+v4 ordinal private artifacts remain included in total hydration writes; they
+are not attributed to this repair. The control-specific unit test checks exact
+read/write bytes, calls and file/directory synchronization counts.
+
+Source `ad7a867bc836bf3c7381f3a1f70a71914237b349` and raw observations are in
+[`cas-uuid-ownership-1228.json`](../../development/evidence/cas-uuid-ownership-1228.json).
+
+| Constructed nodes / edges | New control bytes / allocated | Shared immutable UUID bytes | All private hydration writes |
+|---|---:|---:|---:|
+| 33 / 129 | 1,429 / 4,096 | 3,810 | 4,093 |
+| 4,097 / 129 | 1,440 / 4,096 | 202,946 | 166,775 |
+
+The complete canonical fixture took 18.12 s elapsed, 15.91 s user and 2.30 s
+system, with 153,872 KiB peak RSS. Separate syscall tracing recorded 297,801,224
+read bytes, 38,792,187 write bytes and 8,052 successful fsync calls, with no
+traced errors. OS filesystem input/output were 39,592/101,216 512-byte blocks.
+A separate 1,317-sample scan observed 21,532,672 bytes of unique-inode workspace
+allocation (maximum sample interval 24.2 ms). This includes retained generations,
+private workspaces and portable artifacts; unlinked files and shorter peaks can
+be missed. These whole-fixture observations are not control-copy-only costs or
+process admission limits. The baseline fails its first CREATE, so there is no
+valid baseline runtime comparison and no performance improvement claim.
+
+Validation passed all 24 public publishing tests, 54 membership and 38
+object-store tests, the final writable-transition regression, and all 734 API
+unit cases (733 in the aggregate and the exact-control assertion after its
+focused update). Workspace Clippy, formatting, fast pre-push and gate-registry
+checks passed. Independent review corrected the Windows replacement test;
+required exact-head native CI remains the platform/merge authority.
+
+This ownership repair does not make same-name adoption atomic (#1229), define
+bound-composition removal (#1230), refresh a facade after compaction (#1231), or
+complete the canonical publishing-contract gate (#1221).

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -552,7 +552,7 @@ admission. Required native Bazel CI remains the merge gate.
 The integrated publishing-contract census reproduced ordinary and qualified
 CREATE failures on a constructed CAS parent. Hydration shared the mutable v5
 UUID manifest and receipt, but mutation planning correctly required private
-control-file ownership. Those two controls now use the existing authenticated,
+control-file ownership. Those controls now use the existing authenticated,
 bounded private-copy path. Immutable identity and surrogate runs remain shared;
 retained reads accept extra links only while readonly, with unchanged named-file
 identity, manifest digest/generation and full-run/per-block authentication.
@@ -578,15 +578,22 @@ assert these distinct outcomes, reopen exact selected data, perform another
 mutation and complete a portable round trip. Existing storage tests continue to
 cover cancellation and unfinished private artifact cleanup.
 
-The public hydration fixtures cap the two mutable controls at 2 KiB logical and
+The public hydration fixtures cap applicable mutable controls at 2 KiB logical and
 8 KiB allocated, all private hydration writes at 192 KiB, and the existing copy
-buffer at 64 KiB. Immutable UUID payloads must have the original readonly CAS
+buffer at 64 KiB. Fresh construction has the manifest; the mutation receipt is
+created by the first topology mutation. The control-copy unit test exercises
+both. Immutable UUID payloads must have the original readonly CAS
 inode: zero payload copying or reencoding. The buffer is reused serially across
 files; control file size changes copy I/O and disk use, not this buffer size.
 These are fixture/component bounds, not a whole-process RSS guarantee. Existing
 v4 ordinal private artifacts remain included in total hydration writes; they
 are not attributed to this repair. The control-specific unit test checks exact
 read/write bytes, calls and file/directory synchronization counts.
+The existing 1x/2x/4x lifecycle qualification subtracts these exact authenticated
+control lengths before enforcing the ordinal-copy growth policy. On the fixed
+node / growing edge axis, decimal counts in control JSON may grow while ordinal
+copy bytes remain exactly fixed. The regression still rejects one unaccounted
+write byte and refuses absent or oversized control accounting.
 
 Source `ad7a867bc836bf3c7381f3a1f70a71914237b349` and raw observations are in
 [`cas-uuid-ownership-1228.json`](../../development/evidence/cas-uuid-ownership-1228.json).

--- a/docs/development/evidence/cas-uuid-ownership-1228.json
+++ b/docs/development/evidence/cas-uuid-ownership-1228.json
@@ -1,0 +1,132 @@
+{
+  "issue": 1228,
+  "source_commit": "ad7a867bc836bf3c7381f3a1f70a71914237b349",
+  "baseline_source_commit": "ec7758535ffe7c2a013d5d2808215b19f3008404",
+  "workload": "Public constructed CAS N33 and N4097/E129, 9 CREATEs, DELETE, CREATE, retained snapshot, reopen/query/export/full verify/clean import; hydration probe inspects exact controls and shared immutable UUID inodes.",
+  "hydration": [
+    {
+      "control_allocated_bytes": 4096,
+      "control_bytes": 1429,
+      "shared_immutable_run_bytes": 3810,
+      "nodes": 33,
+      "edges": 129,
+      "materialization": {
+        "files_validated": 20,
+        "bytes_validated": 28036,
+        "files_copied": 8,
+        "bytes_copied": 4093,
+        "files_opened_in_place": 0,
+        "files_reused": 12,
+        "bytes_reused": 23943,
+        "application_read_bytes": 32408,
+        "application_read_calls": 23,
+        "application_write_bytes": 4093,
+        "application_write_calls": 6,
+        "fsync_calls": 16,
+        "file_fsync_calls": 8,
+        "directory_fsync_calls": 8,
+        "strategy": "PrivateMaterialize"
+      }
+    },
+    {
+      "control_allocated_bytes": 4096,
+      "control_bytes": 1440,
+      "shared_immutable_run_bytes": 202946,
+      "nodes": 4097,
+      "edges": 129,
+      "materialization": {
+        "files_validated": 28,
+        "bytes_validated": 562496,
+        "files_copied": 8,
+        "bytes_copied": 166775,
+        "files_opened_in_place": 0,
+        "files_reused": 20,
+        "bytes_reused": 395721,
+        "application_read_bytes": 729550,
+        "application_read_calls": 37,
+        "application_write_bytes": 166775,
+        "application_write_calls": 8,
+        "fsync_calls": 16,
+        "file_fsync_calls": 8,
+        "directory_fsync_calls": 8,
+        "strategy": "PrivateMaterialize"
+      }
+    }
+  ],
+  "runtime": {
+    "elapsed_seconds": 18.12,
+    "user_seconds": 15.91,
+    "system_seconds": 2.3,
+    "peak_rss_kib": 153872,
+    "filesystem_input_512_byte_blocks": 39592,
+    "filesystem_output_512_byte_blocks": 101216,
+    "exit_status": 0
+  },
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 89191,
+        "bytes": 263229459
+      },
+      "pread64": {
+        "calls": 42062,
+        "bytes": 17141117
+      },
+      "write": {
+        "calls": 4411,
+        "bytes": 21361539
+      },
+      "fsync": {
+        "calls": 8052,
+        "bytes": 0
+      },
+      "copy_file_range": {
+        "calls": 3876,
+        "bytes": 17430648
+      }
+    },
+    "read_bytes": 297801224,
+    "write_bytes": 38792187,
+    "errors": [],
+    "elapsed_seconds": 52.38
+  },
+  "workspace_observation": {
+    "command": [
+      "/home/ubuntu/code/graphforge-target-1195/debug/deps/permanent_storage_budgets-c514423ca6fb68a2",
+      "cas_uuid_canonical_create_after_construction_preserves_authorities",
+      "--exact",
+      "--nocapture",
+      "--test-threads=1"
+    ],
+    "sampled_unique_inode_allocated_peak_bytes": 21532672,
+    "sampled_path_logical_peak_bytes": 17923892,
+    "sampled_file_count_peak": 1271,
+    "samples": 1317,
+    "requested_poll_interval_seconds": 0.005,
+    "maximum_observed_sample_interval_seconds": 0.02411847101757303,
+    "vanished_files_during_scan": 26,
+    "exit_status": 0,
+    "limitations": [
+      "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+      "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+      "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+      "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+    ]
+  },
+  "deterministic_budgets": {
+    "mutable_control_logical_bytes": 2048,
+    "mutable_control_allocated_bytes": 8192,
+    "all_private_hydration_write_bytes": 196608,
+    "sequential_copy_buffer_bytes": 65536,
+    "unchanged_immutable_uuid_payload_copy_bytes": 0,
+    "unchanged_immutable_uuid_payload_reencoded_bytes": 0
+  },
+  "limitations": [
+    "The baseline fails its first CREATE; there is no valid before/after timing comparison and no performance improvement claim.",
+    "Process measurements include startup, both sizes, all mutations, queries, authentication and portable operations; they are observations, not RSS or CPU-time admission guarantees.",
+    "Syscall, runtime and sampled disk evidence use separate executions. Syscall totals count requested application bytes; OS block counters describe filesystem I/O.",
+    "Existing v4 ordinal artifacts are private and included in total hydration writes; only v5 mutable controls are newly copied.",
+    "Unlinked open files and short-lived peaks can be missed by workspace pathname sampling; this is not an exact temporary-only disk ceiling.",
+    "Shared runs are authenticated with bounded I/O; zero copying does not mean zero authentication reads."
+  ]
+}


### PR DESCRIPTION
Constructed CAS graphs rejected ordinary and qualified CREATE because hydrated v5 UUID controls had shared inodes, while mutation planning required private ownership. Copy the mutable manifest/receipt through the existing bounded authenticated materializer; keep immutable runs shared only under readonly, retained-identity and digest/block checks. Private construction guards remain strict.

Public regressions cover flat/sharded parents, repeated CREATE/DELETE and surrogate allocation, qualified node/edge ownership, active snapshots, exact reopen/query/export/verify/import, and eight crash/returned-error publication cases. Adversarial tests cover aliases, writable transitions, mutated bytes and path replacement. Exact copy-I/O assertions and deterministic control/allocation budgets accompany source-bound CPU, I/O, RSS and sampled workspace evidence in the assessment.

This repair preserves the shared permanent Parquet policy. Same-name adoption atomicity, bound-composition clear and post-compaction facade refresh remain separate blockers under #1221.

Validation: 54 membership and 38 object-store unit tests; final adversarial authentication test; 733 API unit tests plus the corrected exact-control regression; all 24 public publishing tests; workspace Clippy, formatting, fast pre-push and gate-registry checks. Independent review verified the Windows retained-handle test behavior. The Windows/macOS jobs explicitly run the new shared-run authentication and exact private-control tests. Real 1×/2×/4× lifecycle qualification accounts exact authenticated control bytes before enforcing ordinal-copy bounds, with omitted/excess-work regressions. Workflow lint passed; required exact-head CI remains the merge gate.

Closes #1228
