### PR TITLE
fix(storage): preserve composite edge property ownership across publishing paths

### DIFF
--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -994,6 +994,100 @@ fn require_capabilities(
     Ok(())
 }
 
+/// Cumulative probe I/O and serial decoder peaks. The identity containers are
+/// reported separately: decoder counters are not a bound on process memory.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct EdgeOwnerProbeWork {
+    candidate_routes: usize,
+    target_memberships: usize,
+    resolved_targets: usize,
+    route_name_bytes: usize,
+    physical_bytes: u64,
+    authentication_bytes: u64,
+    authenticated_snapshot_bytes: u64,
+    authenticated_snapshot_peak_bytes: u64,
+    physical_rows: u64,
+    physical_blocks: u64,
+    fragments_considered: u64,
+    row_groups_considered: u64,
+    row_groups_selected: u64,
+    decoder_peak_bytes: u64,
+    decoder_page_reservation_bytes: u64,
+}
+
+/// Construction and ordinary mutation have different exploratory property
+/// owners. Probe only the candidate routes for requested identities, once per
+/// route, using authenticated row presence (including a newest tombstone).
+fn resolve_existing_edge_property_owners(
+    inventory: &graphforge_storage::AuthenticatedPropertyInventory,
+    owners: &mut BTreeMap<Uuid, String>,
+) -> Result<EdgeOwnerProbeWork, GfError> {
+    use graphforge_storage::PropertyRouteKind;
+    let mut candidates = BTreeMap::<String, BTreeSet<[u8; 16]>>::new();
+    for (uuid, route) in owners.iter() {
+        for candidate in [route.as_str(), "_exploratory"] {
+            if inventory
+                .route_schema(PropertyRouteKind::Edge, candidate)
+                .is_some()
+            {
+                if let Some(targets) = candidates.get_mut(candidate) {
+                    targets.insert(uuid.into_bytes());
+                } else {
+                    candidates.insert(candidate.to_owned(), BTreeSet::from([uuid.into_bytes()]));
+                }
+            }
+        }
+    }
+    let mut resolved = BTreeMap::new();
+    let mut total = EdgeOwnerProbeWork {
+        candidate_routes: candidates.len(),
+        target_memberships: candidates.values().map(BTreeSet::len).sum(),
+        route_name_bytes: candidates.keys().map(String::len).sum(),
+        ..EdgeOwnerProbeWork::default()
+    };
+    for (route, targets) in &candidates {
+        let (present, work) =
+            graphforge_storage::read_authenticated_property_presence_for_inventory(
+                inventory,
+                PropertyRouteKind::Edge,
+                route,
+                targets,
+            )?;
+        total.physical_bytes += work.physical_bytes;
+        total.authentication_bytes += work.authentication_bytes;
+        total.authenticated_snapshot_bytes += work.authenticated_snapshot_bytes;
+        total.authenticated_snapshot_peak_bytes = total
+            .authenticated_snapshot_peak_bytes
+            .max(work.authenticated_snapshot_peak_bytes);
+        total.physical_rows += work.physical_rows;
+        total.physical_blocks += work.physical_blocks;
+        total.fragments_considered += work.fragments_considered;
+        total.row_groups_considered += work.row_groups_considered;
+        total.row_groups_selected += work.row_groups_selected;
+        total.decoder_peak_bytes = total.decoder_peak_bytes.max(work.decoder_peak_bytes);
+        total.decoder_page_reservation_bytes = total
+            .decoder_page_reservation_bytes
+            .max(work.decoder_page_reservation_bytes);
+        for uuid in present {
+            if resolved
+                .insert(Uuid::from_bytes(uuid), route.as_str())
+                .is_some()
+            {
+                return Err(GfError::Storage(
+                    "composite edge property owner is ambiguous".into(),
+                ));
+            }
+        }
+    }
+    // No property row means ordinary writer ownership, already derived from
+    // topology. Same-request creations are added by the caller afterwards.
+    total.resolved_targets = resolved.len();
+    for (uuid, route) in resolved {
+        owners.insert(uuid, route.to_owned());
+    }
+    Ok(total)
+}
+
 #[allow(clippy::too_many_lines)]
 fn build_validation_snapshot(
     graph: &GraphForge,
@@ -1137,6 +1231,10 @@ fn build_validation_snapshot(
             }
         }
     }
+    resolve_existing_edge_property_owners(
+        &graph.property_inventory_for_session(),
+        &mut routes.edges,
+    )?;
     if parent.capability("provenance")?.is_some() {
         let ledger = crate::provenance::read_ledger(parent)?;
         snapshot.provenance = ledger
@@ -1922,6 +2020,157 @@ mod tests {
                 capability_version: 1,
             })
             .unwrap();
+    }
+
+    #[test]
+    fn edge_owner_probe_bounds_selected_routes_and_refuses_ambiguity() {
+        let graph = GraphForge::new(None).unwrap();
+        let mut reference_work = None;
+        for unrelated_rows in [33, 4097] {
+            let root = TempDir::new().unwrap();
+            let mut writer =
+                graphforge_storage::GraphWriter::open_at(root.path(), OntologyMode::Exploratory, 1)
+                    .unwrap();
+            for row in 0..129_u128 {
+                let route = if row % 2 == 0 { "_exploratory" } else { "REL0" };
+                writer
+                    .set_edge_properties(
+                        &Uuid::from_u128(row + 1),
+                        Some(route),
+                        HashMap::from([("weight".into(), IrLiteral::Int(row as i64))]),
+                    )
+                    .unwrap();
+            }
+            for row in 0..unrelated_rows {
+                writer
+                    .set_edge_properties(
+                        &Uuid::from_u128(1000 + row),
+                        Some("Unrelated"),
+                        HashMap::from([("text".into(), IrLiteral::Str("unrelated".into()))]),
+                    )
+                    .unwrap();
+            }
+            writer.flush().unwrap();
+            let inventory =
+                graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
+                    &graph.resolved_generation,
+                    root.path(),
+                    graphforge_storage::capture_graph_files(root.path())
+                        .unwrap()
+                        .0,
+                )
+                .unwrap();
+            for targets in [1, 16, 129_u128] {
+                let mut owners = (1..=targets)
+                    .map(|id| (Uuid::from_u128(id), "REL0".to_owned()))
+                    .collect();
+                let work = resolve_existing_edge_property_owners(&inventory, &mut owners).unwrap();
+                for (uuid, owner) in &owners {
+                    assert_eq!(
+                        owner,
+                        if (uuid.as_u128() - 1) % 2 == 0 {
+                            "_exploratory"
+                        } else {
+                            "REL0"
+                        }
+                    );
+                }
+                assert_eq!(work.candidate_routes, 2);
+                assert_eq!(work.target_memberships, 2 * targets as usize);
+                assert_eq!(work.resolved_targets, targets as usize);
+                assert_eq!(work.route_name_bytes, "_exploratoryREL0".len());
+                assert_eq!(work.fragments_considered, 2);
+                assert_eq!(work.row_groups_considered, 2);
+                assert!(work.physical_bytes <= 64 * 1024, "{work:?}");
+                assert!(work.authenticated_snapshot_bytes <= 16 * 1024, "{work:?}");
+                assert!(work.decoder_peak_bytes <= 32 * 1024, "{work:?}");
+                eprintln!("owner-probe unrelated={unrelated_rows} targets={targets}: {work:?}");
+                if targets == 129 {
+                    if let Some(reference) = reference_work {
+                        assert_eq!(
+                            work, reference,
+                            "unrelated route growth must add no probe I/O"
+                        );
+                    } else {
+                        reference_work = Some(work);
+                    }
+                }
+            }
+            drop(inventory);
+            for sequence in 2..=4 {
+                let mut writer = graphforge_storage::GraphWriter::open_at(
+                    root.path(),
+                    OntologyMode::Exploratory,
+                    sequence,
+                )
+                .unwrap();
+                for row in 0..129_u128 {
+                    let route = if row % 2 == 0 { "_exploratory" } else { "REL0" };
+                    writer
+                        .set_edge_properties(
+                            &Uuid::from_u128(row + 1),
+                            Some(route),
+                            HashMap::from([("weight".into(), IrLiteral::Int(sequence))]),
+                        )
+                        .unwrap();
+                }
+                writer.flush().unwrap();
+            }
+            let inventory =
+                graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
+                    &graph.resolved_generation,
+                    root.path(),
+                    graphforge_storage::capture_graph_files(root.path())
+                        .unwrap()
+                        .0,
+                )
+                .unwrap();
+            let mut owners = (1..=129)
+                .map(|id| (Uuid::from_u128(id), "REL0".to_owned()))
+                .collect();
+            let work = resolve_existing_edge_property_owners(&inventory, &mut owners).unwrap();
+            assert_eq!(work.fragments_considered, 8);
+            assert_eq!(work.row_groups_considered, 8);
+            assert_eq!(work.resolved_targets, 129);
+            assert!(work.physical_bytes <= 256 * 1024, "{work:?}");
+            assert!(work.authenticated_snapshot_bytes <= 64 * 1024, "{work:?}");
+            assert!(
+                work.authenticated_snapshot_peak_bytes <= 16 * 1024,
+                "{work:?}"
+            );
+            assert!(work.decoder_peak_bytes <= 32 * 1024, "{work:?}");
+            eprintln!("owner-probe unrelated={unrelated_rows} fragments=8: {work:?}");
+            drop(inventory);
+
+            let mut writer =
+                graphforge_storage::GraphWriter::open_at(root.path(), OntologyMode::Exploratory, 2)
+                    .unwrap();
+            writer
+                .set_edge_properties(&Uuid::from_u128(1), Some("REL0"), HashMap::new())
+                .unwrap();
+            writer.flush().unwrap();
+            let inventory =
+                graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
+                    &graph.resolved_generation,
+                    root.path(),
+                    graphforge_storage::capture_graph_files(root.path())
+                        .unwrap()
+                        .0,
+                )
+                .unwrap();
+            let mut owners = BTreeMap::from([(Uuid::from_u128(1), "REL0".to_owned())]);
+            let before = owners.clone();
+            assert!(
+                resolve_existing_edge_property_owners(&inventory, &mut owners)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("composite edge property owner is ambiguous")
+            );
+            assert_eq!(
+                owners, before,
+                "refusal must not install a partial resolution"
+            );
+        }
     }
 
     #[test]

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -4238,6 +4238,50 @@ fn composite_constructed_edge_properties_preserve_authenticated_owner() {
         }
         drop(graph);
         round_trip(root.path(), &source, fixture, &nodes, &edges);
+        let imported_path = root.path().join("imported");
+        let imported = GraphForge::new(imported_path.to_str()).unwrap();
+        let request = graphforge_api::CompositeTransactionRequest {
+            contract_version: graphforge_api::COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: graphforge_api::WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![
+                graphforge_api::CompositeGraphMutation::SetEdgeProperty {
+                    edge_uuid: edges[0].0,
+                    property: "weight".into(),
+                    value: graphforge_api::PropValue::Int(31),
+                },
+                graphforge_api::CompositeGraphMutation::RemoveEdgeProperty {
+                    edge_uuid: edges[130].0,
+                    property: "weight".into(),
+                },
+            ],
+            knowledge: graphforge_api::CompositeKnowledgeParticipants::default(),
+        };
+        imported
+            .publish_composite_transaction(request.clone())
+            .unwrap();
+        let published = graphforge_storage::resolve_project_generation(&imported_path)
+            .unwrap()
+            .generation_uuid();
+        imported.publish_composite_transaction(request).unwrap();
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&imported_path)
+                .unwrap()
+                .generation_uuid(),
+            published
+        );
+        edges[0].4 = Some(31);
+        edges[130].4 = None;
+        verify_graph(&imported, fixture, &nodes, &edges);
+        drop(imported);
+        verify_graph(
+            &GraphForge::new(imported_path.to_str()).unwrap(),
+            fixture,
+            &nodes,
+            &edges,
+        );
     }
 }
 

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -4038,3 +4038,328 @@ fn facade_compaction_faults_preserve_authority_and_allow_mutation() {
         }
     }
 }
+
+#[test]
+fn composite_constructed_edge_properties_preserve_authenticated_owner() {
+    use futures::TryStreamExt;
+    for node_count in [33, 4097] {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let fixture = Fixture {
+            name: "constructed_edge_property_owner",
+            nodes: node_count,
+            edges: 129,
+            routes: 2,
+            identifiers: Identifiers::Random,
+            properties: true,
+            adjacency: false,
+            heterogeneous: false,
+        };
+        let (mut nodes, mut edges) = rows(fixture);
+        construct(&source, fixture, &nodes, &edges);
+        let mut graph = GraphForge::new(source.to_str()).unwrap();
+        for with_properties in [true, false] {
+            let properties = if with_properties {
+                " {weight: 3, text: 'ordinary'}"
+            } else {
+                ""
+            };
+            let created = graph.execute(&format!(
+                "CREATE (a:Node0 {{score: 1}})-[r:REL0{properties}]->(b:Node1 {{score: 2}}) RETURN a.node_uuid, b.node_uuid, r.edge_uuid"
+            )).unwrap();
+            let batch = &created.batches[0];
+            let source_uuid = uuid_at(batch, 0, 0);
+            let target_uuid = uuid_at(batch, 1, 0);
+            nodes.push((source_uuid, "Node0".into(), Some(1)));
+            nodes.push((target_uuid, "Node1".into(), Some(2)));
+            edges.push((
+                uuid_at(batch, 2, 0),
+                source_uuid,
+                target_uuid,
+                "REL0".into(),
+                with_properties.then_some(3),
+                with_properties.then(|| "ordinary".into()),
+            ));
+        }
+        graph
+            .execute("MATCH (a)-[r]->(b) RETURN r.edge_uuid, r.weight, r.text")
+            .expect("mixed construction/ordinary properties before composite mutation");
+        let ordinary = edges[129].0;
+        let empty = edges[130].0;
+        graph
+            .publish_composite_transaction(graphforge_api::CompositeTransactionRequest {
+                contract_version: graphforge_api::COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                context: graphforge_api::WriteContext {
+                    operation_uuid: OperationId(Uuid::now_v7()),
+                    actor_uuid: None,
+                },
+                graph_mutations: vec![
+                    graphforge_api::CompositeGraphMutation::SetEdgeProperty {
+                        edge_uuid: ordinary,
+                        property: "weight".into(),
+                        value: graphforge_api::PropValue::Int(23),
+                    },
+                    graphforge_api::CompositeGraphMutation::RemoveEdgeProperty {
+                        edge_uuid: ordinary,
+                        property: "text".into(),
+                    },
+                    graphforge_api::CompositeGraphMutation::SetEdgeProperty {
+                        edge_uuid: empty,
+                        property: "weight".into(),
+                        value: graphforge_api::PropValue::Int(29),
+                    },
+                    graphforge_api::CompositeGraphMutation::SetEdgeProperty {
+                        edge_uuid: edges[0].0,
+                        property: "weight".into(),
+                        value: graphforge_api::PropValue::Int(19),
+                    },
+                    graphforge_api::CompositeGraphMutation::RemoveEdgeProperty {
+                        edge_uuid: edges[1].0,
+                        property: "text".into(),
+                    },
+                ],
+                knowledge: graphforge_api::CompositeKnowledgeParticipants::default(),
+            })
+            .unwrap();
+        edges[129].4 = Some(23);
+        edges[129].5 = None;
+        edges[130].4 = Some(29);
+        edges[0].4 = Some(19);
+        edges[1].5 = None;
+        verify_graph(&graph, fixture, &nodes, &edges);
+        let published = publishing_parquet_inventory(&source);
+        assert!(
+            published["parquet_bytes"].as_u64().unwrap() <= 1024 * 1024,
+            "{published}"
+        );
+        assert!(
+            published["parquet_allocated_bytes"].as_u64().unwrap() <= 2 * 1024 * 1024,
+            "{published}"
+        );
+        let mut path_values = graph
+            .execute("MATCH (a)-[r*1..1]->(b) RETURN r")
+            .unwrap()
+            .batches
+            .into_iter()
+            .flat_map(|batch| {
+                let paths = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<ListArray>()
+                    .unwrap();
+                (0..batch.num_rows())
+                    .map(|row| {
+                        let path = paths.value(row);
+                        let edge = path
+                            .as_any()
+                            .downcast_ref::<arrow::array::StructArray>()
+                            .unwrap();
+                        assert_eq!(edge.len(), 1);
+                        let uuid = edge
+                            .column_by_name("edge_uuid")
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<FixedSizeBinaryArray>()
+                            .unwrap();
+                        let weight = edge
+                            .column_by_name("weight")
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<Int64Array>()
+                            .unwrap();
+                        let text = edge
+                            .column_by_name("text")
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<StringArray>()
+                            .unwrap();
+                        (
+                            Uuid::from_slice(uuid.value(0)).unwrap(),
+                            (!weight.is_null(0)).then(|| weight.value(0)),
+                            (!text.is_null(0)).then(|| text.value(0).to_owned()),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        path_values.sort();
+        let mut expected_values = edges
+            .iter()
+            .map(|edge| (edge.0, edge.4, edge.5.clone()))
+            .collect::<Vec<_>>();
+        expected_values.sort();
+        assert_eq!(path_values, expected_values);
+        if node_count == 4097 {
+            let snapshot = graph
+                .execute_stream("MATCH (a)-[r]->(b) RETURN r.edge_uuid, r.weight")
+                .unwrap();
+            let report = graph
+                .compact_graph_delta(
+                    &graphforge_storage::GraphDeltaCompactionRequest {
+                        transaction_uuid: Uuid::now_v7(),
+                        generation_uuid: Uuid::now_v7(),
+                        through_run_sequence: None,
+                        limits: graphforge_storage::GraphDeltaCompactionLimits::default(),
+                        cleanup_after_commit: false,
+                        cleanup_policy: graphforge_storage::ProjectRetentionPolicy::default(),
+                        cleanup_limits: graphforge_storage::ProjectRetentionLimits::default(),
+                    },
+                    None,
+                )
+                .unwrap();
+            assert!(report.output_bytes <= 1024 * 1024, "{report:?}");
+            assert!(report.peak_memory_bytes <= 16 * 1024, "{report:?}");
+            assert_eq!(report.spill_bytes, 0);
+            let compacted = publishing_parquet_inventory(&source);
+            assert!(
+                compacted["parquet_bytes"].as_u64().unwrap() <= 1024 * 1024,
+                "{compacted}"
+            );
+            assert!(
+                compacted["parquet_allocated_bytes"].as_u64().unwrap() <= 2 * 1024 * 1024,
+                "{compacted}"
+            );
+            verify_graph(&graph, fixture, &nodes, &edges);
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let mut snapshot = snapshot;
+            let mut old = BTreeMap::new();
+            while let Some(batch) = runtime.block_on(snapshot.try_next()).unwrap() {
+                for row in 0..batch.num_rows() {
+                    assert!(
+                        old.insert(uuid_at(&batch, 0, row), int_at(&batch, 1, row))
+                            .is_none()
+                    );
+                }
+            }
+            assert_eq!(old, edges.iter().map(|edge| (edge.0, edge.4)).collect());
+        }
+        drop(graph);
+        round_trip(root.path(), &source, fixture, &nodes, &edges);
+    }
+}
+
+#[test]
+fn composite_property_owner_scope_rejects_unnamed_public_edges() {
+    let graph = GraphForge::new(None).unwrap();
+    let error = graph
+        .execute("CREATE (:Node)-[r {weight: 1}]->(:Node) RETURN r.edge_uuid")
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("a created relationship must have exactly one type")
+    );
+    let count = graph.execute("MATCH (n) RETURN count(n)").unwrap();
+    assert_eq!(int_at(&count.batches[0], 0, 0), Some(0));
+}
+
+#[test]
+fn edge_property_union_preserves_null_positions_and_concrete_type_errors() {
+    for removed_first in [0, 1] {
+        let graph = GraphForge::new(None).unwrap();
+        let mut ids = Vec::new();
+        for relation in ["A", "z"] {
+            let result = graph
+                .execute(&format!(
+                    "CREATE (:Node)-[r:{relation} {{value: 'kept'}}]->(:Node) RETURN r.edge_uuid"
+                ))
+                .unwrap();
+            ids.push(uuid_at(&result.batches[0], 0, 0));
+        }
+        for removed in [removed_first, 1 - removed_first] {
+            graph
+                .publish_composite_transaction(graphforge_api::CompositeTransactionRequest {
+                    contract_version: graphforge_api::COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                    context: graphforge_api::WriteContext {
+                        operation_uuid: OperationId(Uuid::now_v7()),
+                        actor_uuid: None,
+                    },
+                    graph_mutations: vec![
+                        graphforge_api::CompositeGraphMutation::RemoveEdgeProperty {
+                            edge_uuid: ids[removed],
+                            property: "value".into(),
+                        },
+                    ],
+                    knowledge: graphforge_api::CompositeKnowledgeParticipants::default(),
+                })
+                .unwrap();
+            let all_null = removed != removed_first;
+            let result = graph
+                .execute("MATCH ()-[r]->() RETURN r.edge_uuid, r.value")
+                .unwrap();
+            let mut observed = BTreeMap::new();
+            for batch in result.batches {
+                for row in 0..batch.num_rows() {
+                    let uuid = uuid_at(&batch, 0, row);
+                    let expected_null = all_null || uuid == ids[removed_first];
+                    assert_eq!(
+                        batch
+                            .column(1)
+                            .logical_nulls()
+                            .is_some_and(|nulls| nulls.is_null(row)),
+                        expected_null,
+                        "removed_first={removed_first} removed={removed} type={:?} values={:?}",
+                        batch.column(1).data_type(),
+                        batch.column(1)
+                    );
+                    observed.insert(uuid, expected_null);
+                }
+            }
+            assert_eq!(observed.len(), 2);
+            let result = graph.execute("MATCH ()-[r*1..1]->() RETURN r").unwrap();
+            let mut paths = BTreeMap::new();
+            for batch in result.batches {
+                let lists = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<ListArray>()
+                    .unwrap();
+                for row in 0..lists.len() {
+                    let path = lists.value(row);
+                    let edge = path
+                        .as_any()
+                        .downcast_ref::<arrow::array::StructArray>()
+                        .unwrap();
+                    let uuid = edge
+                        .column_by_name("edge_uuid")
+                        .unwrap()
+                        .as_any()
+                        .downcast_ref::<FixedSizeBinaryArray>()
+                        .unwrap();
+                    let value = edge.column_by_name("value");
+                    assert_eq!(
+                        value.is_none(),
+                        all_null,
+                        "relationship structs omit properties with no remaining live owner"
+                    );
+                    paths.insert(
+                        Uuid::from_slice(uuid.value(0)).unwrap(),
+                        value.is_none_or(|value| {
+                            value.logical_nulls().is_some_and(|nulls| nulls.is_null(0))
+                        }),
+                    );
+                }
+            }
+            assert_eq!(paths, observed);
+        }
+    }
+    let graph = GraphForge::new(None).unwrap();
+    graph
+        .execute("CREATE (:Node)-[:A {value: 1}]->(:Node)")
+        .unwrap();
+    graph
+        .execute("CREATE (:Node)-[:z {value: 'text'}]->(:Node)")
+        .unwrap();
+    for query in [
+        "MATCH ()-[r]->() RETURN r.value",
+        "MATCH ()-[r*1..1]->() RETURN r",
+    ] {
+        assert!(
+            graph.execute(query).is_err(),
+            "incompatible concrete types must remain an error: {query}"
+        );
+    }
+}

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -3101,6 +3101,11 @@ fn build_edge_prop_children(
             let Some(col) = b.column_by_name(field.name()) else {
                 continue;
             };
+            // A route whose last value was removed advertises Null. Its
+            // contribution is null in the concrete union type as well.
+            if col.data_type() == &arrow::datatypes::DataType::Null {
+                continue;
+            }
             let taken = take(col, &take_by_batch[bi], None).map_err(|e| exec_err(e.to_string()))?;
             child = if prop_batches_by_rel.len() == 1 {
                 // Single relation: `take` alone reproduces the #755 behavior.

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -3666,20 +3666,26 @@ fn lower_var_len_expand(
     // the `edge_uuid` key + any name colliding with the struct's four topology
     // fields (`edge_uuid`/`src_uuid`/`dst_uuid`/`rel_type`). A wildcard (`*`)
     // has no single property file, so it unions EVERY relation's fields (#1023)
-    // — sorted stem order for determinism, first occurrence of a name wins,
+    // — sorted stem order for determinism, first concrete type of a name wins,
     // forced nullable since an edge from a relation without the column is NULL
     // (the exec coalesces each edge's values from its own relation's file).
     let topology_names = ["edge_uuid", "src_uuid", "dst_uuid", "rel_type"];
     let prop_fields: Vec<datafusion::arrow::datatypes::Field> = if rel_name == "*" {
-        let mut seen = std::collections::HashSet::new();
-        let mut fields = Vec::new();
+        let mut positions = std::collections::HashMap::<String, usize>::new();
+        let mut fields: Vec<datafusion::arrow::datatypes::Field> = Vec::new();
         for stem in dir_path.edge_property_stems.clone() {
             let prop_table = edge_property_schema(dir_path, &stem);
             for f in prop_table.fields() {
                 if topology_names.contains(&f.name().as_str()) {
                     continue;
                 }
-                if seen.insert(f.name().clone()) {
+                if let Some(&position) = positions.get(f.name()) {
+                    if fields[position].data_type() == &datafusion::arrow::datatypes::DataType::Null
+                    {
+                        fields[position] = f.as_ref().clone().with_nullable(true);
+                    }
+                } else {
+                    positions.insert(f.name().clone(), fields.len());
                     fields.push(f.as_ref().clone().with_nullable(true));
                 }
             }
@@ -4045,7 +4051,7 @@ fn try_lower_provider_expand(
         .map_or(dst, |_| VarId(u32::MAX.saturating_sub(dst.0)));
 
     // Edge property fields, discovered exactly like `join_edge_properties`:
-    // wildcard traversal unions every relation's fields, first occurrence wins.
+    // wildcard traversal unions every relation's fields, first concrete type wins.
     let edge_schema = if rel_ty.is_none() || matches!(mode, OntologyMode::Exploratory) {
         &*EXPLORATORY_EDGE_SCHEMA
     } else {
@@ -4060,16 +4066,22 @@ fn try_lower_provider_expand(
         vec![rel_name.clone()]
     };
     stems.sort();
-    let mut seen = HashSet::new();
-    let mut edge_prop_fields = Vec::new();
+    let mut positions = std::collections::HashMap::<String, usize>::new();
+    let mut edge_prop_fields: Vec<Arc<datafusion::arrow::datatypes::Field>> = Vec::new();
     for stem in stems {
         let prop_table = edge_property_schema(dir_path, &stem);
         for field in prop_table.fields() {
-            if field.name() != "edge_uuid"
-                && !base_names.contains(field.name().as_str())
-                && seen.insert(field.name().clone())
-            {
-                edge_prop_fields.push(Arc::clone(field));
+            if field.name() != "edge_uuid" && !base_names.contains(field.name().as_str()) {
+                if let Some(&position) = positions.get(field.name()) {
+                    if edge_prop_fields[position].data_type()
+                        == &datafusion::arrow::datatypes::DataType::Null
+                    {
+                        edge_prop_fields[position] = Arc::clone(field);
+                    }
+                } else {
+                    positions.insert(field.name().clone(), edge_prop_fields.len());
+                    edge_prop_fields.push(Arc::clone(field));
+                }
             }
         }
     }

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -398,8 +398,9 @@ pub use property_overlay::{
     AuthenticatedPropertyInventory, PROPERTY_OVERLAY_FORMAT, PROPERTY_OVERLAY_FORMAT_KEY,
     PROPERTY_TOMBSTONE_FIELD, PropertyFragmentId, PropertyInventoryOpenMetrics,
     PropertyOverlayLimits, PropertyOverlayMetrics, PropertyRouteKind, PropertySnapshotRow,
-    enumerate_property_fragments, read_authenticated_property_snapshots_for,
-    read_authenticated_property_snapshots_for_inventory, visit_authenticated_property_snapshots,
+    enumerate_property_fragments, read_authenticated_property_presence_for_inventory,
+    read_authenticated_property_snapshots_for, read_authenticated_property_snapshots_for_inventory,
+    visit_authenticated_property_snapshots,
 };
 
 pub mod catalog;

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -2430,7 +2430,22 @@ pub fn read_authenticated_property_snapshots_for_inventory(
     ),
     GfError,
 > {
-    read_property_targets(inventory, kind, route, targets, None)
+    let result = read_property_targets(inventory, kind, route, targets, None)?;
+    Ok((result.rows, result.metrics))
+}
+
+/// Resolve authenticated target row presence, including newest tombstones.
+/// Unlike live snapshot reads, a removed row still proves its physical owner.
+/// Uses the same schema, UUID ordering, tombstone-value and resource validation.
+pub fn read_authenticated_property_presence_for_inventory(
+    inventory: &AuthenticatedPropertyInventory,
+    kind: PropertyRouteKind,
+    route: &str,
+    targets: &BTreeSet<[u8; 16]>,
+) -> Result<(BTreeSet<[u8; 16]>, PropertyOverlayMetrics), GfError> {
+    let result = read_property_targets(inventory, kind, route, targets, None)?;
+    let present = targets.difference(&result.unresolved).copied().collect();
+    Ok((present, result.metrics))
 }
 
 pub(crate) fn read_replay_property_targets(
@@ -2446,7 +2461,14 @@ pub(crate) fn read_replay_property_targets(
     ),
     GfError,
 > {
-    read_property_targets(inventory, kind, route, targets, Some(max_memory_bytes))
+    let result = read_property_targets(inventory, kind, route, targets, Some(max_memory_bytes))?;
+    Ok((result.rows, result.metrics))
+}
+
+struct TargetPropertyRows {
+    rows: BTreeMap<[u8; 16], PropertySnapshotRow>,
+    unresolved: BTreeSet<[u8; 16]>,
+    metrics: PropertyOverlayMetrics,
 }
 
 #[allow(
@@ -2459,13 +2481,7 @@ fn read_property_targets(
     route: &str,
     targets: &BTreeSet<[u8; 16]>,
     replay_budget: Option<usize>,
-) -> Result<
-    (
-        BTreeMap<[u8; 16], PropertySnapshotRow>,
-        PropertyOverlayMetrics,
-    ),
-    GfError,
-> {
+) -> Result<TargetPropertyRows, GfError> {
     let mut limits = PropertyOverlayLimits::default();
     if let Some(bytes) = replay_budget {
         limits.max_buffered_bytes = bytes as u64;
@@ -2480,7 +2496,11 @@ fn read_property_targets(
     let mut found = BTreeMap::new();
     let mut metrics = PropertyOverlayMetrics::default();
     let Some(fragments) = inventory.routes.get(&(kind, route.to_owned())) else {
-        return Ok((found, metrics));
+        return Ok(TargetPropertyRows {
+            rows: found,
+            unresolved,
+            metrics,
+        });
     };
     let root_path = inventory
         .root_path
@@ -2629,7 +2649,11 @@ fn read_property_targets(
         .saturating_add(metrics.authentication_bytes);
     metrics.logical_rows = u64::try_from(found.len()).unwrap_or(u64::MAX);
     metrics.peak_buffered_rows = metrics.decoder_peak_rows;
-    Ok((found, metrics))
+    Ok(TargetPropertyRows {
+        rows: found,
+        unresolved,
+        metrics,
+    })
 }
 
 #[allow(
@@ -5184,6 +5208,134 @@ mod tests {
         );
         assert!(projected.validation_bytes < full.validation_bytes);
         assert_eq!(projected.per_record_seeks, 0);
+    }
+
+    #[test]
+    fn targeted_presence_retains_removed_owner_without_reviving_values() {
+        let root = TempDir::new().unwrap();
+        let mut entries = Vec::new();
+        for generation in [1, 2] {
+            let id = PropertyFragmentId {
+                generation,
+                ordinal: 0,
+            };
+            let relative = format!("edge_properties/REL/{}", id.file_name());
+            let path = root.path().join(&relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let schema = Arc::new(Schema::new_with_metadata(
+                vec![
+                    Field::new("edge_uuid", DataType::FixedSizeBinary(16), false),
+                    Field::new(PROPERTY_TOMBSTONE_FIELD, DataType::Boolean, false),
+                    Field::new("value", DataType::Int64, true),
+                ],
+                HashMap::from([
+                    (
+                        PROPERTY_OVERLAY_FORMAT_KEY.into(),
+                        PROPERTY_OVERLAY_FORMAT.into(),
+                    ),
+                    (PROPERTY_ROUTE_KEY.into(), "REL".into()),
+                    (PROPERTY_KIND_KEY.into(), "edge".into()),
+                    (PROPERTY_GENERATION_KEY.into(), generation.to_string()),
+                    (PROPERTY_ORDINAL_KEY.into(), "0".into()),
+                ]),
+            ));
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(
+                        FixedSizeBinaryArray::try_from_iter([[1; 16], [2; 16]].into_iter())
+                            .unwrap(),
+                    ),
+                    Arc::new(BooleanArray::from(vec![generation == 2, false])),
+                    Arc::new(Int64Array::from(vec![(generation == 1).then_some(7), None])),
+                ],
+            )
+            .unwrap();
+            let mut writer = ArrowWriter::try_new(
+                File::create(&path).unwrap(),
+                schema,
+                Some(crate::permanent_parquet::writer_properties().build()),
+            )
+            .unwrap();
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+            let bytes = fs::read(&path).unwrap();
+            entries.push(crate::GraphFileEntry {
+                relative_path: relative,
+                byte_length: bytes.len() as u64,
+                content_sha256: digest_hex(&Sha256::digest(&bytes)),
+                role: crate::GraphFileRole::Properties,
+            });
+        }
+        let inventory =
+            AuthenticatedPropertyInventory::from_entries_at_root(root.path(), entries.clone())
+                .unwrap();
+        let targets = BTreeSet::from([[1; 16], [2; 16], [3; 16]]);
+        let (live, live_work) = read_authenticated_property_snapshots_for_inventory(
+            &inventory,
+            PropertyRouteKind::Edge,
+            "REL",
+            &targets,
+        )
+        .unwrap();
+        let (present, work) = read_authenticated_property_presence_for_inventory(
+            &inventory,
+            PropertyRouteKind::Edge,
+            "REL",
+            &targets,
+        )
+        .unwrap();
+        assert_eq!(live.keys().copied().collect::<Vec<_>>(), vec![[2; 16]]);
+        assert_eq!(present, BTreeSet::from([[1; 16], [2; 16]]));
+        assert_eq!(
+            work, live_work,
+            "presence adds no second scan or value decode"
+        );
+        assert_eq!(work.fragments_considered, 2);
+        assert_eq!(work.tombstones, 1);
+        drop(inventory);
+        // Re-admit a deliberately malformed fixture so this checks row
+        // validation, rather than merely failing its prior digest authority.
+        let last = entries.last_mut().unwrap();
+        let path = root.path().join(&last.relative_path);
+        let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(&path).unwrap()).unwrap();
+        let schema = Arc::clone(reader.schema());
+        let batch = reader.build().unwrap().next().unwrap().unwrap();
+        let malformed = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::clone(batch.column(0)),
+                Arc::clone(batch.column(1)),
+                Arc::new(Int64Array::from(vec![Some(9), None])),
+            ],
+        )
+        .unwrap();
+        let mut writer = ArrowWriter::try_new(
+            File::create(&path).unwrap(),
+            malformed.schema(),
+            Some(crate::permanent_parquet::writer_properties().build()),
+        )
+        .unwrap();
+        writer.write(&malformed).unwrap();
+        writer.close().unwrap();
+        let bytes = fs::read(&path).unwrap();
+        last.byte_length = bytes.len() as u64;
+        last.content_sha256 = digest_hex(&Sha256::digest(&bytes));
+        let inventory =
+            AuthenticatedPropertyInventory::from_entries_at_root(root.path(), entries).unwrap();
+        let error = read_authenticated_property_presence_for_inventory(
+            &inventory,
+            PropertyRouteKind::Edge,
+            "REL",
+            &targets,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
+        assert!(
+            error
+                .to_string()
+                .contains("property tombstone carries values")
+        );
     }
 
     #[test]

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -753,3 +753,92 @@ speed improvement. Earlier diagnostic runs were excluded after adding immediate
 post-error retry coverage and fixing the measurement harness to retain a stable
 executable for its child processes. Required CI additionally runs the native
 Windows/macOS lifetime regression; #1221 retains the wider publication close gate.
+
+### Composite edge property ownership (#1224)
+
+The current production writers intentionally have different exploratory property
+owners: construction uses `_exploratory`, while ordinary CREATE uses the logical
+relationship name. Qualified topology carries its authenticated semantic route.
+The composite publisher resolves each requested existing edge against its logical
+or qualified route and `_exploratory`, intersected with admitted property schemas.
+It groups target UUIDs by candidate and reads each selected route once. It retains
+row presence even when the newest row is tombstoned or has no live properties;
+multiple candidate owners refuse before publication. Edges with no property-row
+authority and same-request creations retain ordinary writer ownership. Public
+unnamed CREATE is rejected by binding and is outside this publishing inventory.
+Both canonical staging and GFDR use the resolved owner map. This changes no
+compression, dictionary, row-group, streaming or durability defaults.
+
+The targeted reader's existing full authentication, UUID ordering, schema and
+tombstone-value checks remain in place. Presence is derived from its unresolved
+UUID set; existing live snapshot and replay readers retain their result semantics
+and do not allocate an additional presence set. Probe routes execute serially and
+drop decoded values between routes. Candidate names are retained once, and the
+resolved map borrows those names until installing the existing owner map. There
+are at most two candidate memberships and one resolved entry per requested edge;
+the existing 100,000-entry transaction cap still applies. These container counts
+are not allocator-byte or RSS estimates. The existing per-route 64 MiB decoder
+admission does not include all transaction identity containers.
+
+The added read cost is proportional to authenticated fragments in selected routes,
+not all property routes. Validation currently decodes values to check malformed
+tombstones, followed by selected target decoding; this repair does not claim a
+UUID-only scan. Optimistic baseline capture retains its existing per-field reads.
+The existing composite validation topology scan and identity sets also remain;
+the complete transaction is not request-sized. Probe counters report cumulative
+read/authentication/snapshot work and serial decoder peaks separately from route
+and identity counts. Full-fixture CPU, I/O, RSS and overlapping disk observations
+must include those other costs.
+
+Removing the last string value in one route also exposed a query union error:
+the first route's Null type could mask another route's Utf8 type. Fixed and
+variable traversal now retain the first concrete union type and treat Null-only
+route contributions as nulls. All-Null values remain null; incompatible concrete
+types still fail. Returned relationship structs omit a property once no live
+owner advertises it; explicit property selection yields Arrow logical nulls.
+
+Regression fixtures combine public construction, ordinary CREATE with and without
+properties, composite SET/removal, exact fixed/variable Arrow query results,
+compaction, retained streams, reopen, export/full verification, clean import,
+subsequent mutation, exact retry and a second reopen.
+The fixtures use 33/4,097 original nodes, 129 constructed edges and two newly
+created edges. Published Parquet is capped at 1 MiB logical and 2 MiB allocated;
+compaction output is capped at 1 MiB, reported logical state at 16 KiB and reported
+spill at zero. The logical-state report is not total memory. All inspected
+permanent columns must retain the shared Zstd policy.
+
+A separate deterministic ownership probe checks 1/16/129 targets, two selected
+routes and 33/4,097 unrelated property rows. Its two-fragment ceilings are 64 KiB
+reads, 16 KiB authentication/snapshot writes and 32 KiB decoded row state. The
+same selected payloads must have identical counters despite unrelated growth.
+An eight-fragment case caps total reads at 256 KiB, authentication/snapshot writes
+at 64 KiB, peak snapshot size at 16 KiB and decoded row state at 32 KiB. This
+explicitly admits increasing work when fragments are added within a selected
+route. Authenticated tombstone corruption and ambiguous ownership fail closed.
+
+Source `d30ac7553a6825246333d7f815d6b8fa680b5914` and observations are in
+[`composite-edge-property-ownership-1224.json`](../../development/evidence/composite-edge-property-ownership-1224.json).
+The two-fragment probes read 16,231/18,153 bytes for 1/16–129 targets, with
+4,164 authentication/snapshot bytes, 401/481 read calls and a 2,104-byte peak
+snapshot. Eight fragments required 58,796 read bytes, 15,747 authentication/
+snapshot bytes and 1,378 read calls; peak snapshot size stayed 2,104 bytes.
+Both unrelated-route cardinalities have identical counters. The decoder reports
+408 peak row-state bytes and 2,257 page-reservation bytes in these small fixtures;
+these are deliberately not described as complete process memory.
+
+The frozen public lifecycle test ran separately for runtime, syscall tracing and
+filesystem sampling. Untraced elapsed/user/system times were 14.46/14.36/1.62
+seconds, with 156,492 KiB peak RSS. The traced run recorded 232,819,358 read bytes,
+42,417,574 write bytes and 5,942 fsync calls, with no failed traced calls.
+Successful `copy_file_range` transfers are included in both read and write totals.
+OS filesystem input/output counters were 32,608/99,408 512-byte blocks.
+These whole-fixture costs include construction, authentication, queries, retained
+generations, mutation, compaction and portable work, rather than just the probe.
+
+The 1,324-sample filesystem observation found a 10,649,600-byte unique-inode
+allocation peak and 9,048,977 path-logical bytes, with a maximum 19.8 ms sample
+interval and 28 vanished-file races. This scan cannot prove peaks of unlinked
+or shorter-lived files or directory allocations. The baseline fails the required
+value assertion, so no complete baseline runtime comparison or speed improvement
+is claimed. An earlier successful measurement preceding the subsequent-import
+mutation assertion was superseded by this final workload.

--- a/docs/development/evidence/composite-edge-property-ownership-1224.json
+++ b/docs/development/evidence/composite-edge-property-ownership-1224.json
@@ -1,0 +1,252 @@
+{
+  "issue": 1224,
+  "source_commit": "d30ac7553a6825246333d7f815d6b8fa680b5914",
+  "baseline_source_commit": "1aea7a8b823f5e79ba890c80f822cc50ba06f85f",
+  "workload": "Public construction N33/N4097 E129/two routes; ordinary CREATE adds four nodes and two edges (one without properties); composite edge SET/removal; exact fixed/variable Arrow queries; large-case compaction and retained stream; reopen/export/full verify/clean import; subsequent imported edge SET/removal, exact retry and second reopen.",
+  "command": [
+    "permanent_storage_budgets",
+    "composite_constructed_edge_properties_preserve_authenticated_owner",
+    "--nocapture",
+    "--test-threads=1"
+  ],
+  "runtime": {
+    "elapsed_seconds": 14.46,
+    "user_seconds": 14.36,
+    "system_seconds": 1.62,
+    "peak_rss_kib": 156492,
+    "filesystem_input_512_byte_blocks": 32608,
+    "filesystem_output_512_byte_blocks": 99408,
+    "exit_status": 0
+  },
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 59223,
+        "bytes": 193990320
+      },
+      "pread64": {
+        "calls": 75286,
+        "bytes": 24612567
+      },
+      "write": {
+        "calls": 5773,
+        "bytes": 28201103
+      },
+      "fsync": {
+        "calls": 5942,
+        "bytes": 0
+      },
+      "copy_file_range": {
+        "calls": 2516,
+        "bytes": 14216471
+      }
+    },
+    "read_bytes": 232819358,
+    "write_bytes": 42417574,
+    "errors": [],
+    "elapsed_seconds": 37.98
+  },
+  "workspace_observation": {
+    "command": [
+      "/tmp/gf1224-measure-bin",
+      "composite_constructed_edge_properties_preserve_authenticated_owner",
+      "--nocapture",
+      "--test-threads=1"
+    ],
+    "sampled_unique_inode_allocated_peak_bytes": 10649600,
+    "sampled_path_logical_peak_bytes": 9048977,
+    "sampled_file_count_peak": 680,
+    "samples": 1324,
+    "requested_poll_interval_seconds": 0.005,
+    "maximum_observed_sample_interval_seconds": 0.019791411992628127,
+    "vanished_files_during_scan": 28,
+    "exit_status": 0,
+    "limitations": [
+      "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+      "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+      "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+      "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+    ]
+  },
+  "targeted_owner_probe_observations": [
+    {
+      "unrelated": 33,
+      "targets": 1,
+      "candidate_routes": 2,
+      "target_memberships": 2,
+      "resolved_targets": 1,
+      "route_name_bytes": 16,
+      "physical_bytes": 16231,
+      "authentication_bytes": 4164,
+      "authenticated_snapshot_bytes": 4164,
+      "authenticated_snapshot_peak_bytes": 2104,
+      "physical_rows": 194,
+      "physical_blocks": 401,
+      "fragments_considered": 2,
+      "row_groups_considered": 2,
+      "row_groups_selected": 1,
+      "decoder_peak_bytes": 408,
+      "decoder_page_reservation_bytes": 2257
+    },
+    {
+      "unrelated": 33,
+      "targets": 16,
+      "candidate_routes": 2,
+      "target_memberships": 32,
+      "resolved_targets": 16,
+      "route_name_bytes": 16,
+      "physical_bytes": 18153,
+      "authentication_bytes": 4164,
+      "authenticated_snapshot_bytes": 4164,
+      "authenticated_snapshot_peak_bytes": 2104,
+      "physical_rows": 258,
+      "physical_blocks": 481,
+      "fragments_considered": 2,
+      "row_groups_considered": 2,
+      "row_groups_selected": 2,
+      "decoder_peak_bytes": 408,
+      "decoder_page_reservation_bytes": 2257
+    },
+    {
+      "unrelated": 33,
+      "targets": 129,
+      "candidate_routes": 2,
+      "target_memberships": 258,
+      "resolved_targets": 129,
+      "route_name_bytes": 16,
+      "physical_bytes": 18153,
+      "authentication_bytes": 4164,
+      "authenticated_snapshot_bytes": 4164,
+      "authenticated_snapshot_peak_bytes": 2104,
+      "physical_rows": 258,
+      "physical_blocks": 481,
+      "fragments_considered": 2,
+      "row_groups_considered": 2,
+      "row_groups_selected": 2,
+      "decoder_peak_bytes": 408,
+      "decoder_page_reservation_bytes": 2257
+    },
+    {
+      "unrelated": 33,
+      "fragments": 8,
+      "candidate_routes": 2,
+      "target_memberships": 258,
+      "resolved_targets": 129,
+      "route_name_bytes": 16,
+      "physical_bytes": 58796,
+      "authentication_bytes": 15747,
+      "authenticated_snapshot_bytes": 15747,
+      "authenticated_snapshot_peak_bytes": 2104,
+      "physical_rows": 645,
+      "physical_blocks": 1378,
+      "fragments_considered": 8,
+      "row_groups_considered": 8,
+      "row_groups_selected": 2,
+      "decoder_peak_bytes": 408,
+      "decoder_page_reservation_bytes": 2257
+    },
+    {
+      "unrelated": 4097,
+      "targets": 1,
+      "candidate_routes": 2,
+      "target_memberships": 2,
+      "resolved_targets": 1,
+      "route_name_bytes": 16,
+      "physical_bytes": 16231,
+      "authentication_bytes": 4164,
+      "authenticated_snapshot_bytes": 4164,
+      "authenticated_snapshot_peak_bytes": 2104,
+      "physical_rows": 194,
+      "physical_blocks": 401,
+      "fragments_considered": 2,
+      "row_groups_considered": 2,
+      "row_groups_selected": 1,
+      "decoder_peak_bytes": 408,
+      "decoder_page_reservation_bytes": 2257
+    },
+    {
+      "unrelated": 4097,
+      "targets": 16,
+      "candidate_routes": 2,
+      "target_memberships": 32,
+      "resolved_targets": 16,
+      "route_name_bytes": 16,
+      "physical_bytes": 18153,
+      "authentication_bytes": 4164,
+      "authenticated_snapshot_bytes": 4164,
+      "authenticated_snapshot_peak_bytes": 2104,
+      "physical_rows": 258,
+      "physical_blocks": 481,
+      "fragments_considered": 2,
+      "row_groups_considered": 2,
+      "row_groups_selected": 2,
+      "decoder_peak_bytes": 408,
+      "decoder_page_reservation_bytes": 2257
+    },
+    {
+      "unrelated": 4097,
+      "targets": 129,
+      "candidate_routes": 2,
+      "target_memberships": 258,
+      "resolved_targets": 129,
+      "route_name_bytes": 16,
+      "physical_bytes": 18153,
+      "authentication_bytes": 4164,
+      "authenticated_snapshot_bytes": 4164,
+      "authenticated_snapshot_peak_bytes": 2104,
+      "physical_rows": 258,
+      "physical_blocks": 481,
+      "fragments_considered": 2,
+      "row_groups_considered": 2,
+      "row_groups_selected": 2,
+      "decoder_peak_bytes": 408,
+      "decoder_page_reservation_bytes": 2257
+    },
+    {
+      "unrelated": 4097,
+      "fragments": 8,
+      "candidate_routes": 2,
+      "target_memberships": 258,
+      "resolved_targets": 129,
+      "route_name_bytes": 16,
+      "physical_bytes": 58796,
+      "authentication_bytes": 15747,
+      "authenticated_snapshot_bytes": 15747,
+      "authenticated_snapshot_peak_bytes": 2104,
+      "physical_rows": 645,
+      "physical_blocks": 1378,
+      "fragments_considered": 8,
+      "row_groups_considered": 8,
+      "row_groups_selected": 2,
+      "decoder_peak_bytes": 408,
+      "decoder_page_reservation_bytes": 2257
+    }
+  ],
+  "deterministic_budgets": {
+    "candidate_memberships_per_target": 2,
+    "resolved_entries_per_target": 1,
+    "existing_composite_request_entries": 100000,
+    "two_fragment_read_bytes": 65536,
+    "two_fragment_authentication_and_snapshot_write_bytes": 16384,
+    "eight_fragment_read_bytes": 262144,
+    "eight_fragment_authentication_and_snapshot_write_bytes": 65536,
+    "eight_fragment_snapshot_peak_bytes": 16384,
+    "decoded_row_state_peak_bytes": 32768,
+    "published_parquet_logical_bytes": 1048576,
+    "published_parquet_allocated_bytes": 2097152,
+    "compaction_output_bytes": 1048576,
+    "reported_compaction_logical_state_bytes": 16384,
+    "reported_compaction_spill_bytes": 0,
+    "existing_per_route_decoder_admission_bytes": 67108864
+  },
+  "limitations": [
+    "Baseline fails exact values before compaction. There is no valid whole-fixture baseline CPU/RSS comparison and no claimed performance improvement.",
+    "Probe counters exclude the existing composite topology scan, baseline per-field rereads, publication and query work. Unrelated property-route growth adds no probe I/O; selected-fragment growth explicitly does.",
+    "Identity container counts are not allocator or RSS byte estimates. Decoder row-state counters and compaction logical-state estimates exclude whole-process memory; per-route decoder admission does not include all transaction maps.",
+    "The targeted reader still authenticates selected fragments and validates all row values before selected target decode to enforce tombstone/UUID correctness.",
+    "Runtime, syscall and sampled filesystem evidence use separate serial runs of a frozen executable. Whole-fixture observations include setup, all mutations, authentication, queries, persistence and portable work.",
+    "Filesystem sampling includes overlapping retained/project/private/portable files, deduplicates allocated inodes, and may miss unlinked files, directory allocation and shorter-lived peaks. It is not an exact temporary-only admission limit.",
+    "No compression, dictionary, row-group, streaming or lifecycle default changes. Inspected permanent Parquet must use the shared Zstd policy.",
+    "Earlier successful measurements before adding subsequent imported mutation were superseded and are not used here."
+  ]
+}

--- a/tests/contracts/property-overlay-v1.json
+++ b/tests/contracts/property-overlay-v1.json
@@ -27,6 +27,7 @@
       "PropertyFragmentId", "PropertyInventoryOpenMetrics", "PropertyOverlayLimits",
       "PropertyOverlayMetrics", "PropertyRouteKind", "PropertySnapshotRow",
       "enumerate_property_fragments", "read_authenticated_property_snapshots_for",
+      "read_authenticated_property_presence_for_inventory",
       "read_authenticated_property_snapshots_for_inventory",
       "visit_authenticated_property_snapshots"
     ],
@@ -45,6 +46,7 @@
       "PropertyFragmentId::parse", "PropertyInventoryOpenMetrics", "PropertyOverlayLimits",
       "PropertyOverlayMetrics", "PropertyRouteKind", "PropertySnapshotRow",
       "enumerate_property_fragments", "read_authenticated_property_snapshots_for",
+      "read_authenticated_property_presence_for_inventory",
       "read_authenticated_property_snapshots_for_inventory",
       "visit_authenticated_property_snapshots"
     ],


### PR DESCRIPTION
Composite SET/removal on constructed exploratory edges returned success but left queried values unchanged: construction owns those properties under `_exploratory`, while ordinary CREATE uses the relationship name. Resolve each requested edge from authenticated property-row presence in its candidate owners, including tombstones, and share that result between canonical and GFDR publication. Reject ambiguous owners before publication.

Removing a route's final string value also exposed a Null/string union failure. Fixed and variable traversals now preserve a concrete union type and null contributions; incompatible concrete types still fail. Writer encoding and lifecycle defaults are unchanged.

Public regressions cover constructed and ordinary edges, absent properties, exact values/identities, compaction, retained streams, reopen, export/full verify/clean import, subsequent mutation and exact retry. Deterministic lookup budgets cover target counts, unrelated route growth and selected-fragment growth; the assessment records whole-fixture CPU/RSS, read/write I/O and overlapping disk observations, with their limits.

Validation: 737 API unit tests; final 79 composite unit and nine public composite lifecycle tests; targeted Null-order and authenticated tombstone-corruption tests; workspace clippy, formatting, gate registry and `make pre-push-fast`. Independent source review found no actionable findings. Required exact-head CI remains the merge gate.

Closes #1224

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791634870&installation_model_id=20486&pr_number=1235&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1235&signature=37972d205dab2e8731298488ffaac003cddff26f73b51c2844a9c510c61dce6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->