### PR TITLE
fix(api): refresh facade authority after compaction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1025,6 +1025,7 @@ jobs:
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1
           cargo test -p graphforge-api --lib mapped_portable_tests:: -- --nocapture || route_status=1
           cargo test -p graphforge-api --lib mapped_stream_tests:: -- --nocapture || route_status=1
+          cargo test -p graphforge-api --lib maintenance::tests::in_memory_compaction_cleanup_uses_ephemeral_lifecycle_mode -- --exact --nocapture || route_status=1
           exit "$route_status"
 
       - name: Cross-check Windows publication-kill results against the fault oracle
@@ -1143,6 +1144,7 @@ jobs:
           cargo test -p graphforge-storage --lib mutator::tests::mapped_reserved_delete_preserves_other_routes_and_reopens -- --exact --nocapture || route_status=1
           cargo test -p graphforge-api --lib mapped_portable_tests:: -- --nocapture || route_status=1
           cargo test -p graphforge-api --lib mapped_stream_tests:: -- --nocapture || route_status=1
+          cargo test -p graphforge-api --lib maintenance::tests::in_memory_compaction_cleanup_uses_ephemeral_lifecycle_mode -- --exact --nocapture || route_status=1
           exit "$route_status"
 
       - name: Cross-check macOS publication-kill results against the fault oracle

--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -892,7 +892,7 @@ fn ensure_rebase_compatible(
     Ok(())
 }
 
-fn administrative_contract(
+pub(crate) fn administrative_contract(
     generation: &ResolvedProjectGeneration,
 ) -> Result<AdministrativeContract, GfError> {
     let mut contract = generation

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -2009,14 +2009,18 @@ impl GraphForge {
         // stream is demand-driven and may outlive this call; holding the slot
         // for the full consumer lifetime would serialize all streaming clients.
         drop(admission);
-        Ok(Box::pin(WorkspacePinnedStream {
+        Ok(self.finish_public_stream(stream))
+    }
+
+    fn finish_public_stream(&self, stream: SendableRecordBatchStream) -> SendableRecordBatchStream {
+        Box::pin(WorkspacePinnedStream {
             stream: self.graph_visibility.health.guard_stream(shape_stream(
                 stream,
                 self.ontology_mode,
                 self.ontology.as_ref(),
             )),
             _workspace: Arc::clone(&self.workspace_guard),
-        }))
+        })
     }
 
     /// Streaming query plus a [`RuntimeGuard`] that keeps the instance's

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -416,6 +416,12 @@ pub use search_index::SearchIndexOptions;
 // GraphForge
 // ---------------------------------------------------------------------------
 
+struct PreparedGenerationReadAuthority {
+    properties: Arc<graphforge_storage::AuthenticatedPropertyInventory>,
+    ordinal: Option<graphforge_storage::ordinal_identity_v4::V4OrdinalIdentityHandle>,
+    adjacency: Arc<graphforge_exec::PersistentAdjacencyProvider>,
+}
+
 struct GenerationPropertyAuthority {
     generation_uuid: uuid::Uuid,
     inventory: Arc<graphforge_storage::AuthenticatedPropertyInventory>,
@@ -1011,33 +1017,54 @@ impl GraphForge {
         Arc::clone(&authority.inventory)
     }
 
-    fn install_property_generation(
+    fn prepare_generation_read_authority(
         &self,
         generation: &ResolvedProjectGeneration,
-    ) -> Result<(), GfError> {
-        let replacement = property_inventory_for_hydrated_generation(generation, &self.dir)?;
-        let ordinal_replacement = ordinal_identity_handle(generation, &self.dir)?;
-        let adjacency_replacement = Arc::new(adjacency_provider_for_graph(
-            &self.dir,
+        graph_root: &Path,
+    ) -> Result<PreparedGenerationReadAuthority, GfError> {
+        let properties = property_inventory_for_hydrated_generation(generation, graph_root)?;
+        let ordinal = ordinal_identity_handle(generation, graph_root)?;
+        let adjacency = Arc::new(adjacency_provider_for_graph(
+            graph_root,
             self.ontology_mode,
-            Arc::clone(&replacement),
+            Arc::clone(&properties),
         )?);
+        Ok(PreparedGenerationReadAuthority {
+            properties,
+            ordinal,
+            adjacency,
+        })
+    }
+
+    fn install_prepared_generation_read_authority(
+        &self,
+        generation_uuid: uuid::Uuid,
+        prepared: PreparedGenerationReadAuthority,
+    ) {
         *self
             .property_authority
             .lock()
             .expect("property authority lock poisoned") = GenerationPropertyAuthority {
-            generation_uuid: generation.generation_uuid(),
-            inventory: Arc::clone(&replacement),
+            generation_uuid,
+            inventory: prepared.properties,
         };
         *self
             .current_generation_uuid
             .lock()
-            .expect("generation UUID lock poisoned") = generation.generation_uuid();
+            .expect("generation UUID lock poisoned") = generation_uuid;
         *self
             .adjacency_provider
             .write()
-            .expect("adjacency provider lock poisoned") = adjacency_replacement;
-        self.ordinal_identities.replace(ordinal_replacement);
+            .expect("adjacency provider lock poisoned") = prepared.adjacency;
+        self.ordinal_identities.replace(prepared.ordinal);
+    }
+
+    fn install_property_generation(
+        &self,
+        generation: &ResolvedProjectGeneration,
+    ) -> Result<(), GfError> {
+        let prepared = self.prepare_generation_read_authority(generation, &self.dir)?;
+        self.install_prepared_generation_read_authority(generation.generation_uuid(), prepared);
         Ok(())
     }
 
@@ -1982,11 +2009,14 @@ impl GraphForge {
         // stream is demand-driven and may outlive this call; holding the slot
         // for the full consumer lifetime would serialize all streaming clients.
         drop(admission);
-        Ok(self.graph_visibility.health.guard_stream(shape_stream(
-            stream,
-            self.ontology_mode,
-            self.ontology.as_ref(),
-        )))
+        Ok(Box::pin(WorkspacePinnedStream {
+            stream: self.graph_visibility.health.guard_stream(shape_stream(
+                stream,
+                self.ontology_mode,
+                self.ontology.as_ref(),
+            )),
+            _workspace: Arc::clone(&self.workspace_guard),
+        }))
     }
 
     /// Streaming query plus a [`RuntimeGuard`] that keeps the instance's
@@ -3512,6 +3542,30 @@ impl Shaper {
             cols,
             &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(row_count)),
         )
+    }
+}
+
+// Drop the lazy reader (and its retained descriptors) before the final
+// workspace owner. Compaction may rotate the facade while this stream lives.
+struct WorkspacePinnedStream {
+    stream: SendableRecordBatchStream,
+    _workspace: Arc<tempfile::TempDir>,
+}
+
+impl futures::Stream for WorkspacePinnedStream {
+    type Item = datafusion::error::Result<arrow::record_batch::RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.stream.as_mut().poll_next(context)
+    }
+}
+
+impl datafusion::physical_plan::RecordBatchStream for WorkspacePinnedStream {
+    fn schema(&self) -> arrow::datatypes::SchemaRef {
+        self.stream.schema()
     }
 }
 

--- a/crates/graphforge-api/src/maintenance.rs
+++ b/crates/graphforge-api/src/maintenance.rs
@@ -124,7 +124,7 @@ impl GraphForge {
         // After publication (including a returned error), refresh from actual
         // durable authority rather than reinstalling the previous working tree.
         let refresh = (|| {
-            let current = self.generation_for_read()?;
+            let mut current = self.generation_for_read()?;
             if current.generation_uuid() == expected_parent {
                 return Ok(());
             }
@@ -144,6 +144,19 @@ impl GraphForge {
             }
             // CURRENT authenticates the manifest's transaction and parent even
             // when the publication journal has not yet reached Published.
+            if result.is_err()
+                && current.generation_uuid() == request.generation_uuid
+                && current.transaction_uuid() == request.transaction_uuid
+            {
+                // Finish the selected journal using normal recovery so an
+                // immediate exact retry finds its receipt instead of trying
+                // to compact an already folded, empty delta chain.
+                graphforge_storage::recover_project_transactions_with_mode(
+                    &root,
+                    self.lifecycle_mode,
+                )?;
+                current = self.generation_for_read()?;
+            }
             if crate::composite_publish::administrative_contract(&current)?
                 != crate::composite_publish::administrative_contract(&parent)?
             {

--- a/crates/graphforge-api/src/maintenance.rs
+++ b/crates/graphforge-api/src/maintenance.rs
@@ -8,7 +8,7 @@ use graphforge_storage::{
     GraphDeltaCompactionPolicy, GraphDeltaCompactionReport, GraphDeltaCompactionRequest,
     GraphDeltaCompactionStatus, GraphDeltaJournalLimits, ProjectCleanupReport,
     ProjectReachabilityReport, ProjectRetentionLimits, ProjectRetentionPolicy,
-    compact_graph_delta_with_mode, graph_delta_compaction_status_with_mode,
+    compact_graph_delta_for_parent_with_mode, graph_delta_compaction_status_with_mode,
     inspect_project_reachability_with_mode, preview_graph_delta_compaction_with_mode,
     preview_project_cleanup_with_mode,
 };
@@ -86,19 +86,105 @@ impl GraphForge {
         )
     }
 
-    /// Compact a contiguous verified delta prefix into a new Parquet generation.
+    /// Compact the verified delta chain into a new Parquet generation and
+    /// refresh this facade for subsequent reads and mutations. Existing streams
+    /// retain their original workspace. Current-format compaction requires the
+    /// full chain; a facade made stale by another publisher must be reopened.
     pub fn compact_graph_delta(
-        &self,
+        &mut self,
         request: &GraphDeltaCompactionRequest,
         cancellation: Option<&CancellationToken>,
     ) -> Result<GraphDeltaCompactionReport, GfError> {
-        let root = self.require_mutable_project_root()?;
-        compact_graph_delta_with_mode(
-            root,
+        let root = self.require_mutable_project_root()?.to_path_buf();
+        let visibility = std::sync::Arc::clone(&self.graph_visibility);
+        let _visibility = visibility.acquire(cancellation)?;
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
+        let parent = self.generation_for_read()?;
+        let expected_parent = *self
+            .current_generation_uuid
+            .lock()
+            .expect("generation UUID lock poisoned");
+        if parent.generation_uuid() != expected_parent {
+            return Err(GfError::Project {
+                code: ProjectErrorCode::WriteConflict,
+                message: "project generation changed before facade compaction; reopen the facade"
+                    .into(),
+            });
+        }
+        let result = compact_graph_delta_for_parent_with_mode(
+            &root,
             request,
             cancellation.map(CancellationToken::flag),
             self.lifecycle_mode,
-        )
+            expected_parent,
+        );
+        // Storage stages privately. An unchanged CURRENT needs no restoration.
+        // After publication (including a returned error), refresh from actual
+        // durable authority rather than reinstalling the previous working tree.
+        let refresh = (|| {
+            let current = self.generation_for_read()?;
+            if current.generation_uuid() == expected_parent {
+                return Ok(());
+            }
+            if result.is_err()
+                && !(current.generation_uuid() == request.generation_uuid
+                    && current.transaction_uuid() == request.transaction_uuid
+                    && current.parent_generation_uuid() == Some(expected_parent))
+                && !graphforge_storage::published_project_transaction(
+                    &root,
+                    request.transaction_uuid,
+                )?
+                .is_some_and(|receipt| receipt.generation_uuid == request.generation_uuid)
+            {
+                // A competing writer advanced CURRENT; this failed operation
+                // did not publish and must not change the facade's old view.
+                return Ok(());
+            }
+            // CURRENT authenticates the manifest's transaction and parent even
+            // when the publication journal has not yet reached Published.
+            if crate::composite_publish::administrative_contract(&current)?
+                != crate::composite_publish::administrative_contract(&parent)?
+            {
+                return Err(GfError::Project {
+                    code: ProjectErrorCode::WriteConflict,
+                    message: "workspace authority changed during compaction; reopen the facade"
+                        .into(),
+                });
+            }
+            // Prepare a separate bounded workspace. Existing lazy streams keep
+            // their old paths and immutable identity handles, including on
+            // Windows where retained capabilities deliberately deny deletion.
+            let (dir, workspace, evidence) = crate::hydrate_graph_workspace(&current, false)?;
+            let prepared = self.prepare_generation_read_authority(&current, &dir)?;
+            let catalog = crate::load_runtime_catalog(&dir)?;
+            let bindings = graphforge_storage::semantic_storage_bindings(&current)?;
+            let old_workspace = std::mem::replace(&mut self.workspace_guard, workspace);
+            self.dir = dir;
+            self.graph_open_evidence = evidence;
+            self.install_prepared_generation_read_authority(current.generation_uuid(), prepared);
+            self.resolved_generation = current;
+            *self
+                .runtime_catalog
+                .lock()
+                .expect("runtime catalog poisoned") = catalog;
+            *self
+                .semantic_storage_bindings
+                .lock()
+                .expect("semantic storage binding lock poisoned") = bindings;
+            *self
+                .uuid_membership_index
+                .lock()
+                .expect("UUID membership index lock poisoned") = None;
+            drop(old_workspace);
+            Ok(())
+        })();
+        if let Err(error) = refresh {
+            self.graph_visibility.health.fail(&error);
+            return Err(error);
+        }
+        result
     }
 }
 
@@ -116,7 +202,7 @@ mod tests {
     #[test]
     fn facade_exposes_transaction_and_maintenance_ops() {
         let directory = TempDir::new().unwrap();
-        let graph = GraphForge::new(directory.path().to_str()).unwrap();
+        let mut graph = GraphForge::new(directory.path().to_str()).unwrap();
         let _ = graph.project_open_recovery();
         graph
             .inspect_project_reachability(
@@ -341,77 +427,37 @@ mod tests {
 
     #[test]
     fn in_memory_compaction_cleanup_uses_ephemeral_lifecycle_mode() {
-        use graphforge_storage::{
-            GraphDeltaOp, GraphDeltaOpKind, GraphDeltaPayload, GraphDeltaPublishRequest,
-            ProjectCapability, ProjectGenerationRequest, ProjectStageOutcome,
-        };
-
-        let graph = GraphForge::new(None).unwrap();
-        let root = graph.resolved_generation.container_root();
-        let workspace = tempfile::tempdir().unwrap();
-        let mut writer = graphforge_storage::GraphWriter::open_at(
-            workspace.path(),
-            graphforge_core::OntologyMode::Strict,
-            1_700_000_000_000_000,
-        )
-        .unwrap();
-        writer.flush().unwrap();
-        let (_, files) = graphforge_storage::capture_graph_files(workspace.path()).unwrap();
-        let mut participants = graphforge_storage::empty_workspace_participants().unwrap();
-        participants.insert(0, files);
-        let base = ProjectGenerationRequest {
-            transaction_uuid: Uuid::now_v7(),
-            generation_uuid: Uuid::now_v7(),
-            capabilities: vec![
-                ProjectCapability {
-                    capability_id: "graph".into(),
-                    capability_version: 1,
-                },
-                ProjectCapability {
-                    capability_id: "workspace".into(),
-                    capability_version: 1,
-                },
-            ],
-            participants,
-        };
-        let ProjectStageOutcome::Staged(staged) =
-            graphforge_storage::stage_project_generation_with_graph_tree_mode(
-                root,
-                &base,
-                Some(workspace.path()),
-                graph.lifecycle_mode,
-            )
-            .unwrap()
-        else {
-            panic!("base publication unexpectedly replayed");
-        };
-        staged
-            .validate(|_| Ok(()), |_, _| Ok(()))
-            .unwrap()
-            .publish()
+        let mut graph = GraphForge::new(None).unwrap();
+        let created = graph
+            .execute("CREATE (n:Person) RETURN n.node_uuid")
             .unwrap();
-        graphforge_storage::publish_graph_delta_with_mode(
-            root,
-            &GraphDeltaPublishRequest {
-                transaction_uuid: Uuid::now_v7(),
-                generation_uuid: Uuid::now_v7(),
-                run_uuid: Uuid::now_v7(),
-                operations: vec![GraphDeltaOp {
-                    operation_uuid: Uuid::now_v7(),
-                    kind: GraphDeltaOpKind::UpsertNode,
-                    payload: GraphDeltaPayload::UpsertNodeV2 {
-                        node_uuid: Uuid::now_v7().hyphenated().to_string(),
-                        node_id: 1,
-                        type_ids: vec![graphforge_value::EntityTypeId::decode(1).unwrap()],
-                        created_at_micros: 1,
-                        updated_at_micros: 1,
-                    },
+        let ids = created.batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+            .unwrap();
+        let node = Uuid::from_slice(ids.value(0)).unwrap();
+        graph
+            .publish_composite_transaction(crate::CompositeTransactionRequest {
+                contract_version: crate::COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                context: WriteContext {
+                    operation_uuid: OperationId(Uuid::now_v7()),
+                    actor_uuid: None,
+                },
+                graph_mutations: vec![crate::CompositeGraphMutation::SetNodeProperty {
+                    node_uuid: node,
+                    property: "score".into(),
+                    value: crate::PropValue::Int(7),
                 }],
-                limits: GraphDeltaJournalLimits::default(),
-            },
-            graph.lifecycle_mode,
-        )
-        .unwrap();
+                knowledge: crate::CompositeKnowledgeParticipants::default(),
+            })
+            .unwrap();
+        *graph.uuid_membership_index.lock().unwrap() =
+            Some(graphforge_storage::UuidMembershipIndex::open(&graph.dir).unwrap());
+        let old_dir = graph.dir.clone();
+        let snapshot = graph
+            .execute_stream("MATCH (n) RETURN n.node_uuid, n.score")
+            .unwrap();
         let request = GraphDeltaCompactionRequest {
             transaction_uuid: Uuid::now_v7(),
             generation_uuid: Uuid::now_v7(),
@@ -425,5 +471,10 @@ mod tests {
         let report = graph.compact_graph_delta(&request, None).unwrap();
 
         assert!(report.cleanup.is_some());
+        assert_ne!(graph.dir, old_dir);
+        assert!(graph.uuid_membership_index.lock().unwrap().is_none());
+        assert!(old_dir.exists(), "active stream retains old workspace");
+        drop(snapshot);
+        assert!(!old_dir.exists(), "last stream releases old workspace");
     }
 }

--- a/crates/graphforge-api/src/maintenance.rs
+++ b/crates/graphforge-api/src/maintenance.rs
@@ -132,11 +132,11 @@ impl GraphForge {
                 && !(current.generation_uuid() == request.generation_uuid
                     && current.transaction_uuid() == request.transaction_uuid
                     && current.parent_generation_uuid() == Some(expected_parent))
-                && !graphforge_storage::published_project_transaction(
+                && graphforge_storage::published_project_transaction(
                     &root,
                     request.transaction_uuid,
                 )?
-                .is_some_and(|receipt| receipt.generation_uuid == request.generation_uuid)
+                .is_none_or(|receipt| receipt.generation_uuid != request.generation_uuid)
             {
                 // A competing writer advanced CURRENT; this failed operation
                 // did not publish and must not change the facade's old view.

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -1072,7 +1072,7 @@ fn cas_construction_composite_mutation_and_compaction_preserve_values() {
         .filter(|entry| !(entry.capability_id == "graph" && entry.record_family_id == "files"))
         .collect::<Vec<_>>();
 
-    let graph = GraphForge::new(source.to_str()).unwrap();
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     let request = GraphDeltaCompactionRequest {
         transaction_uuid: Uuid::from_u128(121305),
@@ -1548,7 +1548,7 @@ fn exercise_qualified_property_publication(
         },
         ..Default::default()
     };
-    let graph = GraphForge::new_with_options(source.to_str(), options).unwrap();
+    let mut graph = GraphForge::new_with_options(source.to_str(), options).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     let base = current.graph_files_inventory().unwrap().unwrap();
     assert!(current.declared_graph_files_inventory().unwrap().is_none());
@@ -2182,7 +2182,7 @@ fn exploratory_parent_construction_replays_and_compacts_exact_routes() {
         .unwrap();
     drop(graph);
     nodes[0].2 = Some(123);
-    let graph = GraphForge::new(source.to_str()).unwrap();
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     graph
         .compact_graph_delta(
@@ -2321,7 +2321,7 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
     for edge in &mut edges[129..] {
         edge.3.clone_from(&relation.route);
     }
-    let graph = GraphForge::new(source.to_str()).unwrap();
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     let schemas = |source: &Path| {
         let selected = graphforge_storage::resolve_project_generation(source).unwrap();
@@ -2657,7 +2657,7 @@ fn permanent_publishing_policy_construction_mutation_and_compaction() {
         .unwrap();
     drop(graph);
     nodes[0].2 = Some(123);
-    let graph = GraphForge::new(source.to_str()).unwrap();
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
     let before_compaction = graphforge_storage::resolve_project_generation(&source)
         .unwrap()
@@ -3610,6 +3610,405 @@ fn unbound_ontology_clear_recovers_and_retries_without_rewriting_payloads() {
             verify_graph(&graph, fixture, &expected, &edges);
             drop(graph);
             round_trip(root.path(), &source, fixture, &expected, &edges);
+        }
+    }
+}
+
+#[test]
+fn facade_compaction_refreshes_authority_and_preserves_lazy_snapshot() {
+    for nodes in [33, 4097] {
+        exercise_facade_compaction_refresh(nodes, false);
+    }
+}
+
+#[test]
+fn facade_compaction_rejects_partial_chain_then_refreshes_full_chain() {
+    for nodes in [33, 4097] {
+        exercise_facade_compaction_refresh(nodes, true);
+    }
+}
+
+fn exercise_facade_compaction_refresh(node_count: usize, multiple_deltas: bool) {
+    use futures::TryStreamExt as _;
+    use graphforge_api::{
+        COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation as Mutation,
+        CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
+    };
+    use graphforge_storage::{
+        GraphDeltaCompactionLimits, GraphDeltaCompactionRequest, ProjectRetentionLimits,
+        ProjectRetentionPolicy,
+    };
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "facade_compaction_authority",
+        nodes: node_count,
+        edges: 129,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (mut nodes, edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let parent_objects = cas_uuid_parent_objects(&source);
+    let original_ids = cas_uuid_node_surrogates(&source);
+    let mut graph = GraphForge::new_with_options(
+        source.to_str(),
+        graphforge_api::GraphForgeOptions {
+            resource: graphforge_api::ExecutionResourcePolicy {
+                batch_size: Some(7),
+                target_partitions: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    if multiple_deltas {
+        graph.index_adjacency().unwrap();
+    }
+    graph
+        .publish_composite_transaction(CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![
+                Mutation::SetNodeProperty {
+                    node_uuid: nodes[0].0,
+                    property: "score".into(),
+                    value: PropValue::Int(9),
+                },
+                Mutation::RemoveNodeProperty {
+                    node_uuid: nodes[1].0,
+                    property: "score".into(),
+                },
+            ],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        })
+        .unwrap();
+    nodes[0].2 = Some(9);
+    nodes[1].2 = None;
+    verify_graph(&graph, fixture, &nodes, &edges);
+    if multiple_deltas {
+        graph
+            .publish_composite_transaction(CompositeTransactionRequest {
+                contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                context: WriteContext {
+                    operation_uuid: OperationId(Uuid::now_v7()),
+                    actor_uuid: None,
+                },
+                graph_mutations: vec![Mutation::SetNodeProperty {
+                    node_uuid: nodes[2].0,
+                    property: "score".into(),
+                    value: PropValue::Int(7),
+                }],
+                knowledge: CompositeKnowledgeParticipants::default(),
+            })
+            .unwrap();
+        nodes[2].2 = Some(7);
+    }
+    let expected_snapshot = nodes
+        .iter()
+        .map(|row| (row.0, row.2))
+        .collect::<BTreeMap<_, _>>();
+    let mut snapshot = graph
+        .execute_stream("MATCH (n) RETURN n.node_uuid, n.score")
+        .unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let first = runtime.block_on(snapshot.try_next()).unwrap().unwrap();
+    assert!(first.num_rows() > 0 && first.num_rows() < node_count);
+    let mut request = GraphDeltaCompactionRequest {
+        transaction_uuid: Uuid::now_v7(),
+        generation_uuid: Uuid::now_v7(),
+        through_run_sequence: multiple_deltas.then_some(1),
+        limits: GraphDeltaCompactionLimits::default(),
+        cleanup_after_commit: false,
+        cleanup_policy: ProjectRetentionPolicy::default(),
+        cleanup_limits: ProjectRetentionLimits::default(),
+    };
+    let parent = graphforge_storage::resolve_project_generation(&source)
+        .unwrap()
+        .generation_uuid();
+    let cancelled = graphforge_api::CancellationToken::new();
+    cancelled.cancel();
+    assert!(
+        graph
+            .compact_graph_delta(&request, Some(&cancelled))
+            .is_err()
+    );
+    assert_eq!(
+        graphforge_storage::resolve_project_generation(&source)
+            .unwrap()
+            .generation_uuid(),
+        parent
+    );
+    if multiple_deltas {
+        let error = graph.compact_graph_delta(&request, None).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires the full verified delta chain")
+        );
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .generation_uuid(),
+            parent
+        );
+        verify_graph(&graph, fixture, &nodes, &edges);
+        request.through_run_sequence = None;
+    }
+    let report = graph.compact_graph_delta(&request, None).unwrap();
+    assert!(report.output_bytes <= 1024 * 1024, "{report:?}");
+    // This report accounts logical compaction state, not total process RSS.
+    assert!(report.peak_memory_bytes <= 4 * 1024, "{report:?}");
+    assert_eq!(report.spill_bytes, 0);
+    let compacted_parquet = publishing_parquet_inventory(&source);
+    let hydration = graph.graph_open_evidence();
+    let owned = compacted_parquet["ownership"] == "generation_graph_tree";
+    if owned {
+        // Generation-owned payloads cannot acquire extra immutable CAS links.
+        // Refresh retains the existing streaming private-copy ownership rule.
+        assert!(
+            hydration.application_read_bytes <= 2 * 1024 * 1024,
+            "{hydration:?}"
+        );
+        assert!(
+            hydration.application_write_bytes <= 1024 * 1024,
+            "{hydration:?}"
+        );
+        assert!(hydration.files_copied <= 64, "{hydration:?}");
+        assert!(hydration.fsync_calls <= 128, "{hydration:?}");
+    } else {
+        assert!(hydration.files_reused > 0);
+        assert!(
+            hydration.application_read_bytes <= 1024 * 1024,
+            "{hydration:?}"
+        );
+        assert!(
+            hydration.application_write_bytes <= 192 * 1024,
+            "{hydration:?}"
+        );
+        assert!(hydration.files_copied <= 8, "{hydration:?}");
+        assert!(hydration.fsync_calls <= 16, "{hydration:?}");
+    }
+    println!(
+        "FACADE_COMPACTION_REFRESH {}",
+        json!({"nodes":node_count,"multiple_deltas":multiple_deltas,"owned":owned,"hydration":format!("{hydration:?}"),"compaction":format!("{report:?}"),"parquet_bytes":compacted_parquet["parquet_bytes"]})
+    );
+    verify_graph(&graph, fixture, &nodes, &edges);
+    assert!(
+        graph
+            .compact_graph_delta(&request, None)
+            .unwrap()
+            .publication
+            .unwrap()
+            .idempotent_replay
+    );
+    graph.execute("MATCH (n:Node0) SET n.score = 11").unwrap();
+    for node in &mut nodes {
+        if node.1 == "Node0" {
+            node.2 = Some(11);
+        }
+    }
+    let created = graph
+        .execute("CREATE (n:Node0 {score: 9000}) RETURN n.node_uuid")
+        .unwrap();
+    let retired_uuid = uuid_at(&created.batches[0], 0, 0);
+    let retired_id = cas_uuid_node_surrogates(&source)[&retired_uuid];
+    graph
+        .execute("MATCH (n:Node0 {score: 9000}) DELETE n")
+        .unwrap();
+    let created = graph
+        .execute("CREATE (n:Node0 {score: 9001}) RETURN n.node_uuid")
+        .unwrap();
+    let created_uuid = uuid_at(&created.batches[0], 0, 0);
+    nodes.push((created_uuid, "Node0".into(), Some(9001)));
+    let current_ids = cas_uuid_node_surrogates(&source);
+    assert!(retired_id > *original_ids.values().max().unwrap());
+    assert!(current_ids[&created_uuid] > retired_id);
+    for (uuid, surrogate) in &original_ids {
+        assert_eq!(current_ids[uuid], *surrogate);
+    }
+    let mut retained = vec![first];
+    retained.extend(runtime.block_on(snapshot.try_collect::<Vec<_>>()).unwrap());
+    let mut actual = BTreeMap::new();
+    for batch in retained {
+        for row in 0..batch.num_rows() {
+            assert!(
+                actual
+                    .insert(uuid_at(&batch, 0, row), int_at(&batch, 1, row))
+                    .is_none()
+            );
+        }
+    }
+    assert_eq!(actual, expected_snapshot);
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let latest_parquet = publishing_parquet_inventory(&source);
+    assert!(latest_parquet["parquet_bytes"].as_u64().unwrap() <= 1024 * 1024);
+    cas_uuid_assert_parent_objects(&source, &parent_objects);
+    drop(graph);
+    round_trip(root.path(), &source, fixture, &nodes, &edges);
+}
+
+fn facade_compaction_fault_request() -> graphforge_storage::GraphDeltaCompactionRequest {
+    graphforge_storage::GraphDeltaCompactionRequest {
+        transaction_uuid: Uuid::from_u128(0x1231_001),
+        generation_uuid: Uuid::from_u128(0x1231_002),
+        through_run_sequence: None,
+        limits: graphforge_storage::GraphDeltaCompactionLimits::default(),
+        cleanup_after_commit: false,
+        cleanup_policy: graphforge_storage::ProjectRetentionPolicy::default(),
+        cleanup_limits: graphforge_storage::ProjectRetentionLimits::default(),
+    }
+}
+
+#[test]
+fn facade_compaction_fault_child() {
+    use futures::TryStreamExt as _;
+    let Ok(source) = std::env::var("GF_FACADE_COMPACTION_ROOT") else {
+        return;
+    };
+    let mut graph = GraphForge::new(Some(&source)).unwrap();
+    let query = "MATCH (n) RETURN n.node_uuid, n.score ORDER BY n.node_uuid";
+    let exact_rows = |batches: Vec<RecordBatch>| {
+        batches
+            .iter()
+            .flat_map(|batch| {
+                (0..batch.num_rows()).map(|row| (uuid_at(batch, 0, row), int_at(batch, 1, row)))
+            })
+            .collect::<Vec<_>>()
+    };
+    let before = exact_rows(graph.execute(query).unwrap().batches);
+    let stream = graph.execute_stream(query).unwrap();
+    let error = graph
+        .compact_graph_delta(&facade_compaction_fault_request(), None)
+        .unwrap_err();
+    assert_eq!(error.code(), "GF_PUBLICATION_FAILED");
+    assert_eq!(exact_rows(graph.execute(query).unwrap().batches), before);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    assert_eq!(
+        exact_rows(runtime.block_on(stream.try_collect::<Vec<_>>()).unwrap()),
+        before
+    );
+    // This transaction is outside the injected operation's scope. Success
+    // proves the same facade selected the committed compaction, when present.
+    graph.execute("MATCH (n:Node0) SET n.score = 31").unwrap();
+    graph.execute("CREATE (:Node0 {score: 9001})").unwrap();
+}
+
+#[test]
+fn facade_compaction_faults_preserve_authority_and_allow_mutation() {
+    for boundary in [
+        "project.before_current_replace",
+        "project.after_current_replace",
+    ] {
+        for returned_error in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let source = root.path().join("source");
+            let fixture = Fixture {
+                name: "facade_compaction_recovery",
+                nodes: 33,
+                edges: 129,
+                routes: 2,
+                identifiers: Identifiers::Random,
+                properties: true,
+                adjacency: false,
+                heterogeneous: false,
+            };
+            let (mut nodes, edges) = rows(fixture);
+            construct(&source, fixture, &nodes, &edges);
+            let graph = GraphForge::new(source.to_str()).unwrap();
+            graph
+                .publish_composite_transaction(graphforge_api::CompositeTransactionRequest {
+                    contract_version: graphforge_api::COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                    context: graphforge_api::WriteContext {
+                        operation_uuid: OperationId(Uuid::now_v7()),
+                        actor_uuid: None,
+                    },
+                    graph_mutations: vec![
+                        graphforge_api::CompositeGraphMutation::SetNodeProperty {
+                            node_uuid: nodes[0].0,
+                            property: "score".into(),
+                            value: graphforge_api::PropValue::Int(9),
+                        },
+                    ],
+                    knowledge: graphforge_api::CompositeKnowledgeParticipants::default(),
+                })
+                .unwrap();
+            nodes[0].2 = Some(9);
+            drop(graph);
+            let parent = graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .generation_uuid();
+            let objects = cas_uuid_parent_objects(&source);
+            let hook = format!("{boundary}{}", if returned_error { ".error" } else { "" });
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "facade_compaction_fault_child", "--nocapture"])
+                .env("GF_FACADE_COMPACTION_ROOT", &source)
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINTS",
+                    "graphforge-internal-subprocess-v1",
+                )
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", &hook)
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINT_TRANSACTION",
+                    facade_compaction_fault_request()
+                        .transaction_uuid
+                        .to_string(),
+                )
+                .output()
+                .unwrap();
+            assert_eq!(
+                output.status.code(),
+                Some(if returned_error { 0 } else { 86 }),
+                "{hook}: {} {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let mut graph = GraphForge::new(source.to_str()).unwrap();
+            if returned_error {
+                for node in &mut nodes {
+                    if node.1 == "Node0" {
+                        node.2 = Some(31);
+                    }
+                }
+                let created = graph
+                    .execute("MATCH (n:Node0 {score: 9001}) RETURN n.node_uuid")
+                    .unwrap();
+                nodes.push((
+                    uuid_at(&created.batches[0], 0, 0),
+                    "Node0".into(),
+                    Some(9001),
+                ));
+            } else {
+                assert_eq!(
+                    graphforge_storage::resolve_project_generation(&source)
+                        .unwrap()
+                        .generation_uuid()
+                        != parent,
+                    boundary == "project.after_current_replace"
+                );
+                for _ in 0..2 {
+                    graph
+                        .compact_graph_delta(&facade_compaction_fault_request(), None)
+                        .unwrap();
+                }
+            }
+            verify_graph(&graph, fixture, &nodes, &edges);
+            cas_uuid_assert_parent_objects(&source, &objects);
+            drop(graph);
+            round_trip(root.path(), &source, fixture, &nodes, &edges);
         }
     }
 }

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -3901,6 +3901,20 @@ fn facade_compaction_fault_child() {
         exact_rows(runtime.block_on(stream.try_collect::<Vec<_>>()).unwrap()),
         before
     );
+    if graphforge_storage::resolve_project_generation(Path::new(&source))
+        .unwrap()
+        .generation_uuid()
+        == facade_compaction_fault_request().generation_uuid
+    {
+        assert!(
+            graph
+                .compact_graph_delta(&facade_compaction_fault_request(), None)
+                .unwrap()
+                .publication
+                .unwrap()
+                .idempotent_replay
+        );
+    }
     // This transaction is outside the injected operation's scope. Success
     // proves the same facade selected the committed compaction, when present.
     graph.execute("MATCH (n:Node0) SET n.score = 31").unwrap();

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -2407,6 +2407,18 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
         )
         .unwrap();
     assert_eq!(before, schemas(&source));
+    graph
+        .execute("MATCH (n:`mixed:NewNode`) WHERE n.score IS NOT NULL SET n.score = 124")
+        .unwrap();
+    let created = graph
+        .execute("CREATE (n:`mixed:NewNode`) RETURN n.node_uuid")
+        .unwrap();
+    nodes.push((
+        uuid_at(&created.batches[0], 0, 0),
+        "mixed:entity:NewNode".into(),
+        None,
+    ));
+    assert_eq!(before, schemas(&source));
     drop(graph);
     let graph = GraphForge::new(source.to_str()).unwrap();
     verify_graph(&graph, fixture, &nodes, &edges);
@@ -2422,7 +2434,7 @@ fn exploratory_parent_and_qualified_child_replay_preserve_semantic_routes() {
         1
     );
     assert_eq!(uuid_at(&expected_score.batches[0], 0, 0), changed_node);
-    assert_eq!(int_at(&expected_score.batches[0], 1, 0), Some(123));
+    assert_eq!(int_at(&expected_score.batches[0], 1, 0), Some(124));
     drop(graph);
     round_trip(root.path(), &source, fixture, &nodes, &edges);
     for path in [&source, &root.path().join("imported")] {

--- a/crates/graphforge-bindings-node/src/lib.rs
+++ b/crates/graphforge-bindings-node/src/lib.rs
@@ -6373,8 +6373,8 @@ impl GraphForge {
         &self,
         request: transaction::GraphDeltaCompactionInput,
     ) -> Result<transaction::GraphDeltaCompactionReportOutput> {
-        let graph = self.open_write_guard()?;
-        transaction::compact(&graph, request, None)
+        let mut graph = self.open_write_guard()?;
+        transaction::compact(&mut graph, request, None)
     }
 
     /// Remove all nodes and edges (in-memory instances only).

--- a/crates/graphforge-bindings-node/src/transaction.rs
+++ b/crates/graphforge-bindings-node/src/transaction.rs
@@ -675,7 +675,7 @@ pub(crate) fn preview_compaction(
 }
 
 pub(crate) fn compact(
-    graph: &graphforge_api::GraphForge,
+    graph: &mut graphforge_api::GraphForge,
     input: GraphDeltaCompactionInput,
     cancellation: Option<&CancellationToken>,
 ) -> Result<GraphDeltaCompactionReportOutput> {

--- a/crates/graphforge-bindings-py/src/lib.rs
+++ b/crates/graphforge-bindings-py/src/lib.rs
@@ -6524,7 +6524,7 @@ impl GraphForge {
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (*, transaction_uuid, generation_uuid, through_run_sequence=None, cleanup_after_commit=false, retained_ancestors=None, cancellation=None))]
     fn compact_graph_delta<'py>(
-        &self,
+        &mut self,
         py: Python<'py>,
         transaction_uuid: &str,
         generation_uuid: &str,

--- a/crates/graphforge-bindings-py/src/transaction.rs
+++ b/crates/graphforge-bindings-py/src/transaction.rs
@@ -616,7 +616,7 @@ pub(crate) mod ops {
     }
 
     pub(crate) fn compact_graph_delta<'py>(
-        forge: &GraphForge,
+        forge: &mut GraphForge,
         py: Python<'py>,
         transaction_uuid: &str,
         generation_uuid: &str,

--- a/crates/graphforge-cli/src/lib.rs
+++ b/crates/graphforge-cli/src/lib.rs
@@ -1385,7 +1385,7 @@ fn run_with_allocation(
                 .map_err(Into::into);
         }
         Command::Maintenance { command } => {
-            return maintenance_cli::run_maintenance(&graph, command, cli.json, output)
+            return maintenance_cli::run_maintenance(&mut graph, command, cli.json, output)
                 .map(|()| 0)
                 .map_err(Into::into);
         }

--- a/crates/graphforge-cli/src/maintenance_cli.rs
+++ b/crates/graphforge-cli/src/maintenance_cli.rs
@@ -353,7 +353,7 @@ pub(crate) fn run_transaction(
 }
 
 pub(crate) fn run_maintenance(
-    graph: &GraphForge,
+    graph: &mut GraphForge,
     command: MaintenanceCommand,
     json: bool,
     output: &mut dyn Write,

--- a/crates/graphforge-storage/src/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/src/graph_delta_compaction.rs
@@ -294,7 +294,31 @@ pub fn compact_graph_delta_with_mode(
     cancel: Option<&AtomicBool>,
     mode: crate::filesystem_admission::ProjectLifecycleMode,
 ) -> Result<GraphDeltaCompactionReport, GfError> {
-    compact_graph_delta_after_prepare(container_root, request, cancel, mode, |_| Ok(()))
+    compact_graph_delta_after_prepare(container_root, request, cancel, mode, None, |_| Ok(()))
+}
+
+/// Compact only from the facade's expected parent, or replay an already
+/// committed exact request. The parent check precedes replay preparation;
+/// publication still uses the storage transaction's normal conflict checks.
+///
+/// # Errors
+/// Returns a write conflict for a stale parent and the errors of
+/// [`compact_graph_delta_with_mode`] for compaction and publication failures.
+pub fn compact_graph_delta_for_parent_with_mode(
+    container_root: impl AsRef<Path>,
+    request: &GraphDeltaCompactionRequest,
+    cancel: Option<&AtomicBool>,
+    mode: crate::filesystem_admission::ProjectLifecycleMode,
+    expected_parent: Uuid,
+) -> Result<GraphDeltaCompactionReport, GfError> {
+    compact_graph_delta_after_prepare(
+        container_root,
+        request,
+        cancel,
+        mode,
+        Some(expected_parent),
+        |_| Ok(()),
+    )
 }
 
 fn compact_graph_delta_after_prepare(
@@ -302,6 +326,7 @@ fn compact_graph_delta_after_prepare(
     request: &GraphDeltaCompactionRequest,
     cancel: Option<&AtomicBool>,
     mode: crate::filesystem_admission::ProjectLifecycleMode,
+    expected_parent: Option<Uuid>,
     before_stage: impl FnOnce(&Path) -> Result<(), GfError>,
 ) -> Result<GraphDeltaCompactionReport, GfError> {
     let started = Instant::now();
@@ -325,6 +350,12 @@ fn compact_graph_delta_after_prepare(
     }
 
     let parent = resolve_project_generation(root)?;
+    if expected_parent.is_some_and(|expected| expected != parent.generation_uuid()) {
+        return Err(GfError::Project {
+            code: ProjectErrorCode::WriteConflict,
+            message: "project generation changed before facade compaction".into(),
+        });
+    }
     let prepared = prepare_compaction(root, &parent, request, cancel)?;
     check_cancel(cancel)?;
 
@@ -1017,6 +1048,7 @@ mod crash_oracle_tests {
             &request,
             None,
             crate::filesystem_admission::ProjectLifecycleMode::Durable,
+            None,
             |_| Ok(()),
         )
         .unwrap_err();
@@ -1042,6 +1074,49 @@ mod crash_oracle_tests {
             .unwrap()
             .len(),
             1
+        );
+    }
+
+    #[test]
+    fn expected_parent_compaction_rejects_a_newer_current_before_preparation() {
+        let root = tempfile::tempdir().unwrap();
+        publish_graph_base(root.path());
+        let expected_parent = publish_one_node_delta(root.path());
+        let (competitor, staged) = stage_graph_clone(root.path());
+        staged
+            .validate(|_| Ok(()), |_, _| Ok(()))
+            .unwrap()
+            .publish()
+            .unwrap();
+        let request = GraphDeltaCompactionRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            through_run_sequence: None,
+            limits: GraphDeltaCompactionLimits::default(),
+            cleanup_after_commit: false,
+            cleanup_policy: ProjectRetentionPolicy::default(),
+            cleanup_limits: ProjectRetentionLimits::default(),
+        };
+        let error = compact_graph_delta_after_prepare(
+            root.path(),
+            &request,
+            None,
+            crate::filesystem_admission::ProjectLifecycleMode::Durable,
+            Some(expected_parent),
+            |_| panic!("stale parent must fail before preparation"),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_WRITE_CONFLICT");
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            competitor
+        );
+        assert!(
+            published_project_transaction(root.path(), request.transaction_uuid)
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -204,7 +204,8 @@ pub use project_recovery::{
     ProjectOpenRecoveryKind, ProjectRecoveryDeferral, ProjectRecoveryGenerationClass,
     ProjectRecoveryReport, open_or_initialize_ephemeral_project_with_recovery,
     open_or_initialize_project_with_recovery, recover_project_on_open,
-    recover_project_transactions, remove_durable_project_root,
+    recover_project_transactions, recover_project_transactions_with_mode,
+    remove_durable_project_root,
 };
 
 pub mod project_retention;

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -158,9 +158,9 @@ pub use graph_delta_compaction::{
     GraphDeltaCompactionRequest, GraphDeltaCompactionStatus,
     MAX_COMPACTION_CANCELLATION_CHECK_ROWS, MAX_COMPACTION_DISK_BYTES, MAX_COMPACTION_INPUT_BYTES,
     MAX_COMPACTION_MEMORY_BYTES, MAX_COMPACTION_OUTPUT_ROWS, MAX_COMPACTION_SPILL_BYTES,
-    compact_graph_delta, compact_graph_delta_with_mode, graph_delta_compaction_status,
-    graph_delta_compaction_status_with_mode, preview_graph_delta_compaction,
-    preview_graph_delta_compaction_with_mode,
+    compact_graph_delta, compact_graph_delta_for_parent_with_mode, compact_graph_delta_with_mode,
+    graph_delta_compaction_status, graph_delta_compaction_status_with_mode,
+    preview_graph_delta_compaction, preview_graph_delta_compaction_with_mode,
 };
 
 pub mod project_generation;

--- a/crates/graphforge-storage/src/project_failpoint.rs
+++ b/crates/graphforge-storage/src/project_failpoint.rs
@@ -32,6 +32,13 @@ pub(crate) fn hit(
     let Ok(active) = std::env::var(ACTIVE_ENV) else {
         return Ok(());
     };
+    // A subprocess may keep exercising the same facade after an injected
+    // publication error without also faulting its subsequent transactions.
+    if let Ok(target) = std::env::var("GRAPHFORGE_PROJECT_FAILPOINT_TRANSACTION")
+        && transaction_uuid.map(|uuid| uuid.to_string()).as_deref() != Some(target.as_str())
+    {
+        return Ok(());
+    }
     if active == name {
         std::process::exit(EXIT_CODE);
     }

--- a/crates/graphforge-storage/src/project_recovery.rs
+++ b/crates/graphforge-storage/src/project_recovery.rs
@@ -451,9 +451,23 @@ fn looks_like_atomicwrite_temp(path: &Path) -> bool {
 pub fn recover_project_transactions(
     container_root: impl AsRef<Path>,
 ) -> Result<ProjectRecoveryReport, GfError> {
-    let admission = crate::filesystem_admission::admit_project_lifecycle(
+    recover_project_transactions_with_mode(
         container_root,
         crate::filesystem_admission::ProjectLifecycleMode::Durable,
+    )
+}
+
+/// Recover transactions using the lifecycle mode established by the facade.
+///
+/// # Errors
+/// Returns the same admission and recovery errors as [`recover_project_transactions`].
+pub fn recover_project_transactions_with_mode(
+    container_root: impl AsRef<Path>,
+    mode: crate::filesystem_admission::ProjectLifecycleMode,
+) -> Result<ProjectRecoveryReport, GfError> {
+    let admission = crate::filesystem_admission::admit_project_lifecycle(
+        container_root,
+        mode,
         crate::filesystem_admission::ProjectRootRequirement::Existing,
     )?;
     admission.revalidate_identity()?;

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -675,3 +675,81 @@ valid complete-runtime baseline comparison or performance improvement is
 claimed. Compression, dictionary, row-group and streaming policies remain
 unchanged. Same-name promotion (#1229), post-compaction facade refresh (#1231)
 and the canonical publishing-contract close gate (#1221) remain separate.
+
+## Facade authority after compaction (#1231)
+
+A successful storage compaction previously left the calling facade's private
+workspace and generation UUID at the old parent. Its next SET failed, and
+updating only the UUID would risk republishing the pre-compaction graph.
+Compaction now prepares a fresh private workspace and all authenticated reader
+state before installing the selected generation, runtime catalog and semantic
+bindings. Rust compaction takes `&mut self`; Python, Node and CLI remain thin
+callers. Independent publishers still require reopening a stale facade.
+
+The existing lifecycle admission and writer guards remain authoritative. The
+storage entrypoint checks the facade's expected parent before preparing replay.
+After an error immediately following CURRENT replacement, the authenticated
+manifest's transaction, generation and parent identify the committed operation
+even before its journal reaches Published. Normal transaction recovery then
+completes the receipt, making an immediate same-facade exact retry idempotent.
+Uncommitted errors leave the facade
+unchanged. A changed workspace administration contract is refused rather than
+silently replacing the facade's ontology configuration.
+
+Bare lazy streams retain their original private workspace. The inner reader
+and its identity handles drop before the last workspace owner, including on
+Windows where the identity capabilities deny deletion. Refresh drops old cached
+UUID membership handles before releasing the old workspace. No recovery epoch
+is incremented on a normal rotation, so old streams remain usable.
+
+Public fixtures cover 33 and 4,097 randomly identified nodes, 129 edges, two
+logical routes, 1,024-row construction shards, nullable properties and both CAS
+and adjacency-backed generation-owned publication. A separate mixed
+exploratory/qualified fixture performs same-facade qualified SET and CREATE
+after compaction, preserving route schemas and portable results. They exercise node SET and
+property removal, full compaction, exact retry, same-handle SET/CREATE/DELETE,
+non-reused surrogates, a partially consumed old stream, reopen, exact query,
+export, full verify and clean import. Current-format partial compaction remains
+an explicit refusal; the two-delta fixture verifies refusal followed by full
+compaction. Four subprocess cases distinguish crash recovery from same-handle
+continuation after returned errors before/after CURRENT replacement. Existing
+exploratory edge-property ownership work remains tracked by #1224.
+
+The CAS refresh reuses immutable payloads and copies existing private controls:
+4,093/166,775 bytes for the two sizes, with 38,546/741,133 application read bytes
+and 16 fsyncs. Its deterministic fixture ceilings are 192 KiB writes, 1 MiB
+reads, eight copied files and 16 fsyncs. The adjacency-backed path has actual
+generation-owned payloads and retains the existing streaming private-copy rule:
+59,655/790,203 writes, 59,934/790,482 reads and 74/96 fsyncs. Its separate ceilings
+are 1 MiB writes, 2 MiB reads, 64 copied files and 128 fsyncs. These ownership
+costs are not compression exceptions. Every inspected permanent Parquet column
+remains Zstd after compaction and subsequent mutation.
+
+Both paths cap fixture staged output and later Parquet payload at 1 MiB,
+reported logical compaction state at 4 KiB and reported spill at zero. The state
+report is not total process memory: it does not substitute for reader/native
+codec accounting or observed RSS. Existing bounded hydration and replay buffer
+policies are unchanged. Live snapshots can retain old private controls until
+their consumers release them; filesystem sampling must count overlapping
+owners and deduplicate shared immutable inodes.
+
+Source `269fa1dcb74db73555d0a79975c56b099dd34cb9` and raw observations are in
+[`facade-compaction-authority-1231.json`](../../development/evidence/facade-compaction-authority-1231.json).
+A frozen test executable ran `facade_compaction_ --nocapture --test-threads=1`
+for each separate observation. Untraced elapsed/user/system times were
+63.58/60.11/6.51 seconds and peak RSS was 160,248 KiB. Syscall tracing recorded
+697,969,055 successful read bytes, 126,544,483 successful write bytes and
+19,952 fsync calls; six `read` EAGAIN results remain explicit in the raw census.
+OS filesystem input/output were 140,976/306,752 512-byte blocks. These figures
+include construction, queries, authentication, fault subprocesses and portable
+operations, not only the refresh.
+
+The 4,819-sample scan observed 16,953,344 bytes of unique-inode allocation and
+14,558,966 path-logical bytes, with a maximum 23.1 ms interval and 74 vanished
+file races. Directory allocation, unlinked files and shorter-lived peaks are
+not established by this scan. The baseline fails the first post-compaction
+mutation, so there is no valid complete baseline runtime comparison or claimed
+speed improvement. Earlier diagnostic runs were excluded after adding immediate
+post-error retry coverage and fixing the measurement harness to retain a stable
+executable for its child processes. Required CI additionally runs the native
+Windows/macOS lifetime regression; #1221 retains the wider publication close gate.

--- a/docs/development/evidence/facade-compaction-authority-1231.json
+++ b/docs/development/evidence/facade-compaction-authority-1231.json
@@ -1,0 +1,264 @@
+{
+  "issue": 1231,
+  "source_commit": "269fa1dcb74db73555d0a79975c56b099dd34cb9",
+  "baseline_source_commit": "4e397d250ba77c1aaa7e493c857dadd667f638c0",
+  "workload": "Public constructed N33 and N4097/E129/two routes, CAS and adjacency-backed generation-owned, nullable node properties, one/two deltas, partial-chain refusal, compaction, exact retry, same-handle SET/CREATE/DELETE, lazy old stream, stable UUID/surrogates, reopen/export/full verify/clean import; four crash/returned-error cases at CURRENT boundaries.",
+  "command": [
+    "permanent_storage_budgets",
+    "facade_compaction_",
+    "--nocapture",
+    "--test-threads=1"
+  ],
+  "fixture_budgets": [
+    {
+      "multiple_deltas": false,
+      "nodes": 33,
+      "owned": false,
+      "parquet_bytes": 26126,
+      "hydration": {
+        "files_validated": 24,
+        "bytes_validated": 34174,
+        "files_copied": 8,
+        "bytes_copied": 4093,
+        "files_opened_in_place": 0,
+        "files_reused": 16,
+        "bytes_reused": 30081,
+        "application_read_bytes": 38546,
+        "application_read_calls": 27,
+        "application_write_bytes": 4093,
+        "application_write_calls": 6,
+        "fsync_calls": 16,
+        "file_fsync_calls": 8,
+        "directory_fsync_calls": 8
+      },
+      "compaction": {
+        "input_runs": 1,
+        "compacted_runs": 1,
+        "retained_suffix_runs": 0,
+        "input_rows": 2,
+        "output_rows": 162,
+        "input_bytes": 522,
+        "output_bytes": 34174,
+        "spill_bytes": 0,
+        "peak_memory_bytes": 1568,
+        "elapsed_ms": 167
+      }
+    },
+    {
+      "multiple_deltas": false,
+      "nodes": 4097,
+      "owned": false,
+      "parquet_bytes": 204213,
+      "hydration": {
+        "files_validated": 35,
+        "bytes_validated": 574079,
+        "files_copied": 8,
+        "bytes_copied": 166775,
+        "files_opened_in_place": 0,
+        "files_reused": 27,
+        "bytes_reused": 407304,
+        "application_read_bytes": 741133,
+        "application_read_calls": 44,
+        "application_write_bytes": 166775,
+        "application_write_calls": 8,
+        "fsync_calls": 16,
+        "file_fsync_calls": 8,
+        "directory_fsync_calls": 8
+      },
+      "compaction": {
+        "input_runs": 1,
+        "compacted_runs": 1,
+        "retained_suffix_runs": 0,
+        "input_rows": 2,
+        "output_rows": 4226,
+        "input_bytes": 522,
+        "output_bytes": 574079,
+        "spill_bytes": 0,
+        "peak_memory_bytes": 1568,
+        "elapsed_ms": 467
+      }
+    },
+    {
+      "multiple_deltas": true,
+      "nodes": 33,
+      "owned": true,
+      "parquet_bytes": 28308,
+      "hydration": {
+        "files_validated": 37,
+        "bytes_validated": 59655,
+        "files_copied": 37,
+        "bytes_copied": 59655,
+        "files_opened_in_place": 0,
+        "files_reused": 0,
+        "bytes_reused": 0,
+        "application_read_bytes": 59934,
+        "application_read_calls": 34,
+        "application_write_bytes": 59655,
+        "application_write_calls": 33,
+        "fsync_calls": 74,
+        "file_fsync_calls": 74,
+        "directory_fsync_calls": 0
+      },
+      "compaction": {
+        "input_runs": 2,
+        "compacted_runs": 2,
+        "retained_suffix_runs": 0,
+        "input_rows": 3,
+        "output_rows": 162,
+        "input_bytes": 860,
+        "output_bytes": 59655,
+        "spill_bytes": 0,
+        "peak_memory_bytes": 2460,
+        "elapsed_ms": 180
+      }
+    },
+    {
+      "multiple_deltas": true,
+      "nodes": 4097,
+      "owned": true,
+      "parquet_bytes": 206416,
+      "hydration": {
+        "files_validated": 48,
+        "bytes_validated": 790203,
+        "files_copied": 48,
+        "bytes_copied": 790203,
+        "files_opened_in_place": 0,
+        "files_reused": 0,
+        "bytes_reused": 0,
+        "application_read_bytes": 790482,
+        "application_read_calls": 49,
+        "application_write_bytes": 790203,
+        "application_write_calls": 44,
+        "fsync_calls": 96,
+        "file_fsync_calls": 96,
+        "directory_fsync_calls": 0
+      },
+      "compaction": {
+        "input_runs": 2,
+        "compacted_runs": 2,
+        "retained_suffix_runs": 0,
+        "input_rows": 3,
+        "output_rows": 4226,
+        "input_bytes": 860,
+        "output_bytes": 790203,
+        "spill_bytes": 0,
+        "peak_memory_bytes": 2460,
+        "elapsed_ms": 580
+      }
+    }
+  ],
+  "runtime": {
+    "elapsed_seconds": 63.58,
+    "user_seconds": 60.11,
+    "system_seconds": 6.51,
+    "peak_rss_kib": 160248,
+    "filesystem_input_512_byte_blocks": 140976,
+    "filesystem_output_512_byte_blocks": 306752,
+    "exit_status": 0
+  },
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 264897,
+        "bytes": 556546211
+      },
+      "pread64": {
+        "calls": 362673,
+        "bytes": 111618601
+      },
+      "write": {
+        "calls": 21830,
+        "bytes": 96740240
+      },
+      "fsync": {
+        "calls": 19952,
+        "bytes": 0
+      },
+      "copy_file_range": {
+        "calls": 6444,
+        "bytes": 29804243
+      }
+    },
+    "read_bytes": 697969055,
+    "write_bytes": 126544483,
+    "errors": [
+      {
+        "syscall": "read",
+        "result": -1,
+        "detail": "EAGAIN (Resource temporarily unavailable)"
+      },
+      {
+        "syscall": "read",
+        "result": -1,
+        "detail": "EAGAIN (Resource temporarily unavailable)"
+      },
+      {
+        "syscall": "read",
+        "result": -1,
+        "detail": "EAGAIN (Resource temporarily unavailable)"
+      },
+      {
+        "syscall": "read",
+        "result": -1,
+        "detail": "EAGAIN (Resource temporarily unavailable)"
+      },
+      {
+        "syscall": "read",
+        "result": -1,
+        "detail": "EAGAIN (Resource temporarily unavailable)"
+      },
+      {
+        "syscall": "read",
+        "result": -1,
+        "detail": "EAGAIN (Resource temporarily unavailable)"
+      }
+    ],
+    "elapsed_seconds": 166.92
+  },
+  "workspace_observation": {
+    "command": [
+      "/tmp/gf1231-measure-bin",
+      "facade_compaction_",
+      "--nocapture",
+      "--test-threads=1"
+    ],
+    "sampled_unique_inode_allocated_peak_bytes": 16953344,
+    "sampled_path_logical_peak_bytes": 14558966,
+    "sampled_file_count_peak": 971,
+    "samples": 4819,
+    "requested_poll_interval_seconds": 0.005,
+    "maximum_observed_sample_interval_seconds": 0.02311074099270627,
+    "vanished_files_during_scan": 74,
+    "exit_status": 0,
+    "limitations": [
+      "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+      "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+      "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+      "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+    ]
+  },
+  "deterministic_budgets": {
+    "cas_refresh_write_bytes": 196608,
+    "cas_refresh_read_bytes": 1048576,
+    "cas_refresh_copied_files": 8,
+    "cas_refresh_fsync_calls": 16,
+    "owned_refresh_write_bytes": 1048576,
+    "owned_refresh_read_bytes": 2097152,
+    "owned_refresh_copied_files": 64,
+    "owned_refresh_fsync_calls": 128,
+    "compaction_staged_output_bytes": 1048576,
+    "reported_compaction_logical_state_bytes": 4096,
+    "reported_spill_bytes": 0,
+    "post_mutation_parquet_payload_bytes": 1048576,
+    "hydration_sequential_copy_buffer_bytes": 65536
+  },
+  "limitations": [
+    "The baseline fails its first post-compaction SET; no valid complete baseline runtime or performance improvement comparison exists.",
+    "Timing/RSS and syscall I/O include setup, authentication, mutations, queries and portable work, and are whole-fixture observations rather than isolated refresh costs or process admission limits.",
+    "CAS shares immutable payloads. Generation-owned graph files retain their existing streaming private-copy ownership rule; the two fixtures differ by adjacency publication and delta count and are not a controlled performance comparison.",
+    "The reported compaction logical-state estimate excludes whole-process and native-codec memory; existing replay admission remains authoritative.",
+    "Runtime, syscall and sampled workspace measurements use separate serial executions.",
+    "Workspace sampling counts overlapping retained/private/portable artifacts, deduplicates inode allocation, and may miss unlinked/short-lived peaks or directory allocation; it is not an exact temporary-only bound.",
+    "Compression, dictionary, row-group and streaming policies are unchanged. All current permanent Parquet columns are checked for Zstd after compaction and subsequent mutations."
+  ]
+}


### PR DESCRIPTION
Compaction published a new generation while leaving the calling facade's private workspace and reader authorities at the old parent. The next SET failed, and a UUID-only refresh could republish stale data. This change prepares and installs the complete selected workspace, property/ordinal/adjacency authorities, catalog and bindings; active lazy streams retain the old workspace until their readers release it.

The Rust facade operation now requires mutable access, with thin Python/Node/CLI callers updated accordingly. Existing storage entrypoints keep their lifecycle behavior. The facade checks its expected parent, preserves writer/admission guards, and runs normal recovery after an authenticated own post-CURRENT error so an immediate exact retry finds the completed receipt. Current-format partial compaction remains an explicit refusal.

Validation covers CAS and actual adjacency-backed generation-owned publishing at 33/4,097 nodes, two logical routes and sharded construction; same-handle SET/CREATE/DELETE, null/removal semantics, non-reused IDs, lazy snapshots, reopen, exact query, export/full verify/clean import, and mixed exploratory/qualified-route SET/CREATE. Four subprocess cases distinguish crash recovery from same-facade continuation after returned errors before/after CURRENT. The populated UUID-cache/workspace-release test is selected into Windows and macOS CI.

Resource assertions preserve CAS sharing (192 KiB writes/1 MiB reads/eight copies/16 fsyncs) and separately bound existing generation-owned private copying (1 MiB writes/2 MiB reads/64 copies/128 fsyncs). Staged output and later Parquet payload stay within 1 MiB for these fixtures; reported logical compaction state stays within 4 KiB with zero reported spill. Compression is checked after compaction and later mutations. These are fixture component budgets, not universal process-RSS limits. Source-bound CPU, RSS, syscall I/O and sampled inode-allocation evidence is recorded in the storage assessment; the invalid baseline cannot support a complete-lifecycle speed comparison.

Local validation: 736 API unit tests; all 31 public-storage tests; five storage compaction tests; targeted immediate error-retry and mixed-route additions; workspace clippy with warnings denied; formatting, gate registry and `make pre-push-fast`. Required exact-head CI and native lanes must pass before merge. Independent review findings were verified and repaired; no outstanding local finding remains.

Closes #1231. Part of #1194; canonical publishing-contract gate #1221 remains open. The remaining exploratory edge-property owner case stays on reopened #1224, and same-name ontology promotion remains #1229. No compatibility or migration machinery is introduced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791631438&installation_model_id=20486&pr_number=1234&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1234&signature=f55247086675085e5930f511c62e6dcde717c16a8a8e8c7eefb582342f2e10f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->