### PR TITLE
fix(api): publish complete ontology promotion atomically

### DIFF
--- a/crates/graphforge-api/BUILD.bazel
+++ b/crates/graphforge-api/BUILD.bazel
@@ -206,6 +206,14 @@ gf_rust_integration_test(
 )
 
 gf_rust_integration_test(
+    name = "ontology_adoption_retry",
+    srcs = ["tests/ontology_adoption_retry.rs"],
+    crate = ":graphforge_api",
+    data = _API_TEST_DATA,
+    deps = _API_DEPS,
+)
+
+gf_rust_integration_test(
     name = "permanent_storage_budgets",
     srcs = ["tests/permanent_storage_budgets.rs"],
     crate = ":graphforge_api",
@@ -568,6 +576,7 @@ test_suite(
         ":public_lifecycle_conformance",
         ":release_load_construction",
         ":resumable_construction_surface",
+        ":ontology_adoption_retry",
         ":permanent_storage_budgets",
         ":scale_g500_ladder",
         ":scale_g500_scale20",

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -100,6 +100,22 @@ impl GraphForge {
     /// # Errors
     /// Returns a structured ontology, validation, publication, or idempotency error.
     pub fn adopt_ontology(&mut self, request: AdoptOntologyRequest) -> Result<(), GfError> {
+        self.adopt_ontology_cancellable(request, None)
+    }
+
+    /// Adopt an ontology, polling cancellation before selecting the complete generation.
+    ///
+    /// # Errors
+    /// Returns validation, cancellation, publication, or idempotency errors.
+    #[allow(clippy::too_many_lines)] // compile, stage, select and recover one ontology transaction
+    pub fn adopt_ontology_cancellable(
+        &mut self,
+        request: AdoptOntologyRequest,
+        cancellation: Option<&crate::CancellationToken>,
+    ) -> Result<(), GfError> {
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
         let AdoptOntologyRequest {
             context,
             path,
@@ -162,9 +178,96 @@ impl GraphForge {
             canonical_ontology_sha256: Some(encode_hex(&Sha256::digest(canonical_bytes))),
             canonical_ontology: Some(canonical_ontology),
         };
+        // The operation identifies the authored request, not regenerated Parquet
+        // bytes (whose fragment identities may differ after recovery).
+        let mut operation = Sha256::new();
+        operation.update(b"graphforge-ontology-adoption/1");
+        operation.update(context.operation_uuid.0.as_bytes());
+        operation.update(
+            serde_json::to_vec(&(context.actor_uuid, &record, &composition))
+                .map_err(|error| GfError::Ontology(error.to_string()))?,
+        );
+        let operation_fingerprint: [u8; 32] = operation.finalize().into();
+        let generation_uuid = graphforge_core::canonical::uuid_v8(operation_fingerprint);
+        if let Some(receipt) = graphforge_storage::published_project_transaction(
+            self.resolved_generation.container_root(),
+            context.operation_uuid.0,
+        )? {
+            if receipt.generation_uuid != generation_uuid {
+                return Err(GfError::Validation(
+                    "ontology adoption operation identity conflict".into(),
+                ));
+            }
+            let current = self.generation_for_read()?;
+            if current.generation_uuid()
+                != *self
+                    .current_generation_uuid
+                    .lock()
+                    .expect("generation UUID lock poisoned")
+            {
+                return Err(GfError::Validation(
+                    "project generation changed before ontology retry; reopen the project".into(),
+                ));
+            }
+            return Ok(());
+        }
         let mut configuration = current_configuration(self)?;
         configuration.ontology_mode = mode;
-        publish_workspace_records(
+        let handle = OntologyHandle::new(runtime);
+        if let Some(previous) = &self.ontology {
+            for name in previous.entity_type_names() {
+                if previous.entity_type_id(name) != handle.entity_type_id(name) {
+                    return Err(GfError::Validation(
+                        "ontology replacement changes existing entity type identities".into(),
+                    ));
+                }
+            }
+            for name in previous.relation_type_names() {
+                if previous.relation_type_id(name) != handle.relation_type_id(name) {
+                    return Err(GfError::Validation(
+                        "ontology replacement changes existing relation type identities".into(),
+                    ));
+                }
+            }
+        }
+        let catalog = self
+            .runtime_catalog
+            .lock()
+            .expect("runtime catalog lock")
+            .clone();
+        let promotes = catalog
+            .entity_type_names_with_ids()
+            .any(|(_, name)| handle.entity_type_id(name).is_some())
+            || catalog
+                .relation_type_names_with_ids()
+                .any(|(_, name)| handle.relation_type_id(name).is_some());
+        // Reconcile only a separate authenticated workspace. A failed candidate
+        // cannot mutate the facade or any retained stream's graph authority.
+        let mut candidate = if promotes {
+            let parent = self.generation_for_read()?;
+            let expected = *self
+                .current_generation_uuid
+                .lock()
+                .expect("generation UUID lock poisoned");
+            if parent.generation_uuid() != expected {
+                return Err(GfError::Validation(
+                    "project generation changed before ontology promotion".into(),
+                ));
+            }
+            let candidate = crate::hydrate_graph_workspace(&parent, false)?;
+            graphforge_storage::promote_runtime_graph_for_ontology(
+                &candidate.0,
+                &handle,
+                &catalog,
+            )?;
+            Some(candidate)
+        } else {
+            None
+        };
+        if let Some(token) = cancellation {
+            token.checkpoint()?;
+        }
+        let publication = publish_workspace_records_inner(
             self,
             context.operation_uuid.0,
             context.actor_uuid,
@@ -172,36 +275,58 @@ impl GraphForge {
             &configuration,
             Some(&composition),
             None,
-            None,
-            None,
-        )?;
-        self.ontology = Some(OntologyHandle::new(runtime));
+            Some(generation_uuid),
+            candidate.as_ref().map(|candidate| candidate.0.as_path()),
+            cancellation,
+            true,
+            Some(operation_fingerprint),
+        );
+        if publication.is_err() {
+            let current = graphforge_storage::resolve_project_generation(
+                self.resolved_generation.container_root(),
+            )?;
+            if current.transaction_uuid() != context.operation_uuid.0 {
+                graphforge_storage::recover_project_transactions_with_mode(
+                    current.container_root(),
+                    self.lifecycle_mode,
+                )?;
+                return publication;
+            }
+            // An error after CURRENT still selects the complete candidate.
+            // Finish the normal transaction receipt before allowing exact retry.
+            graphforge_storage::recover_project_transactions_with_mode(
+                current.container_root(),
+                self.lifecycle_mode,
+            )?;
+            // Another identical attempt may have selected a different physical
+            // candidate. Always recover readers from the selected authority.
+            candidate = Some(crate::hydrate_graph_workspace(&current, false)?);
+            self.resolved_generation = current;
+        }
+        self.ontology = Some(handle);
         self.ontology_document = Some(document);
         self.ontology_mode = requested_mode;
-        // Promote same-named tagged exploratory labels onto ontology TypeIds so
-        // algorithms/query see one logical population after adopt (#702/#725).
-        {
-            let catalog = self
-                .runtime_catalog
+        if let Some((dir, workspace, evidence)) = candidate {
+            if publication.is_err() {
+                let prepared =
+                    self.prepare_generation_read_authority(&self.resolved_generation, &dir)?;
+                self.install_prepared_generation_read_authority(
+                    self.resolved_generation.generation_uuid(),
+                    prepared,
+                );
+            }
+            self.dir = dir;
+            self.workspace_guard = workspace;
+            self.graph_open_evidence = evidence;
+            *self
+                .uuid_membership_index
                 .lock()
-                .expect("runtime catalog lock")
-                .clone();
-            graphforge_storage::reconcile_runtime_entity_label_ids(
-                &self.dir,
-                self.ontology.as_ref(),
-                &catalog,
-            )?;
+                .expect("UUID membership index lock poisoned") = None;
+        } else {
+            self.install_property_generation(&self.resolved_generation)?;
         }
-        *self
-            .adjacency_provider
-            .write()
-            .expect("adjacency provider lock poisoned") =
-            std::sync::Arc::new(crate::adjacency_provider_for_graph(
-                &self.dir,
-                self.ontology_mode,
-                self.property_inventory_for_session(),
-            )?);
-        Ok(())
+
+        publication
     }
 
     /// Publish explicit ontology absence and return the project to exploratory mode.
@@ -283,6 +408,8 @@ pub(crate) fn publish_workspace_records(
         generation_uuid_override,
         None,
         cancellation,
+        false,
+        None,
     )
 }
 
@@ -312,6 +439,8 @@ pub(crate) fn publish_workspace_records_with_graph_tree(
         Some(generation_uuid_override),
         Some(candidate_graph_root),
         cancellation,
+        false,
+        None,
     )
 }
 
@@ -327,6 +456,8 @@ fn publish_workspace_records_inner(
     generation_uuid_override: Option<uuid::Uuid>,
     candidate_graph_root: Option<&std::path::Path>,
     cancellation: Option<&crate::CancellationToken>,
+    prepare_candidate_readers: bool,
+    operation_fingerprint: Option<[u8; 32]>,
 ) -> Result<(), GfError> {
     if let Some(token) = cancellation {
         token.checkpoint()?;
@@ -432,13 +563,62 @@ fn publish_workspace_records_inner(
     let selected_graph_root = candidate_graph_root
         .map(std::path::Path::to_path_buf)
         .or_else(|| generation_owned.then(|| parent.graph_tree_root()));
-    let receipt = match graphforge_storage::stage_project_generation_with_graph_tree_mode(
-        &root,
-        &request,
-        selected_graph_root.as_deref(),
-        graph.lifecycle_mode,
-    )? {
-        ProjectStageOutcome::AlreadyPublished(receipt) => receipt,
+    let mut prepared_candidate = None;
+    let mut prepared_generation = None;
+    let mut prepare =
+        |generation: &graphforge_storage::ResolvedProjectGeneration| -> Result<(), GfError> {
+            if let Some(dir) = candidate_graph_root {
+                let properties =
+                    crate::property_inventory_for_hydrated_generation(generation, dir)?;
+                let ordinal = crate::ordinal_identity_handle(generation, dir)?;
+                let mode = match configuration.ontology_mode {
+                    WorkspaceOntologyMode::None => OntologyMode::Exploratory,
+                    WorkspaceOntologyMode::Advisory => OntologyMode::Advisory,
+                    WorkspaceOntologyMode::Strict => OntologyMode::Strict,
+                };
+                let adjacency = std::sync::Arc::new(crate::adjacency_provider_for_graph(
+                    dir,
+                    mode,
+                    std::sync::Arc::clone(&properties),
+                )?);
+                prepared_candidate = Some(crate::PreparedGenerationReadAuthority {
+                    properties,
+                    ordinal,
+                    adjacency,
+                });
+                prepared_generation = Some(generation.clone());
+            }
+            if let Some(token) = cancellation {
+                token.checkpoint()?;
+            }
+            Ok(())
+        };
+    let staged = if let Some(fingerprint) = operation_fingerprint {
+        graphforge_storage::stage_project_generation_optimistic_with_graph_tree_mode(
+            &root,
+            &request,
+            fingerprint,
+            selected_graph_root.as_deref(),
+            graph.lifecycle_mode,
+        )?
+    } else {
+        graphforge_storage::stage_project_generation_with_graph_tree_mode(
+            &root,
+            &request,
+            selected_graph_root.as_deref(),
+            graph.lifecycle_mode,
+        )?
+    };
+    let receipt = match staged {
+        ProjectStageOutcome::AlreadyPublished(receipt) => {
+            if prepare_candidate_readers && candidate_graph_root.is_some() {
+                return Err(GfError::Validation(
+                    "ontology operation was published concurrently; recover selected authority"
+                        .into(),
+                ));
+            }
+            receipt
+        }
         ProjectStageOutcome::Staged(staged) => {
             if let Some(token) = cancellation {
                 token.checkpoint()?;
@@ -455,7 +635,10 @@ fn publish_workspace_records_inner(
             if let Some(token) = cancellation {
                 token.checkpoint()?;
             }
-            if let Some(lease) = &publication_lease {
+            if prepare_candidate_readers && candidate_graph_root.is_some() {
+                validated
+                    .publish_with_reader_preparation(publication_lease.as_ref(), &mut prepare)?
+            } else if let Some(lease) = &publication_lease {
                 validated.publish_with_graph_objects(lease)?
             } else {
                 validated.publish()?
@@ -466,7 +649,14 @@ fn publish_workspace_records_inner(
         .current_generation_uuid
         .lock()
         .expect("generation UUID lock poisoned") = receipt.generation_uuid;
-    graph.resolved_generation = graphforge_storage::resolve_project_generation(&root)?;
+    graph.resolved_generation = if let Some(generation) = prepared_generation {
+        generation
+    } else {
+        graphforge_storage::resolve_project_generation(&root)?
+    };
+    if let Some(prepared) = prepared_candidate {
+        graph.install_prepared_generation_read_authority(receipt.generation_uuid, prepared);
+    }
     Ok(())
 }
 

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -194,9 +194,10 @@ impl GraphForge {
             context.operation_uuid.0,
         )? {
             if receipt.generation_uuid != generation_uuid {
-                return Err(GfError::Validation(
-                    "ontology adoption operation identity conflict".into(),
-                ));
+                return Err(GfError::Project {
+                    code: graphforge_core::ProjectErrorCode::TransactionConflict,
+                    message: "ontology adoption operation identity conflict".into(),
+                });
             }
             let current = self.generation_for_read()?;
             if current.generation_uuid()

--- a/crates/graphforge-api/tests/ontology_adoption_retry.rs
+++ b/crates/graphforge-api/tests/ontology_adoption_retry.rs
@@ -139,3 +139,19 @@ fn typed_readoption_refuses_changed_identity_assignment_before_current() {
         assert_eq!(people(&reopened), expected);
     }
 }
+
+#[test]
+fn conflicting_adoption_retry_preserves_the_public_idempotency_error() {
+    let root = tempfile::tempdir().unwrap();
+    let project = root.path().join("project");
+    let mut graph = GraphForge::new(project.to_str()).unwrap();
+    let request = request(root.path());
+    graph.adopt_ontology(request.clone()).unwrap();
+    let before = selected(&project);
+    let mut conflict = request;
+    conflict.mode = OntologyMode::Strict;
+    let error = graph.adopt_ontology(conflict).unwrap_err();
+    assert_eq!(error.code(), "GF_IDEMPOTENCY_CONFLICT");
+    assert_eq!(selected(&project), before);
+    assert_eq!(graph.ontology_mode(), OntologyMode::Advisory);
+}

--- a/crates/graphforge-api/tests/ontology_adoption_retry.rs
+++ b/crates/graphforge-api/tests/ontology_adoption_retry.rs
@@ -1,0 +1,141 @@
+//! Public adoption replay must preserve facade and selected-generation authority.
+
+use arrow::array::FixedSizeBinaryArray;
+use graphforge_api::{AdoptOntologyRequest, GraphForge, OntologyMode, OperationId, WriteContext};
+use std::path::Path;
+use uuid::Uuid;
+
+fn request(root: &Path) -> AdoptOntologyRequest {
+    let path = root.join("promotion.yaml");
+    std::fs::write(
+        &path,
+        "ontology_id: retry\nversion: \"1\"\nentity_types:\n  - name: Person\n    abstract: false\nrelation_types: []\n",
+    )
+    .unwrap();
+    AdoptOntologyRequest {
+        context: WriteContext {
+            operation_uuid: OperationId(Uuid::from_u128(1_229_801)),
+            actor_uuid: None,
+        },
+        path,
+        mode: OntologyMode::Advisory,
+    }
+}
+
+fn selected(root: &Path) -> Uuid {
+    graphforge_storage::resolve_project_generation(root)
+        .unwrap()
+        .generation_uuid()
+}
+
+fn people(graph: &GraphForge) -> Vec<Uuid> {
+    let result = graph
+        .execute("MATCH (n:Person) RETURN n.node_uuid")
+        .unwrap();
+    let mut ids = Vec::new();
+    for batch in result.batches {
+        let values = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            ids.push(Uuid::from_slice(values.value(row)).unwrap());
+        }
+    }
+    ids.sort_unstable();
+    ids
+}
+
+#[test]
+fn exact_replay_on_a_stale_handle_cannot_succeed_with_exploratory_authority() {
+    let root = tempfile::tempdir().unwrap();
+    let project = root.path().join("project");
+    let graph = GraphForge::new(project.to_str()).unwrap();
+    graph.execute("CREATE (:Person), (:Person)").unwrap();
+    drop(graph);
+    let mut first = GraphForge::new(project.to_str()).unwrap();
+    let mut stale = GraphForge::new(project.to_str()).unwrap();
+    let expected = people(&first);
+    assert_eq!(expected.len(), 2);
+    let adoption = request(root.path());
+    first.adopt_ontology(adoption.clone()).unwrap();
+    let published = selected(&project);
+
+    let replay = stale.adopt_ontology(adoption.clone());
+    assert_eq!(selected(&project), published);
+    if replay.is_ok() {
+        assert_eq!(stale.ontology_mode(), OntologyMode::Advisory);
+        assert_eq!(people(&stale), expected);
+    }
+
+    // An explicit stale-handle refusal is safe; reopening must make the exact
+    // same authored request succeed without publishing another generation.
+    let mut reopened = GraphForge::new(project.to_str()).unwrap();
+    reopened.adopt_ontology(adoption).unwrap();
+    assert_eq!(reopened.ontology_mode(), OntologyMode::Advisory);
+    assert_eq!(people(&reopened), expected);
+    assert_eq!(selected(&project), published);
+}
+
+#[test]
+fn exact_replay_after_subsequent_mutation_never_rewinds_current() {
+    let root = tempfile::tempdir().unwrap();
+    let project = root.path().join("project");
+    let mut graph = GraphForge::new(project.to_str()).unwrap();
+    graph.execute("CREATE (:Person)").unwrap();
+    let adoption = request(root.path());
+    graph.adopt_ontology(adoption.clone()).unwrap();
+    let adopted = selected(&project);
+    let mut stale = GraphForge::new(project.to_str()).unwrap();
+    graph.execute("CREATE (:Person)").unwrap();
+    let newer = selected(&project);
+    assert_ne!(newer, adopted);
+    let expected = people(&graph);
+    assert_eq!(expected.len(), 2);
+
+    let stale_replay = stale.adopt_ontology(adoption.clone());
+    assert_eq!(selected(&project), newer);
+    if stale_replay.is_ok() {
+        assert_eq!(people(&stale), expected);
+    }
+
+    graph.adopt_ontology(adoption.clone()).unwrap();
+    assert_eq!(selected(&project), newer);
+    assert_eq!(people(&graph), expected);
+    let mut reopened = GraphForge::new(project.to_str()).unwrap();
+    reopened.adopt_ontology(adoption).unwrap();
+    assert_eq!(selected(&project), newer);
+    assert_eq!(people(&reopened), expected);
+}
+
+#[test]
+fn typed_readoption_refuses_changed_identity_assignment_before_current() {
+    let root = tempfile::tempdir().unwrap();
+    let project = root.path().join("project");
+    let mut graph = GraphForge::new(project.to_str()).unwrap();
+    let mut adoption = request(root.path());
+    std::fs::write(&adoption.path, "ontology_id: retry\nversion: \"1\"\nentity_types:\n  - name: Person\n    abstract: false\n  - name: Ghost\n    abstract: false\nrelation_types: []\n").unwrap();
+    graph.adopt_ontology(adoption.clone()).unwrap();
+    graph.execute("CREATE (:Person), (:Person)").unwrap();
+    let expected = people(&graph);
+    assert_eq!(expected.len(), 2);
+    let before = selected(&project);
+
+    for (operation, declarations) in [
+        (
+            1_229_802,
+            "  - name: Ghost\n    abstract: false\n  - name: Person\n    abstract: false\n",
+        ),
+        (1_229_803, "  - name: Ghost\n    abstract: false\n"),
+    ] {
+        adoption.context.operation_uuid = OperationId(Uuid::from_u128(operation));
+        std::fs::write(&adoption.path, format!("ontology_id: retry\nversion: \"2\"\nentity_types:\n{declarations}relation_types: []\n")).unwrap();
+        assert!(graph.adopt_ontology(adoption.clone()).is_err());
+        assert_eq!(selected(&project), before);
+        assert_eq!(graph.ontology_mode(), OntologyMode::Advisory);
+        assert_eq!(people(&graph), expected);
+        let reopened = GraphForge::new(project.to_str()).unwrap();
+        assert_eq!(people(&reopened), expected);
+    }
+}

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -178,7 +178,11 @@ fn uuid_at(batch: &RecordBatch, column: usize, row: usize) -> Uuid {
     .unwrap()
 }
 fn int_at(batch: &RecordBatch, column: usize, row: usize) -> Option<i64> {
-    (!batch.column(column).is_null(row)).then(|| {
+    (!batch
+        .column(column)
+        .logical_nulls()
+        .is_some_and(|nulls| nulls.is_null(row)))
+    .then(|| {
         batch
             .column(column)
             .as_any()
@@ -234,7 +238,12 @@ fn verify_graph(
             .downcast_ref::<StringArray>()
             .unwrap();
         for row in 0..batch.num_rows() {
-            let text = if f.properties && !batch.column(5).is_null(row) {
+            let text = if f.properties
+                && !batch
+                    .column(5)
+                    .logical_nulls()
+                    .is_some_and(|nulls| nulls.is_null(row))
+            {
                 Some(
                     batch
                         .column(5)
@@ -277,8 +286,16 @@ fn verify_graph(
 }
 
 fn round_trip(root: &Path, source: &Path, f: Fixture, nodes: &[Node], edges: &[Edge]) -> String {
+    round_trip_checked(root, source, |graph| verify_graph(graph, f, nodes, edges))
+}
+
+fn round_trip_checked(
+    root: &Path,
+    source: &Path,
+    verify: impl Fn(&GraphForge) -> String,
+) -> String {
     let graph = GraphForge::new(source.to_str()).unwrap();
-    let fingerprint = verify_graph(&graph, f, nodes, edges);
+    let fingerprint = verify(&graph);
     let limits = PortableV2Limits::default();
     let package = root.join("graph.gfpb");
     let exported = graph
@@ -319,7 +336,7 @@ fn round_trip(root: &Path, source: &Path, f: Fixture, nodes: &[Node], edges: &[E
     .unwrap();
     assert_eq!(exported.package_digest, imported.package_digest);
     let imported = GraphForge::new(imported_path.to_str()).unwrap();
-    assert_eq!(verify_graph(&imported, f, nodes, edges), fingerprint);
+    assert_eq!(verify(&imported), fingerprint);
     fingerprint
 }
 
@@ -4404,6 +4421,529 @@ fn edge_property_union_preserves_null_positions_and_concrete_type_errors() {
         assert!(
             graph.execute(query).is_err(),
             "incompatible concrete types must remain an error: {query}"
+        );
+    }
+}
+
+fn promotion_request(root: &Path) -> graphforge_api::AdoptOntologyRequest {
+    let ontology = root.join("promotion.yaml");
+    std::fs::write(&ontology, "ontology_id: https://example.test/promotion\nversion: \"1\"\nentity_types:\n  - name: Node0\n    abstract: false\nrelation_types:\n  - name: REL0\n    src: Node0\n    dst: Node0\nproperties:\n  - owner: Node0\n    name: score\n    type: int64\n    nullable: true\n  - owner: REL0\n    name: weight\n    type: int64\n    nullable: true\n  - owner: REL0\n    name: text\n    type: utf8\n    nullable: true\n").unwrap();
+    graphforge_api::AdoptOntologyRequest {
+        context: graphforge_api::WriteContext {
+            operation_uuid: OperationId(Uuid::from_u128(1229001)),
+            actor_uuid: None,
+        },
+        path: ontology,
+        mode: graphforge_api::OntologyMode::Advisory,
+    }
+}
+
+fn verify_promoted_graph(graph: &GraphForge, nodes: &[Node], edges: &[Edge]) {
+    verify_promoted_route(graph, nodes, edges, "Node0", "REL0");
+}
+
+fn verify_promoted_route(
+    graph: &GraphForge,
+    nodes: &[Node],
+    edges: &[Edge],
+    label: &str,
+    route: &str,
+) {
+    let mut actual = graph
+        .execute(&format!("MATCH (n:{label}) RETURN n.node_uuid, n.score"))
+        .unwrap()
+        .batches
+        .iter()
+        .flat_map(|batch| {
+            (0..batch.num_rows())
+                .map(|row| (uuid_at(batch, 0, row), int_at(batch, 1, row)))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut expected = nodes.iter().map(|n| (n.0, n.2)).collect::<Vec<_>>();
+    actual.sort();
+    expected.sort();
+    assert_eq!(actual, expected);
+    let mut actual_edges = Vec::new();
+    for batch in graph.execute(&format!("MATCH (a)-[r:{route}]->(b) RETURN r.edge_uuid, a.node_uuid, b.node_uuid, r.weight, r.text")).unwrap_or_else(|error| panic!("route={route}: {error}")).batches {
+        for row in 0..batch.num_rows() {
+            let column = batch.column(4);
+            let text = if column.data_type() == &DataType::Null || column.is_null(row) { None } else if let Some(text) = column.as_any().downcast_ref::<StringArray>() {
+                Some(text.value(row).to_owned())
+            } else {
+                Some(column.as_any().downcast_ref::<arrow::array::StringViewArray>().expect("text must be an Arrow string").value(row).to_owned())
+            };
+            actual_edges.push((uuid_at(&batch, 0, row), uuid_at(&batch, 1, row), uuid_at(&batch, 2, row), route.to_owned(), int_at(&batch, 3, row), text));
+        }
+    }
+    actual_edges.sort();
+    let mut expected_edges = edges.to_vec();
+    expected_edges.sort();
+    assert_eq!(actual_edges, expected_edges);
+}
+
+#[test]
+fn same_name_adoption_publishes_complete_constructed_authority() {
+    use futures::TryStreamExt as _;
+    for node_count in [33, 4097] {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let fixture = Fixture {
+            name: "same_name_promotion",
+            nodes: node_count,
+            edges: 129,
+            routes: 1,
+            identifiers: Identifiers::Random,
+            properties: true,
+            adjacency: false,
+            heterogeneous: false,
+        };
+        let (mut nodes, mut edges) = rows(fixture);
+        construct(&source, fixture, &nodes, &edges);
+        let base_ids = cas_uuid_node_surrogates(&source);
+        let objects = cas_uuid_parent_objects(&source);
+        let mut graph = GraphForge::new(source.to_str()).unwrap();
+        let query = "MATCH (n) RETURN n.node_uuid, n.score ORDER BY n.node_uuid";
+        let expected_snapshot = graph.execute(query).unwrap();
+        let stream = graph.execute_stream(query).unwrap();
+        let mut request = promotion_request(root.path());
+        if node_count == 4097 {
+            request.mode = graphforge_api::OntologyMode::Strict;
+        }
+        graph.adopt_ontology(request.clone()).unwrap();
+        verify_promoted_graph(&graph, &nodes, &edges);
+        assert_eq!(cas_uuid_node_surrogates(&source), base_ids);
+        let selected = graphforge_storage::resolve_project_generation(&source)
+            .unwrap()
+            .generation_uuid();
+        graph.adopt_ontology(request).unwrap();
+        assert_eq!(
+            graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .generation_uuid(),
+            selected
+        );
+        verify_promoted_graph(&graph, &nodes, &edges);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let snapshot = runtime.block_on(stream.try_collect::<Vec<_>>()).unwrap();
+        let snapshot_rows = |batches: Vec<RecordBatch>| {
+            batches
+                .iter()
+                .flat_map(|batch| {
+                    (0..batch.num_rows())
+                        .map(|row| (uuid_at(batch, 0, row), int_at(batch, 1, row)))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            snapshot_rows(snapshot),
+            snapshot_rows(expected_snapshot.batches)
+        );
+        cas_uuid_assert_parent_objects(&source, &objects);
+        let result = graph
+            .execute("CREATE (n:Node0 {score: 9001229}) RETURN n.node_uuid")
+            .unwrap();
+        let new_uuid = uuid_at(&result.batches[0], 0, 0);
+        assert!(cas_uuid_node_surrogates(&source)[&new_uuid] > *base_ids.values().max().unwrap());
+        nodes.push((new_uuid, "Node0".into(), Some(9001229)));
+        verify_promoted_graph(&graph, &nodes, &edges);
+        drop(graph);
+        let graph = GraphForge::new(source.to_str()).unwrap();
+        verify_promoted_graph(&graph, &nodes, &edges);
+        let package = root.path().join("promotion.gfpb");
+        let limits = PortableV2Limits::default();
+        let exported = graph
+            .export_portable_v2(
+                &PortableV2ExportRequest {
+                    selection: PortableSelection::Current,
+                    output_path: package.clone(),
+                    representation: PortableV2Output::Bundle,
+                    profile: PortableV2SelectionProfile::Complete,
+                    subset: None,
+                    limits,
+                },
+                None,
+                |_| {},
+            )
+            .unwrap();
+        let verified = verify_portable_v2(
+            &PortableVerifyRequest {
+                input: package.clone(),
+                mode: PortableV2Mode::Full,
+                limits,
+            },
+            None,
+        )
+        .unwrap();
+        assert_eq!(exported.package_digest, verified.package_digest);
+        let imported = root.path().join("imported");
+        GraphForge::import_portable_v2(
+            &imported,
+            &PortableV2ImportRequest {
+                input: package,
+                operation_id: OperationId(Uuid::from_u128(1229002)),
+                limits,
+            },
+            None,
+        )
+        .unwrap();
+        let graph = GraphForge::new(imported.to_str()).unwrap();
+        verify_promoted_graph(&graph, &nodes, &edges);
+        graph
+            .execute("MATCH (n:Node0 {score: 9001229}) SET n.score = 9001230")
+            .unwrap();
+        nodes.last_mut().unwrap().2 = Some(9001230);
+        verify_promoted_graph(&graph, &nodes, &edges);
+        graph
+            .publish_composite_transaction(graphforge_api::CompositeTransactionRequest {
+                contract_version: graphforge_api::COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                context: graphforge_api::WriteContext {
+                    operation_uuid: OperationId(Uuid::now_v7()),
+                    actor_uuid: None,
+                },
+                graph_mutations: vec![
+                    graphforge_api::CompositeGraphMutation::SetEdgeProperty {
+                        edge_uuid: edges[0].0,
+                        property: "weight".into(),
+                        value: graphforge_api::PropValue::Int(1229),
+                    },
+                    graphforge_api::CompositeGraphMutation::RemoveEdgeProperty {
+                        edge_uuid: edges[1].0,
+                        property: "weight".into(),
+                    },
+                ],
+                knowledge: graphforge_api::CompositeKnowledgeParticipants::default(),
+            })
+            .unwrap();
+        edges[0].4 = Some(1229);
+        edges[1].4 = None;
+        verify_promoted_graph(&graph, &nodes, &edges);
+        drop(graph);
+        let graph = GraphForge::new(imported.to_str()).unwrap();
+        verify_promoted_graph(&graph, &nodes, &edges);
+    }
+}
+
+#[test]
+fn ontology_promotion_fault_child() {
+    use futures::TryStreamExt as _;
+    let Ok(source) = std::env::var("GF_ONTOLOGY_PROMOTION_ROOT") else {
+        return;
+    };
+    let source = Path::new(&source);
+    let request = promotion_request(source.parent().unwrap());
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    let query = "MATCH (n) RETURN n.node_uuid, n.score ORDER BY n.node_uuid";
+    let before = graph.execute(query).unwrap();
+    let stream = graph.execute_stream(query).unwrap();
+    let error = graph.adopt_ontology(request.clone()).unwrap_err();
+    assert_eq!(error.code(), "GF_PUBLICATION_FAILED", "{error}");
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let selected_query = if selected.transaction_uuid() == request.context.operation_uuid.0 {
+        "MATCH (n:Node0) RETURN n.node_uuid, n.score ORDER BY n.node_uuid"
+    } else {
+        query
+    };
+    let exact = |batches: Vec<RecordBatch>| {
+        batches
+            .iter()
+            .flat_map(|batch| {
+                (0..batch.num_rows())
+                    .map(|row| (uuid_at(batch, 0, row), int_at(batch, 1, row)))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        exact(graph.execute(selected_query).unwrap().batches),
+        exact(before.batches.clone())
+    );
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    assert_eq!(
+        exact(runtime.block_on(stream.try_collect::<Vec<_>>()).unwrap()),
+        exact(before.batches)
+    );
+    if selected.transaction_uuid() == request.context.operation_uuid.0 {
+        graph.adopt_ontology(request).unwrap();
+    }
+    graph.execute("CREATE (:Node0 {score: 9001229})").unwrap();
+}
+
+#[test]
+fn ontology_promotion_faults_select_complete_authority_and_retry() {
+    let executable = tempfile::tempdir().unwrap();
+    let frozen = executable.path().join("promotion-fault-tests");
+    std::fs::copy(std::env::current_exe().unwrap(), &frozen).unwrap();
+    for boundary in [
+        "project.before_current_replace",
+        "project.after_current_replace",
+    ] {
+        for returned_error in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let source = root.path().join("source");
+            let fixture = Fixture {
+                name: "promotion_fault",
+                nodes: 33,
+                edges: 129,
+                routes: 1,
+                identifiers: Identifiers::Random,
+                properties: true,
+                adjacency: false,
+                heterogeneous: false,
+            };
+            let (mut nodes, edges) = rows(fixture);
+            construct(&source, fixture, &nodes, &edges);
+            let prior = graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .generation_uuid();
+            let request = promotion_request(root.path());
+            let hook = format!("{boundary}{}", if returned_error { ".error" } else { "" });
+            let output = std::process::Command::new(&frozen)
+                .args(["--exact", "ontology_promotion_fault_child", "--nocapture"])
+                .env("GF_ONTOLOGY_PROMOTION_ROOT", &source)
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINTS",
+                    "graphforge-internal-subprocess-v1",
+                )
+                .env("GRAPHFORGE_PROJECT_FAILPOINT", &hook)
+                .env(
+                    "GRAPHFORGE_PROJECT_FAILPOINT_TRANSACTION",
+                    request.context.operation_uuid.0.to_string(),
+                )
+                .output()
+                .unwrap();
+            assert_eq!(
+                output.status.code(),
+                Some(if returned_error { 0 } else { 86 }),
+                "{hook}: {} {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let mut graph = GraphForge::new(source.to_str()).unwrap();
+            let current = graphforge_storage::resolve_project_generation(&source).unwrap();
+            if !returned_error && boundary == "project.before_current_replace" {
+                assert_eq!(current.generation_uuid(), prior);
+                verify_graph(&graph, fixture, &nodes, &edges);
+            }
+            if returned_error {
+                let batches = graph
+                    .execute("MATCH (n:Node0 {score: 9001229}) RETURN n.node_uuid")
+                    .unwrap()
+                    .batches;
+                let uuid = uuid_at(&batches[0], 0, 0);
+                nodes.push((uuid, "Node0".into(), Some(9001229)));
+            }
+            graph.adopt_ontology(request).unwrap();
+            verify_promoted_graph(&graph, &nodes, &edges);
+        }
+    }
+}
+
+#[test]
+fn ontology_promotion_cancellation_and_conflict_preserve_prior_view() {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "promotion_cancel",
+        nodes: 33,
+        edges: 129,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (nodes, edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    let request = promotion_request(root.path());
+    let before = clear_publication_files(&source);
+    let cancellation = graphforge_api::CancellationToken::new();
+    cancellation.cancel();
+    assert!(
+        graph
+            .adopt_ontology_cancellable(request.clone(), Some(&cancellation))
+            .is_err()
+    );
+    assert_eq!(clear_publication_files(&source), before);
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let other = GraphForge::new(source.to_str()).unwrap();
+    other.execute("CREATE (:Node0 {score: 9001229})").unwrap();
+    let current = graphforge_storage::resolve_project_generation(&source)
+        .unwrap()
+        .generation_uuid();
+    assert!(graph.adopt_ontology(request).is_err());
+    assert_eq!(
+        graphforge_storage::resolve_project_generation(&source)
+            .unwrap()
+            .generation_uuid(),
+        current
+    );
+    verify_graph(&graph, fixture, &nodes, &edges);
+}
+
+#[test]
+fn ontology_promotion_preserves_mixed_routes_and_reencoding_scope() {
+    for (node_count, edge_count, routes) in [(33, 129, 2), (4097, 4097, 4)] {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let fixture = Fixture {
+            name: "promotion_mixed",
+            nodes: node_count,
+            edges: edge_count,
+            routes,
+            identifiers: Identifiers::Random,
+            properties: true,
+            adjacency: false,
+            heterogeneous: false,
+        };
+        let (nodes, edges) = rows(fixture);
+        let verify = |graph: &GraphForge| {
+            for route in 0..routes {
+                let label = format!("Node{route}");
+                let relation = format!("REL{route}");
+                verify_promoted_route(
+                    graph,
+                    &nodes
+                        .iter()
+                        .filter(|n| n.1 == label)
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    &edges
+                        .iter()
+                        .filter(|e| e.3 == relation)
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    &label,
+                    &relation,
+                );
+            }
+            Sha256::digest(serde_json::to_vec(&(&nodes, &edges)).unwrap())
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>()
+        };
+        construct(&source, fixture, &nodes, &edges);
+        let before = publishing_parquet_inventory(&source);
+        let old_objects = cas_uuid_parent_objects(&source);
+        let mut graph = GraphForge::new(source.to_str()).unwrap();
+        let request = promotion_request(root.path());
+        let started = Instant::now();
+        graph.adopt_ontology(request.clone()).unwrap();
+        let elapsed_ns = started.elapsed().as_nanos();
+        verify(&graph);
+        cas_uuid_assert_parent_objects(&source, &old_objects);
+        let after = publishing_parquet_inventory(&source);
+        let files = after["files"].as_array().unwrap();
+        // Fixed-width identity/property payloads plus bounded shard framing.
+        // This is a representative encoding ceiling, not a process-memory bound.
+        let payload_limit =
+            node_count as u64 * 64 + edge_count as u64 * 128 + files.len() as u64 * 8192 + 65536;
+        assert!(after["parquet_bytes"].as_u64().unwrap() <= payload_limit);
+        assert!(
+            after["parquet_allocated_bytes"].as_u64().unwrap()
+                <= after["parquet_bytes"].as_u64().unwrap() + files.len() as u64 * 4096
+        );
+        let changed = files
+            .iter()
+            .filter(|file| {
+                !before["files"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|old| old["path"] == file["path"] && old["sha256"] == file["sha256"])
+            })
+            .collect::<Vec<_>>();
+        let changed_bytes = changed
+            .iter()
+            .map(|file| file["bytes"].as_u64().unwrap())
+            .sum::<u64>();
+        println!(
+            "ONTOLOGY_PROMOTION {}",
+            json!({
+                "nodes":node_count,"edges":edge_count,"routes":routes,
+                "promotion_ns":elapsed_ns,"before":before,"after":after,
+                "changed_parquet_files":changed.len(),"changed_parquet_bytes":changed_bytes,
+                "parquet_payload_limit_bytes":payload_limit,
+            })
+        );
+        // A second authored operation on the already promoted mixed graph must
+        // preserve exact semantics and avoid repeating property ownership moves.
+        let mut again = request;
+        again.context.operation_uuid = OperationId(Uuid::from_u128(1229010));
+        graph.adopt_ontology(again).unwrap();
+        verify(&graph);
+        assert_eq!(
+            publishing_parquet_inventory(&source),
+            after,
+            "already promoted routes must not be reencoded"
+        );
+        drop(graph);
+        round_trip_checked(root.path(), &source, verify);
+    }
+}
+
+#[test]
+fn ontology_promotion_bounds_changed_control_inventory() {
+    for (node_count, edge_count, routes) in [(33, 129, 2), (4097, 4097, 4)] {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        let fixture = Fixture {
+            name: "promotion_controls",
+            nodes: node_count,
+            edges: edge_count,
+            routes,
+            identifiers: Identifiers::Random,
+            properties: true,
+            adjacency: false,
+            heterogeneous: false,
+        };
+        let (nodes, edges) = rows(fixture);
+        construct(&source, fixture, &nodes, &edges);
+        let inventory = || {
+            graphforge_storage::resolve_project_generation(&source)
+                .unwrap()
+                .graph_files_inventory()
+                .unwrap()
+                .unwrap()
+        };
+        let before = inventory();
+        let mut graph = GraphForge::new(source.to_str()).unwrap();
+        graph
+            .adopt_ontology(promotion_request(root.path()))
+            .unwrap();
+        let after = inventory();
+        let controls = after
+            .files
+            .iter()
+            .filter(|entry| {
+                !entry.relative_path.ends_with(".parquet")
+                    && !before.files.iter().any(|old| {
+                        old.relative_path == entry.relative_path
+                            && old.content_sha256 == entry.content_sha256
+                    })
+            })
+            .collect::<Vec<_>>();
+        let bytes = controls.iter().map(|entry| entry.byte_length).sum::<u64>();
+        // Identity and ordinal records remain full-width; allow their complete
+        // representation plus bounded control framing, without quadratic growth.
+        let limit = (node_count + edge_count) as u64 * 80 + controls.len() as u64 * 1024 + 65536;
+        assert!(bytes <= limit, "changed controls {bytes} exceed {limit}");
+        println!(
+            "ONTOLOGY_PROMOTION_CONTROLS {}",
+            json!({
+                "nodes":node_count,"edges":edge_count,"routes":routes,
+                "changed_control_bytes":bytes,"changed_control_files":controls.len(),
+                "control_byte_limit":limit,
+                "controls":controls.iter().map(|entry| json!({"path":entry.relative_path,"bytes":entry.byte_length})).collect::<Vec<_>>()
+            })
         );
     }
 }

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 266,
-  "releaseSurfaceDigest": "88063e340c9fe29d290dda9442a4e8aa8311d0515a3154ed69340b23c3bfc4ae",
+  "releaseSurfaceCount": 267,
+  "releaseSurfaceDigest": "9c5cda8accc92758d15741874439ad5d194e4e64483a275f36c2ef7c5aedfe49",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "c07b80a5bb8c6d907d1c02d0862702965c94730e21bd71302e0288ba2c7af4b1"
-EXPECTED_RELEASE_DIGEST = "88063e340c9fe29d290dda9442a4e8aa8311d0515a3154ed69340b23c3bfc4ae"
+EXPECTED_RUST_DIGEST = "3199148900ac01b875528b26e6d900423998dcaaa5cc40014c200e55400afc13"
+EXPECTED_RELEASE_DIGEST = "9c5cda8accc92758d15741874439ad5d194e4e64483a275f36c2ef7c5aedfe49"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -257,7 +257,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 266
+    assert len(release_methods) == 267
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 
@@ -347,6 +347,10 @@ def _classification_report() -> dict[str, object]:
             "reason": reason,
         }
 
+    # Cancellation-token ownership remains Rust-only; existing adoption stays equivalent.
+    assert (
+        classifications["GraphForge.adopt_ontology_cancellable"]["classification"] == "not-exposed"
+    )
     assert classifications["GraphForge.explain_stage"]["classification"] == "not-exposed"
     assert classifications["GraphForge.explain_stage"]["python_id"] == ""
 

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -423,9 +423,9 @@ pub use catalog::{
 pub mod runtime_entity_labels;
 pub use runtime_entity_labels::{
     RUNTIME_ENTITY_LABEL_ENCODING_VERSION, RuntimeEntityLabelReconcile,
-    has_runtime_entity_label_encoding_marker, reconcile_runtime_entity_label_ids,
-    runtime_entity_plan_id_is_disjoint_from_ontology, validate_runtime_entity_label_ids,
-    write_runtime_entity_label_encoding_marker,
+    has_runtime_entity_label_encoding_marker, promote_runtime_graph_for_ontology,
+    reconcile_runtime_entity_label_ids, runtime_entity_plan_id_is_disjoint_from_ontology,
+    validate_runtime_entity_label_ids, write_runtime_entity_label_encoding_marker,
 };
 
 pub mod parquet_scan;

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1420,6 +1420,8 @@ impl StagedProjectGeneration {
     }
 }
 
+type ReaderPreparation<'a> = &'a mut dyn FnMut(&ResolvedProjectGeneration) -> Result<(), GfError>;
+
 impl ValidatedProjectGeneration {
     /// Durably install the generation, then atomically replace `CURRENT`.
     ///
@@ -1427,7 +1429,7 @@ impl ValidatedProjectGeneration {
     /// Returns a stable publication error whose diagnostic states whether the
     /// commit point was crossed.
     pub fn publish(mut self) -> Result<ProjectPublicationReceipt, GfError> {
-        self.publish_with_optional_graph_objects(None, None)
+        self.publish_with_optional_graph_objects(None, None, None)
     }
 
     /// Publish a compact graph generation while holding its CAS lease through
@@ -1436,7 +1438,7 @@ impl ValidatedProjectGeneration {
         mut self,
         lease: &crate::GraphObjectPublicationLease,
     ) -> Result<ProjectPublicationReceipt, GfError> {
-        self.publish_with_optional_graph_objects(Some(lease), None)
+        self.publish_with_optional_graph_objects(Some(lease), None, None)
     }
 
     /// Publish a compact graph while polling cancellation until the atomic
@@ -1446,13 +1448,27 @@ impl ValidatedProjectGeneration {
         lease: &crate::GraphObjectPublicationLease,
         cancelled: &mut dyn FnMut() -> bool,
     ) -> Result<ProjectPublicationReceipt, GfError> {
-        self.publish_with_optional_graph_objects(Some(lease), Some(cancelled))
+        self.publish_with_optional_graph_objects(Some(lease), Some(cancelled), None)
+    }
+
+    /// Prepare authenticated readers against the durable candidate before CURRENT.
+    /// The callback runs under the normal publication lock and cannot select a generation.
+    ///
+    /// # Errors
+    /// Callback failure leaves CURRENT unchanged; publication errors retain their commit status.
+    pub fn publish_with_reader_preparation(
+        mut self,
+        lease: Option<&crate::GraphObjectPublicationLease>,
+        prepare: &mut dyn FnMut(&ResolvedProjectGeneration) -> Result<(), GfError>,
+    ) -> Result<ProjectPublicationReceipt, GfError> {
+        self.publish_with_optional_graph_objects(lease, None, Some(prepare))
     }
 
     fn publish_with_optional_graph_objects(
         &mut self,
         graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
         cancellation: Option<&mut dyn FnMut() -> bool>,
+        preparation: Option<ReaderPreparation<'_>>,
     ) -> Result<ProjectPublicationReceipt, GfError> {
         self.0.admission.revalidate_identity()?;
         let lifecycle_admission = self.0.admission.readmit_for_publish()?;
@@ -1467,6 +1483,7 @@ impl ValidatedProjectGeneration {
                 graph_object_lease,
                 lifecycle_admission.as_ref(),
                 cancellation,
+                preparation,
             )
             .map_err(|error| {
                 if matches!(error, GfError::Project { .. } | GfError::Api { .. }) {
@@ -1523,6 +1540,7 @@ impl ValidatedProjectGeneration {
         graph_object_lease: Option<&crate::GraphObjectPublicationLease>,
         lifecycle_admission: Option<&crate::filesystem_admission::ProjectLifecycleAdmission>,
         cancellation: Option<&mut dyn FnMut() -> bool>,
+        preparation: Option<ReaderPreparation<'_>>,
     ) -> Result<ProjectPublicationReceipt, GfError> {
         let staged = &self.0;
         let compact_graph = has_compact_graph_participant(staged)?;
@@ -1546,6 +1564,14 @@ impl ValidatedProjectGeneration {
                 .join(staged.generation_uuid.hyphenated().to_string());
             verify_optional_graph_tree_with_lease(&durable_root, &staged.participants, lease)?;
             lease.revalidate_for_root(staged.parent.container_root())?;
+        }
+        if let Some(prepare) = preparation {
+            let candidate = crate::resolve_verified_generation(
+                &staged.root,
+                staged.generation_uuid,
+                manifest_sha256,
+            )?;
+            prepare(&candidate)?;
         }
         replace_current(
             staged,
@@ -3480,6 +3506,77 @@ mod tests {
                 .unwrap()
                 .generation_uuid(),
             parent
+        );
+    }
+
+    #[test]
+    fn reader_preparation_failure_preserves_current_and_recovers_candidate() {
+        let root = project();
+        let parent = resolve_project_generation(root.path()).unwrap();
+        let current_bytes = fs::read(root.path().join("CURRENT")).unwrap();
+        let request = request(vec![participant("graph", "nodes", b"candidate")]);
+        let ProjectStageOutcome::Staged(staged) =
+            stage_project_generation(root.path(), &request).unwrap()
+        else {
+            panic!("new request unexpectedly replayed");
+        };
+        let validated = staged.validate(|_| Ok(()), |_, _| Ok(())).unwrap();
+        let refusal = || GfError::Project {
+            code: ProjectErrorCode::WriteConflict,
+            message: "reader preparation deliberately refused candidate".into(),
+        };
+        let mut calls = 0;
+        let error = validated
+            .publish_with_reader_preparation(None, &mut |candidate| {
+                calls += 1;
+                assert_eq!(candidate.generation_uuid(), request.generation_uuid);
+                assert_eq!(
+                    candidate
+                        .participant_snapshot("graph", "nodes")?
+                        .unwrap()
+                        .bytes,
+                    b"candidate"
+                );
+                assert_eq!(
+                    fs::read(root.path().join("CURRENT")).unwrap(),
+                    current_bytes
+                );
+                Err(refusal())
+            })
+            .unwrap_err();
+        assert_eq!(calls, 1);
+        assert_eq!(error.code(), refusal().code());
+        assert_eq!(error.to_string(), refusal().to_string());
+        assert_eq!(
+            fs::read(root.path().join("CURRENT")).unwrap(),
+            current_bytes
+        );
+        assert_eq!(
+            resolve_project_generation(root.path())
+                .unwrap()
+                .generation_uuid(),
+            parent.generation_uuid()
+        );
+        let candidate_path = root
+            .path()
+            .join(GENERATIONS_DIR)
+            .join(request.generation_uuid.hyphenated().to_string());
+        assert!(
+            candidate_path.exists(),
+            "preparation runs against a durable candidate"
+        );
+        let recovered = crate::recover_project_transactions(root.path()).unwrap();
+        assert_eq!(recovered.aborted_journals, 1);
+        assert_eq!(recovered.removed_generations, 1);
+        assert!(!candidate_path.exists());
+        assert_eq!(
+            fs::read(root.path().join("CURRENT")).unwrap(),
+            current_bytes
+        );
+        assert!(
+            published_project_transaction(root.path(), request.transaction_uuid)
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -520,6 +520,21 @@ impl AuthenticatedPropertyInventory {
         })
     }
 
+    /// Narrow an already authenticated inventory to transaction-owned property
+    /// fragments while retaining the complete graph and semantic-route admission.
+    pub(crate) fn retain_property_fragment_paths(
+        &mut self,
+        paths: &std::collections::HashSet<PathBuf>,
+    ) {
+        let Some(root) = &self.root_path else {
+            return;
+        };
+        self.routes.retain(|_, fragments| {
+            fragments.retain(|fragment| paths.contains(&root.join(&fragment.physical_relative)));
+            !fragments.is_empty()
+        });
+    }
+
     /// Return admitted immutable property fragments in oldest-to-newest order.
     /// The caller must retain this inventory while using its physical paths.
     #[must_use]

--- a/crates/graphforge-storage/src/runtime_entity_labels.rs
+++ b/crates/graphforge-storage/src/runtime_entity_labels.rs
@@ -21,14 +21,16 @@ use std::sync::Arc;
 
 use arrow::array::{Array, ListArray, UInt32Array, UInt32Builder};
 use arrow::datatypes::{DataType, Field};
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use graphforge_core::{GfError, TypeId};
 use graphforge_ir::RuntimeCatalog;
 use graphforge_ontology::OntologyHandle;
 use graphforge_value::{EntityTypeId, PrimaryEntityTypeId, RuntimeEntityId};
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{normalize_topology_nodes, read_nodes};
+use crate::catalog::normalize_topology_nodes;
+#[cfg(test)]
+use crate::catalog::read_nodes;
 use crate::schemas::TOPOLOGY_NODES_SCHEMA;
 use crate::staging::RewriteBatch;
 
@@ -435,8 +437,399 @@ fn merge_remaps(
     Ok(remap)
 }
 
-fn read_topology_batches(dir: &Path) -> Result<Vec<RecordBatch>, GfError> {
-    normalize_topology_nodes(read_nodes(dir).map_err(pq_err)?).map_err(pq_err)
+// Process one topology decoder batch at a time. Targeted authenticated property
+// reads and private fragment commits prevent property windows growing with the graph.
+fn promote_node_properties(
+    dir: &Path,
+    ontology: &OntologyHandle,
+    runtime_catalog: &RuntimeCatalog,
+) -> Result<(), GfError> {
+    use arrow::array::FixedSizeBinaryArray;
+    use std::collections::{BTreeMap, BTreeSet};
+    let remaps = adoption_name_remaps(Some(ontology), runtime_catalog)?;
+    if remaps.is_empty() {
+        return Ok(());
+    }
+    let source = crate::property_overlay::authenticated_property_inventory_for_route(
+        dir,
+        crate::PropertyRouteKind::Node,
+        "_untyped",
+    )?;
+    let Some(schema) = source.route_schema(crate::PropertyRouteKind::Node, "_untyped") else {
+        return Ok(());
+    };
+    let names = runtime_catalog
+        .entity_type_names_with_ids()
+        .filter_map(|(id, name)| {
+            remaps
+                .contains_key(&EntityTypeId::runtime(id))
+                .then_some((EntityTypeId::runtime(id).encode(), name.to_owned()))
+        })
+        .collect::<HashMap<_, _>>();
+    for path in crate::mutator::node_parquet_files(dir)? {
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+            std::fs::File::open(path).map_err(pq_err)?,
+        )
+        .map_err(pq_err)?
+        .with_batch_size(4096)
+        .build()
+        .map_err(pq_err)?;
+        for batch in reader {
+            let batch = batch.map_err(pq_err)?;
+            let primary = batch
+                .column_by_name("type_id")
+                .and_then(|a| a.as_any().downcast_ref::<UInt32Array>())
+                .ok_or_else(|| storage_err("missing node primary label"))?;
+            let uuids = batch
+                .column_by_name("node_uuid")
+                .and_then(|a| a.as_any().downcast_ref::<FixedSizeBinaryArray>())
+                .ok_or_else(|| storage_err("missing node UUID"))?;
+            let mut targets = BTreeMap::<String, BTreeSet<[u8; 16]>>::new();
+            for row in 0..batch.num_rows() {
+                if let Some(name) = names.get(&primary.value(row)) {
+                    targets
+                        .entry(name.clone())
+                        .or_default()
+                        .insert(uuids.value(row).try_into().map_err(pq_err)?);
+                }
+            }
+            for (name, targets) in targets {
+                let (rows, _) =
+                    crate::property_overlay::read_authenticated_property_snapshots_for_inventory(
+                        &source,
+                        crate::PropertyRouteKind::Node,
+                        "_untyped",
+                        &targets,
+                    )?;
+                if rows.is_empty() {
+                    continue;
+                }
+                let mut staged = RewriteBatch::new();
+                crate::writer::stage_promoted_properties(
+                    &mut staged,
+                    dir,
+                    &name,
+                    crate::PropertyRouteKind::Node,
+                    schema.as_ref(),
+                    &rows,
+                )?;
+                let current_source =
+                    crate::property_overlay::authenticated_property_inventory_for_route(
+                        dir,
+                        crate::PropertyRouteKind::Node,
+                        "_untyped",
+                    )?;
+                crate::writer::stage_property_tombstones_authenticated(
+                    &mut staged,
+                    dir,
+                    &current_source,
+                    crate::PropertyRouteKind::Node,
+                    "_untyped",
+                    &rows.keys().copied().collect::<HashSet<_>>(),
+                )?;
+                staged.commit_at(dir)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)] // bounded ownership transfer and source tombstones form one operation
+fn promote_edge_properties(dir: &Path) -> Result<HashSet<std::path::PathBuf>, GfError> {
+    use arrow::array::{FixedSizeBinaryArray, StringArray};
+    use std::collections::{BTreeMap, BTreeSet};
+    let inventory = crate::property_overlay::authenticated_property_inventory(dir)?;
+    let kind = crate::PropertyRouteKind::Edge;
+    let mut transferred = HashSet::new();
+    let Some(schema) = inventory.route_schema(kind, "_exploratory") else {
+        return Ok(transferred);
+    };
+    for (_, path) in inventory.edge_files(Some("_exploratory")) {
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+            std::fs::File::open(path).map_err(pq_err)?,
+        )
+        .map_err(pq_err)?
+        .with_batch_size(4096)
+        .build()
+        .map_err(pq_err)?;
+        for batch in reader {
+            let batch = batch.map_err(pq_err)?;
+            let names = batch
+                .column_by_name("rel_type_name")
+                .and_then(|a| a.as_any().downcast_ref::<StringArray>())
+                .ok_or_else(|| storage_err("missing exploratory relation name"))?;
+            let uuids = batch
+                .column_by_name("edge_uuid")
+                .and_then(|a| a.as_any().downcast_ref::<FixedSizeBinaryArray>())
+                .ok_or_else(|| storage_err("missing edge UUID"))?;
+            let mut targets = BTreeMap::<String, BTreeSet<[u8; 16]>>::new();
+            for row in 0..batch.num_rows() {
+                let name = names.value(row);
+                targets
+                    .entry(name.to_owned())
+                    .or_default()
+                    .insert(uuids.value(row).try_into().map_err(pq_err)?);
+            }
+            for (name, targets) in targets {
+                let (mut rows, _) =
+                    crate::property_overlay::read_authenticated_property_snapshots_for_inventory(
+                        &inventory,
+                        kind,
+                        "_exploratory",
+                        &targets,
+                    )?;
+                let (present, _) =
+                    crate::property_overlay::read_authenticated_property_presence_for_inventory(
+                        &inventory,
+                        kind,
+                        "_exploratory",
+                        &targets,
+                    )?;
+                for uuid in present {
+                    rows.entry(uuid)
+                        .or_insert_with(|| crate::PropertySnapshotRow {
+                            uuid,
+                            tombstone: true,
+                            values: BTreeMap::new(),
+                        });
+                }
+                if rows.is_empty() {
+                    continue;
+                }
+                let prior_destination =
+                    crate::property_overlay::authenticated_property_inventory_for_route(
+                        dir, kind, &name,
+                    )?;
+                let prior_paths = prior_destination
+                    .property_fragments(kind, &name)
+                    .into_iter()
+                    .map(|fragment| fragment.path)
+                    .collect::<HashSet<_>>();
+                let mut staged = RewriteBatch::new();
+                crate::writer::stage_promoted_properties(
+                    &mut staged,
+                    dir,
+                    &name,
+                    kind,
+                    schema.as_ref(),
+                    &rows,
+                )?;
+                let current_source =
+                    crate::property_overlay::authenticated_property_inventory_for_route(
+                        dir,
+                        kind,
+                        "_exploratory",
+                    )?;
+                crate::writer::stage_property_tombstones_authenticated(
+                    &mut staged,
+                    dir,
+                    &current_source,
+                    kind,
+                    "_exploratory",
+                    &rows.keys().copied().collect::<HashSet<_>>(),
+                )?;
+                staged.commit_at(dir)?;
+                let current_destination =
+                    crate::property_overlay::authenticated_property_inventory_for_route(
+                        dir, kind, &name,
+                    )?;
+                transferred.extend(
+                    current_destination
+                        .property_fragments(kind, &name)
+                        .into_iter()
+                        .map(|fragment| fragment.path)
+                        .filter(|path| !prior_paths.contains(path)),
+                );
+            }
+        }
+    }
+    Ok(transferred)
+}
+
+// Tombstones remain property ownership evidence. Remove every physical source
+// occurrence after transferring that ownership, including old snapshots.
+fn stage_retired_edge_property_owners(
+    dir: &Path,
+    transferred: &HashSet<std::path::PathBuf>,
+    staged: &mut RewriteBatch,
+) -> Result<(), GfError> {
+    use arrow::array::{BooleanArray, FixedSizeBinaryArray};
+    use std::collections::BTreeSet;
+    if transferred.is_empty() {
+        return Ok(());
+    }
+    let inventory =
+        crate::property_overlay::authenticated_property_inventory_for_rewrite(dir, staged)?;
+    let mut transferred_inventory =
+        crate::property_overlay::authenticated_property_inventory_for_rewrite(dir, staged)?;
+    transferred_inventory.retain_property_fragment_paths(transferred);
+    let kind = crate::PropertyRouteKind::Edge;
+    let routes = transferred_inventory.routes(kind).collect::<Vec<_>>();
+    let final_summary = inventory
+        .route_schema(kind, "_exploratory")
+        .and_then(|schema| {
+            schema
+                .metadata()
+                .get(crate::property_overlay::PROPERTY_LIVE_SCHEMA_KEY)
+                .cloned()
+        });
+    let fragments = inventory.property_fragments(kind, "_exploratory");
+    let last_fragment = fragments.last().map(|fragment| fragment.path.clone());
+    if routes.is_empty() {
+        return Ok(());
+    }
+    for fragment in fragments {
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+            std::fs::File::open(&fragment.path).map_err(pq_err)?,
+        )
+        .map_err(pq_err)?
+        .with_batch_size(4096)
+        .build()
+        .map_err(pq_err)?;
+        // Historical summaries counted the removed ownership. Preserve the
+        // current cumulative summary only on the newest source fragment.
+        let mut metadata = reader.schema().metadata().clone();
+        metadata.remove(crate::property_overlay::PROPERTY_LIVE_SCHEMA_KEY);
+        if Some(&fragment.path) == last_fragment.as_ref()
+            && let Some(summary) = &final_summary
+        {
+            metadata.insert(
+                crate::property_overlay::PROPERTY_LIVE_SCHEMA_KEY.into(),
+                summary.clone(),
+            );
+        }
+        metadata.insert(
+            crate::property_overlay::PROPERTY_OVERLAY_FORMAT_KEY.into(),
+            crate::property_overlay::PROPERTY_OVERLAY_FORMAT.into(),
+        );
+        metadata.insert(
+            crate::property_overlay::PROPERTY_ROUTE_KEY.into(),
+            "_exploratory".into(),
+        );
+        metadata.insert(
+            crate::property_overlay::PROPERTY_KIND_KEY.into(),
+            "edge".into(),
+        );
+        metadata.insert(
+            crate::property_overlay::PROPERTY_GENERATION_KEY.into(),
+            fragment.id.generation.to_string(),
+        );
+        metadata.insert(
+            crate::property_overlay::PROPERTY_ORDINAL_KEY.into(),
+            fragment.id.ordinal.to_string(),
+        );
+        let schema = Arc::new(reader.schema().as_ref().clone().with_metadata(metadata));
+        let batches = reader.map(|batch| {
+            let batch = batch.map_err(pq_err)?;
+            let uuids = batch
+                .column_by_name("edge_uuid")
+                .and_then(|a| a.as_any().downcast_ref::<FixedSizeBinaryArray>())
+                .ok_or_else(|| storage_err("edge property UUID missing"))?;
+            let targets = (0..batch.num_rows())
+                .map(|row| uuids.value(row).try_into().map_err(pq_err))
+                .collect::<Result<BTreeSet<[u8; 16]>, _>>()?;
+            let mut retired = BTreeSet::new();
+            for route in &routes {
+                let (present, _) =
+                    crate::property_overlay::read_authenticated_property_presence_for_inventory(
+                        &transferred_inventory,
+                        kind,
+                        route,
+                        &targets,
+                    )?;
+                retired.extend(present);
+            }
+            let keep = BooleanArray::from(
+                (0..batch.num_rows())
+                    .map(|row| {
+                        !retired.contains(
+                            &<[u8; 16]>::try_from(uuids.value(row)).expect("validated UUID width"),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            let filtered = arrow::compute::filter_record_batch(&batch, &keep).map_err(pq_err)?;
+            RecordBatch::try_new(schema.clone(), filtered.columns().to_vec()).map_err(pq_err)
+        });
+        staged.stage_batches(&fragment.path, schema.clone(), batches)?;
+    }
+    Ok(())
+}
+
+fn stage_promoted_edges(dir: &Path, staged: &mut RewriteBatch) -> Result<bool, GfError> {
+    use arrow::array::{BooleanArray, StringArray, UInt64Array};
+    let inventory =
+        crate::property_overlay::authenticated_property_inventory_for_rewrite(dir, staged)?;
+    let mut changed = false;
+    for (_, path) in inventory.edge_files(Some("_exploratory")) {
+        let reader = || -> Result<_, GfError> {
+            parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+                std::fs::File::open(&path).map_err(pq_err)?,
+            )
+            .map_err(pq_err)?
+            .with_batch_size(4096)
+            .build()
+            .map_err(pq_err)
+        };
+        let mut file_changed = false;
+        for batch in reader()? {
+            let batch = batch.map_err(pq_err)?;
+            let names = batch
+                .column_by_name("rel_type_name")
+                .and_then(|a| a.as_any().downcast_ref::<StringArray>())
+                .ok_or_else(|| storage_err("exploratory edge relation name missing"))?;
+            let routes = (0..batch.num_rows())
+                .map(|row| names.value(row))
+                .collect::<std::collections::BTreeSet<_>>();
+            for route in routes {
+                let selected = arrow::compute::filter_record_batch(
+                    &batch,
+                    &BooleanArray::from(
+                        (0..batch.num_rows())
+                            .map(|row| names.value(row) == route)
+                            .collect::<Vec<_>>(),
+                    ),
+                )
+                .map_err(pq_err)?;
+                let schema = crate::TYPED_EDGE_SCHEMA.clone();
+                let columns = schema
+                    .fields()
+                    .iter()
+                    .map(|field| {
+                        selected
+                            .column_by_name(field.name())
+                            .cloned()
+                            .ok_or_else(|| storage_err("promoted edge field missing"))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let selected = RecordBatch::try_new(schema.clone(), columns).map_err(pq_err)?;
+                let ids = selected
+                    .column_by_name("edge_id")
+                    .and_then(|a| a.as_any().downcast_ref::<UInt64Array>())
+                    .ok_or_else(|| storage_err("promoted edge ID missing"))?;
+                let first = ids.value(0);
+                let last = ids.value(ids.len() - 1);
+                let component = staged.route_component(dir, route)?;
+                let target = dir
+                    .join("topology/edges")
+                    .join(component)
+                    .join(format!("{first:020}-{last:020}.parquet"));
+                if target.exists() || staged.staged_temp(&target).is_some() {
+                    return Err(storage_err("promoted edge surrogate range already exists"));
+                }
+                staged.stage(&target, schema, &selected)?;
+                file_changed = true;
+            }
+        }
+        if file_changed {
+            let schema = reader()?.schema();
+            // Ontology modes read every named relationship through its own
+            // route, including Advisory names not declared by the ontology.
+            staged.stage_batches(&path, schema, std::iter::empty())?;
+            changed = true;
+        }
+    }
+    Ok(changed)
 }
 
 fn reconcile_inner(
@@ -444,6 +837,7 @@ fn reconcile_inner(
     ontology: Option<&OntologyHandle>,
     runtime_catalog: &RuntimeCatalog,
     rewrite: bool,
+    promotion: bool,
 ) -> Result<RuntimeEntityLabelReconcile, GfError> {
     let marked = has_runtime_entity_label_encoding_marker(dir);
     let ontology_ids = ontology_entity_ids(ontology);
@@ -463,7 +857,13 @@ fn reconcile_inner(
     // Nothing to validate or rewrite: skip topology I/O entirely. This keeps
     // non-parquet legacy snapshot placeholders out of the migration path and
     // avoids a full nodes.parquet scan on already-reconciled projects.
-    if collisions.is_empty() && remap.is_empty() {
+    let promotes_relations = promotion
+        && ontology.is_some_and(|ontology| {
+            runtime_catalog
+                .relation_type_names_with_ids()
+                .any(|(_, name)| ontology.relation_type_id(name).is_some())
+        });
+    if collisions.is_empty() && remap.is_empty() && !promotes_relations {
         if rewrite && !marked {
             write_runtime_entity_label_encoding_marker(dir)?;
         }
@@ -474,51 +874,64 @@ fn reconcile_inner(
         });
     }
 
-    let batches = read_topology_batches(dir)?;
-
-    if !marked {
-        let collision_hits = collect_untagged_label_hits(&batches, &collisions)?;
-        if !collision_hits.is_empty() {
-            let mut ids = collision_hits.into_iter().collect::<Vec<_>>();
-            ids.sort_unstable();
-            return Err(storage_err(format!(
-                "runtime entity label ID collision with ontology type IDs; \
-                 cannot safely migrate untagged node labels for raw ids {ids:?} \
-                 (identity domains must remain disjoint)"
-            )));
-        }
-    }
-
+    let candidate_keys = remap.keys().copied().collect::<HashSet<_>>();
     let mut remapped_label_values = 0u64;
-    if !remap.is_empty() {
-        let candidate_keys = remap.keys().copied().collect::<HashSet<_>>();
-        let needs_migration = !collect_label_hits(&batches, &candidate_keys)?.is_empty();
-        if needs_migration {
-            if !rewrite {
+    let mut staged = RewriteBatch::new();
+    for path in crate::mutator::node_parquet_files(dir)? {
+        let reader = || -> Result<_, GfError> {
+            parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+                std::fs::File::open(&path).map_err(pq_err)?,
+            )
+            .map_err(pq_err)?
+            .with_batch_size(4096)
+            .build()
+            .map_err(pq_err)
+        };
+        let mut needs_rewrite = false;
+        for batch in reader()? {
+            let batches = normalize_topology_nodes(vec![batch.map_err(pq_err)?]).map_err(pq_err)?;
+            if !marked && !collect_untagged_label_hits(&batches, &collisions)?.is_empty() {
                 return Err(storage_err(
-                    "runtime entity label IDs require writable reconciliation; \
-                     read-only open cannot rewrite topology",
+                    "runtime entity label ID collision with ontology type IDs",
                 ));
             }
-            let mut staged = RewriteBatch::new();
-            for path in crate::mutator::node_parquet_files(dir)? {
-                let source = normalize_topology_nodes(
-                    crate::catalog::read_parquet_or_empty(&path, TOPOLOGY_NODES_SCHEMA.clone())
-                        .map_err(pq_err)?,
-                )
-                .map_err(pq_err)?;
-                let (rewritten, remapped) = remap_batches(source, &remap)?;
-                remapped_label_values = remapped_label_values.saturating_add(remapped);
-                if remapped > 0 {
-                    let merged = arrow::compute::concat_batches(&TOPOLOGY_NODES_SCHEMA, &rewritten)
-                        .map_err(|e| storage_err(e.to_string()))?;
-                    staged.restage(&path, TOPOLOGY_NODES_SCHEMA.clone(), &merged)?;
-                }
-            }
-            if remapped_label_values > 0 {
-                crate::uuid_membership::commit_uuid_neutral_topology_rewrite(dir, staged)?;
-            }
+            needs_rewrite |= !collect_label_hits(&batches, &candidate_keys)?.is_empty();
         }
+        if !needs_rewrite {
+            continue;
+        }
+        if !rewrite {
+            return Err(storage_err(
+                "runtime entity label IDs require writable reconciliation; read-only open cannot rewrite topology",
+            ));
+        }
+        let batches = reader()?.map(|batch| {
+            let source = normalize_topology_nodes(vec![batch.map_err(pq_err)?]).map_err(pq_err)?;
+            let (mut rewritten, count) = remap_batches(source, &remap)?;
+            remapped_label_values = remapped_label_values.saturating_add(count);
+            Ok(rewritten.remove(0))
+        });
+        staged.stage_batches(&path, TOPOLOGY_NODES_SCHEMA.clone(), batches)?;
+    }
+    if promotion
+        && remapped_label_values > 0
+        && let Some(ontology) = ontology
+    {
+        promote_node_properties(dir, ontology, runtime_catalog)?;
+    }
+    let edges_changed = if promotion
+        && rewrite
+        && ontology.is_some()
+        && (remapped_label_values > 0 || promotes_relations)
+    {
+        let transferred = promote_edge_properties(dir)?;
+        stage_retired_edge_property_owners(dir, &transferred, &mut staged)?;
+        stage_promoted_edges(dir, &mut staged)?
+    } else {
+        false
+    };
+    if remapped_label_values > 0 || edges_changed {
+        crate::uuid_membership::commit_uuid_neutral_topology_rewrite(dir, staged)?;
     }
 
     if rewrite && !marked {
@@ -545,7 +958,20 @@ pub fn reconcile_runtime_entity_label_ids(
     ontology: Option<&OntologyHandle>,
     runtime_catalog: &RuntimeCatalog,
 ) -> Result<RuntimeEntityLabelReconcile, GfError> {
-    reconcile_inner(dir, ontology, runtime_catalog, true)
+    reconcile_inner(dir, ontology, runtime_catalog, true, false)
+}
+
+/// Promote labels and property/relationship routes in a private adoption candidate.
+/// The caller must publish this complete tree with its ontology before installing readers.
+///
+/// # Errors
+/// Refuses ambiguous identities or property owners and propagates authenticated I/O failures.
+pub fn promote_runtime_graph_for_ontology(
+    dir: &Path,
+    ontology: &OntologyHandle,
+    runtime_catalog: &RuntimeCatalog,
+) -> Result<RuntimeEntityLabelReconcile, GfError> {
+    reconcile_inner(dir, Some(ontology), runtime_catalog, true, true)
 }
 
 /// Validate runtime entity label encoding without rewriting topology.
@@ -562,7 +988,7 @@ pub fn validate_runtime_entity_label_ids(
     ontology: Option<&OntologyHandle>,
     runtime_catalog: &RuntimeCatalog,
 ) -> Result<RuntimeEntityLabelReconcile, GfError> {
-    reconcile_inner(dir, ontology, runtime_catalog, false)
+    reconcile_inner(dir, ontology, runtime_catalog, false, false)
 }
 
 /// Pure helper: tagged runtime entity plan IDs stay disjoint from ontology IDs.
@@ -711,7 +1137,7 @@ mod tests {
     fn membership_remap_preserves_absent_original_primary() {
         let directory = TempDir::new().unwrap();
         write_nodes(directory.path(), &[&[0]]);
-        let batch = read_topology_batches(directory.path()).unwrap().remove(0);
+        let batch = read_nodes(directory.path()).unwrap().remove(0);
         let mut columns = batch.columns().to_vec();
         columns[batch.schema().index_of("type_id").unwrap()] =
             Arc::new(UInt32Array::from(vec![u32::MAX]));

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -6018,6 +6018,117 @@ pub fn remove_edge_properties(
     Ok(touched)
 }
 
+/// Move one bounded set of exploratory snapshots into its promoted owner.
+pub(crate) fn stage_promoted_properties(
+    staged: &mut RewriteBatch,
+    dir: &Path,
+    stem: &str,
+    kind: crate::PropertyRouteKind,
+    source_schema: &Schema,
+    source: &BTreeMap<[u8; 16], crate::PropertySnapshotRow>,
+) -> Result<(), GfError> {
+    let inventory =
+        crate::property_overlay::authenticated_property_inventory_for_route(dir, kind, stem)?;
+    let targets = source.keys().copied().collect();
+    let (before, _) = crate::property_overlay::read_authenticated_property_snapshots_for_inventory(
+        &inventory, kind, stem, &targets,
+    )?;
+    if kind == crate::PropertyRouteKind::Edge {
+        let (present, _) =
+            crate::property_overlay::read_authenticated_property_presence_for_inventory(
+                &inventory, kind, stem, &targets,
+            )?;
+        if !present.is_empty() {
+            return Err(GfError::Validation(
+                "ontology promotion has overlapping edge property owners".into(),
+            ));
+        }
+    }
+    let destination = inventory.route_schema(kind, stem);
+    let mut source_metadata = source_schema.metadata().clone();
+    source_metadata.insert(
+        match kind {
+            crate::PropertyRouteKind::Node => "graphforge.entity_type",
+            crate::PropertyRouteKind::Edge => "graphforge.rel_type",
+        }
+        .into(),
+        stem.into(),
+    );
+    let source_schema = source_schema.clone().with_metadata(source_metadata);
+    let mut schemas = vec![&source_schema];
+    if let Some(schema) = &destination {
+        schemas.push(schema.as_ref());
+    }
+    let authority = crate::property_overlay::merge_property_route_schemas(kind, stem, schemas)?;
+    let mut metadata = authority.metadata().clone();
+    if let Some(summary) = destination.as_ref().and_then(|schema| {
+        schema
+            .metadata()
+            .get(crate::property_overlay::PROPERTY_LIVE_SCHEMA_KEY)
+    }) {
+        metadata.insert(
+            crate::property_overlay::PROPERTY_LIVE_SCHEMA_KEY.into(),
+            summary.clone(),
+        );
+    }
+    let authority = Arc::new(authority.as_ref().clone().with_metadata(metadata));
+    let rows = source
+        .iter()
+        .filter(|(_, row)| !row.tombstone)
+        .map(|(uuid, row)| {
+            let mut values = before
+                .get(uuid)
+                .map_or_else(BTreeMap::new, |row| row.values.clone());
+            values.extend(row.values.clone());
+            PropRow {
+                node_uuid: *uuid,
+                props: values.into_iter().collect(),
+            }
+        })
+        .collect::<Vec<_>>();
+    match kind {
+        crate::PropertyRouteKind::Node => stage_node_property_file(
+            staged,
+            dir,
+            stem,
+            &rows,
+            Some(authority),
+            inventory.generation_authority(),
+            Some(&before),
+        ),
+        crate::PropertyRouteKind::Edge => {
+            let rows = rows
+                .into_iter()
+                .map(|row| EdgePropRow {
+                    edge_uuid: row.node_uuid,
+                    props: row.props,
+                })
+                .collect::<Vec<_>>();
+            stage_edge_property_file(
+                staged,
+                dir,
+                stem,
+                &rows,
+                Some(authority),
+                inventory.generation_authority(),
+                Some(&before),
+            )?;
+            let tombstones = source
+                .iter()
+                .filter_map(|(uuid, row)| row.tombstone.then_some(*uuid))
+                .collect::<HashSet<_>>();
+            stage_property_tombstones_authenticated(
+                staged,
+                dir,
+                &inventory,
+                kind,
+                stem,
+                &tombstones,
+            )
+        }
+    }
+}
+
 fn stage_node_property_file(
     staged: &mut RewriteBatch,
     dir: &Path,
@@ -10103,6 +10214,114 @@ mod tests {
             "empty_compressor_bytes":empty_compressor_bytes,
             "empty_decompressor_bytes":decompressor.sizeof(),
             "measurements":measurements})
+        );
+    }
+}
+
+#[cfg(test)]
+mod promotion_full_width_tests {
+    use super::*;
+    use arrow::array::UInt64Array;
+    use graphforge_ontology::{OntologyCompiler, OntologyHandle, OntologyLoader};
+
+    #[test]
+    fn same_name_promotion_preserves_full_width_authorities_and_allocation() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut catalog = graphforge_ir::RuntimeCatalog::new();
+        let runtime_id = catalog.intern_label("Person").unwrap();
+        catalog.intern_relation_type("KNOWS").unwrap();
+        let label = graphforge_value::EntityTypeId::runtime(runtime_id);
+        let left = Uuid::from_u128(1229801);
+        let right = Uuid::from_u128(1229802);
+        let edge = Uuid::from_u128(1229803);
+        let node_base = u64::MAX - 8;
+        let edge_base = u64::from(u32::MAX) + 7;
+        let mut writer = GraphWriter::open_at(dir.path(), OntologyMode::Exploratory, 1).unwrap();
+        writer.next_node_id = node_base;
+        writer.next_edge_id = edge_base;
+        assert_eq!(writer.create_node(left, label).unwrap(), node_base);
+        assert_eq!(writer.create_node(right, label).unwrap(), node_base + 1);
+        assert_eq!(
+            writer.create_edge(edge, "KNOWS", &left, &right).unwrap(),
+            edge_base
+        );
+        writer.flush().unwrap();
+        drop(writer);
+        crate::runtime_entity_labels::persist_runtime_catalog(dir.path(), &catalog).unwrap();
+        let document = OntologyLoader::load_yaml("ontology_id: wide\nversion: \"1\"\nentity_types:\n  - name: Person\n    abstract: false\nrelation_types:\n  - name: KNOWS\n    src: Person\n    dst: Person\n".as_bytes()).unwrap();
+        let ontology = OntologyHandle::new(OntologyCompiler::compile(&document).unwrap());
+        crate::promote_runtime_graph_for_ontology(dir.path(), &ontology, &catalog).unwrap();
+        let mut membership = crate::UuidMembershipIndex::open(dir.path()).unwrap();
+        assert_eq!(
+            membership.lookup_node_surrogates(&[left, right]).unwrap().0,
+            [Some(node_base), Some(node_base + 1)]
+        );
+        drop(membership);
+        let inventory =
+            crate::property_overlay::authenticated_property_inventory(dir.path()).unwrap();
+        let batches =
+            crate::read_edges_from_inventory(&inventory, "KNOWS", OntologyMode::Strict).unwrap();
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        let batch = batches.iter().find(|batch| batch.num_rows() != 0).unwrap();
+        for (name, expected) in [("edge_uuid", edge), ("src_uuid", left), ("dst_uuid", right)] {
+            assert_eq!(
+                batch
+                    .column_by_name(name)
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+                    .unwrap()
+                    .value(0),
+                expected.as_bytes()
+            );
+        }
+        for (name, expected) in [
+            ("edge_id", edge_base),
+            ("src_id", node_base),
+            ("dst_id", node_base + 1),
+        ] {
+            assert_eq!(
+                batch
+                    .column_by_name(name)
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .value(0),
+                expected
+            );
+        }
+        let created = Uuid::from_u128(1229804);
+        let next_edge = Uuid::from_u128(1229805);
+        let mut writer = GraphWriter::open_at(dir.path(), OntologyMode::Advisory, 2).unwrap();
+        writer.register_existing_endpoints(&[left]).unwrap();
+        assert_eq!(
+            writer
+                .create_node(
+                    created,
+                    graphforge_value::EntityTypeId::ontology(
+                        ontology.entity_type_id("Person").unwrap()
+                    )
+                    .unwrap()
+                )
+                .unwrap(),
+            node_base + 2
+        );
+        assert_eq!(
+            writer
+                .create_edge(next_edge, "KNOWS", &left, &created)
+                .unwrap(),
+            edge_base + 1
+        );
+        writer.flush().unwrap();
+        drop(writer);
+        let mut membership = crate::UuidMembershipIndex::open(dir.path()).unwrap();
+        assert_eq!(
+            membership
+                .lookup_node_surrogates(&[left, right, created])
+                .unwrap()
+                .0,
+            [Some(node_base), Some(node_base + 1), Some(node_base + 2)]
         );
     }
 }

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -842,3 +842,89 @@ or shorter-lived files or directory allocations. The baseline fails the required
 value assertion, so no complete baseline runtime comparison or speed improvement
 is claimed. An earlier successful measurement preceding the subsequent-import
 mutation assertion was superseded by this final workload.
+
+## Atomic ontology promotion (#1229)
+
+Same-name ontology adoption now stages labels, relationship routes, property
+ownership and identity receipts alongside the ontology/composition/configuration
+participants. Authenticated property, ordinal and adjacency readers are prepared
+before CURRENT changes. Promotion runs on a private authenticated workspace;
+ordinary reopen does not run its property/relationship moves. Changed files use
+the shared permanent Parquet policy, preserving the existing dictionary and
+row-group settings. Unchanged immutable objects remain shared.
+
+Advisory named relationships use per-name topology/property routes, including
+names absent from the ontology. Tagged unknown node labels remain runtime
+identities. Old shared exploratory property occurrences are retired only for
+UUIDs actually transferred into new destination fragments; ambiguous destination
+ownership is refused. Topology remapping/splitting batches and property-transfer target sets contain
+at most 4,096 rows. Property probes retain their existing authenticated decode
+limits. These limits are not a whole-process memory bound.
+
+Retries identify the authored request rather than regenerated physical files.
+An interrupted pre-CURRENT attempt recovers without changing the prior facade;
+a selected candidate is rehydrated from its authenticated generation after a
+post-CURRENT error. A stale handle cannot report successful retry while retaining
+old readers. Replaying an operation after a subsequent mutation does not rewind
+CURRENT. Replacement ontologies that reorder or remove existing numeric entity
+or relationship identities are refused before publication. This preserves the
+current representation without adding migration or compatibility machinery.
+
+The tests exercise 33/4,097 nodes, 129/4,097 edges, two/four mixed routes, nullable
+integer/string properties, Advisory and Strict adoption, exact UUID/endpoints,
+active streams, repeat adoption, ordinary CREATE, reopen, export, full package
+verification, clean import and subsequent ordinary/composite SET/REMOVE. A
+storage test separately seeds node IDs near `u64::MAX` and edge IDs above
+`u32::MAX`, proving exact promotion, authenticated membership and subsequent
+allocation. Unlabelled node-property reads in ontology mode remain the existing
+lowerer's unsupported multi-table-union case; the promotion oracle uses the
+correctly labelled public queries required by #1229.
+
+[Source-bound resource evidence](../../development/evidence/ontology-promotion-1229.json)
+records the frozen executable digest, source hashes, complete Parquet inventories,
+control-file inventories, CPU/RSS, selected syscall I/O and allocation sampling.
+The pre-repair baseline fails its first post-adoption query with unauthenticated
+ordinal authority. It is not a complete comparative performance baseline, and
+this correctness repair claims no speed or storage improvement from it.
+
+| Mixed fixture | Before Parquet bytes | After Parquet bytes | Changed Parquet bytes | Changed non-Parquet graph bytes |
+| --- | ---: | ---: | ---: | ---: |
+| 33 nodes / 129 edges / 2 routes | 23,720 | 35,823 | 28,616 | 7,591 |
+| 4,097 nodes / 4,097 edges / 4 routes | 565,549 | 684,810 | 572,555 | 274,504 |
+
+Promotion creates per-route framing and source tombstone/control records. Its
+identity receipt refresh remains a correctness cost. Repeat adoption on these
+mixed graphs reencodes no Parquet, and the existing disjoint metadata-only
+fixture retains all 18 immutable files (20,842 bytes) with zero payload
+reencoding. The tests retain exact old object identity/content and enforce
+representation-derived payload/allocation/control ceilings. These budgets do
+not cap the number of retained historical generations.
+
+The frozen mixed-route executable completes both full lifecycle fixtures in
+47.42 seconds: 42.21 user / 2.42 system CPU seconds and 140,664 KiB maximum RSS.
+Linux reports 91,752 input and 173,312 output filesystem blocks (512 bytes each).
+A separate trace observes 476,600,039 bytes returned by `read`/`pread64` and
+65,772,431 by `write`/`pwrite64`, with 7,083 successful `fsync` calls. These include
+metadata and repeated authentication; they are not unique payload bytes and
+exclude untraced kernel-copy/vectored I/O.
+
+A separate 5 ms allocation observer sees a 13,410,304-byte peak, deduplicated by
+device/inode across all retained generations, private workspaces and portable
+artifacts under one TMPDIR. Its longest observed interval is 125.3 ms; brief and
+unlinked-open allocations can be missed. This is a sampled simultaneous owner
+peak, not a hard temporary-space bound. Do not add it to the overlapping
+permanent-object inventory. Runs used warm caches and could overlap validation;
+no comparative timing claim follows from these observations.
+
+Reproduce on an admitted native filesystem, with an isolated Cargo target:
+
+```sh
+cargo test -p graphforge-api --test permanent_storage_budgets --no-run
+# Copy the reported executable before tracing or subprocess measurements.
+cp /path/to/reported/executable /path/to/frozen-promotion-tests
+TMPDIR=/path/on/native-root /usr/bin/time -v /path/to/frozen-promotion-tests \
+  ontology_promotion_preserves_mixed_routes_and_reencoding_scope \
+  --exact --nocapture --test-threads=1
+cargo test -p graphforge-api --test ontology_adoption_retry
+cargo test -p graphforge-storage --lib reader_preparation_failure
+```

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -881,11 +881,14 @@ lowerer's unsupported multi-table-union case; the promotion oracle uses the
 correctly labelled public queries required by #1229.
 
 [Source-bound resource evidence](../../development/evidence/ontology-promotion-1229.json)
-records the frozen executable digest, source hashes, complete Parquet inventories,
+records measured implementation `b7197fdb`, the frozen executable digest, source
+hashes, complete Parquet inventories,
 control-file inventories, CPU/RSS, selected syscall I/O and allocation sampling.
 The pre-repair baseline fails its first post-adoption query with unauthenticated
 ordinal authority. It is not a complete comparative performance baseline, and
-this correctness repair claims no speed or storage improvement from it.
+this correctness repair claims no speed or storage improvement from it. The
+subsequent conflicting-retry error-code correction affects a refusal branch
+outside this measured successful workload and has its own regression.
 
 | Mixed fixture | Before Parquet bytes | After Parquet bytes | Changed Parquet bytes | Changed non-Parquet graph bytes |
 | --- | ---: | ---: | ---: | ---: |

--- a/docs/development/bazel-migration-ledger.md
+++ b/docs/development/bazel-migration-ledger.md
@@ -87,6 +87,7 @@ Authoritative machine-readable map: `tools/bazel/parity/migration_target_map.jso
 | `graphforge-api` | `algorithm_public_surface` | `integration-test` | `crates/graphforge-api/tests/algorithm_public_surface.rs` | `//crates/graphforge-api:algorithm_public_surface` | `mapped` | #8 |
 | `graphforge-api` | `search_public_surface` | `integration-test` | `crates/graphforge-api/tests/search_public_surface.rs` | `//crates/graphforge-api:search_public_surface` | `mapped` | #8 |
 | `graphforge-api` | `scale_g500_scale20` | `integration-test` | `crates/graphforge-api/tests/scale_g500_scale20.rs` | `//crates/graphforge-api:scale_g500_scale20` | `mapped` | #710 |
+| `graphforge-api` | `ontology_adoption_retry` | `integration-test` | `crates/graphforge-api/tests/ontology_adoption_retry.rs` | `//crates/graphforge-api:ontology_adoption_retry` | `mapped` | #1229 atomic promotion retry and type identity refusal |
 | `graphforge-api` | `permanent_storage_budgets` | `integration-test` | `crates/graphforge-api/tests/permanent_storage_budgets.rs` | `//crates/graphforge-api:permanent_storage_budgets` | `mapped` | #1196 permanent ownership and lossless codec assessment |
 | `graphforge-api` | `scale_g500_ladder` | `integration-test` | `crates/graphforge-api/tests/scale_g500_ladder.rs` | `//crates/graphforge-api:scale_g500_ladder` | `mapped` | #736 |
 | `graphforge-api` | `provider_public_surface` | `integration-test` | `crates/graphforge-api/tests/provider_public_surface.rs` | `//crates/graphforge-api:provider_public_surface` | `mapped` | #8 |

--- a/docs/development/evidence/ontology-promotion-1229.json
+++ b/docs/development/evidence/ontology-promotion-1229.json
@@ -1,0 +1,6019 @@
+{
+  "issue": 1229,
+  "base_commit": "525b29c36250ca09f5ce1ae5422b9a98c17ecb49",
+  "source_files_sha256": {
+    "crates/graphforge-api/src/workspace_ontology.rs": "c2590b35eb7d5b39e0ee18c96f38cc63b22157504d7e2bef7b739df23d463320",
+    "crates/graphforge-storage/src/project_publication.rs": "f386ad342185767141a4c90edbba36b23008a59ca5eaf26fd3e5ab4361216e07",
+    "crates/graphforge-storage/src/property_overlay.rs": "2a6fc071fa96c8698e72e75f97a6046740256315ebf2a5382a92ae8e19bd2c0e",
+    "crates/graphforge-storage/src/runtime_entity_labels.rs": "c4d819daa5d70df38a44efae02cf26e57f2190ef32f38a8b928fe83abc7dc579",
+    "crates/graphforge-storage/src/writer.rs": "be3c3c37469b6676ced49550e73f9fcf1a594be100a203217c1f0cb57612ed6f"
+  },
+  "frozen_executable_sha256": "d1424686f97a5099f299e6e8a176ab3d3146fe686839bd8be13f07b1fe1faada",
+  "command": [
+    "/tmp/gf1229-measure-bin",
+    "ontology_promotion_preserves_mixed_routes_and_reencoding_scope",
+    "--nocapture",
+    "--test-threads=1"
+  ],
+  "source_note": "Frozen after runtime implementation. Later additions are storage callback-failure and API control-budget tests, not changes to the measured workload or runtime.",
+  "fixtures": [
+    {
+      "after": {
+        "files": [
+          {
+            "allocated_bytes": 4096,
+            "bytes": 3227,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000000003-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 65
+              }
+            ],
+            "sha256": "6c73fca2f38b8f50ffc110f03229836b9e14dfcd525d2cb6ea83733822299d53"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 3489,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000000004-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 64
+              }
+            ],
+            "sha256": "b8f0f6d792e7cb5daf626d27b1f3376199107e6435a0e0436c627bfdc5c6904c"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "95e123f42fe3be0144194d29011cf696af085d724565c11187863f3ee21edcc8"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000001.parquet",
+            "row_groups": [],
+            "sha256": "37279656718c42f8e941a51d8f4a44f466d9d4a366bd1fedec30bccff4df942e"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000003-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "2e5830315e4f0e187bea132f050cababccdfe8ff27dfdee637f6d5b5a3b15cad"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000004-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "d2526302fecd58350274786b8c806db149540214ba1c650d88d3a0d6174d5eb4"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1916,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-aeb7eb899a83db93e915e0ddf8892a2c32eaf48d9e2c8c0c44c456efdbe31a0c/00000000000000000002-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 17
+              }
+            ],
+            "sha256": "d61ff318baed6c3c6de71bc8e46c12d43075fe61745f4d6a2e0c0571abd8a8fd"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1928,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 17
+              }
+            ],
+            "sha256": "3ef195ca6c67928b147a3acc4b25f46630b183135fe8f01aeb80c30f34b79b53"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1910,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000001.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 16
+              }
+            ],
+            "sha256": "ac97ed0f29c87203f6b4f4fe4ab7a0f5400e826ee3cbcb5d570db0cc90f56bad"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1808,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000002-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 17
+              }
+            ],
+            "sha256": "cfccd2951cbe40c912f6fb329166bfbf120b4c656da38c138735ab95115eee0e"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 4948,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1,
+              "first_inversion": null,
+              "last": 129,
+              "prefix": [
+                1,
+                4,
+                6,
+                8,
+                11,
+                12,
+                13,
+                15,
+                16,
+                19,
+                20,
+                24
+              ],
+              "rows": 65
+            },
+            "path": "topology/edges/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000000001-00000000000000000129.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 65
+              }
+            ],
+            "sha256": "bb76956608067d1bd004383b4d9f4540286c427bce13af820629693a7df5d9be"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 4908,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 2,
+              "first_inversion": null,
+              "last": 128,
+              "prefix": [
+                2,
+                3,
+                5,
+                7,
+                9,
+                10,
+                14,
+                17,
+                18,
+                21,
+                22,
+                23
+              ],
+              "rows": 64
+            },
+            "path": "topology/edges/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000000002-00000000000000000128.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 64
+              }
+            ],
+            "sha256": "f04e173c869e14124d2549355fbd7756379663619a5dec41f690918b567cee82"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1284,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": null,
+              "first_inversion": null,
+              "last": null,
+              "prefix": [],
+              "rows": 0
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000129.parquet",
+            "row_groups": [],
+            "sha256": "20d84fd5238191279f830be7b85d0c358a825cb5bae2082025741a92a3ae5896"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2840,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000000001-00000000000000000033.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 33
+              }
+            ],
+            "sha256": "29837311f4fe651b9ea65c8a98eab284d211812badcc7716cae1fa0a8fd1bdb2"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2557,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/runtime_catalog.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "entry_kind"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "name"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "runtime_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "observation_count"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "first_seen"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "last_seen"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "owner_label"
+                  }
+                ],
+                "rows": 10
+              }
+            ],
+            "sha256": "935951912bb4e663a1960de176bf2ccbc864e6fe873193af58dd4eab0ff24492"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 812,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/surrogate_tails.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "max_node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "max_edge_id"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "7e027bc4b95d99868ab8da8bfaf58d1997c22ff31105708e86a658b2b7fc6ac3"
+          }
+        ],
+        "ownership": "generation_graph_tree",
+        "parquet_allocated_bytes": 73728,
+        "parquet_bytes": 35823
+      },
+      "before": {
+        "files": [
+          {
+            "allocated_bytes": 4096,
+            "bytes": 3251,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 65
+              }
+            ],
+            "sha256": "37a254daf45506704e16a124d37e8d5c9374d87eef33505a16a663dc5d21dcf6"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 3513,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000001.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 64
+              }
+            ],
+            "sha256": "016f929ffe3659acedf69591fac7aa300d468a9ef1ddee534a61301b5bf94d84"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1928,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 17
+              }
+            ],
+            "sha256": "3ef195ca6c67928b147a3acc4b25f46630b183135fe8f01aeb80c30f34b79b53"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1910,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000001.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 16
+              }
+            ],
+            "sha256": "ac97ed0f29c87203f6b4f4fe4ab7a0f5400e826ee3cbcb5d570db0cc90f56bad"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6909,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1,
+              "first_inversion": null,
+              "last": 129,
+              "prefix": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12
+              ],
+              "rows": 129
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000129.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "rel_type_name"
+                  }
+                ],
+                "rows": 129
+              }
+            ],
+            "sha256": "e1eee234c125ad36f4c945d276756118f12eb8f33f60fc3a408e62be6a761c4a"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2840,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000000001-00000000000000000033.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 33
+              }
+            ],
+            "sha256": "2e12ccd478b445bf84575e81e1f24f3bb3f0dbcc8a6aa83dabfcb2f0055bf0bf"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2557,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/runtime_catalog.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "entry_kind"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "name"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "runtime_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "observation_count"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "first_seen"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "last_seen"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "owner_label"
+                  }
+                ],
+                "rows": 10
+              }
+            ],
+            "sha256": "935951912bb4e663a1960de176bf2ccbc864e6fe873193af58dd4eab0ff24492"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 812,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/surrogate_tails.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "max_node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "max_edge_id"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "7e027bc4b95d99868ab8da8bfaf58d1997c22ff31105708e86a658b2b7fc6ac3"
+          }
+        ],
+        "ownership": "cas",
+        "parquet_allocated_bytes": 36864,
+        "parquet_bytes": 23720
+      },
+      "changed_parquet_bytes": 28616,
+      "changed_parquet_files": 12,
+      "edges": 129,
+      "nodes": 33,
+      "parquet_payload_limit_bytes": 215232,
+      "promotion_ns": 505590305,
+      "routes": 2
+    },
+    {
+      "after": {
+        "files": [
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6887,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000000006-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 257
+              }
+            ],
+            "sha256": "15f1432538128455ec3dc7b257e3b6deb2d22d7f0b207bd9e9e7b46a12f73ae0"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6518,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000000010-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 240
+              }
+            ],
+            "sha256": "b4f8e382067057c58704726faacb0606acd22b85a8ff54ba8afee8407698739c"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6971,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000000014-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 256
+              }
+            ],
+            "sha256": "5a8f6f1a567db780166e3eaa8877ed33334f93321d1bb4427d22971e8fe6d657"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7143,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000000018-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 271
+              }
+            ],
+            "sha256": "1efd5d791b89b379c12a2a50a61d8785e8839681cd29aa7edcf4ef0742e24ae5"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1882,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000000022-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "ffe60b154425fe1a65c973b8d5388cad7f6a9e1c23b38672cf17e6e51312f1c6"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6636,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8731bedd71098287ec4a9382e873c97f5430fc15ec08bb090bcdc97f4e0a18dd/00000000000000000008-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 245
+              }
+            ],
+            "sha256": "71795c022a0cc05e46297b46c59f7615786980978d7bdeaffa4c9f346433781e"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7114,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8731bedd71098287ec4a9382e873c97f5430fc15ec08bb090bcdc97f4e0a18dd/00000000000000000012-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 266
+              }
+            ],
+            "sha256": "5555caef58930971b359219e637311cc07edd8f63f7b14aa0c11816fe3dc0d13"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6792,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8731bedd71098287ec4a9382e873c97f5430fc15ec08bb090bcdc97f4e0a18dd/00000000000000000016-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 251
+              }
+            ],
+            "sha256": "7e26558bd434698ac3dc1a50db19b33c7251557d8a0f3106965a98f7adfcca54"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6980,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8731bedd71098287ec4a9382e873c97f5430fc15ec08bb090bcdc97f4e0a18dd/00000000000000000020-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 262
+              }
+            ],
+            "sha256": "ebe7e6258caaf501197fe86f34c90ab09535fa9ee20a8336d7eb518287267582"
+          },
+          {
+            "allocated_bytes": 12288,
+            "bytes": 8231,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000000007-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 277
+              }
+            ],
+            "sha256": "e231db73d08b9875e18709afee9f1807a70806a1c632097dad9564752cdaed0e"
+          },
+          {
+            "allocated_bytes": 12288,
+            "bytes": 8199,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000000011-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 274
+              }
+            ],
+            "sha256": "75d781a8f2d7db79adba9b642731617396fd60de8728c19ad2b5996c2163a912"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7375,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000000015-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 240
+              }
+            ],
+            "sha256": "d80eb7228aa369a823c05a3e1b7f3195cca9f98edd3e3a79b276d211e17c2c6a"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7198,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000000019-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 233
+              }
+            ],
+            "sha256": "76a46ac567f159abcbe0dad278cfb40cda42e2bc4d6c2ec564977cd78a88ab4c"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7504,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d09b9f3fd8e257c1dc993b44f3ee3622a83125907226ba50eb32d2f88cdda44f/00000000000000000009-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 245
+              }
+            ],
+            "sha256": "7487641a9c58442259c0660ab82e9173fe6d7e21b210649619925dca1f4cef88"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7505,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d09b9f3fd8e257c1dc993b44f3ee3622a83125907226ba50eb32d2f88cdda44f/00000000000000000013-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 244
+              }
+            ],
+            "sha256": "b2dc61aadc644268c1918242f7fc2a8d39b056d0010c933371f3b45d62f2f082"
+          },
+          {
+            "allocated_bytes": 12288,
+            "bytes": 8227,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d09b9f3fd8e257c1dc993b44f3ee3622a83125907226ba50eb32d2f88cdda44f/00000000000000000017-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 277
+              }
+            ],
+            "sha256": "2cf09748b3d973011fbddbf81ad1d8595b9adb94b0ade4126a0ed2d8a2b3ec5c"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7789,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d09b9f3fd8e257c1dc993b44f3ee3622a83125907226ba50eb32d2f88cdda44f/00000000000000000021-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  }
+                ],
+                "rows": 258
+              }
+            ],
+            "sha256": "0bd28dc0620fcc6c537a43fbd29f43d61ab7cd60603898f5d643f8ff954037ca"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "95e123f42fe3be0144194d29011cf696af085d724565c11187863f3ee21edcc8"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000001.parquet",
+            "row_groups": [],
+            "sha256": "37279656718c42f8e941a51d8f4a44f466d9d4a366bd1fedec30bccff4df942e"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000002.parquet",
+            "row_groups": [],
+            "sha256": "4f481c12ee98383d62cfc4a12c18b5da6fdffb5d72a2a5ad2c1e2d84f0a79b6f"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000003.parquet",
+            "row_groups": [],
+            "sha256": "068db47e618894e43b05ee8b2aaa4afbdf96981fd322d54394b9214c62689416"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000004.parquet",
+            "row_groups": [],
+            "sha256": "803033c02bd4dbae6afb5bc56bda462ccfd04487ee227c6556936fc23152f73d"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000005.parquet",
+            "row_groups": [],
+            "sha256": "08ff585a1c99cb1ac47c8185b24f140d5003a44b8fceb7ebaf741609ed22607a"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000006.parquet",
+            "row_groups": [],
+            "sha256": "9a5681032696cae1bc298b2d4d2e851bc0f07614db53ce308a71046fd9b241d6"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000007.parquet",
+            "row_groups": [],
+            "sha256": "fe4a0d3b8ae2bd1acbc6cbfdfa176db0cdd723039312ec7cce4e49b46d5a64c9"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000008.parquet",
+            "row_groups": [],
+            "sha256": "56909b9ed2044683397c0a5f02e8f4890207c840e0826477afe4748e812214aa"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000009.parquet",
+            "row_groups": [],
+            "sha256": "0d0fd2ef2f632dcb1a4bf16cc66edc0242bbb0472c5125063bcb26d05c5ac0c5"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000010.parquet",
+            "row_groups": [],
+            "sha256": "252df3de2be672318baf4ea41b9c8347f4025d522245f6c57d32b40c4b1abe71"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000011.parquet",
+            "row_groups": [],
+            "sha256": "58ac8e888d17d893fd6c6fac3ab68c598eb4b3999ac19fbdc77fd92978cd880b"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000012.parquet",
+            "row_groups": [],
+            "sha256": "97a60085739936cf30c9bf572a5a26f1c7c9dace0dbec3fa61bda367407313d6"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000013.parquet",
+            "row_groups": [],
+            "sha256": "f4ed45ea88cedc66bda46dd149a7c8884eb9c7ec45e58085a7cee84a72a89a2a"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000014.parquet",
+            "row_groups": [],
+            "sha256": "7eb1c7f85b6a7fe3367bed715b83d722de0de584e730a85cb8100fcfd7413778"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000015.parquet",
+            "row_groups": [],
+            "sha256": "e388ac2a005ac3fedca69ac7aef373f068aa0f5599a7213f75a5acb183779510"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000016.parquet",
+            "row_groups": [],
+            "sha256": "88f74f55fc0d03991561a436fd3013cac2e748f987658efc816ab49109c94ce9"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000006-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "f203e7713b6754d4048b066b631ca90b53a83ad0e88beb19fc40e28875a2c216"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000007-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "7c7adffce1729e3af9c15ca45ce6a782a0e60b8f54c1f5c86364ac2e213f5f2b"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000008-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "a137470621f74516cbe0a9a370bd06bfeb7bb654bc4a11c46ef54084aafc5a8f"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000009-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "ccef5967c9625327ddef38379163f4512b0548ea317e3538781608b0841485f3"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000010-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "c83372543109185cc4f2bc95cc904fb2f2ed96527bc407751da05d2600cd9ec3"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000011-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "99040d81ae8a38716a1d063df1796b852f428c8cdf877adb195f304fbfc8a358"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000012-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "3ef9d8e9d09524de81f4e2a9d422a0ae03873fac9684c4647e15a25e56e47b88"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000013-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "ec7a9913e160456724888bb2f30dca45e1d203e563762b8f5b3022e680b16e70"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000014-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "4e45562dbb34570832580a6cd2a17da35e53a4b4082035521fb8feeff53c1f9a"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000015-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "b6ec14e5285539717f318aa192926ccd7221c267a6e72ac5cd0736d99d0acd3d"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000016-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "72134c4068c0fa03cb4a41be75c4865c7956ad1a835aaee4a94b4b12f6c64a94"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000017-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "1f13fdff18bc745034140dfdaf33197cb4d37ed5515fd76d29f84257d60dc8d1"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000018-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "48b968f53928854076e40c78dd90aef8a1bba305bea27ebbfb55a0ebb0bf511f"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000019-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "be3a331becd8251570f7a00e6a79fa30db32b5759ff19a394d49bb91326529e7"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000020-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "0324984360dc5f712cfab838728fa050f9c3af7e9c092f950954b2e060dee541"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000021-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "68170acf1bd386cd47816eddac73332a80069df309fe6a308025e1eb06286e32"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1049,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000022-00000000000000000000.parquet",
+            "row_groups": [],
+            "sha256": "2fb01096be605748b850832e921f05c4e438d00656110c1890be7880bcb069b7"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6825,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-aeb7eb899a83db93e915e0ddf8892a2c32eaf48d9e2c8c0c44c456efdbe31a0c/00000000000000000002-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 271
+              }
+            ],
+            "sha256": "5fcd81339ca13b9b69f9f572015dc06e94134b708d9ffc5baa0baf4a9860163f"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6511,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-aeb7eb899a83db93e915e0ddf8892a2c32eaf48d9e2c8c0c44c456efdbe31a0c/00000000000000000003-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 255
+              }
+            ],
+            "sha256": "3d728210b6e7714b54323bd5b3db25c3a6a2a1a23bd58c256c59cf22ad5a29f4"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6310,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-aeb7eb899a83db93e915e0ddf8892a2c32eaf48d9e2c8c0c44c456efdbe31a0c/00000000000000000004-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 243
+              }
+            ],
+            "sha256": "f03dbf2e671e1dc4e8227260452cf5a68cfe675d9120c6cb4ab02511b0597721"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6563,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-aeb7eb899a83db93e915e0ddf8892a2c32eaf48d9e2c8c0c44c456efdbe31a0c/00000000000000000005-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 256
+              }
+            ],
+            "sha256": "082d565b20d706d45c71bbf19ebf0dd8f05ce57fbd06d61f568127492bebb115"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6837,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 271
+              }
+            ],
+            "sha256": "7efb20191625d7a3a0a1e25a0cef9eec6f277141c50f0c1b9cd2fdc01c355681"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6770,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000001.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 268
+              }
+            ],
+            "sha256": "5a84757af058d424fe6848a0f55a5d9e493bcd745a3420fb93a42b6ad727fbd5"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6184,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000002.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 236
+              }
+            ],
+            "sha256": "812a9426716db466519ea281711037fbf123a55fbcb00fb6dd451ba42e4dff94"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6450,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000003.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 249
+              }
+            ],
+            "sha256": "20f55e6dc2087b1f707de2a57dcbe1276e0d268895ae04b94b07716109d4b852"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6523,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000004.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 255
+              }
+            ],
+            "sha256": "428dbe5beeb0f467099bd9cc0a811fc6dd135024342b58c1269e34d078ca18cb"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6467,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000005.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 250
+              }
+            ],
+            "sha256": "71e83226c672252d306f715ff7e2e9b4793ad95912678bbab0866f7598ec0e4e"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6700,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000006.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 265
+              }
+            ],
+            "sha256": "1f6c925e56a044313371dff9cc2bba5910bbd4987fd9952e67d0099ee34acb32"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6530,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000007.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 254
+              }
+            ],
+            "sha256": "537e977aed70cbe9b0f617d9580d7a0cc220a720f512a759a89e45eea93a2931"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6322,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000008.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 243
+              }
+            ],
+            "sha256": "32678b25c9e38b9b2a9f4c40dbf4161612954c29e3bf0bf52a614c0af6139779"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6822,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000009.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 269
+              }
+            ],
+            "sha256": "e21d6356f02de9f374573d67ce058fa483101a626829aa9851487e529fcdbf9e"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6541,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000010.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 255
+              }
+            ],
+            "sha256": "4cf95c981e49d8a0018f31954450aaa4966860ed730fe2987455925b96806719"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6549,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000011.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 257
+              }
+            ],
+            "sha256": "ce779c917d68ec65932bcd446c00d815a8e786425180d9e7af5457a688437f4a"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6575,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000012.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 256
+              }
+            ],
+            "sha256": "0330d96ce32cf5feb5a6fb5645b22f6d0436e2f094de1b7530a0cc1b335e0526"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6167,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000013.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 236
+              }
+            ],
+            "sha256": "699b41d9d9e6c61cdbbfd33f6f2f3985ebba8e6d6f5e591cdcf34330efd0f709"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6813,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000014.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 268
+              }
+            ],
+            "sha256": "867075bb26cf3b15dc7af6a1506904c895570ae4ffdb0e6f5ff8c9d4c96b2b2d"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6718,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000015.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 264
+              }
+            ],
+            "sha256": "9297b06813fdee292c01d16a9c2c14ca26f22d4d21128f65a6cfddb0db2d9519"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1608,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000016.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "4840e44492aa8d7072a17eb322096050ef7c986df313d3602e747a15774c769e"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 5891,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000002-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 271
+              }
+            ],
+            "sha256": "cbbd1c97eb5e530efc01c2108d929046b289151fbc30b2d72f56ec9a33df5f77"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 5635,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000003-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 255
+              }
+            ],
+            "sha256": "aa222700cf84eb4dce8d291b87a976cdf1b2b3f0fb6d123263e242c4cd101bc6"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 5443,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000004-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 243
+              }
+            ],
+            "sha256": "6802cee55e52f8e6d304b90ed5c3ee1b0b8569e69e1a673dbd089537cc1b9a1f"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 5650,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000005-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 256
+              }
+            ],
+            "sha256": "0cc73532c15b5889567d8042049bf072bcbb3e95eef35a1be2a162d7f7ccca75"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 17304,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 5,
+              "first_inversion": null,
+              "last": 1023,
+              "prefix": [
+                5,
+                11,
+                16,
+                17,
+                18,
+                20,
+                21,
+                24,
+                25,
+                26,
+                35,
+                36
+              ],
+              "rows": 257
+            },
+            "path": "topology/edges/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000000005-00000000000000001023.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 257
+              }
+            ],
+            "sha256": "ff13f9bfed75b8eebb25c8e60d98e8d4a63702a942100b32dd6d9e85ae5ed35d"
+          },
+          {
+            "allocated_bytes": 16384,
+            "bytes": 16112,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1025,
+              "first_inversion": null,
+              "last": 2038,
+              "prefix": [
+                1025,
+                1028,
+                1029,
+                1032,
+                1036,
+                1037,
+                1044,
+                1050,
+                1052,
+                1055,
+                1056,
+                1058
+              ],
+              "rows": 240
+            },
+            "path": "topology/edges/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000001025-00000000000000002038.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 240
+              }
+            ],
+            "sha256": "4a10099bdfe55235ffc5c02c0d794be4a421980cec14db7f37d7930b4634e094"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 17013,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 2051,
+              "first_inversion": null,
+              "last": 3069,
+              "prefix": [
+                2051,
+                2065,
+                2069,
+                2071,
+                2073,
+                2087,
+                2090,
+                2094,
+                2100,
+                2117,
+                2118,
+                2119
+              ],
+              "rows": 256
+            },
+            "path": "topology/edges/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000002051-00000000000000003069.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 256
+              }
+            ],
+            "sha256": "1ba65dc08a82a9acec1db76b6105e134bf48fff75715eff541d6009038b3223f"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 17946,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 3074,
+              "first_inversion": null,
+              "last": 4095,
+              "prefix": [
+                3074,
+                3081,
+                3082,
+                3084,
+                3085,
+                3086,
+                3087,
+                3088,
+                3089,
+                3090,
+                3093,
+                3096
+              ],
+              "rows": 271
+            },
+            "path": "topology/edges/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000003074-00000000000000004095.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 271
+              }
+            ],
+            "sha256": "41c97db73630f41ac08ee45f224cbb79f1185383f10d4f49a3824f0b848f3156"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2550,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 4097,
+              "first_inversion": null,
+              "last": 4097,
+              "prefix": [
+                4097
+              ],
+              "rows": 1
+            },
+            "path": "topology/edges/r-4e10c40fe48dd872662f70c90e3ea4f07ed607b7a4dd3d51030e2df11b1dc60f/00000000000000004097-00000000000000004097.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "b7db025ecf9cd8a61b02cf1df21f7bdd05682f3132a91a1024f1790d70dc2c9e"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 16509,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 2,
+              "first_inversion": null,
+              "last": 1024,
+              "prefix": [
+                2,
+                6,
+                13,
+                19,
+                22,
+                27,
+                28,
+                29,
+                34,
+                43,
+                48,
+                54
+              ],
+              "rows": 245
+            },
+            "path": "topology/edges/r-8731bedd71098287ec4a9382e873c97f5430fc15ec08bb090bcdc97f4e0a18dd/00000000000000000002-00000000000000001024.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 245
+              }
+            ],
+            "sha256": "2016ce05e7e8ccc06f4f407aed1feee18152755fbe3e4de6feab1af3a3c94b12"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 17685,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1033,
+              "first_inversion": null,
+              "last": 2047,
+              "prefix": [
+                1033,
+                1035,
+                1042,
+                1046,
+                1048,
+                1053,
+                1060,
+                1062,
+                1068,
+                1077,
+                1086,
+                1087
+              ],
+              "rows": 266
+            },
+            "path": "topology/edges/r-8731bedd71098287ec4a9382e873c97f5430fc15ec08bb090bcdc97f4e0a18dd/00000000000000001033-00000000000000002047.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 266
+              }
+            ],
+            "sha256": "650c0915a1c9e5e2f83461ce8698e450d485c7cabbe46c4f12b6ac97ffc26e8b"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 16733,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 2050,
+              "first_inversion": null,
+              "last": 3072,
+              "prefix": [
+                2050,
+                2053,
+                2054,
+                2055,
+                2061,
+                2062,
+                2074,
+                2075,
+                2084,
+                2085,
+                2086,
+                2088
+              ],
+              "rows": 251
+            },
+            "path": "topology/edges/r-8731bedd71098287ec4a9382e873c97f5430fc15ec08bb090bcdc97f4e0a18dd/00000000000000002050-00000000000000003072.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 251
+              }
+            ],
+            "sha256": "56be809ece6de522f2464718d6e190265df34a6eaa72a5019d170a43442f0c2c"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 17438,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 3073,
+              "first_inversion": null,
+              "last": 4087,
+              "prefix": [
+                3073,
+                3078,
+                3080,
+                3095,
+                3100,
+                3102,
+                3111,
+                3115,
+                3121,
+                3124,
+                3127,
+                3138
+              ],
+              "rows": 262
+            },
+            "path": "topology/edges/r-8731bedd71098287ec4a9382e873c97f5430fc15ec08bb090bcdc97f4e0a18dd/00000000000000003073-00000000000000004087.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 262
+              }
+            ],
+            "sha256": "7dc681695d668bd55a2d01095a1c1c7a72c97a86d255039eeaf4b48f6f769e92"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 18391,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 3,
+              "first_inversion": null,
+              "last": 1018,
+              "prefix": [
+                3,
+                4,
+                8,
+                12,
+                50,
+                55,
+                60,
+                65,
+                67,
+                74,
+                75,
+                83
+              ],
+              "rows": 277
+            },
+            "path": "topology/edges/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000000003-00000000000000001018.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 277
+              }
+            ],
+            "sha256": "80099cf80cda464cdb500e6b268bd7bd6e41149ab1e75e858176a74a4470507b"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 18128,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1027,
+              "first_inversion": null,
+              "last": 2048,
+              "prefix": [
+                1027,
+                1031,
+                1043,
+                1045,
+                1051,
+                1054,
+                1059,
+                1061,
+                1071,
+                1076,
+                1082,
+                1083
+              ],
+              "rows": 274
+            },
+            "path": "topology/edges/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000001027-00000000000000002048.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 274
+              }
+            ],
+            "sha256": "d854a0dc0311a9752f79c2067231c8ef4bfd0cf5a1644f2bc5e0a4bd67be984e"
+          },
+          {
+            "allocated_bytes": 16384,
+            "bytes": 16113,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 2049,
+              "first_inversion": null,
+              "last": 3071,
+              "prefix": [
+                2049,
+                2052,
+                2058,
+                2063,
+                2067,
+                2068,
+                2072,
+                2077,
+                2078,
+                2079,
+                2082,
+                2083
+              ],
+              "rows": 240
+            },
+            "path": "topology/edges/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000002049-00000000000000003071.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 240
+              }
+            ],
+            "sha256": "97689d1382c808fb1a0ce9236ddf024d8b9c4a6308eff905522f96f7b47c8f95"
+          },
+          {
+            "allocated_bytes": 16384,
+            "bytes": 15748,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 3075,
+              "first_inversion": null,
+              "last": 4096,
+              "prefix": [
+                3075,
+                3077,
+                3083,
+                3091,
+                3092,
+                3094,
+                3098,
+                3103,
+                3104,
+                3108,
+                3114,
+                3116
+              ],
+              "rows": 233
+            },
+            "path": "topology/edges/r-8901e0537d1b7278fbb82f7ec7af9b666cf84343a29e231469d98b71a7ed17ba/00000000000000003075-00000000000000004096.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 233
+              }
+            ],
+            "sha256": "0f2012c11c485f2f56825360e961f20e10fed0e498ac0f13036e5eb4a9bd893d"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 16502,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1,
+              "first_inversion": null,
+              "last": 1016,
+              "prefix": [
+                1,
+                7,
+                9,
+                10,
+                14,
+                15,
+                23,
+                30,
+                31,
+                32,
+                33,
+                37
+              ],
+              "rows": 245
+            },
+            "path": "topology/edges/r-d09b9f3fd8e257c1dc993b44f3ee3622a83125907226ba50eb32d2f88cdda44f/00000000000000000001-00000000000000001016.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 245
+              }
+            ],
+            "sha256": "8c82cd195b7a53e735b8ae938ec4312d36ffc258b6eae9e111947022d517a8b8"
+          },
+          {
+            "allocated_bytes": 16384,
+            "bytes": 16357,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1026,
+              "first_inversion": null,
+              "last": 2046,
+              "prefix": [
+                1026,
+                1030,
+                1034,
+                1038,
+                1039,
+                1040,
+                1041,
+                1047,
+                1049,
+                1057,
+                1063,
+                1064
+              ],
+              "rows": 244
+            },
+            "path": "topology/edges/r-d09b9f3fd8e257c1dc993b44f3ee3622a83125907226ba50eb32d2f88cdda44f/00000000000000001026-00000000000000002046.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 244
+              }
+            ],
+            "sha256": "f79045b5a3535ccb5deea1f8c31447931f2b7f83b3e077f837647e9bdd35269b"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 18267,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 2056,
+              "first_inversion": null,
+              "last": 3070,
+              "prefix": [
+                2056,
+                2057,
+                2059,
+                2060,
+                2064,
+                2066,
+                2070,
+                2076,
+                2080,
+                2081,
+                2089,
+                2092
+              ],
+              "rows": 277
+            },
+            "path": "topology/edges/r-d09b9f3fd8e257c1dc993b44f3ee3622a83125907226ba50eb32d2f88cdda44f/00000000000000002056-00000000000000003070.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 277
+              }
+            ],
+            "sha256": "6e35ae2a0b2e92b97c2097914f0229700c6b57f4b96b8480140294cc154cfde7"
+          },
+          {
+            "allocated_bytes": 20480,
+            "bytes": 17254,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 3076,
+              "first_inversion": null,
+              "last": 4093,
+              "prefix": [
+                3076,
+                3079,
+                3101,
+                3105,
+                3106,
+                3117,
+                3118,
+                3123,
+                3126,
+                3131,
+                3132,
+                3137
+              ],
+              "rows": 258
+            },
+            "path": "topology/edges/r-d09b9f3fd8e257c1dc993b44f3ee3622a83125907226ba50eb32d2f88cdda44f/00000000000000003076-00000000000000004093.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  }
+                ],
+                "rows": 258
+              }
+            ],
+            "sha256": "3dc082d79e5e7bf067020f0a864f22e670d9419755d8912ed3f051b0a5088769"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1284,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": null,
+              "first_inversion": null,
+              "last": null,
+              "prefix": [],
+              "rows": 0
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000001024.parquet",
+            "row_groups": [],
+            "sha256": "20d84fd5238191279f830be7b85d0c358a825cb5bae2082025741a92a3ae5896"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1284,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": null,
+              "first_inversion": null,
+              "last": null,
+              "prefix": [],
+              "rows": 0
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000001025-00000000000000002048.parquet",
+            "row_groups": [],
+            "sha256": "20d84fd5238191279f830be7b85d0c358a825cb5bae2082025741a92a3ae5896"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1284,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": null,
+              "first_inversion": null,
+              "last": null,
+              "prefix": [],
+              "rows": 0
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000002049-00000000000000003072.parquet",
+            "row_groups": [],
+            "sha256": "20d84fd5238191279f830be7b85d0c358a825cb5bae2082025741a92a3ae5896"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1284,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": null,
+              "first_inversion": null,
+              "last": null,
+              "prefix": [],
+              "rows": 0
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000003073-00000000000000004096.parquet",
+            "row_groups": [],
+            "sha256": "20d84fd5238191279f830be7b85d0c358a825cb5bae2082025741a92a3ae5896"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1284,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": null,
+              "first_inversion": null,
+              "last": null,
+              "prefix": [],
+              "rows": 0
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000004097-00000000000000004097.parquet",
+            "row_groups": [],
+            "sha256": "20d84fd5238191279f830be7b85d0c358a825cb5bae2082025741a92a3ae5896"
+          },
+          {
+            "allocated_bytes": 24576,
+            "bytes": 21933,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000000001-00000000000000001024.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "45a42d5dee01eccb28ccb3814fe4ffd7bad20201bd57b59bcd71d793f81bc1c4"
+          },
+          {
+            "allocated_bytes": 24576,
+            "bytes": 21569,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000001025-00000000000000002048.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "1e9f2139d60860c8a579d4be5814464a78134c9ade10223f867fd4de46d679f1"
+          },
+          {
+            "allocated_bytes": 24576,
+            "bytes": 21569,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000002049-00000000000000003072.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "5622a340a37e0e52c5473f398f9a8c2401588289ddc50924c462e8bb28fcaf83"
+          },
+          {
+            "allocated_bytes": 24576,
+            "bytes": 21569,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000003073-00000000000000004096.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "329626d83cf07dae01d495887d0b828e3276bcf555b4b79dc96fba4c67990983"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2229,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000004097-00000000000000004097.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "aae9c73541513c3fe3f8cb978d892333444e92b5ee0f1e4424ebeaddbc6f3ea5"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2638,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/runtime_catalog.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "entry_kind"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "name"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "runtime_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "observation_count"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "first_seen"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "last_seen"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "owner_label"
+                  }
+                ],
+                "rows": 20
+              }
+            ],
+            "sha256": "2580ea6636508d47eb68458088b21d687cbcafd6dc9413e2220bc1c4ceb243f8"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 812,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/surrogate_tails.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "max_node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "max_edge_id"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "2444dbfcaa6def97e78c7ac0994eab1a5d34961ab401fb81203f3e79b979e651"
+          }
+        ],
+        "ownership": "generation_graph_tree",
+        "parquet_allocated_bytes": 933888,
+        "parquet_bytes": 684810
+      },
+      "before": {
+        "files": [
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6911,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 257
+              }
+            ],
+            "sha256": "19fa79a3ff45ee2339251d775f788ee637840940cfd3eb63128100871bbea33b"
+          },
+          {
+            "allocated_bytes": 12288,
+            "bytes": 8255,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000001.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 277
+              }
+            ],
+            "sha256": "681b30b63b14cac278faee81e2679aa8df06fb1874b74194fbbadaa8adab20d2"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6660,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000002.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 245
+              }
+            ],
+            "sha256": "91c1eb663b54eac30c5424332fb07a15f5bfdb10763b912ab17b73f1395f6cce"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7528,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000003.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 245
+              }
+            ],
+            "sha256": "b623b38d809dfbb5fa02ed7740325f27670250a250268edfc5bd56df984048fa"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6542,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000004.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 240
+              }
+            ],
+            "sha256": "ffc9f8c4d5a6ca8c7e001ba5b3b395c607c3096dcbc218e8c3f0f74866c3d86d"
+          },
+          {
+            "allocated_bytes": 12288,
+            "bytes": 8223,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000005.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 274
+              }
+            ],
+            "sha256": "a48a597b07ef4973ec9c62cb63a27ea4d6b3ba443b383c2f5a0929e5bf103057"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7138,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000006.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 266
+              }
+            ],
+            "sha256": "8abf50dcf8421c3b9d3ccc4bf5649cdff8930a79723040dd79b686599e053355"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7529,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000007.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 244
+              }
+            ],
+            "sha256": "53e80dfea43d43c8d8295d9a1dfff966243aed885d62cb0018e707cee5f7b5ed"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6995,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000008.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 256
+              }
+            ],
+            "sha256": "3c6c1707263cb3c117f2a2488319b4bfc4b7440e1c9236ad6fd07916d16dc678"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7399,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000009.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 240
+              }
+            ],
+            "sha256": "67b537838cd7a37d84444a038b4f39a4849f7667efff0114a62e5608d3356505"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6816,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000010.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 251
+              }
+            ],
+            "sha256": "c5a66cdc5f4c0b235ef77a6403ea7f3cb0895eee3431e43171d73cdc7a0e6f0d"
+          },
+          {
+            "allocated_bytes": 12288,
+            "bytes": 8251,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000011.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 277
+              }
+            ],
+            "sha256": "b20c698de33035daa41a60194e18e193fe37e72be16e39b0dff10563390d117c"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7167,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000012.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 271
+              }
+            ],
+            "sha256": "ef71c9fc18e724b3cf37a3eb292207c3d8b9cfef09564a026469bac435889a69"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7222,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000013.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 233
+              }
+            ],
+            "sha256": "3e50404cf5120958b32f3b81924a467f76f8dc97e641186369ba02a70da73bd6"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7004,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000014.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 262
+              }
+            ],
+            "sha256": "cfba2a37ae215ce863b80a7dfb180a83752e3b89b6c749cf3094ce9944363ee1"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 7813,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000015.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 258
+              }
+            ],
+            "sha256": "b3a5584716020bc009f398c25edbcad71c37982a39800a6715018d829147b895"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1906,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "edge_properties/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000000016.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "weight"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "text"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "8e4c149724bc000aaee4890fb120e1efbe752d85086c93608498ce0c1b23ab9e"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6837,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000000.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 271
+              }
+            ],
+            "sha256": "7efb20191625d7a3a0a1e25a0cef9eec6f277141c50f0c1b9cd2fdc01c355681"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6770,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000001.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 268
+              }
+            ],
+            "sha256": "5a84757af058d424fe6848a0f55a5d9e493bcd745a3420fb93a42b6ad727fbd5"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6184,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000002.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 236
+              }
+            ],
+            "sha256": "812a9426716db466519ea281711037fbf123a55fbcb00fb6dd451ba42e4dff94"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6450,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000003.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 249
+              }
+            ],
+            "sha256": "20f55e6dc2087b1f707de2a57dcbe1276e0d268895ae04b94b07716109d4b852"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6523,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000004.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 255
+              }
+            ],
+            "sha256": "428dbe5beeb0f467099bd9cc0a811fc6dd135024342b58c1269e34d078ca18cb"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6467,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000005.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 250
+              }
+            ],
+            "sha256": "71e83226c672252d306f715ff7e2e9b4793ad95912678bbab0866f7598ec0e4e"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6700,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000006.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 265
+              }
+            ],
+            "sha256": "1f6c925e56a044313371dff9cc2bba5910bbd4987fd9952e67d0099ee34acb32"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6530,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000007.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 254
+              }
+            ],
+            "sha256": "537e977aed70cbe9b0f617d9580d7a0cc220a720f512a759a89e45eea93a2931"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6322,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000008.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 243
+              }
+            ],
+            "sha256": "32678b25c9e38b9b2a9f4c40dbf4161612954c29e3bf0bf52a614c0af6139779"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6822,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000009.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 269
+              }
+            ],
+            "sha256": "e21d6356f02de9f374573d67ce058fa483101a626829aa9851487e529fcdbf9e"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6541,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000010.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 255
+              }
+            ],
+            "sha256": "4cf95c981e49d8a0018f31954450aaa4966860ed730fe2987455925b96806719"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6549,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000011.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 257
+              }
+            ],
+            "sha256": "ce779c917d68ec65932bcd446c00d815a8e786425180d9e7af5457a688437f4a"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6575,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000012.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 256
+              }
+            ],
+            "sha256": "0330d96ce32cf5feb5a6fb5645b22f6d0436e2f094de1b7530a0cc1b335e0526"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6167,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000013.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 236
+              }
+            ],
+            "sha256": "699b41d9d9e6c61cdbbfd33f6f2f3985ebba8e6d6f5e591cdcf34330efd0f709"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6813,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000014.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 268
+              }
+            ],
+            "sha256": "867075bb26cf3b15dc7af6a1506904c895570ae4ffdb0e6f5ff8c9d4c96b2b2d"
+          },
+          {
+            "allocated_bytes": 8192,
+            "bytes": 6718,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000015.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 264
+              }
+            ],
+            "sha256": "9297b06813fdee292c01d16a9c2c14ca26f22d4d21128f65a6cfddb0db2d9519"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 1608,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000016.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "__gf_property_tombstone"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "score"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "4840e44492aa8d7072a17eb322096050ef7c986df313d3602e747a15774c769e"
+          },
+          {
+            "allocated_bytes": 61440,
+            "bytes": 61391,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1,
+              "first_inversion": null,
+              "last": 1024,
+              "prefix": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12
+              ],
+              "rows": 1024
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000000001-00000000000000001024.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "rel_type_name"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "cc7ad78c54b90f85130081fb5f5ee81e58a50a5deb02c0cff2e706fd2863ddbd"
+          },
+          {
+            "allocated_bytes": 61440,
+            "bytes": 61028,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 1025,
+              "first_inversion": null,
+              "last": 2048,
+              "prefix": [
+                1025,
+                1026,
+                1027,
+                1028,
+                1029,
+                1030,
+                1031,
+                1032,
+                1033,
+                1034,
+                1035,
+                1036
+              ],
+              "rows": 1024
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000001025-00000000000000002048.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "rel_type_name"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "b5133ee45923cbbdd2ffc57acdd3891bfe13282fe61c2e8bcfbd56f170c589ac"
+          },
+          {
+            "allocated_bytes": 61440,
+            "bytes": 61014,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 2049,
+              "first_inversion": null,
+              "last": 3072,
+              "prefix": [
+                2049,
+                2050,
+                2051,
+                2052,
+                2053,
+                2054,
+                2055,
+                2056,
+                2057,
+                2058,
+                2059,
+                2060
+              ],
+              "rows": 1024
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000002049-00000000000000003072.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "rel_type_name"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "57d2e13d42adc267be4b5fa90b89d803d78160ae0d04ce3c6c8c110ffd88b656"
+          },
+          {
+            "allocated_bytes": 61440,
+            "bytes": 61021,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 3073,
+              "first_inversion": null,
+              "last": 4096,
+              "prefix": [
+                3073,
+                3074,
+                3075,
+                3076,
+                3077,
+                3078,
+                3079,
+                3080,
+                3081,
+                3082,
+                3083,
+                3084
+              ],
+              "rows": 1024
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000003073-00000000000000004096.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "rel_type_name"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "2e0bc121d8e69c82a58eac557eb2db8dca9755005e48d1888e6b147f3853b949"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2841,
+            "codec_pairs": null,
+            "edge_id_order": {
+              "first": 4097,
+              "first_inversion": null,
+              "last": 4097,
+              "prefix": [
+                4097
+              ],
+              "rows": 1
+            },
+            "path": "topology/edges/r-d418446a2dd7f837aa2867f6d34c26ffd1d4af1cbfa0d506a31c9dd47ed79c22/00000000000000004097-00000000000000004097.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "edge_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "src_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "dst_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "edge_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "src_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "dst_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "rel_type_name"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "e305d6926eb2265d3619d918236aa9d4a1e9271733a12de4c72db6de11fda222"
+          },
+          {
+            "allocated_bytes": 24576,
+            "bytes": 21933,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000000001-00000000000000001024.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "163b8cc805c846851fecf0cc39e68d43a8f7fca9d163980aed2d19a801b74fdd"
+          },
+          {
+            "allocated_bytes": 24576,
+            "bytes": 21569,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000001025-00000000000000002048.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "de7d78a2dd8f357851c8f39ffbe0fd3ec1bb4894fb50c2dc527ea7cbcf7dbc7d"
+          },
+          {
+            "allocated_bytes": 24576,
+            "bytes": 21569,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000002049-00000000000000003072.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "bdfa696044f1126521be857a8f33d2b42c70d9a542f5975ddfc861c9c531fd65"
+          },
+          {
+            "allocated_bytes": 24576,
+            "bytes": 21569,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000003073-00000000000000004096.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1024
+              }
+            ],
+            "sha256": "fdf646fb02f21909527174408cb80e173621661d8d2f84b88f8836ba8038367b"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2229,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/nodes/00000000000000004097-00000000000000004097.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE]",
+                    "path": "node_uuid"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "type_ids.list.item"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "created_at"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "updated_at"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "aae9c73541513c3fe3f8cb978d892333444e92b5ee0f1e4424ebeaddbc6f3ea5"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 2638,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/runtime_catalog.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "entry_kind"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "name"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "runtime_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "observation_count"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "first_seen"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "last_seen"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "owner_label"
+                  }
+                ],
+                "rows": 20
+              }
+            ],
+            "sha256": "2580ea6636508d47eb68458088b21d687cbcafd6dc9413e2220bc1c4ceb243f8"
+          },
+          {
+            "allocated_bytes": 4096,
+            "bytes": 812,
+            "codec_pairs": null,
+            "edge_id_order": null,
+            "path": "topology/surrogate_tails.parquet",
+            "row_groups": [
+              {
+                "columns": [
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "max_node_id"
+                  },
+                  {
+                    "codec": "ZSTD(ZstdLevel(1))",
+                    "encodings": "[PLAIN, RLE, RLE_DICTIONARY]",
+                    "path": "max_edge_id"
+                  }
+                ],
+                "rows": 1
+              }
+            ],
+            "sha256": "2444dbfcaa6def97e78c7ac0994eab1a5d34961ab401fb81203f3e79b979e651"
+          }
+        ],
+        "ownership": "cas",
+        "parquet_allocated_bytes": 643072,
+        "parquet_bytes": 565549
+      },
+      "changed_parquet_bytes": 572555,
+      "changed_parquet_files": 85,
+      "edges": 4097,
+      "nodes": 4097,
+      "parquet_payload_limit_bytes": 1712320,
+      "promotion_ns": 26839742653,
+      "routes": 4
+    }
+  ],
+  "changed_control_budgets": [
+    {
+      "changed_control_bytes": 7591,
+      "changed_control_files": 10,
+      "control_byte_limit": 88736,
+      "controls": [
+        {
+          "bytes": 574,
+          "path": "semantic-routes.json"
+        },
+        {
+          "bytes": 71,
+          "path": "topology/generation.json"
+        },
+        {
+          "bytes": 0,
+          "path": "topology/uuid-membership/forward-v4-2-e3b0c44298fc1c14.uuidx"
+        },
+        {
+          "bytes": 3018,
+          "path": "topology/uuid-membership/identities-v5-l1-2-31e8c7cad8d365da.uuidx"
+        },
+        {
+          "bytes": 1435,
+          "path": "topology/uuid-membership/manifest.json"
+        },
+        {
+          "bytes": 792,
+          "path": "topology/uuid-membership/node-surrogates-v5-l1-2-2c0a160859f42c01.uuidx"
+        },
+        {
+          "bytes": 1213,
+          "path": "topology/uuid-membership/ordinal-v4-manifest.json"
+        },
+        {
+          "bytes": 244,
+          "path": "topology/uuid-membership/ordinal-v4-receipt.json"
+        },
+        {
+          "bytes": 0,
+          "path": "topology/uuid-membership/tombstones-v4-2-e3b0c44298fc1c14.uuidx"
+        },
+        {
+          "bytes": 244,
+          "path": "topology/uuid-membership/topology-receipt.json"
+        }
+      ],
+      "edges": 129,
+      "nodes": 33,
+      "routes": 2
+    },
+    {
+      "changed_control_bytes": 274504,
+      "changed_control_files": 10,
+      "control_byte_limit": 731296,
+      "controls": [
+        {
+          "bytes": 770,
+          "path": "semantic-routes.json"
+        },
+        {
+          "bytes": 72,
+          "path": "topology/generation.json"
+        },
+        {
+          "bytes": 0,
+          "path": "topology/uuid-membership/forward-v4-2-e3b0c44298fc1c14.uuidx"
+        },
+        {
+          "bytes": 172074,
+          "path": "topology/uuid-membership/identities-v5-l1-2-882d7bba25b83416.uuidx"
+        },
+        {
+          "bytes": 1448,
+          "path": "topology/uuid-membership/manifest.json"
+        },
+        {
+          "bytes": 98328,
+          "path": "topology/uuid-membership/node-surrogates-v5-l1-2-8246fb253b7adf63.uuidx"
+        },
+        {
+          "bytes": 1324,
+          "path": "topology/uuid-membership/ordinal-v4-manifest.json"
+        },
+        {
+          "bytes": 244,
+          "path": "topology/uuid-membership/ordinal-v4-receipt.json"
+        },
+        {
+          "bytes": 0,
+          "path": "topology/uuid-membership/tombstones-v4-2-e3b0c44298fc1c14.uuidx"
+        },
+        {
+          "bytes": 244,
+          "path": "topology/uuid-membership/topology-receipt.json"
+        }
+      ],
+      "edges": 4097,
+      "nodes": 4097,
+      "routes": 4
+    }
+  ],
+  "process": {
+    "user_seconds": 42.21,
+    "system_seconds": 2.42,
+    "elapsed_seconds": 47.42,
+    "maximum_rss_kib": 140664,
+    "filesystem_input_blocks": 91752,
+    "filesystem_output_blocks": 173312,
+    "linux_io_block_bytes": 512,
+    "exit_status": 0
+  },
+  "selected_syscall_trace": {
+    "syscalls": {
+      "read": {
+        "calls": 91386,
+        "returned_bytes": 350402834
+      },
+      "pread64": {
+        "calls": 294235,
+        "returned_bytes": 126197205
+      },
+      "write": {
+        "calls": 9363,
+        "returned_bytes": 65772431
+      },
+      "fsync": {
+        "calls": 7083,
+        "returned_bytes": 0
+      }
+    },
+    "failed_syscalls": {},
+    "selected_read_returned_bytes": 476600039,
+    "selected_write_returned_bytes": 65772431,
+    "limitations": [
+      "Only read, pread64, write, pwrite64, fsync and fdatasync traced; not a total including kernel-copy or vectored I/O.",
+      "Reads and writes include metadata, test output and repeat authentication, not unique graph payload bytes.",
+      "Separate instrumented run; do not compare its elapsed time to uninstrumented CPU measurements."
+    ]
+  },
+  "workspace_sampling": {
+    "command": [
+      "/tmp/gf1229-measure-bin",
+      "ontology_promotion_preserves_mixed_routes_and_reencoding_scope",
+      "--nocapture",
+      "--test-threads=1"
+    ],
+    "sampled_unique_inode_allocated_peak_bytes": 13410304,
+    "sampled_path_logical_peak_bytes": 10916305,
+    "sampled_file_count_peak": 945,
+    "samples": 3702,
+    "requested_poll_interval_seconds": 0.005,
+    "maximum_observed_sample_interval_seconds": 0.12528308801120147,
+    "vanished_files_during_scan": 57,
+    "exit_status": 0,
+    "limitations": [
+      "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+      "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+      "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+      "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+    ]
+  },
+  "baseline": {
+    "commit": "525b29c3",
+    "result": "FAILED: successful adoption leaves selected ordinal authority unauthenticated on first public query",
+    "log": "/tmp/gf1229-baseline.log",
+    "comparable_complete_performance_baseline": false
+  },
+  "limitations": [
+    "Correctness repair; no performance improvement claimed against the incomplete baseline.",
+    "Process resource run covers both fixtures and full construction/query/readoption/reopen/export/full-verify/clean-import, not only promotion.",
+    "Source payload and changed-control bytes are authenticated selected-file inventories, not process RSS or simultaneous lifecycle allocations.",
+    "Workspace observer counts all overlapping owners under its private TMPDIR and deduplicates allocated bytes by device/inode; logical path bytes are not deduplicated.",
+    "Sampled allocation can miss brief or unlinked-open files. The 4096-row promotion topology-batch cap and payload/control ceilings are deterministic; RSS and sampled workspace peaks are observations, not hard bounds.",
+    "Runs are independent on the same host with warm caches and possible concurrent validation load; elapsed times are not comparative benchmarks.",
+    "Earlier lifecycle and mixed-route diagnostics include incomplete implementations and fixture-oracle errors; they are not performance baselines."
+  ]
+}

--- a/docs/development/evidence/ontology-promotion-1229.json
+++ b/docs/development/evidence/ontology-promotion-1229.json
@@ -15,7 +15,7 @@
     "--nocapture",
     "--test-threads=1"
   ],
-  "source_note": "Frozen after runtime implementation. Later additions are storage callback-failure and API control-budget tests, not changes to the measured workload or runtime.",
+  "source_note": "Frozen successful-workload implementation recorded in b7197fdb. Later tests add reader-preparation/control-budget coverage. A subsequent correction restores GF_IDEMPOTENCY_CONFLICT only for conflicting retry requests; this branch is not exercised by the measured successful workload. Source hashes refer to the measured implementation, not that error-code correction.",
   "fixtures": [
     {
       "after": {
@@ -6015,5 +6015,6 @@
     "Sampled allocation can miss brief or unlinked-open files. The 4096-row promotion topology-batch cap and payload/control ceilings are deterministic; RSS and sampled workspace peaks are observations, not hard bounds.",
     "Runs are independent on the same host with warm caches and possible concurrent validation load; elapsed times are not comparative benchmarks.",
     "Earlier lifecycle and mixed-route diagnostics include incomplete implementations and fixture-oracle errors; they are not performance baselines."
-  ]
+  ],
+  "measured_implementation_commit": "b7197fdb6c27006eaa78bfd6dedc8a694a36fbef"
 }

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 384)
+        self.assertEqual(len(GATE.public_methods()), 385)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "c07b80a5bb8c6d907d1c02d0862702965c94730e21bd71302e0288ba2c7af4b1",
+  "public_method_digest": "3199148900ac01b875528b26e6d900423998dcaaa5cc40014c200e55400afc13",
   "method_policy": {
     "receiver_defaults": {
       "PortableV2ImportResult": "release-tested",
@@ -259,6 +259,7 @@
         "GraphForge.add_edge",
         "GraphForge.add_node",
         "GraphForge.adopt_ontology",
+        "GraphForge.adopt_ontology_cancellable",
         "GraphForge.clear_ontology",
         "GraphForge.labels",
         "GraphForge.node_count",
@@ -299,6 +300,10 @@
         {
           "path": "crates/graphforge-api/src/checkpoint_graph_diff.rs",
           "symbol": "extracts_uuid_ordered_logical_nodes_and_edges_from_pinned_generation"
+        },
+        {
+          "path": "crates/graphforge-api/tests/permanent_storage_budgets.rs",
+          "symbol": "ontology_promotion_cancellation_and_conflict_preserve_prior_view"
         }
       ]
     },

--- a/tools/bazel/parity/migration_target_map.json
+++ b/tools/bazel/parity/migration_target_map.json
@@ -1,7 +1,7 @@
 {
   "schema": "graphforge.bazel-migration-target-map.v1",
   "issue": 6,
-  "cargo_target_count": 124,
+  "cargo_target_count": 125,
   "targets": [
     {
       "package": "graphforge-api",
@@ -1242,6 +1242,16 @@
       "bazel_label": "//crates/graphforge-api:permanent_storage_budgets",
       "exception_id": null,
       "notes": "#1196 permanent ownership and codec assessment"
+    },
+    {
+      "package": "graphforge-api",
+      "target": "ontology_adoption_retry",
+      "class": "integration-test",
+      "source": "crates/graphforge-api/tests/ontology_adoption_retry.rs",
+      "status": "mapped",
+      "bazel_label": "//crates/graphforge-api:ontology_adoption_retry",
+      "exception_id": null,
+      "notes": "#1229 atomic ontology promotion retry and type identity refusal"
     }
   ],
   "exceptions": [


### PR DESCRIPTION
Same-name ontology adoption could select CURRENT before reconciling graph labels, then fail its first query with unauthenticated ordinal authority. Stage labels, per-name relationship/property ownership and identity receipts in a private authenticated candidate; prepare readers before CURRENT and install that complete generation. Keep this promotion path separate from ordinary reopen and retain disjoint metadata-only payload reuse.

Use stable authored-operation identity for interrupted retries, recover from selected authority, and refuse stale-facade success or replacement ontologies that reinterpret existing numeric type IDs. Preserve full-width surrogates, active streams and shared permanent Parquet settings. No compatibility readers or migration machinery.

Validation:
- Public Advisory/Strict construction → promotion → exact query → reopen → export/full verification → clean import → ordinary/composite mutation passes. Mixed fixtures cover 33/4,097 nodes, 129/4,097 edges, 2/4 routes and nullable typed properties; repeat adoption reencodes no Parquet.
- Exact conflicting retries preserve `GF_IDEMPOTENCY_CONFLICT`; four direct retry regressions pass. Rust, Python and Node surface manifests plus the Bazel target map include the new coverage.
- Before/after-CURRENT crash and returned-error cases, cancellation, conflict, stale retries, type-ID refusal, full-width identity/allocation and reader-preparation refusal pass.
- 737 API unit tests pass. Storage: 1,086 pass, two existing ignores, one unchanged test hard-codes `/tmp` and fails filesystem admission on this host before its assertions. Required CI remains the merge gate.
- Workspace Clippy, formatting, fast pre-push and gate-registry checks passed during validation; full local pre-push completed with the same hard-coded `/tmp` admission failure in storage coverage (1,085 passed, one failed, two existing ignores). The coverage run also passed 737 API unit tests and preceding integration suites.
- Source-bound evidence and deterministic payload/control budgets are in `ontology-promotion-1229.json` and the permanent-storage assessment. This is a correctness cost, not an improvement claim against the incomplete failing baseline. Process RSS and sampled simultaneous allocation are explicitly distinct from hard bounds.

Initial CI failure census: Windows/macOS native checks and Rust quality passed. Policy/Bazel/Python failures came from missing new-surface registrations; Node exposed the conflicting-retry error code. Both causes are corrected together at the current head, with existing binding assertions preserved. Required Test Suite / CI Gate run 34486875612 passed at exact head `c6436eef3619f5ce854e5b6701716c2d9e67191f`, including authoritative Bazel, real lifecycle producers, both bindings, Windows/macOS durability and concurrency. Independent review found no remaining blockers; no unresolved review threads; merge state CLEAN. Local five-case Cargo/Bazel parity passes at `c6436eef` with the admitted native TMPDIR; the initial default-`/tmp` refusal is retained in the local diagnostic log.

Closes #1229
