### PR TITLE
fix: preserve constructed properties in named edge queries

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -4056,6 +4056,137 @@ fn facade_compaction_faults_preserve_authority_and_allow_mutation() {
     }
 }
 
+// Both physical property owners contribute only by exact edge UUID. Keep the
+// named traversal oracle independent of wildcard reads and publication routing.
+fn verify_named_edge_property_owners(graph: &GraphForge, edges: &[Edge]) {
+    for relation in ["REL0", "REL1"] {
+        let mut paths = Vec::new();
+        let query =
+            format!("MATCH (a)-[r:{relation}*1..1]->(b) RETURN r, a.node_uuid, b.node_uuid");
+        for batch in graph
+            .execute(&query)
+            .unwrap_or_else(|error| panic!("{query}: {error}"))
+            .batches
+        {
+            let lists = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .unwrap();
+            for row in 0..batch.num_rows() {
+                let path = lists.value(row);
+                let edge = path
+                    .as_any()
+                    .downcast_ref::<arrow::array::StructArray>()
+                    .unwrap();
+                assert_eq!(edge.len(), 1);
+                let uuid = edge
+                    .column_by_name("edge_uuid")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
+                let weight = edge
+                    .column_by_name("weight")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap();
+                let text = edge.column_by_name("text").unwrap();
+                let text = if text.logical_nulls().is_some_and(|nulls| nulls.is_null(0)) {
+                    None
+                } else if let Some(values) = text.as_any().downcast_ref::<StringArray>() {
+                    Some(values.value(0).to_owned())
+                } else {
+                    Some(
+                        text.as_any()
+                            .downcast_ref::<arrow::array::StringViewArray>()
+                            .expect("typed string property")
+                            .value(0)
+                            .to_owned(),
+                    )
+                };
+                paths.push((
+                    Uuid::from_slice(uuid.value(0)).unwrap(),
+                    uuid_at(&batch, 1, row),
+                    uuid_at(&batch, 2, row),
+                    relation.to_owned(),
+                    (!weight.is_null(0)).then(|| weight.value(0)),
+                    text,
+                ));
+            }
+        }
+        let mut expected = edges
+            .iter()
+            .filter(|edge| edge.3 == relation)
+            .cloned()
+            .collect::<Vec<_>>();
+        paths.sort();
+        expected.sort();
+        assert_eq!(paths, expected, "{query}");
+        for (pattern, edge, filtered) in [
+            (format!("MATCH (a)-[r:{relation}]->(b)"), "r", false),
+            (
+                format!("MATCH (a)-[r:{relation}]->(b) WITH a, r, b MATCH (a)-[r:{relation}]->(b)"),
+                "r",
+                false,
+            ),
+            (
+                format!(
+                    "MATCH (a)-[r:{relation}]->(b) WHERE r.weight IS NOT NULL AND r.text IS NULL"
+                ),
+                "r",
+                true,
+            ),
+        ] {
+            let query = format!(
+                "{pattern} RETURN {edge}.edge_uuid, a.node_uuid, b.node_uuid, {edge}.weight, {edge}.text"
+            );
+            let mut actual = Vec::new();
+            for batch in graph
+                .execute(&query)
+                .unwrap_or_else(|error| panic!("{query}: {error}"))
+                .batches
+            {
+                for row in 0..batch.num_rows() {
+                    let text = batch.column(4);
+                    let text = if text.logical_nulls().is_some_and(|nulls| nulls.is_null(row)) {
+                        None
+                    } else if let Some(values) = text.as_any().downcast_ref::<StringArray>() {
+                        Some(values.value(row).to_owned())
+                    } else {
+                        Some(
+                            text.as_any()
+                                .downcast_ref::<arrow::array::StringViewArray>()
+                                .expect("typed string property")
+                                .value(row)
+                                .to_owned(),
+                        )
+                    };
+                    actual.push((
+                        uuid_at(&batch, 0, row),
+                        uuid_at(&batch, 1, row),
+                        uuid_at(&batch, 2, row),
+                        relation.to_owned(),
+                        int_at(&batch, 3, row),
+                        text,
+                    ));
+                }
+            }
+            let mut expected = edges
+                .iter()
+                .filter(|edge| {
+                    edge.3 == relation && (!filtered || (edge.4.is_some() && edge.5.is_none()))
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            actual.sort();
+            expected.sort();
+            assert_eq!(actual, expected, "{query}");
+        }
+    }
+}
+
 #[test]
 fn composite_constructed_edge_properties_preserve_authenticated_owner() {
     use futures::TryStreamExt;
@@ -4075,6 +4206,7 @@ fn composite_constructed_edge_properties_preserve_authenticated_owner() {
         let (mut nodes, mut edges) = rows(fixture);
         construct(&source, fixture, &nodes, &edges);
         let mut graph = GraphForge::new(source.to_str()).unwrap();
+        verify_named_edge_property_owners(&graph, &edges);
         for with_properties in [true, false] {
             let properties = if with_properties {
                 " {weight: 3, text: 'ordinary'}"
@@ -4101,6 +4233,7 @@ fn composite_constructed_edge_properties_preserve_authenticated_owner() {
         graph
             .execute("MATCH (a)-[r]->(b) RETURN r.edge_uuid, r.weight, r.text")
             .expect("mixed construction/ordinary properties before composite mutation");
+        verify_named_edge_property_owners(&graph, &edges);
         let ordinary = edges[129].0;
         let empty = edges[130].0;
         graph
@@ -4144,6 +4277,7 @@ fn composite_constructed_edge_properties_preserve_authenticated_owner() {
         edges[0].4 = Some(19);
         edges[1].5 = None;
         verify_graph(&graph, fixture, &nodes, &edges);
+        verify_named_edge_property_owners(&graph, &edges);
         let published = publishing_parquet_inventory(&source);
         assert!(
             published["parquet_bytes"].as_u64().unwrap() <= 1024 * 1024,
@@ -4237,6 +4371,7 @@ fn composite_constructed_edge_properties_preserve_authenticated_owner() {
                 "{compacted}"
             );
             verify_graph(&graph, fixture, &nodes, &edges);
+            verify_named_edge_property_owners(&graph, &edges);
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -4254,7 +4389,10 @@ fn composite_constructed_edge_properties_preserve_authenticated_owner() {
             assert_eq!(old, edges.iter().map(|edge| (edge.0, edge.4)).collect());
         }
         drop(graph);
-        round_trip(root.path(), &source, fixture, &nodes, &edges);
+        round_trip_checked(root.path(), &source, |graph| {
+            verify_named_edge_property_owners(graph, &edges);
+            verify_graph(graph, fixture, &nodes, &edges)
+        });
         let imported_path = root.path().join("imported");
         let imported = GraphForge::new(imported_path.to_str()).unwrap();
         let request = graphforge_api::CompositeTransactionRequest {
@@ -4292,11 +4430,16 @@ fn composite_constructed_edge_properties_preserve_authenticated_owner() {
         edges[0].4 = Some(31);
         edges[130].4 = None;
         verify_graph(&imported, fixture, &nodes, &edges);
+        verify_named_edge_property_owners(&imported, &edges);
         drop(imported);
         verify_graph(
             &GraphForge::new(imported_path.to_str()).unwrap(),
             fixture,
             &nodes,
+            &edges,
+        );
+        verify_named_edge_property_owners(
+            &GraphForge::new(imported_path.to_str()).unwrap(),
             &edges,
         );
     }
@@ -4315,6 +4458,38 @@ fn composite_property_owner_scope_rejects_unnamed_public_edges() {
     );
     let count = graph.execute("MATCH (n) RETURN count(n)").unwrap();
     assert_eq!(int_at(&count.batches[0], 0, 0), Some(0));
+}
+
+#[test]
+fn named_edge_property_owners_refuse_incompatible_concrete_types() {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "named_owner_type_conflict",
+        nodes: 3,
+        edges: 2,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (nodes, edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    graph
+        .execute("CREATE (:Node0)-[:REL0 {weight: 'incompatible'}]->(:Node0)")
+        .unwrap();
+    for query in [
+        "MATCH ()-[r:REL0]->() RETURN r.weight",
+        "MATCH ()-[r:REL0*1..1]->() RETURN r",
+        "MATCH (a)-[r:REL0]->(b) WITH a, r, b MATCH (a)-[r:REL0]->(b) RETURN r.weight",
+    ] {
+        assert!(
+            graph.execute(query).is_err(),
+            "incompatible concrete owners must not be coerced: {query}"
+        );
+    }
 }
 
 #[test]

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -2977,19 +2977,85 @@ fn build_edge_list_column(
     Ok(Arc::new(list))
 }
 
+fn read_target_edge_properties(
+    inventory: &graphforge_storage::AuthenticatedPropertyInventory,
+    stem: &str,
+    targets: &std::collections::BTreeSet<[u8; 16]>,
+    property_names: &[String],
+    owners: &mut std::collections::BTreeSet<[u8; 16]>,
+) -> Result<Vec<arrow::record_batch::RecordBatch>, GfError> {
+    let selected = graphforge_storage::read_authenticated_property_targets_for_inventory(
+        inventory,
+        graphforge_storage::PropertyRouteKind::Edge,
+        stem,
+        targets,
+    )?;
+    if selected.present.iter().any(|uuid| !owners.insert(*uuid)) {
+        return Err(GfError::Project {
+            code: graphforge_core::ProjectErrorCode::ProjectCorrupt,
+            message: "edge properties have multiple authenticated owners".into(),
+        });
+    }
+    let schema = inventory.route_schema(graphforge_storage::PropertyRouteKind::Edge, stem);
+    match schema {
+        Some(schema) => {
+            let indices = schema
+                .fields()
+                .iter()
+                .enumerate()
+                .filter(|(_, field)| {
+                    field.name() == "edge_uuid" || property_names.contains(field.name())
+                })
+                .map(|(index, _)| index)
+                .collect::<Vec<_>>();
+            let projected = schema
+                .project(&indices)
+                .map_err(GfError::from_execution_error)?;
+            Ok(vec![selected.edge_batch(&projected)?])
+        }
+        None => Ok(Vec::new()),
+    }
+}
+
+fn edge_property_stems(
+    inventory: Option<&graphforge_storage::AuthenticatedPropertyInventory>,
+    dir: &Path,
+    rel_type_name: &str,
+) -> Vec<String> {
+    if rel_type_name == "*" {
+        match inventory {
+            Some(inventory) => inventory
+                .routes(graphforge_storage::PropertyRouteKind::Edge)
+                .map(str::to_owned)
+                .collect(),
+            None => graphforge_storage::list_edge_property_stems(dir),
+        }
+    } else {
+        let mut candidates = vec![rel_type_name.to_owned()];
+        let has_shared = match inventory {
+            Some(inventory) => inventory
+                .route_schema(graphforge_storage::PropertyRouteKind::Edge, "_exploratory")
+                .is_some(),
+            None => graphforge_storage::list_edge_property_stems(dir)
+                .iter()
+                .any(|stem| stem == "_exploratory"),
+        };
+        if rel_type_name != "_exploratory" && has_shared {
+            candidates.push("_exploratory".to_owned());
+        }
+        candidates.sort();
+        candidates
+    }
+}
+
 /// Build one child array per edge-property struct field (#755), in field order.
 ///
-/// Reads the relation's `edge_properties/<REL>.parquet` once (keyed by
-/// `edge_uuid`), then `take`s each property column at the row matching each
-/// flattened hop's `edge_uuid` — `None` for an edge with no property row yields a
-/// NULL (LEFT-join semantics). A field advertised in the schema but absent on disk
-/// becomes an all-NULL column. Returns an empty Vec when there are no prop fields.
+/// Authenticates candidate owners and retains values for flattened hop UUIDs.
+/// Named traversals select the logical route and shared construction route;
+/// wildcard traversals select every route. Tombstones participate in ownership
+/// refusal but never contribute values. Missing properties become NULL under
+/// the lowering's nullable union schema. Returns no children without properties.
 /// `hop_edge_uuids` is in flattened hop order (matching the topology children).
-///
-/// A wildcard traversal (`*`, #1023) reads EVERY relation's property file:
-/// each hop's values come from the file owning its `edge_uuid` (an edge belongs
-/// to exactly one relation), coalesced per field — NULL where the owning
-/// relation lacks the column, matching the lowering's nullable union schema.
 fn build_edge_prop_children(
     inventory: Option<&graphforge_storage::AuthenticatedPropertyInventory>,
     rel_type_name: &str,
@@ -3008,20 +3074,10 @@ fn build_edge_prop_children(
         return Ok(Vec::new());
     }
 
-    // Read each property file once and concat to a single batch per relation
-    // (absent files contribute nothing). Typed traversals read one file; a
-    // wildcard reads all of them, in the lowering's sorted-stem order.
-    let stems: Vec<String> = if rel_type_name == "*" {
-        match inventory {
-            Some(inventory) => inventory
-                .routes(graphforge_storage::PropertyRouteKind::Edge)
-                .map(str::to_owned)
-                .collect(),
-            None => graphforge_storage::list_edge_property_stems(dir),
-        }
-    } else {
-        vec![rel_type_name.to_owned()]
-    };
+    // Resolve selected rows once per candidate route, then assemble hop order.
+    let stems = edge_property_stems(inventory, dir, rel_type_name);
+    let targets = hop_edge_uuids.iter().copied().collect();
+    let mut owners = std::collections::BTreeSet::new();
     let mut prop_batches_by_rel = Vec::with_capacity(stems.len());
     let property_names = prop_fields
         .iter()
@@ -3029,15 +3085,12 @@ fn build_edge_prop_children(
         .collect::<Vec<_>>();
     for stem in &stems {
         let batches = match inventory {
-            Some(inventory) => graphforge_storage::read_edge_properties_projected_from_inventory(
-                dir,
-                inventory,
-                stem,
-                &property_names,
-            ),
-            None => graphforge_storage::read_edge_properties_projected(dir, stem, &property_names),
-        }
-        .map_err(|e| exec_err(e.to_string()))?;
+            Some(inventory) => {
+                read_target_edge_properties(inventory, stem, &targets, &property_names, &mut owners)
+            }
+            None => graphforge_storage::read_edge_properties_projected(dir, stem, &property_names)
+                .map_err(|e| exec_err(e.to_string())),
+        }?;
         if let Some(first) = batches.first() {
             prop_batches_by_rel.push(
                 concat_batches(&first.schema(), &batches).map_err(|e| exec_err(e.to_string()))?,
@@ -3046,7 +3099,7 @@ fn build_edge_prop_children(
     }
 
     // edge_uuid -> (owning batch, row within it). An edge belongs to exactly
-    // one relation, so first-wins is a no-op for well-formed data.
+    // one physical owner; duplicate ownership is corruption, not precedence.
     let mut uuid_to_loc: HashMap<[u8; 16], (usize, u32)> = HashMap::new();
     for (bi, b) in prop_batches_by_rel.iter().enumerate() {
         let key = b
@@ -3069,11 +3122,16 @@ fn build_edge_prop_children(
             }
             let mut u = [0u8; 16];
             u.copy_from_slice(key.value(r));
-            uuid_to_loc.entry(u).or_insert((
+            let location = (
                 bi,
                 u32::try_from(r)
                     .map_err(|_| exec_err(format!("edge-property row {r} exceeds u32")))?,
-            ));
+            );
+            if uuid_to_loc.insert(u, location).is_some() {
+                return Err(exec_err(
+                    "edge properties have multiple physical owners".into(),
+                ));
+            }
         }
     }
 

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -3670,10 +3670,10 @@ fn lower_var_len_expand(
     // forced nullable since an edge from a relation without the column is NULL
     // (the exec coalesces each edge's values from its own relation's file).
     let topology_names = ["edge_uuid", "src_uuid", "dst_uuid", "rel_type"];
-    let prop_fields: Vec<datafusion::arrow::datatypes::Field> = if rel_name == "*" {
+    let prop_fields: Vec<datafusion::arrow::datatypes::Field> = {
         let mut positions = std::collections::HashMap::<String, usize>::new();
         let mut fields: Vec<datafusion::arrow::datatypes::Field> = Vec::new();
-        for stem in dir_path.edge_property_stems.clone() {
+        for stem in edge_property_candidate_stems(dir_path, &rel_name) {
             let prop_table = edge_property_schema(dir_path, &stem);
             for f in prop_table.fields() {
                 if topology_names.contains(&f.name().as_str()) {
@@ -3691,14 +3691,6 @@ fn lower_var_len_expand(
             }
         }
         fields
-    } else {
-        let prop_table = edge_property_schema(dir_path, &rel_name);
-        prop_table
-            .fields()
-            .iter()
-            .filter(|f| !topology_names.contains(&f.name().as_str()))
-            .map(|f| f.as_ref().clone())
-            .collect()
     };
 
     // The output extends the input with the destination node's columns,
@@ -4060,12 +4052,7 @@ fn try_lower_provider_expand(
     let edge_fields: Vec<Arc<datafusion::arrow::datatypes::Field>> =
         edge_schema.fields().iter().cloned().collect();
     let base_names: HashSet<&str> = edge_fields.iter().map(|f| f.name().as_str()).collect();
-    let mut stems = if rel_name == "*" {
-        dir_path.edge_property_stems.clone()
-    } else {
-        vec![rel_name.clone()]
-    };
-    stems.sort();
+    let stems = edge_property_candidate_stems(dir_path, &rel_name);
     let mut positions = std::collections::HashMap::<String, usize>::new();
     let mut edge_prop_fields: Vec<Arc<datafusion::arrow::datatypes::Field>> = Vec::new();
     for stem in stems {
@@ -4356,10 +4343,9 @@ fn edge_property_read_source(
 ///
 /// Returns `scan` unchanged when:
 /// - there is no read directory (schema-only lowering),
-/// - `rel_ty` is `None` (a wildcard edge scan has no single relation file), or
 /// - the edge-property table has no columns beyond the `edge_uuid` join key.
 ///
-/// Otherwise it opens `edge_properties/<rel>.parquet`, LEFT-joins on `edge_uuid`
+/// Otherwise it reads selected property owners, LEFT-joins on `edge_uuid`
 /// (preserving edges with no property row yet), and re-qualifies each property
 /// column under the edge var alias so `var_<edge>.<prop>` resolves. The base
 /// topology columns are read from the edge `scan`'s own schema (typed and
@@ -4417,6 +4403,9 @@ fn join_edge_properties(
         };
         let registered = catalog.and_then(|catalog| catalog.semantic_edge_property_schema(rel_ty));
         push_source(rel_name.clone(), registered);
+        if rel_name != "_exploratory" && dir.edge_properties.contains_key("_exploratory") {
+            push_source("_exploratory".into(), None);
+        }
     } else {
         for stem in dir.edge_property_stems.clone() {
             push_source(stem, None);
@@ -4425,13 +4414,15 @@ fn join_edge_properties(
     if prop_sources.is_empty() {
         return Ok(scan);
     }
+    validate_edge_property_owner_types(&prop_sources)?;
 
     let wildcard = rel_ty.is_none();
     let mut joined = scan;
     let mut prop_refs: StdHashMap<String, Vec<DfExpr>> = StdHashMap::new();
     for (idx, (stem, prop_table, prop_cols)) in prop_sources.into_iter().enumerate() {
         let prop_alias = format!("{edge_alias}__eprops_{idx}");
-        let prop_src = edge_property_read_source(&stem, rel_ty, catalog, &prop_table);
+        let source_type = if stem == "_exploratory" { None } else { rel_ty };
+        let prop_src = edge_property_read_source(&stem, source_type, catalog, &prop_table);
         let prop_scan = LogicalPlanBuilder::scan(prop_alias.clone(), prop_src, None)
             .and_then(LogicalPlanBuilder::build)
             .map_unsupported_expr()?;
@@ -4441,7 +4432,7 @@ fn join_edge_properties(
         // relation-specific property file never contributes to another relation.
         let mut join_pred =
             col(format!("{edge_alias}.edge_uuid")).eq(col(format!("{prop_alias}.edge_uuid")));
-        if wildcard {
+        if wildcard && stem != "_exploratory" {
             join_pred = join_pred.and(col(format!("{edge_alias}.rel_type_name")).eq(lit(stem)));
         }
         joined = LogicalPlanBuilder::from(joined)
@@ -4492,6 +4483,51 @@ fn node_property_schema(
         .cloned()
         .unwrap_or_else(|| graphforge_ir::arrow_schema::PROPERTY_BASE_SCHEMA.clone())
 }
+fn validate_edge_property_owner_types(
+    prop_sources: &[(String, datafusion::arrow::datatypes::SchemaRef, Vec<String>)],
+) -> Result<(), LoweringError> {
+    // The relational reference must not silently coerce two concrete owner
+    // schemas where provider hydration would reject them. Null is absence.
+    let mut property_types = HashMap::new();
+    for (_, schema, names) in prop_sources {
+        for name in names {
+            let datatype = schema
+                .field_with_name(name)
+                .map_unsupported_expr()?
+                .data_type();
+            if datatype == &datafusion::arrow::datatypes::DataType::Null {
+                continue;
+            }
+            if let Some(prior) = property_types.insert(name, datatype)
+                && prior != datatype
+            {
+                return Err(LoweringError::UnsupportedExpr(
+                    "incompatible concrete edge property owner types".into(),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// A named relation can have ordinary per-name properties and constructed
+// exploratory properties. These are current physical owners, not aliases.
+fn edge_property_candidate_stems(snapshot: &LoweringSnapshot, relation: &str) -> Vec<String> {
+    let mut stems = if relation == "*" {
+        snapshot.edge_property_stems.clone()
+    } else {
+        let mut candidates = vec![relation.to_owned()];
+        if relation != "_exploratory" && snapshot.edge_properties.contains_key("_exploratory") {
+            candidates.push("_exploratory".to_owned());
+        }
+        candidates
+    };
+    stems.sort();
+    stems.dedup();
+    stems
+}
+
 fn edge_property_schema(
     snapshot: &LoweringSnapshot,
     stem: &str,

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -398,9 +398,10 @@ pub use property_overlay::{
     AuthenticatedPropertyInventory, PROPERTY_OVERLAY_FORMAT, PROPERTY_OVERLAY_FORMAT_KEY,
     PROPERTY_TOMBSTONE_FIELD, PropertyFragmentId, PropertyInventoryOpenMetrics,
     PropertyOverlayLimits, PropertyOverlayMetrics, PropertyRouteKind, PropertySnapshotRow,
-    enumerate_property_fragments, read_authenticated_property_presence_for_inventory,
-    read_authenticated_property_snapshots_for, read_authenticated_property_snapshots_for_inventory,
-    visit_authenticated_property_snapshots,
+    PropertyTargetSnapshots, enumerate_property_fragments,
+    read_authenticated_property_presence_for_inventory, read_authenticated_property_snapshots_for,
+    read_authenticated_property_snapshots_for_inventory,
+    read_authenticated_property_targets_for_inventory, visit_authenticated_property_snapshots,
 };
 
 pub mod catalog;

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -2543,6 +2543,7 @@ fn read_property_targets(
     }
     let mut unresolved = targets.clone();
     let mut found = BTreeMap::new();
+    let mut retained_bytes = 0;
     let mut metrics = PropertyOverlayMetrics::default();
     let Some(fragments) = inventory.routes.get(&(kind, route.to_owned())) else {
         return Ok(TargetPropertyRows {
@@ -2632,7 +2633,7 @@ fn read_property_targets(
             page_reservation_bytes,
             replay: replay_budget.is_some(),
         };
-        admission.check(0, found.values().map(snapshot_charge).sum())?;
+        admission.check(0, retained_bytes)?;
         metrics.decoder_page_reservation_bytes = metrics
             .decoder_page_reservation_bytes
             .max(page_reservation_bytes);
@@ -2648,7 +2649,7 @@ fn read_property_targets(
             &mut metrics,
             admission,
             targeted_batch_rows,
-            found.values().map(snapshot_charge).sum(),
+            retained_bytes,
         )?;
         let validation_bytes = counts.bytes.load(Ordering::Relaxed);
         let validation_read_calls = counts.blocks.load(Ordering::Relaxed);
@@ -2668,6 +2669,7 @@ fn read_property_targets(
                 &counts,
                 &mut unresolved,
                 &mut found,
+                &mut retained_bytes,
                 &mut metrics,
             )?;
         }
@@ -2696,6 +2698,11 @@ fn read_property_targets(
     metrics.physical_bytes = metrics
         .physical_bytes
         .saturating_add(metrics.authentication_bytes);
+    #[cfg(test)]
+    assert_eq!(
+        retained_bytes,
+        found.values().map(snapshot_charge).sum::<u64>()
+    );
     metrics.logical_rows = u64::try_from(found.len()).unwrap_or(u64::MAX);
     metrics.peak_buffered_rows = metrics.decoder_peak_rows;
     Ok(TargetPropertyRows {
@@ -2801,6 +2808,7 @@ fn decode_target_row_groups(
     counts: &Arc<ReadCounts>,
     unresolved: &mut std::collections::BTreeSet<[u8; 16]>,
     found: &mut BTreeMap<[u8; 16], PropertySnapshotRow>,
+    retained_bytes: &mut u64,
     metrics: &mut PropertyOverlayMetrics,
 ) -> Result<(), GfError> {
     let reader = open_counted_retained_property_builder(
@@ -2814,12 +2822,7 @@ fn decode_target_row_groups(
     .map_err(parquet_error)?;
     for batch in reader {
         let batch = batch.map_err(authenticated_arrow_error)?;
-        charge_target_batch(
-            metrics,
-            &batch,
-            options.admission,
-            found.values().map(snapshot_charge).sum(),
-        )?;
+        charge_target_batch(metrics, &batch, options.admission, *retained_bytes)?;
         let decoded = decode_snapshot_batch(&batch, options.kind.uuid_field())?;
         if decoded
             .iter()
@@ -2833,9 +2836,14 @@ fn decode_target_row_groups(
             batch.get_array_memory_size() as u64,
             decoded
                 .iter()
-                .chain(found.values())
                 .map(snapshot_charge)
-                .sum(),
+                .sum::<u64>()
+                .checked_add(*retained_bytes)
+                .ok_or_else(|| {
+                    options
+                        .admission
+                        .error("property target memory charge overflow")
+                })?,
         )?;
         metrics.decoder_peak_bytes = metrics
             .decoder_peak_bytes
@@ -2846,6 +2854,15 @@ fn decode_target_row_groups(
                 if row.tombstone {
                     metrics.tombstones = metrics.tombstones.saturating_add(1);
                 } else {
+                    // Unresolved UUIDs are removed once, so each retained live
+                    // snapshot contributes exactly once across all fragments.
+                    *retained_bytes = retained_bytes
+                        .checked_add(snapshot_charge(&row))
+                        .ok_or_else(|| {
+                            options
+                                .admission
+                                .error("property target memory charge overflow")
+                        })?;
                     found.insert(row.uuid, row);
                 }
             }
@@ -3665,7 +3682,20 @@ fn record_charge(record: &SpoolRecord) -> u64 {
         .saturating_add(values)
 }
 
+#[cfg(test)]
+thread_local! {
+    // Count actual serialization work on this test thread, without changing
+    // production counters or depending on elapsed time and host load.
+    static SNAPSHOT_CHARGE_CALLS: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
 pub(crate) fn snapshot_charge(row: &PropertySnapshotRow) -> u64 {
+    #[cfg(test)]
+    SNAPSHOT_CHARGE_CALLS.with(|calls| {
+        if let Some(count) = calls.get() {
+            calls.set(Some(count + 1));
+        }
+    });
     let values = serde_json::to_vec(&row.values).map_or(u64::MAX, |encoded| {
         u64::try_from(encoded.len()).unwrap_or(u64::MAX)
     });
@@ -6049,6 +6079,42 @@ mod tests {
             }
             assert_eq!(metrics.per_record_seeks, 0);
             prior_bytes = metrics.physical_bytes;
+
+            let inventory = authenticated_property_inventory_for_route(
+                dir.path(),
+                PropertyRouteKind::Node,
+                "Person",
+            )
+            .unwrap();
+            for targets in [BTreeSet::from([uuids[0]]), uuids.iter().copied().collect()] {
+                SNAPSHOT_CHARGE_CALLS.with(|calls| calls.set(Some(0)));
+                let selected = read_authenticated_property_targets_for_inventory(
+                    &inventory,
+                    PropertyRouteKind::Node,
+                    "Person",
+                    &targets,
+                )
+                .unwrap();
+                let charge_calls = SNAPSHOT_CHARGE_CALLS.with(|calls| calls.replace(None).unwrap());
+                assert_eq!(selected.present, targets);
+                assert_eq!(
+                    selected.rows.keys().copied().collect::<BTreeSet<_>>(),
+                    targets
+                );
+                assert_eq!(selected.metrics.physical_rows, (rows * 2) as u64);
+                assert_eq!(selected.metrics.decoder_peak_rows, 2);
+                // Each decoded row is charged for its individual limit, live
+                // decode admission, and peak evidence. Each retained target is
+                // charged when inserted and once by the independent test-only
+                // final counter audit. Rescanning all retained rows for every
+                // two-row batch exceeds this linear work ceiling.
+                assert!(
+                    charge_calls <= 3 * rows + 2 * targets.len(),
+                    "rows={rows} targets={} charge_calls={charge_calls}",
+                    targets.len()
+                );
+                assert!(charge_calls >= rows, "counter must observe real row work");
+            }
         }
         assert_eq!(byte_deltas.len(), 2);
         assert!(

--- a/crates/graphforge-storage/src/property_overlay.rs
+++ b/crates/graphforge-storage/src/property_overlay.rs
@@ -2449,6 +2449,40 @@ pub fn read_authenticated_property_snapshots_for_inventory(
     Ok((result.rows, result.metrics))
 }
 
+/// Selected logical values and tombstone-inclusive ownership from one read.
+pub struct PropertyTargetSnapshots {
+    /// Latest live snapshots for requested UUIDs only.
+    pub rows: BTreeMap<[u8; 16], PropertySnapshotRow>,
+    /// Requested UUIDs with a physical owner, including newest tombstones.
+    pub present: BTreeSet<[u8; 16]>,
+    /// Exact admission, authentication and decode work for this read.
+    pub metrics: PropertyOverlayMetrics,
+}
+
+impl PropertyTargetSnapshots {
+    /// Materialize selected live edge rows in their declared Arrow representation.
+    /// Uses the canonical property encoder, including tagged and temporal values.
+    pub fn edge_batch(&self, schema: &arrow::datatypes::Schema) -> Result<RecordBatch, GfError> {
+        crate::writer::edge_property_snapshots_batch(schema, &self.rows)
+    }
+}
+
+/// Read selected values and owner presence without a second fragment scan.
+/// Uses the same authenticated decoder and resource limits as mutation reads.
+pub fn read_authenticated_property_targets_for_inventory(
+    inventory: &AuthenticatedPropertyInventory,
+    kind: PropertyRouteKind,
+    route: &str,
+    targets: &BTreeSet<[u8; 16]>,
+) -> Result<PropertyTargetSnapshots, GfError> {
+    let result = read_property_targets(inventory, kind, route, targets, None)?;
+    Ok(PropertyTargetSnapshots {
+        present: targets.difference(&result.unresolved).copied().collect(),
+        rows: result.rows,
+        metrics: result.metrics,
+    })
+}
+
 /// Resolve authenticated target row presence, including newest tombstones.
 /// Unlike live snapshot reads, a removed row still proves its physical owner.
 /// Uses the same schema, UUID ordering, tombstone-value and resource validation.
@@ -5308,6 +5342,33 @@ mod tests {
         );
         assert_eq!(work.fragments_considered, 2);
         assert_eq!(work.tombstones, 1);
+        let selected = read_authenticated_property_targets_for_inventory(
+            &inventory,
+            PropertyRouteKind::Edge,
+            "REL",
+            &targets,
+        )
+        .unwrap();
+        assert_eq!(selected.present, present);
+        assert_eq!(selected.rows, live);
+        assert_eq!(
+            selected.metrics, work,
+            "combined values and ownership scan once"
+        );
+        let schema = Schema::new(vec![
+            Field::new("edge_uuid", DataType::FixedSizeBinary(16), false),
+            Field::new("value", DataType::Int64, true),
+            Field::new("null_only", DataType::Null, true),
+        ]);
+        let batch = selected.edge_batch(&schema).unwrap();
+        assert_eq!(
+            batch.num_rows(),
+            1,
+            "tombstones never revive a property row"
+        );
+        assert_eq!(batch.column(1).null_count(), 1);
+        assert_eq!(batch.column(2).logical_null_count(), 1);
+        assert_eq!(batch.schema().as_ref(), &schema);
         drop(inventory);
         // Re-admit a deliberately malformed fixture so this checks row
         // validation, rather than merely failing its prior digest authority.

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -6644,6 +6644,52 @@ fn property_snapshot_fragment_schema(
     Arc::new(Schema::new_with_metadata(fields, metadata))
 }
 
+pub(crate) fn edge_property_snapshots_batch(
+    schema: &Schema,
+    snapshots: &BTreeMap<[u8; 16], crate::PropertySnapshotRow>,
+) -> Result<RecordBatch, GfError> {
+    if snapshots.is_empty() {
+        return Ok(RecordBatch::new_empty(Arc::new(schema.clone())));
+    }
+    let rows = snapshots
+        .values()
+        .map(|row| EdgePropRow {
+            edge_uuid: row.uuid,
+            props: row
+                .values
+                .iter()
+                .filter(|(name, _)| schema.column_with_name(name).is_some())
+                .map(|(name, value)| (name.clone(), value.clone()))
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    let indices = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| field.data_type() != &DataType::Null)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let concrete = schema.project(&indices).map_err(pq_err)?;
+    let batch = property_rows_batch_with_schema(&concrete, EDGE_PROPERTY_UUID_FIELD, &rows)?;
+    let columns = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            if field.data_type() == &DataType::Null {
+                arrow::array::new_null_array(&DataType::Null, rows.len())
+            } else {
+                Arc::clone(
+                    batch
+                        .column_by_name(field.name())
+                        .expect("projected property field"),
+                )
+            }
+        })
+        .collect();
+    RecordBatch::try_new(Arc::new(schema.clone()), columns).map_err(pq_err)
+}
+
 fn property_snapshot_chunk_with_schema(
     base: &Schema,
     fragment_schema: SchemaRef,
@@ -8483,6 +8529,77 @@ mod tests {
             x.data_type(),
             &DataType::Struct(heterogeneous_scalar_fields())
         );
+
+        // The targeted edge reader uses the same canonical encoder in memory.
+        // Verify its tagged values and temporal fields survive that boundary,
+        // including explicit Null and negative timestamp/duration components.
+        let rows = [
+            IrLiteral::Null,
+            IrLiteral::Int(1),
+            IrLiteral::Str("two".into()),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let uuid = Uuid::from_u128(index as u128 + 1).into_bytes();
+            (
+                uuid,
+                crate::PropertySnapshotRow {
+                    uuid,
+                    tombstone: false,
+                    values: BTreeMap::from([
+                        ("x".into(), value),
+                        ("at".into(), IrLiteral::DateTime(-1_234_567 + index as i64)),
+                        (
+                            "elapsed".into(),
+                            IrLiteral::Duration {
+                                months: -2,
+                                days: 3,
+                                seconds: -4,
+                                nanos: 5,
+                            },
+                        ),
+                    ]),
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+        let selected = crate::PropertyTargetSnapshots {
+            present: rows.keys().copied().collect(),
+            rows,
+            metrics: Default::default(),
+        };
+        let edge_schema = Schema::new_with_metadata(
+            vec![
+                uuid_field(EDGE_PROPERTY_UUID_FIELD),
+                Field::new("x", DataType::Struct(heterogeneous_scalar_fields()), true),
+                crate::schemas::ts_field("at"),
+                Field::new(
+                    "elapsed",
+                    DataType::Struct(crate::schemas::duration_struct_fields()),
+                    true,
+                ),
+            ],
+            HashMap::from([("fixture".into(), "targeted-edge-types".into())]),
+        );
+        let encoded = selected.edge_batch(&edge_schema).unwrap();
+        assert_eq!(encoded.schema().as_ref(), &edge_schema);
+        let mut decoded = BTreeMap::new();
+        decode_property_batch(&encoded, EDGE_PROPERTY_UUID_FIELD, |uuid, values| {
+            assert!(decoded.insert(uuid, values).is_none());
+        })
+        .unwrap();
+        let expected = selected
+            .rows
+            .iter()
+            .map(|(uuid, row)| {
+                (
+                    *uuid,
+                    row.values.clone().into_iter().collect::<HashMap<_, _>>(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(decoded, expected);
     }
 
     #[test]

--- a/docs/book/architecture/permanent-storage-assessment.md
+++ b/docs/book/architecture/permanent-storage-assessment.md
@@ -931,3 +931,82 @@ TMPDIR=/path/on/native-root /usr/bin/time -v /path/to/frozen-promotion-tests \
 cargo test -p graphforge-api --test ontology_adoption_retry
 cargo test -p graphforge-storage --lib reader_preparation_failure
 ```
+
+
+### Named traversal ownership follow-up (#1224)
+
+Named fixed and variable traversals now discover both the logical relationship
+property route and the authenticated `_exploratory` construction route. Ordinary
+and constructed edges of the same relation retain their separate current owners.
+Provider hydration reads requested values and tombstone-inclusive owner presence
+in one authenticated target read per candidate. Multiple owners refuse as
+`GF_PROJECT_CORRUPT`; tombstones never revive values. Unrelated named routes are
+not added to the candidate set. Already-bound traversal coverage exercises
+provider hydration followed by bound-edge constraints; the relational join is a
+differential-testing reference path, not the normal project execution path.
+
+Target batches use the existing canonical property encoder, preserving tagged
+scalars, temporal components and schema metadata. Null-only and empty selections
+have explicit Arrow handling. Direct tests cover those cases, tagged Null/Int/Str,
+negative timestamps and signed durations, while incompatible concrete owner types
+still refuse. Exact named queries and nullable filters extend the existing
+33/4,097-node public lifecycle through compaction, reopen, portable full
+verification/import, subsequent mutation and retry.
+
+The combined-reader test requires identical work counters to the existing single
+snapshot/presence read. Existing N/2N/4N targeted tests retain one result and at most
+two decoded rows while checking exact authentication and read accounting. These
+are decoder and selected-work budgets, not a complete query memory bound. Target
+snapshots, tombstone presence sets, projected value clones and Arrow output can
+overlap; the decoder's logical peak excludes these retained owners. Projection
+avoids cloning unrequested fields, but selected snapshots still contain their
+full property maps. Native process measurements must include that overlap.
+
+
+The named-reader review exposed quadratic memory-charge computation in the
+existing target decoder: each two-row batch serialized all retained property
+maps twice even when replay admission ignored that charge. Retained bytes are
+now accumulated once per accepted live UUID across fragments, with checked
+overflow and unchanged admission. A test-only independent sum verifies the
+counter. The N/2N/4N test now selects both one UUID and all 128/256/512 UUIDs;
+serialization calls must stay within `3 * stored_rows + 2 * targets`,
+including the test-only final audit. This deterministic CPU-work ceiling rejects
+the previous quadratic computation without timing thresholds.
+
+
+A frozen, unchanged common wildcard fixture (66 nodes, 4,097 edges, two routes,
+construction windows and portable round trip) completed on all three sources.
+Merged-main control `c481cc15` took 4.15 seconds elapsed / 3.11 seconds user CPU;
+the unmerged repeated-charge implementation `a55ed14d` took 83.91 / 82.89;
+linear accounting `260445ce` took 3.96 / 2.94. Peak RSS was respectively
+137,996 / 138,984 / 140,584 KiB. These are single serial observations with
+uncontrolled cache state, not statistical evidence of a speedup over main.
+They quantify removal of the introduced quadratic cost. The named-query
+correctness failure on main remains separate and supplies no valid full named
+lifecycle timing baseline.
+
+
+The complete named-query lifecycle was measured separately with frozen source
+`260445ce`: elapsed/user/system time 36.30/47.89/2.60 seconds, peak RSS 158,604 KiB,
+and OS input/output 32,608/300,952 512-byte blocks. A separate traced run recorded
+481,987,200 read bytes and 140,358,591 write bytes, including successful
+`copy_file_range` in both totals, with 6,212 fsync calls and no traced errors.
+These totals include the additional exact named queries throughout the lifecycle;
+they are not comparable to the earlier wildcard-only lifecycle timing.
+
+A third run sampled 10,899,456 peak allocated bytes after deduplicating shared
+inodes across retained/project/private/portable files. Its maximum observed
+sampling interval was 20.13 ms; unlinked open files, directory allocation and
+shorter-lived peaks can be missed. This is neither a temporary-only total nor a
+hard admission bound. Full provenance, process/native observations, decoder
+budgets and limitations are in
+[`named-edge-property-ownership-1224.json`](../../development/evidence/named-edge-property-ownership-1224.json).
+
+Final validation passed all 41 frozen public publishing tests, all 24
+property-overlay unit tests, ten compaction integration tests, workspace clippy,
+formatting, fast checks and gate registry validation. An earlier broad run passed
+737 API unit tests but its integration process was invalidated by concurrent
+executable replacement; it reported subprocess failures and was later interrupted
+at the superseded quadratic large fixture. That integration run is not green
+and contributes no performance evidence. All recovery cases passed in the final
+immutable executable run.

--- a/docs/development/evidence/named-edge-property-ownership-1224.json
+++ b/docs/development/evidence/named-edge-property-ownership-1224.json
@@ -1,0 +1,172 @@
+{
+  "issue": 1224,
+  "source_commit": "260445ceac30691e57b3162fbaf0ca31342d0703",
+  "executable_sha256": "c052e6507d0cf2aec266f88d455926807f8da9f534530d2bb3687f63a2c32028",
+  "baseline_source_commit": "c481cc1539b94b0dba7e9092b443408a331ae749",
+  "workload": "Public construction N33/N4097 E129/two routes; exact named fixed/variable, bound-edge constraints and nullable filters plus wildcard oracles throughout; ordinary CREATE adds four nodes and two edges (one without properties); composite edge SET/removal; exact fixed/variable Arrow queries; large-case compaction and retained stream; reopen/export/full verify/clean import; subsequent imported edge SET/removal, exact retry and second reopen.",
+  "command": [
+    "permanent_storage_budgets",
+    "composite_constructed_edge_properties_preserve_authenticated_owner",
+    "--nocapture",
+    "--test-threads=1"
+  ],
+  "runtime": {
+    "elapsed_seconds": 36.3,
+    "user_seconds": 47.89,
+    "system_seconds": 2.6,
+    "peak_rss_kib": 158604,
+    "filesystem_input_512_byte_blocks": 32608,
+    "filesystem_output_512_byte_blocks": 300952,
+    "exit_status": 0
+  },
+  "common_fixture_comparison": {
+    "fixture": "exploratory_construction_groups_bounded_windows_by_physical_route",
+    "workload": "66 nodes /4097 edges /2 routes; deterministic SHA256-derived UUIDs; two public construction windows; exact wildcard queries, reopen/export/full verification/import. Fixture and assertions are unchanged across these executables.",
+    "runs": [
+      {
+        "variant": "main",
+        "source_commit": "c481cc1539b94b0dba7e9092b443408a331ae749",
+        "executable_sha256": "7fe0cb3e0ef12517bcfb6ebbe1f6c5cb9626f67c5e5532a8fc1cde76ba9e2b3f",
+        "runtime": {
+          "elapsed_seconds": 4.15,
+          "user_seconds": 3.11,
+          "system_seconds": 0.7,
+          "peak_rss_kib": 137996,
+          "filesystem_input_512_byte_blocks": 58328,
+          "filesystem_output_512_byte_blocks": 25360,
+          "exit_status": 0
+        }
+      },
+      {
+        "variant": "quadratic",
+        "source_commit": "a55ed14d3cb216d8cef98e2523d6824adf6f2f50",
+        "executable_sha256": "a034fc3d35c22a6640748317fac33e221fde7ee24971ac3f175700e5679ff6a4",
+        "runtime": {
+          "elapsed_seconds": 83.91,
+          "user_seconds": 82.89,
+          "system_seconds": 0.68,
+          "peak_rss_kib": 138984,
+          "filesystem_input_512_byte_blocks": 58328,
+          "filesystem_output_512_byte_blocks": 21040,
+          "exit_status": 0
+        }
+      },
+      {
+        "variant": "linear",
+        "source_commit": "260445ceac30691e57b3162fbaf0ca31342d0703",
+        "executable_sha256": "c052e6507d0cf2aec266f88d455926807f8da9f534530d2bb3687f63a2c32028",
+        "runtime": {
+          "elapsed_seconds": 3.96,
+          "user_seconds": 2.94,
+          "system_seconds": 0.68,
+          "peak_rss_kib": 140584,
+          "filesystem_input_512_byte_blocks": 58328,
+          "filesystem_output_512_byte_blocks": 21040,
+          "exit_status": 0
+        }
+      }
+    ],
+    "limitations": [
+      "Single serial untraced observation per executable, not a statistical benchmark; OS cache state is not controlled.",
+      "Main control runtime sources are c481cc15 plus a separate unused failing named-query test. The common wildcard fixture passes and is the only comparator here.",
+      "The superseded a55ed14d reader was never merged. Its repair is not claimed as an improvement over merged main.",
+      "These whole-fixture CPU/RSS/block-I/O observations include construction, validation and portable work, not isolated query operator timing."
+    ]
+  },
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 121262,
+        "bytes": 345494589
+      },
+      "pread64": {
+        "calls": 327866,
+        "bytes": 121428362
+      },
+      "write": {
+        "calls": 20098,
+        "bytes": 125294342
+      },
+      "fsync": {
+        "calls": 6212,
+        "bytes": 0
+      },
+      "copy_file_range": {
+        "calls": 2682,
+        "bytes": 15064249
+      }
+    },
+    "read_bytes": 481987200,
+    "write_bytes": 140358591,
+    "errors": [],
+    "elapsed_seconds": 72.93
+  },
+  "validation": {
+    "final_frozen_publishing_suite": {
+      "passed": 41,
+      "failed": 0
+    },
+    "property_overlay_unit_tests": {
+      "passed": 24,
+      "failed": 0
+    },
+    "compaction_integration_tests": {
+      "passed": 10,
+      "failed": 0
+    },
+    "superseded_run": "Initial broad API unit suite passed 737 tests; initial integration run was invalidated by executable replacement and then interrupted at the known quadratic large fixture. It is not green or performance evidence."
+  },
+  "workspace_observation": {
+    "command": [
+      "/tmp/gf1224-named-measure-bin",
+      "composite_constructed_edge_properties_preserve_authenticated_owner",
+      "--nocapture",
+      "--test-threads=1"
+    ],
+    "sampled_unique_inode_allocated_peak_bytes": 10899456,
+    "sampled_path_logical_peak_bytes": 9268404,
+    "sampled_file_count_peak": 680,
+    "samples": 3020,
+    "requested_poll_interval_seconds": 0.005,
+    "maximum_observed_sample_interval_seconds": 0.020123091991990805,
+    "vanished_files_during_scan": 29,
+    "exit_status": 0,
+    "limitations": [
+      "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+      "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+      "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+      "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+    ]
+  },
+  "deterministic_budgets": {
+    "target_fixture_stored_rows": [
+      128,
+      256,
+      512
+    ],
+    "target_selections": [
+      "one UUID",
+      "all UUIDs"
+    ],
+    "snapshot_charge_calls_ceiling": "3 * stored_rows + 2 * target_count (includes independent test-only audit)",
+    "target_decoder_peak_rows": 2,
+    "combined_values_presence_metrics": "exact equality with one existing snapshot/presence reader",
+    "published_parquet_logical_bytes": 1048576,
+    "published_parquet_allocated_bytes": 2097152,
+    "compaction_output_bytes": 1048576,
+    "reported_compaction_logical_state_bytes": 16384,
+    "reported_compaction_spill_bytes": 0,
+    "existing_per_route_decoder_admission_bytes": 67108864
+  },
+  "limitations": [
+    "Merged-main named-query reproduction fails immediate exact values. There is no valid whole named-lifecycle baseline timing comparison and no claimed improvement against that failure. A separate unchanged common wildcard fixture supplies a valid main control.",
+    "Target decoder counters exclude the existing composite topology scan, publication, other query work and retained target values; route authentication work remains proportional to selected fragments.",
+    "Identity container counts are not allocator or RSS byte estimates. Decoder row-state counters and compaction logical-state estimates exclude whole-process memory; per-route decoder admission does not include all transaction maps.",
+    "The targeted reader still authenticates selected fragments and validates all row values before selected target decode to enforce tombstone/UUID correctness.",
+    "Runtime, syscall and sampled filesystem evidence use separate serial runs of a frozen executable. Whole-fixture observations include setup, all mutations, authentication, queries, persistence and portable work.",
+    "Filesystem sampling includes overlapping retained/project/private/portable files, deduplicates allocated inodes, and may miss unlinked files, directory allocation and shorter-lived peaks. It is not an exact temporary-only admission limit.",
+    "No compression, dictionary, row-group, streaming or lifecycle default changes. Inspected permanent Parquet must use the shared Zstd policy.",
+    "Earlier a55ed14d named-reader measurements are superseded by incremental retained-byte accounting. A separately frozen same-fixture comparison measures that internal repair; it is not a before/after improvement claim against merged main.",
+    "Decoder peaks exclude target snapshots, presence sets, projected value clones and Arrow outputs. Whole-process RSS includes overlapping owners; it is observed, not a hard bound."
+  ]
+}

--- a/tests/contracts/property-overlay-v1.json
+++ b/tests/contracts/property-overlay-v1.json
@@ -29,6 +29,7 @@
       "enumerate_property_fragments", "read_authenticated_property_snapshots_for",
       "read_authenticated_property_presence_for_inventory",
       "read_authenticated_property_snapshots_for_inventory",
+      "read_authenticated_property_targets_for_inventory", "PropertyTargetSnapshots",
       "visit_authenticated_property_snapshots"
     ],
     "property_overlay_module": [
@@ -48,6 +49,7 @@
       "enumerate_property_fragments", "read_authenticated_property_snapshots_for",
       "read_authenticated_property_presence_for_inventory",
       "read_authenticated_property_snapshots_for_inventory",
+      "read_authenticated_property_targets_for_inventory", "PropertyTargetSnapshots", "PropertyTargetSnapshots::edge_batch",
       "visit_authenticated_property_snapshots"
     ],
     "authenticated_staging": [


### PR DESCRIPTION
Named relationship queries returned null properties for edges created by public exploratory construction: schema discovery and hydration selected the logical relation route, while construction publishes those values under `_exploratory`. Fixed and variable traversals now resolve both authenticated candidate owners, preserve nullable and concrete Arrow types, and refuse duplicate owners including tombstones.

The reader retains only requested UUID values and reads values plus ownership together. Review caught quadratic retained-value charging when this existing reader handled large query selections; incremental accounting preserves admission and adds a deterministic linear-work regression. Permanent encoding and lifecycle publication settings are unchanged.

Validation covers constructed and ordinary-created edges of the same relation, named fixed/variable queries, bound-edge constraints, nullable filters, SET/removal, compaction, retained snapshots, reopen, export/full verification/clean import and subsequent mutation/retry at 33/4,097 nodes. Storage tests cover tombstone ownership, exact single-read work, tagged/temporal representation and incompatible concrete types. The final frozen publishing suite passed all 41 tests; all 24 property-overlay and ten compaction tests passed. Workspace clippy, formatting, fast checks and gate registry validation pass. Resource evidence is recorded in the architecture assessment and its source-bound JSON.

Closes #1224.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791646491&installation_model_id=20486&pr_number=1237&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1237&signature=d48abee1cd340b03db68e2eb2e1f2d2d9cfd418dfe7deefe5f0ec215c648f8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->