### PR TITLE
fix(api): reject ontology removal that strands semantic bindings

### DIFF
--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -207,7 +207,9 @@ impl GraphForge {
     /// Publish explicit ontology absence and return the project to exploratory mode.
     ///
     /// # Errors
-    /// Returns a structured publication or idempotency error.
+    /// Returns a structured validation error if a semantic-bindings participant
+    /// still requires composition authority (including empty bindings), or a
+    /// publication or idempotency error.
     pub fn clear_ontology(&mut self, request: ClearOntologyRequest) -> Result<(), GfError> {
         let ClearOntologyRequest { context } = request;
         let mut configuration = current_configuration(self)?;
@@ -341,6 +343,22 @@ fn publish_workspace_records_inner(
             "project generation changed before ontology publication".into(),
         ));
     }
+    // Every semantic-bindings participant, including an empty one, is owned
+    // by its persisted composition. Refuse removal before creating staging
+    // files or publication journals; clear must leave the facade unchanged.
+    if composition.is_none()
+        && (semantic_bindings.is_some()
+            || parent
+                .participant_snapshot(
+                    graphforge_storage::GRAPH_CAPABILITY_ID,
+                    graphforge_storage::GRAPH_SEMANTIC_BINDINGS_FAMILY,
+                )?
+                .is_some())
+    {
+        return Err(GfError::Validation(
+            "semantic bindings require their persisted ontology composition".into(),
+        ));
+    }
     let has_graph_files = parent
         .participant_snapshot(
             graphforge_storage::GRAPH_CAPABILITY_ID,
@@ -472,6 +490,16 @@ fn validate_workspace_record_inventory(
     if ontology_count != 1 || configuration_count != 1 || composition_count > 1 {
         return Err(GfError::Validation(
             "workspace generation must contain exactly one ontology and one configuration".into(),
+        ));
+    }
+    if composition_count != 1
+        && metadata.iter().any(|entry| {
+            entry.capability_id == graphforge_storage::GRAPH_CAPABILITY_ID
+                && entry.record_family_id == graphforge_storage::GRAPH_SEMANTIC_BINDINGS_FAMILY
+        })
+    {
+        return Err(GfError::Validation(
+            "semantic bindings require their persisted ontology composition".into(),
         ));
     }
     Ok(())
@@ -747,6 +775,89 @@ mod tests {
         assert!(
             validate_workspace_record_inventory(&[configuration.clone(), configuration]).is_err()
         );
+    }
+
+    #[test]
+    fn workspace_inventory_retains_composition_for_semantic_bindings() {
+        let ontology = staged_workspace(graphforge_storage::WORKSPACE_ONTOLOGY_FAMILY);
+        let configuration = staged_workspace(graphforge_storage::WORKSPACE_CONFIGURATION_FAMILY);
+        let composition =
+            staged_workspace(graphforge_storage::WORKSPACE_ONTOLOGY_COMPOSITION_FAMILY);
+        for row_count in [0, 4] {
+            let mut bindings = staged_workspace(graphforge_storage::GRAPH_SEMANTIC_BINDINGS_FAMILY);
+            bindings.capability_id = graphforge_storage::GRAPH_CAPABILITY_ID.into();
+            bindings.row_count = row_count;
+            assert!(
+                validate_workspace_record_inventory(&[
+                    ontology.clone(),
+                    configuration.clone(),
+                    bindings.clone(),
+                ])
+                .is_err()
+            );
+            assert!(
+                validate_workspace_record_inventory(&[
+                    ontology.clone(),
+                    configuration.clone(),
+                    composition.clone(),
+                    bindings,
+                ])
+                .is_ok()
+            );
+        }
+    }
+
+    #[test]
+    fn workspace_candidate_bindings_without_composition_refuse_before_staging() {
+        let root = tempfile::tempdir().unwrap();
+        let mut graph = GraphForge::new(root.path().to_str()).unwrap();
+        let parent = graph.resolved_generation.generation_uuid();
+        let inventory = graph.resolved_generation.participant_snapshots().unwrap();
+        let ontology = graph.workspace_ontology().unwrap();
+        let configuration = graph.workspace_configuration().unwrap();
+        let bindings = graphforge_storage::SemanticStorageBindings {
+            contract_version: graphforge_storage::GRAPH_SEMANTIC_BINDINGS_VERSION,
+            composition_fingerprint: "invalid-unowned-candidate".into(),
+            bindings: vec![],
+        };
+        let error = publish_workspace_records(
+            &mut graph,
+            uuid::Uuid::from_u128(1230001),
+            None,
+            &ontology,
+            &configuration,
+            None,
+            Some(&bindings),
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(error, GfError::Validation(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("semantic bindings require their persisted ontology composition")
+        );
+        let selected = graphforge_storage::resolve_project_generation(root.path()).unwrap();
+        assert_eq!(selected.generation_uuid(), parent);
+        assert_eq!(selected.participant_snapshots().unwrap(), inventory);
+        let token = crate::CancellationToken::new();
+        token.cancel();
+        assert!(
+            publish_workspace_records(
+                &mut graph,
+                uuid::Uuid::from_u128(1230002),
+                None,
+                &ontology,
+                &configuration,
+                None,
+                None,
+                None,
+                Some(&token),
+            )
+            .is_err()
+        );
+        assert_eq!(graph.resolved_generation.generation_uuid(), parent);
     }
 
     #[test]

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -3312,3 +3312,304 @@ fn cas_uuid_publication_faults_recover_and_allow_retry() {
         }
     }
 }
+
+#[test]
+fn bound_ontology_clear_refuses_before_publication_and_preserves_graph() {
+    for node_count in [33, 4097] {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let fixture = Fixture {
+            name: "bound_ontology_clear",
+            nodes: node_count,
+            edges: 129,
+            routes: 1,
+            identifiers: Identifiers::Random,
+            properties: false,
+            adjacency: false,
+            heterogeneous: false,
+        };
+        let (mut nodes, edges) = rows(fixture);
+        construct(&source, fixture, &nodes, &edges);
+        configure_composite_ontology(root.path(), &source, true);
+        for populated in [false, true] {
+            if populated {
+                let children = vec![
+                    (id(3, 0, true), "NewNode".into(), Some(17)),
+                    (id(3, 1, true), "NewNode".into(), None),
+                ];
+                construct(
+                    &source,
+                    Fixture {
+                        properties: true,
+                        ..fixture
+                    },
+                    &children,
+                    &[],
+                );
+                nodes.extend(children.into_iter().map(|mut node| {
+                    node.1 = "mixed:entity:NewNode".into();
+                    // Unlabelled projection excludes ontology properties; verify
+                    // the qualified nullable score independently below.
+                    node.2 = None;
+                    node
+                }));
+            }
+            let mut graph = GraphForge::new(source.to_str()).unwrap();
+            let parent = graphforge_storage::resolve_project_generation(&source).unwrap();
+            let bindings = graphforge_storage::semantic_storage_bindings(&parent)
+                .unwrap()
+                .unwrap();
+            assert!(!bindings.bindings.is_empty());
+            let participants = parent.participant_snapshots().unwrap();
+            let ontology = graph.workspace_ontology().unwrap();
+            let composition = graph.workspace_ontology_composition().unwrap();
+            let configuration = graph.workspace_configuration().unwrap();
+            let objects = cas_uuid_parent_objects(&source);
+            let query = "MATCH (n) RETURN n.node_uuid ORDER BY n.node_uuid";
+            let expected = graph.execute(query).unwrap();
+            let stream = graph.execute_stream(query).unwrap();
+            let files = clear_publication_files(&source);
+            let request = graphforge_api::ClearOntologyRequest {
+                context: graphforge_api::WriteContext {
+                    operation_uuid: OperationId(Uuid::now_v7()),
+                    actor_uuid: None,
+                },
+            };
+            for _ in 0..2 {
+                let error = graph.clear_ontology(request.clone()).unwrap_err();
+                assert!(
+                    matches!(error, graphforge_core::GfError::Validation(_)),
+                    "{error:?}"
+                );
+                assert!(
+                    error
+                        .to_string()
+                        .contains("semantic bindings require their persisted ontology composition"),
+                    "{error}"
+                );
+                assert_eq!(clear_publication_files(&source), files);
+                let selected = graphforge_storage::resolve_project_generation(&source).unwrap();
+                assert_eq!(selected.generation_uuid(), parent.generation_uuid());
+                assert_eq!(selected.participant_snapshots().unwrap(), participants);
+                assert_eq!(graph.workspace_ontology().unwrap(), ontology);
+                assert_eq!(graph.workspace_ontology_composition().unwrap(), composition);
+                assert_eq!(graph.workspace_configuration().unwrap(), configuration);
+                assert_eq!(
+                    graph.ontology_mode(),
+                    graphforge_api::OntologyMode::Advisory
+                );
+            }
+            cas_uuid_assert_parent_objects(&source, &objects);
+            use futures::TryStreamExt as _;
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let retained: Vec<RecordBatch> = runtime.block_on(stream.try_collect()).unwrap();
+            assert_eq!(
+                retained
+                    .iter()
+                    .map(|batch| batch.columns())
+                    .collect::<Vec<_>>(),
+                expected
+                    .batches
+                    .iter()
+                    .map(|batch| batch.columns())
+                    .collect::<Vec<_>>()
+            );
+            verify_graph(&graph, fixture, &nodes, &edges);
+            if populated {
+                let values = graph.execute("MATCH (n:`mixed:NewNode`) RETURN n.node_uuid, n.score ORDER BY n.node_uuid").unwrap();
+                assert_eq!(values.stats.rows_produced, 2);
+                let scores = values
+                    .batches
+                    .iter()
+                    .flat_map(|batch| {
+                        (0..batch.num_rows())
+                            .map(|row| (uuid_at(batch, 0, row), int_at(batch, 1, row)))
+                    })
+                    .collect::<BTreeMap<_, _>>();
+                assert_eq!(
+                    scores,
+                    BTreeMap::from([(id(3, 0, true), Some(17)), (id(3, 1, true), None)])
+                );
+            }
+            drop(graph);
+            let portable = root.path().join(format!("portable-{populated}"));
+            std::fs::create_dir(&portable).unwrap();
+            round_trip(&portable, &source, fixture, &nodes, &edges);
+            if populated {
+                for path in [&source, &portable.join("imported")] {
+                    let graph = GraphForge::new(path.to_str()).unwrap();
+                    let values = graph
+                        .execute("MATCH (n:`mixed:NewNode`) RETURN n.node_uuid, n.score")
+                        .unwrap();
+                    let scores = values
+                        .batches
+                        .iter()
+                        .flat_map(|batch| {
+                            (0..batch.num_rows())
+                                .map(|row| (uuid_at(batch, 0, row), int_at(batch, 1, row)))
+                        })
+                        .collect::<BTreeMap<_, _>>();
+                    assert_eq!(
+                        scores,
+                        BTreeMap::from([(id(3, 0, true), Some(17)), (id(3, 1, true), None)])
+                    );
+                }
+            }
+            println!(
+                "BOUND_CLEAR_BUDGET {}",
+                json!({"nodes":node_count,"qualified_rows_present":populated,"retained_files":files.len(),"new_files":0,"changed_file_bytes":0,"new_allocated_bytes":0})
+            );
+        }
+    }
+}
+
+// Snapshot all durable files, including CURRENT and publication journals. A
+// refused clear must not stage a candidate or allocate a replacement payload.
+fn clear_publication_files(root: &Path) -> BTreeMap<std::path::PathBuf, (String, u64)> {
+    let mut files = BTreeMap::new();
+    let mut directories = vec![root.to_path_buf()];
+    while let Some(directory) = directories.pop() {
+        for entry in std::fs::read_dir(directory).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                directories.push(path);
+            } else {
+                let file = File::open(&path).unwrap();
+                files.insert(
+                    path.strip_prefix(root).unwrap().to_path_buf(),
+                    (
+                        digest_hex(&std::fs::read(&path).unwrap()),
+                        graphforge_filesystem::file_space_usage(&file)
+                            .unwrap()
+                            .allocated_bytes,
+                    ),
+                );
+            }
+        }
+    }
+    files
+}
+
+fn unbound_clear_request() -> graphforge_api::ClearOntologyRequest {
+    graphforge_api::ClearOntologyRequest {
+        context: graphforge_api::WriteContext {
+            operation_uuid: OperationId(Uuid::from_u128(1230003)),
+            actor_uuid: None,
+        },
+    }
+}
+
+#[test]
+fn unbound_ontology_clear_fault_child() {
+    let Ok(source) = std::env::var("GF_UNBOUND_CLEAR_ROOT") else {
+        return;
+    };
+    let mut graph = GraphForge::new(Some(&source)).unwrap();
+    let error = graph.clear_ontology(unbound_clear_request()).unwrap_err();
+    assert_eq!(error.code(), "GF_PUBLICATION_FAILED");
+}
+
+#[test]
+fn unbound_ontology_clear_recovers_and_retries_without_rewriting_payloads() {
+    for boundary in [
+        "project.before_current_replace",
+        "project.after_current_replace",
+    ] {
+        for returned_error in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let source = root.path().join("source");
+            let fixture = Fixture {
+                name: "unbound_clear_recovery",
+                nodes: 33,
+                edges: 129,
+                routes: 1,
+                identifiers: Identifiers::Random,
+                properties: false,
+                adjacency: false,
+                heterogeneous: false,
+            };
+            let (nodes, edges) = rows(fixture);
+            construct(&source, fixture, &nodes, &edges);
+            let ontology = root.path().join("ontology.yaml");
+            std::fs::write(&ontology, "ontology_id: clear\nversion: \"1\"\nentity_types:\n  - name: Unused\n    abstract: false\nrelation_types: []\n").unwrap();
+            let mut graph = GraphForge::new(source.to_str()).unwrap();
+            graph
+                .adopt_ontology(graphforge_api::AdoptOntologyRequest {
+                    context: graphforge_api::WriteContext {
+                        operation_uuid: OperationId(Uuid::now_v7()),
+                        actor_uuid: None,
+                    },
+                    path: ontology,
+                    mode: graphforge_api::OntologyMode::Advisory,
+                })
+                .unwrap();
+            drop(graph);
+            let parent = graphforge_storage::resolve_project_generation(&source).unwrap();
+            let inventory = parent.graph_files_inventory().unwrap();
+            let objects = cas_uuid_parent_objects(&source);
+            let hook = format!("{boundary}{}", if returned_error { ".error" } else { "" });
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "unbound_ontology_clear_fault_child",
+                    "--nocapture",
+                ])
+                .env("GF_UNBOUND_CLEAR_ROOT", &source)
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINTS",
+                    "graphforge-internal-subprocess-v1",
+                )
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", &hook)
+                .output()
+                .unwrap();
+            assert_eq!(
+                output.status.code(),
+                Some(if returned_error { 0 } else { 86 }),
+                "{hook}: {} {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let mut graph = GraphForge::new(source.to_str()).unwrap();
+            let recovered = graphforge_storage::resolve_project_generation(&source).unwrap();
+            assert_eq!(
+                recovered.generation_uuid() != parent.generation_uuid(),
+                boundary == "project.after_current_replace"
+            );
+            assert_eq!(
+                graph.ontology_mode(),
+                if boundary == "project.after_current_replace" {
+                    graphforge_api::OntologyMode::Exploratory
+                } else {
+                    graphforge_api::OntologyMode::Advisory
+                }
+            );
+            verify_graph(&graph, fixture, &nodes, &edges);
+            for _ in 0..2 {
+                graph.clear_ontology(unbound_clear_request()).unwrap();
+            }
+            assert_eq!(
+                graph.ontology_mode(),
+                graphforge_api::OntologyMode::Exploratory
+            );
+            assert_eq!(
+                graphforge_storage::resolve_project_generation(&source)
+                    .unwrap()
+                    .graph_files_inventory()
+                    .unwrap(),
+                inventory
+            );
+            cas_uuid_assert_parent_objects(&source, &objects);
+            let created = graph
+                .execute("CREATE (n:Node0) RETURN n.node_uuid")
+                .unwrap();
+            let mut expected = nodes.clone();
+            expected.push((uuid_at(&created.batches[0], 0, 0), "Node0".into(), None));
+            verify_graph(&graph, fixture, &expected, &edges);
+            drop(graph);
+            round_trip(root.path(), &source, fixture, &expected, &edges);
+        }
+    }
+}

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -624,3 +624,54 @@ required exact-head native CI remains the platform/merge authority.
 This ownership repair does not make same-name adoption atomic (#1229), define
 bound-composition removal (#1230), refresh a facade after compaction (#1231), or
 complete the canonical publishing-contract gate (#1221).
+
+### Composition authority removal boundary (#1230)
+
+A workspace generation may not remove its composition while retaining a
+`graph/semantic_bindings` participant. This includes an empty binding list:
+current-format authentication pins that participant to its composition
+fingerprint regardless of whether qualified rows exist. Workspace publication
+now returns `GfError::Validation` before participant staging or publication
+journals if either retained or candidate bindings lack a composition. Staged
+inventory validation independently checks the cross-participant requirement.
+No binding or graph data is discarded. Unbound ontology clear remains supported.
+
+Public fixtures construct 33 and 4,097 exploratory nodes with 129 edges, adopt
+a disjoint ontology and publish its composition, then attempt clear before and
+after constructing two qualified nodes with non-null/null Int64 properties.
+Repeated refusal preserves CURRENT, every participant, facade configuration and
+ontology state, retained query results, every durable file digest/allocation and
+original readonly CAS inode identities. Exact graph and qualified properties
+survive reopen, export, full portable verification and clean import. Each
+refusal has deterministic zero-new-file, zero-changed-file-byte and
+zero-new-allocated-file-byte budgets. Source inspection establishes refusal
+before staging; file snapshots alone do not detect transient files or directory
+allocation. The operation still performs the existing authentication reads.
+
+Four subprocess cases cover process exit and returned error immediately before
+and after CURRENT replacement for eligible unbound clear. Reopen selects the
+expected old or cleared generation, exact retry succeeds, unchanged graph
+payloads retain their CAS identities, and a subsequent public CREATE survives a
+complete portable round trip. Unit tests cover empty candidate bindings,
+zero/nonzero binding row counts in staged metadata, and cancellation before
+publication. Existing composition certification verifies stale parents and
+forged plans without weakening reader authentication.
+
+Source `f1cf815577d07a697ce1ad505aa3fd2cd6db1cb0` and raw observations are in
+[`bound-ontology-clear-1230.json`](../../development/evidence/bound-ontology-clear-1230.json).
+The full refusal fixture took 9.83 s elapsed, 6.67 s user and 1.77 s system,
+with 136,936 KiB peak RSS. Separate syscall tracing recorded 132,373,775 read
+bytes, 16,648,242 write bytes and 5,862 successful fsync calls with no traced
+errors. OS filesystem input/output were 140,000/46,504 512-byte blocks. These
+include construction, composition, file hashing, queries and portable work;
+they are not isolated refusal costs or whole-process admission budgets.
+
+A separate 978-sample scan observed 6,479,872 bytes of unique-inode workspace
+allocation, with a maximum sample interval of 15.3 ms and 27 vanished-file
+races. It includes retained generations, private workspaces and portable
+artifacts; unlinked files and shorter peaks can be missed. This is not an exact
+temporary-only ceiling. The baseline publishes an unreadable project, so no
+valid complete-runtime baseline comparison or performance improvement is
+claimed. Compression, dictionary, row-group and streaming policies remain
+unchanged. Same-name promotion (#1229), post-compaction facade refresh (#1231)
+and the canonical publishing-contract close gate (#1221) remain separate.

--- a/docs/development/evidence/bound-ontology-clear-1230.json
+++ b/docs/development/evidence/bound-ontology-clear-1230.json
@@ -1,0 +1,111 @@
+{
+  "issue": 1230,
+  "source_commit": "f1cf815577d07a697ce1ad505aa3fd2cd6db1cb0",
+  "baseline_source_commit": "67412c498580ee60b23171a7bbd0b0617160ea94",
+  "workload": "Public construction N33 and N4097/E129, disjoint ontology adoption and composition publication, refusal before and after two qualified child nodes with nullable Int64 scores, repeated clear refusal, retained snapshot, exact graph/authority/file verification, reopen/export/full verify/clean import.",
+  "refusal_budgets": [
+    {
+      "changed_file_bytes": 0,
+      "new_allocated_bytes": 0,
+      "new_files": 0,
+      "nodes": 33,
+      "qualified_rows_present": false,
+      "retained_files": 137
+    },
+    {
+      "changed_file_bytes": 0,
+      "new_allocated_bytes": 0,
+      "new_files": 0,
+      "nodes": 33,
+      "qualified_rows_present": true,
+      "retained_files": 234
+    },
+    {
+      "changed_file_bytes": 0,
+      "new_allocated_bytes": 0,
+      "new_files": 0,
+      "nodes": 4097,
+      "qualified_rows_present": false,
+      "retained_files": 181
+    },
+    {
+      "changed_file_bytes": 0,
+      "new_allocated_bytes": 0,
+      "new_files": 0,
+      "nodes": 4097,
+      "qualified_rows_present": true,
+      "retained_files": 272
+    }
+  ],
+  "runtime": {
+    "elapsed_seconds": 9.83,
+    "user_seconds": 6.67,
+    "system_seconds": 1.77,
+    "peak_rss_kib": 136936,
+    "filesystem_input_512_byte_blocks": 140000,
+    "filesystem_output_512_byte_blocks": 46504,
+    "exit_status": 0
+  },
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 54654,
+        "bytes": 132196107
+      },
+      "pread64": {
+        "calls": 516,
+        "bytes": 177668
+      },
+      "write": {
+        "calls": 3475,
+        "bytes": 16648242
+      },
+      "fsync": {
+        "calls": 5862,
+        "bytes": 0
+      }
+    },
+    "read_bytes": 132373775,
+    "write_bytes": 16648242,
+    "errors": [],
+    "elapsed_seconds": 35.28
+  },
+  "workspace_observation": {
+    "command": [
+      "/home/ubuntu/code/graphforge-target-1195/debug/deps/permanent_storage_budgets-c514423ca6fb68a2",
+      "bound_ontology_clear_refuses_before_publication_and_preserves_graph",
+      "--exact",
+      "--nocapture",
+      "--test-threads=1"
+    ],
+    "sampled_unique_inode_allocated_peak_bytes": 6479872,
+    "sampled_path_logical_peak_bytes": 4873701,
+    "sampled_file_count_peak": 545,
+    "samples": 978,
+    "requested_poll_interval_seconds": 0.005,
+    "maximum_observed_sample_interval_seconds": 0.015292290016077459,
+    "vanished_files_during_scan": 27,
+    "exit_status": 0,
+    "limitations": [
+      "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+      "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+      "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+      "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+    ]
+  },
+  "deterministic_budgets": {
+    "refusal_new_durable_files": 0,
+    "refusal_changed_durable_file_bytes": 0,
+    "refusal_new_durable_file_allocated_bytes": 0,
+    "refusal_graph_reencoded_bytes": 0
+  },
+  "limitations": [
+    "The baseline erroneously accepts clear and publishes a project that cannot reopen; no valid complete baseline runtime or performance improvement comparison exists.",
+    "Timing/RSS and I/O are whole-fixture observations including setup, authentication, all-file SHA/allocation checks, queries and portable operations, not isolated clear costs or process admission limits.",
+    "Preflight reuses authenticated parent validation and reads participant metadata; zero rewrite does not mean zero authentication I/O.",
+    "Runtime, syscall and sampled workspace measurements use separate executions.",
+    "Durable-file equality excludes directory allocation and cannot alone detect short-lived files; source control flow independently establishes refusal before staging.",
+    "Workspace sampling includes retained and portable artifacts, can miss unlinked/short-lived peaks, and does not establish an exact temporary-only bound.",
+    "Existing encoding, streaming, dictionaries and row-group defaults are unchanged."
+  ]
+}


### PR DESCRIPTION
Clearing ontology authority after a composition has published semantic bindings currently succeeds but leaves a project that cannot reopen. Refuse that unsupported removal before staging, including empty binding participants, and independently enforce the cross-participant requirement during workspace validation. Eligible unbound clear retains its existing publication and retry behavior.

Public tests cover 33/4,097-node constructed CAS parents before/after qualified child construction, nullable properties, exact CURRENT/participant/facade/file preservation, retained snapshots and reopen/export/full verification/clean import. Four subprocess crash/returned-error cases cover supported clear around CURRENT replacement, retry and subsequent mutation. Refusal has zero changed/new durable files or allocated file bytes; source-bound CPU, read/write I/O, RSS and sampled workspace costs are recorded in the assessment and raw evidence. Existing permanent Parquet policy and lifecycle implementations remain intact.

Validation passed: 736 API unit tests; the bound-clear public fixture and four unbound crash/error cases; three multi-ontology certification tests (including cancellation, forged plans and stale parents); workspace Clippy with warnings denied; fast pre-push; gate-registry validation; formatting and diff checks. Required exact-head CI is the remaining merge gate. Independent source review found no actionable issue.

Closes #1230. Canonical #1221 and epic #1194 remain open for their other criteria.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791626657&installation_model_id=20486&pr_number=1233&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1233&signature=2dc960a375dc079b4ef47334bd7d597c99710831936b8da29f13d4e354e6e612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->