### PR TITLE
fix(storage): enforce current publishing contract and prove lifecycle continuity

### DIFF
--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -4025,6 +4025,15 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         let graph = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
         graph.execute("CREATE (:Person {name: 'Ada'})").unwrap();
+        let created = graph
+            .execute("CREATE (n:Person) RETURN n.node_uuid")
+            .unwrap();
+        let ids = created.batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+            .unwrap();
+        let node_uuid = uuid::Uuid::from_slice(ids.value(0)).unwrap().to_string();
         drop(graph);
         graphforge_storage::publish_graph_delta(
             project.path(),
@@ -4034,13 +4043,15 @@ mod tests {
                 run_uuid: uuid::Uuid::new_v4(),
                 operations: vec![GraphDeltaOp {
                     operation_uuid: uuid::Uuid::new_v4(),
-                    kind: GraphDeltaOpKind::UpsertNode,
-                    payload: GraphDeltaPayload::UpsertNodeV2 {
-                        node_uuid: uuid::Uuid::new_v4().hyphenated().to_string(),
-                        node_id: 2,
-                        type_ids: vec![graphforge_value::EntityTypeId::decode(1).unwrap()],
-                        created_at_micros: 2,
-                        updated_at_micros: 2,
+                    kind: GraphDeltaOpKind::SetNodeProperty,
+                    payload: GraphDeltaPayload::SetNodeProperty {
+                        node_uuid,
+                        property_stem: "_untyped".into(),
+                        key: "rank".into(),
+                        value: graphforge_storage::encode_graph_delta_value(
+                            &graphforge_ir::IrLiteral::Int(7),
+                        )
+                        .unwrap(),
                     },
                 }],
                 limits: GraphDeltaJournalLimits::default(),
@@ -4065,6 +4076,27 @@ mod tests {
             .unwrap()
             .value(0);
         assert_eq!(total, 2);
+        let ranks = reopened
+            .execute("MATCH (n:Person) WHERE n.rank = 7 RETURN n.rank AS rank")
+            .unwrap();
+        assert_eq!(
+            ranks
+                .batches
+                .iter()
+                .map(arrow::record_batch::RecordBatch::num_rows)
+                .sum::<usize>(),
+            1
+        );
+        assert_eq!(
+            ranks.batches[0]
+                .column_by_name("rank")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0),
+            7
+        );
         assert!(!reopened.dir.join("deltas").exists());
         assert!(reopened.graph_open_evidence().files_reused > 0);
         assert!(reopened.graph_open_evidence().files_copied > 0);

--- a/crates/graphforge-api/src/maintenance.rs
+++ b/crates/graphforge-api/src/maintenance.rs
@@ -331,38 +331,31 @@ mod tests {
         let directory = TempDir::new().unwrap();
         let graph = GraphForge::new(directory.path().to_str()).unwrap();
         graph.execute("CREATE (:Base)").unwrap();
+        let created = graph.execute("CREATE (n) RETURN n.node_uuid").unwrap();
+        let ids = created.batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+            .unwrap();
+        let replayed_node = Uuid::from_slice(ids.value(0)).unwrap().to_string();
         drop(graph);
 
-        let replayed_node = Uuid::now_v7().hyphenated().to_string();
         graphforge_storage::publish_graph_delta(
             directory.path(),
             &GraphDeltaPublishRequest {
                 transaction_uuid: Uuid::now_v7(),
                 generation_uuid: Uuid::now_v7(),
                 run_uuid: Uuid::now_v7(),
-                operations: vec![
-                    GraphDeltaOp {
-                        operation_uuid: Uuid::now_v7(),
-                        kind: GraphDeltaOpKind::UpsertNode,
-                        payload: GraphDeltaPayload::UpsertNodeV2 {
-                            node_uuid: replayed_node.clone(),
-                            node_id: 2,
-                            type_ids: Vec::new(),
-                            created_at_micros: 1_700_000_000_000_001,
-                            updated_at_micros: 1_700_000_000_000_001,
-                        },
+                operations: vec![GraphDeltaOp {
+                    operation_uuid: Uuid::now_v7(),
+                    kind: GraphDeltaOpKind::SetNodeProperty,
+                    payload: GraphDeltaPayload::SetNodeProperty {
+                        node_uuid: replayed_node,
+                        property_stem: "_untyped".into(),
+                        key: "rank".into(),
+                        value: encode_graph_delta_value(&IrLiteral::Int(7)).unwrap(),
                     },
-                    GraphDeltaOp {
-                        operation_uuid: Uuid::now_v7(),
-                        kind: GraphDeltaOpKind::SetNodeProperty,
-                        payload: GraphDeltaPayload::SetNodeProperty {
-                            node_uuid: replayed_node,
-                            property_stem: "_untyped".into(),
-                            key: "rank".into(),
-                            value: encode_graph_delta_value(&IrLiteral::Int(7)).unwrap(),
-                        },
-                    },
-                ],
+                }],
                 limits: GraphDeltaJournalLimits::default(),
             },
         )

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -5122,3 +5122,350 @@ fn ontology_promotion_bounds_changed_control_inventory() {
         );
     }
 }
+
+fn publishing_contract_verify(graph: &GraphForge, nodes: &[Node], edges: &[Edge]) -> String {
+    for (query, expected) in [
+        ("MATCH (n) RETURN count(n)", nodes.len()),
+        ("MATCH ()-[r]->() RETURN count(r)", edges.len()),
+    ] {
+        let result = graph.execute(query).unwrap();
+        assert_eq!(int_at(&result.batches[0], 0, 0), Some(expected as i64));
+    }
+    for route in 0..2 {
+        let label = format!("Node{route}");
+        let relation = format!("REL{route}");
+        verify_promoted_route(
+            graph,
+            &nodes
+                .iter()
+                .filter(|n| n.1 == label)
+                .cloned()
+                .collect::<Vec<_>>(),
+            &edges
+                .iter()
+                .filter(|e| e.3 == relation)
+                .cloned()
+                .collect::<Vec<_>>(),
+            &label,
+            &relation,
+        );
+    }
+    digest_hex(&serde_json::to_vec(&(nodes, edges)).unwrap())
+}
+
+#[test]
+fn publishing_contract_alternates_supported_paths_and_refuses_topology_journals() {
+    exercise_publishing_contract(33, false);
+}
+#[test]
+fn publishing_contract_flat_ontology() {
+    exercise_publishing_contract(33, true);
+}
+#[test]
+fn publishing_contract_sharded_exploratory() {
+    exercise_publishing_contract(4097, false);
+}
+#[test]
+fn publishing_contract_sharded_ontology() {
+    exercise_publishing_contract(4097, true);
+}
+
+fn exercise_publishing_contract(count: usize, typed: bool) {
+    use graphforge_api::{
+        COMPOSITE_TRANSACTION_CONTRACT_VERSION, CompositeGraphMutation as Mutation,
+        CompositeKnowledgeParticipants, CompositeTransactionRequest, PropValue, WriteContext,
+    };
+    use graphforge_storage::{
+        GraphDeltaCompactionLimits, GraphDeltaCompactionRequest, GraphDeltaOp, GraphDeltaOpKind,
+        GraphDeltaPayload, GraphDeltaPublishRequest, ProjectRetentionLimits,
+        ProjectRetentionPolicy,
+    };
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "publishing_contract",
+        nodes: count,
+        edges: 129,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (mut nodes, mut edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let initial = graphforge_storage::resolve_project_generation(&source).unwrap();
+    let inventory = initial.graph_files_inventory().unwrap().unwrap();
+    let node_shards = inventory
+        .files
+        .iter()
+        .filter(|entry| entry.relative_path.starts_with("topology/nodes/"))
+        .count();
+    if count > 4096 {
+        assert!(
+            node_shards > 1,
+            "large fixture must use sharded node authority"
+        );
+    }
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    if typed {
+        graph
+            .adopt_ontology(promotion_request(root.path()))
+            .unwrap();
+    }
+    publishing_contract_verify(&graph, &nodes, &edges);
+    let initial_ids = cas_uuid_node_surrogates(&source);
+    let initial_edge_ids = publishing_edge_surrogates(&source);
+    let before = clear_publication_files(&source);
+    for payload in [
+        GraphDeltaPayload::UpsertNodeV2 {
+            node_uuid: nodes[0].0.to_string(),
+            node_id: initial_ids[&nodes[0].0],
+            type_ids: vec![],
+            created_at_micros: 1,
+            updated_at_micros: 2,
+        },
+        GraphDeltaPayload::UpsertEdgeV2 {
+            edge_uuid: edges[0].0.to_string(),
+            src_uuid: nodes[0].0.to_string(),
+            dst_uuid: Uuid::now_v7().to_string(),
+            rel_type: "REL1".into(),
+            edge_id: 1,
+            src_id: initial_ids[&nodes[0].0],
+            dst_id: u64::MAX,
+            created_at_micros: 1,
+        },
+        GraphDeltaPayload::DeleteNode {
+            node_uuid: nodes[0].0.to_string(),
+        },
+        GraphDeltaPayload::DeleteEdge {
+            edge_uuid: edges[0].0.to_string(),
+        },
+    ] {
+        let kind = match payload {
+            GraphDeltaPayload::UpsertNodeV2 { .. } => GraphDeltaOpKind::UpsertNode,
+            GraphDeltaPayload::UpsertEdgeV2 { .. } => GraphDeltaOpKind::UpsertEdge,
+            GraphDeltaPayload::DeleteNode { .. } => GraphDeltaOpKind::DeleteNode,
+            _ => GraphDeltaOpKind::DeleteEdge,
+        };
+        let error = graphforge_storage::publish_graph_delta(
+            &source,
+            &GraphDeltaPublishRequest {
+                transaction_uuid: Uuid::now_v7(),
+                generation_uuid: Uuid::now_v7(),
+                run_uuid: Uuid::now_v7(),
+                operations: vec![GraphDeltaOp {
+                    operation_uuid: Uuid::now_v7(),
+                    kind,
+                    payload,
+                }],
+                limits: Default::default(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_PROJECT_FORMAT");
+        assert_eq!(clear_publication_files(&source), before);
+    }
+    graph
+        .publish_composite_transaction(CompositeTransactionRequest {
+            contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+            context: WriteContext {
+                operation_uuid: OperationId(Uuid::now_v7()),
+                actor_uuid: None,
+            },
+            graph_mutations: vec![
+                Mutation::SetNodeProperty {
+                    node_uuid: nodes[0].0,
+                    property: "score".into(),
+                    value: PropValue::Int(1221),
+                },
+                Mutation::RemoveNodeProperty {
+                    node_uuid: nodes[1].0,
+                    property: "score".into(),
+                },
+                Mutation::SetEdgeProperty {
+                    edge_uuid: edges[0].0,
+                    property: "weight".into(),
+                    value: PropValue::Int(1221),
+                },
+                Mutation::RemoveEdgeProperty {
+                    edge_uuid: edges[1].0,
+                    property: "text".into(),
+                },
+            ],
+            knowledge: CompositeKnowledgeParticipants::default(),
+        })
+        .unwrap();
+    assert!(
+        graphforge_storage::resolve_project_generation(&source)
+            .unwrap()
+            .graph_files_inventory()
+            .unwrap()
+            .unwrap()
+            .files
+            .iter()
+            .any(|entry| entry.relative_path.starts_with("deltas/")),
+        "fixture must exercise actual GFDR"
+    );
+    nodes[0].2 = Some(1221);
+    nodes[1].2 = None;
+    edges[0].4 = Some(1221);
+    edges[1].5 = None;
+    publishing_contract_verify(&graph, &nodes, &edges);
+    let report = graph
+        .compact_graph_delta(
+            &GraphDeltaCompactionRequest {
+                transaction_uuid: Uuid::now_v7(),
+                generation_uuid: Uuid::now_v7(),
+                through_run_sequence: None,
+                limits: GraphDeltaCompactionLimits::default(),
+                cleanup_after_commit: false,
+                cleanup_policy: ProjectRetentionPolicy::default(),
+                cleanup_limits: ProjectRetentionLimits::default(),
+            },
+            None,
+        )
+        .unwrap();
+    assert!(report.output_bytes <= 2 * 1024 * 1024);
+    assert!(
+        report.peak_memory_bytes <= 8 * 1024,
+        "logical replay accounting: {report:?}"
+    );
+    publishing_contract_verify(&graph, &nodes, &edges);
+    let created = graph
+        .execute("CREATE (n:Node0 {score: 91221}) RETURN n.node_uuid")
+        .unwrap();
+    let retired_uuid = uuid_at(&created.batches[0], 0, 0);
+    let retired_id = cas_uuid_node_surrogates(&source)[&retired_uuid];
+    graph
+        .execute("MATCH (n:Node0 {score: 91221}) DELETE n")
+        .unwrap();
+    drop(graph);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let created = graph
+        .execute("CREATE (n:Node0 {score: 92221}) RETURN n.node_uuid")
+        .unwrap();
+    let created_uuid = uuid_at(&created.batches[0], 0, 0);
+    nodes.push((created_uuid, "Node0".into(), Some(92221)));
+    let ids = cas_uuid_node_surrogates(&source);
+    assert!(retired_id > *initial_ids.values().max().unwrap());
+    assert!(ids[&created_uuid] > retired_id);
+    for (uuid, id) in &initial_ids {
+        assert_eq!(ids[uuid], *id);
+    }
+    let edge_query = "MATCH (a:Node0 {score: 1221}), (b:Node0 {score: 92221}) CREATE (a)-[e:REL0 {weight: 1221001}]->(b) RETURN e.edge_uuid";
+    let result = graph.execute(edge_query).unwrap();
+    assert_eq!(result.stats.rows_produced, 1);
+    let retired_edge = uuid_at(&result.batches[0], 0, 0);
+    let retired_edge_id = publishing_edge_surrogates(&source)[&retired_edge];
+    graph
+        .execute("MATCH ()-[e:REL0 {weight: 1221001}]->() DELETE e")
+        .unwrap();
+    drop(graph);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let result = graph
+        .execute(&edge_query.replace("1221001", "1221002"))
+        .unwrap();
+    let added_edge = uuid_at(&result.batches[0], 0, 0);
+    edges.push((
+        added_edge,
+        nodes[0].0,
+        created_uuid,
+        "REL0".into(),
+        Some(1221002),
+        None,
+    ));
+    let edge_ids = publishing_edge_surrogates(&source);
+    assert!(retired_edge_id > *initial_edge_ids.values().max().unwrap());
+    assert!(edge_ids[&added_edge] > retired_edge_id);
+    for (uuid, id) in &initial_edge_ids {
+        assert_eq!(edge_ids[uuid], *id);
+    }
+    publishing_contract_verify(&graph, &nodes, &edges);
+    drop(graph);
+    round_trip_checked(root.path(), &source, |graph| {
+        publishing_contract_verify(graph, &nodes, &edges)
+    });
+    let imported_path = root.path().join("imported");
+    let imported = GraphForge::new(imported_path.to_str()).unwrap();
+    let imported_before = cas_uuid_node_surrogates(&imported_path);
+    assert_eq!(imported_before, ids);
+    let created = imported
+        .execute("CREATE (n:Node0 {score: 93221}) RETURN n.node_uuid")
+        .unwrap();
+    let created_uuid = uuid_at(&created.batches[0], 0, 0);
+    nodes.push((created_uuid, "Node0".into(), Some(93221)));
+    assert!(cas_uuid_node_surrogates(&imported_path)[&created_uuid] > *ids.values().max().unwrap());
+    assert_eq!(publishing_edge_surrogates(&imported_path), edge_ids);
+    let result = imported.execute("MATCH (a:Node0 {score: 1221}), (b:Node0 {score: 93221}) CREATE (a)-[e:REL0 {weight: 1221003}]->(b) RETURN e.edge_uuid").unwrap();
+    let added_edge = uuid_at(&result.batches[0], 0, 0);
+    edges.push((
+        added_edge,
+        nodes[0].0,
+        created_uuid,
+        "REL0".into(),
+        Some(1221003),
+        None,
+    ));
+    assert!(
+        publishing_edge_surrogates(&imported_path)[&added_edge] > *edge_ids.values().max().unwrap()
+    );
+    publishing_contract_verify(&imported, &nodes, &edges);
+    drop(imported);
+    publishing_contract_verify(
+        &GraphForge::new(imported_path.to_str()).unwrap(),
+        &nodes,
+        &edges,
+    );
+    println!(
+        "PUBLISHING_CONTRACT {}",
+        json!({"nodes":count,"typed":typed,"routes":2,"compaction_output_bytes":report.output_bytes,"logical_replay_peak_bytes":report.peak_memory_bytes})
+    );
+}
+
+fn publishing_edge_surrogates(source: &Path) -> BTreeMap<Uuid, u64> {
+    use arrow::array::UInt64Array;
+    let selected = graphforge_storage::resolve_project_generation(source).unwrap();
+    let inventory = selected.graph_files_inventory().unwrap().unwrap();
+    let owned = selected.declared_graph_files_inventory().unwrap().is_some();
+    let mut ids = BTreeMap::new();
+    for entry in inventory.files.iter().filter(|entry| {
+        entry.relative_path.starts_with("topology/edges/")
+            && entry.relative_path.ends_with(".parquet")
+    }) {
+        let path = if owned {
+            selected.graph_tree_root().join(&entry.relative_path)
+        } else {
+            graphforge_storage::graph_object_path(source, &entry.content_sha256).unwrap()
+        };
+        for batch in ParquetRecordBatchReaderBuilder::try_new(File::open(path).unwrap())
+            .unwrap()
+            .build()
+            .unwrap()
+        {
+            let batch = batch.unwrap();
+            let uuids = batch
+                .column_by_name("edge_uuid")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
+            let values = batch
+                .column_by_name("edge_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .unwrap();
+            for row in 0..batch.num_rows() {
+                assert!(
+                    ids.insert(
+                        Uuid::from_slice(uuids.value(row)).unwrap(),
+                        values.value(row)
+                    )
+                    .is_none()
+                );
+            }
+        }
+    }
+    ids
+}

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -5214,7 +5214,7 @@ fn exercise_publishing_contract(count: usize, typed: bool) {
             edge.1 = uuid7(edge.1);
             edge.2 = uuid7(edge.2);
         }
-        let mut graph = GraphForge::new(source.to_str()).unwrap();
+        let graph = GraphForge::new(source.to_str()).unwrap();
         let graph_mutations = nodes
             .iter()
             .map(|(uuid, label, score)| Mutation::CreateNode {

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -187,7 +187,7 @@ fn int_at(batch: &RecordBatch, column: usize, row: usize) -> Option<i64> {
             .column(column)
             .as_any()
             .downcast_ref::<Int64Array>()
-            .unwrap()
+            .unwrap_or_else(|| panic!("expected Int64 at column {column}: {:?}", batch.schema()))
             .value(row)
     })
 }
@@ -5193,7 +5193,77 @@ fn exercise_publishing_contract(count: usize, typed: bool) {
         heterogeneous: false,
     };
     let (mut nodes, mut edges) = rows(fixture);
-    construct(&source, fixture, &nodes, &edges);
+    if count > 4096 {
+        construct(&source, fixture, &nodes, &edges);
+    } else {
+        // Empty-project composite CREATE publishes flat topology; construction
+        // sessions publish shards even when the input fits in a single shard.
+        // Composite CREATE requires UUIDv7. Preserve deterministic fixture bytes
+        // apart from the version/variant bits, including every endpoint.
+        let uuid7 = |uuid: Uuid| {
+            let mut bytes = *uuid.as_bytes();
+            bytes[6] = (bytes[6] & 0x0f) | 0x70;
+            bytes[8] = (bytes[8] & 0x3f) | 0x80;
+            Uuid::from_bytes(bytes)
+        };
+        for node in &mut nodes {
+            node.0 = uuid7(node.0);
+        }
+        for edge in &mut edges {
+            edge.0 = uuid7(edge.0);
+            edge.1 = uuid7(edge.1);
+            edge.2 = uuid7(edge.2);
+        }
+        let mut graph = GraphForge::new(source.to_str()).unwrap();
+        let graph_mutations = nodes
+            .iter()
+            .map(|(uuid, label, score)| Mutation::CreateNode {
+                node_uuid: *uuid,
+                label: label.clone(),
+                properties: score
+                    .map(|value| ("score".into(), PropValue::Int(value)))
+                    .into_iter()
+                    .collect(),
+            })
+            .chain(
+                edges
+                    .iter()
+                    .map(
+                        |(uuid, source, target, route, weight, text)| Mutation::CreateEdge {
+                            edge_uuid: *uuid,
+                            source_uuid: *source,
+                            target_uuid: *target,
+                            rel_type: route.clone(),
+                            properties: weight
+                                .map(|value| ("weight".into(), PropValue::Int(value)))
+                                .into_iter()
+                                .chain(
+                                    text.clone()
+                                        .map(|value| ("text".into(), PropValue::Str(value))),
+                                )
+                                .collect(),
+                        },
+                    ),
+            )
+            .collect();
+        graph
+            .publish_composite_transaction(CompositeTransactionRequest {
+                contract_version: COMPOSITE_TRANSACTION_CONTRACT_VERSION,
+                context: WriteContext {
+                    operation_uuid: OperationId(Uuid::now_v7()),
+                    actor_uuid: None,
+                },
+                graph_mutations,
+                knowledge: CompositeKnowledgeParticipants::default(),
+            })
+            .unwrap();
+    }
+    let mut graph = GraphForge::new(source.to_str()).unwrap();
+    if typed {
+        graph
+            .adopt_ontology(promotion_request(root.path()))
+            .unwrap();
+    }
     let initial = graphforge_storage::resolve_project_generation(&source).unwrap();
     let inventory = initial.graph_files_inventory().unwrap().unwrap();
     let node_shards = inventory
@@ -5206,12 +5276,14 @@ fn exercise_publishing_contract(count: usize, typed: bool) {
             node_shards > 1,
             "large fixture must use sharded node authority"
         );
-    }
-    let mut graph = GraphForge::new(source.to_str()).unwrap();
-    if typed {
-        graph
-            .adopt_ontology(promotion_request(root.path()))
-            .unwrap();
+    } else {
+        assert_eq!(node_shards, 0, "small fixture must use flat node authority");
+        assert!(
+            inventory
+                .files
+                .iter()
+                .any(|entry| entry.relative_path == "topology/nodes.parquet")
+        );
     }
     publishing_contract_verify(&graph, &nodes, &edges);
     let initial_ids = cas_uuid_node_surrogates(&source);

--- a/crates/graphforge-cli/src/maintenance_cli/tests.rs
+++ b/crates/graphforge-cli/src/maintenance_cli/tests.rs
@@ -437,8 +437,14 @@ fn compaction_cli_preserves_typed_delta_graph_and_reports_work() {
     let root = tempfile::tempdir().unwrap();
     let graph = GraphForge::new(root.path().to_str()).unwrap();
     graph.execute("CREATE (:Base)").unwrap();
+    let created = graph.execute("CREATE (n) RETURN n.node_uuid").unwrap();
+    let ids = created.batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+        .unwrap();
+    let node = Uuid::from_slice(ids.value(0)).unwrap();
     drop(graph);
-    let node = Uuid::now_v7();
     graphforge_storage::publish_graph_delta(
         root.path(),
         &GraphDeltaPublishRequest {
@@ -446,29 +452,16 @@ fn compaction_cli_preserves_typed_delta_graph_and_reports_work() {
             generation_uuid: Uuid::now_v7(),
             run_uuid: Uuid::now_v7(),
             limits: GraphDeltaJournalLimits::default(),
-            operations: vec![
-                GraphDeltaOp {
-                    operation_uuid: Uuid::now_v7(),
-                    kind: GraphDeltaOpKind::UpsertNode,
-                    payload: GraphDeltaPayload::UpsertNodeV2 {
-                        node_uuid: node.to_string(),
-                        node_id: 2,
-                        type_ids: vec![],
-                        created_at_micros: 1_700_000_000_000_001,
-                        updated_at_micros: 1_700_000_000_000_001,
-                    },
+            operations: vec![GraphDeltaOp {
+                operation_uuid: Uuid::now_v7(),
+                kind: GraphDeltaOpKind::SetNodeProperty,
+                payload: GraphDeltaPayload::SetNodeProperty {
+                    node_uuid: node.to_string(),
+                    property_stem: "_untyped".into(),
+                    key: "rank".into(),
+                    value: encode_graph_delta_value(&IrLiteral::Int(7)).unwrap(),
                 },
-                GraphDeltaOp {
-                    operation_uuid: Uuid::now_v7(),
-                    kind: GraphDeltaOpKind::SetNodeProperty,
-                    payload: GraphDeltaPayload::SetNodeProperty {
-                        node_uuid: node.to_string(),
-                        property_stem: "_untyped".into(),
-                        key: "rank".into(),
-                        value: encode_graph_delta_value(&IrLiteral::Int(7)).unwrap(),
-                    },
-                },
-            ],
+            }],
         },
     )
     .unwrap();

--- a/crates/graphforge-storage/benches/m6_storage.rs
+++ b/crates/graphforge-storage/benches/m6_storage.rs
@@ -16,13 +16,15 @@ fn fixture(count: usize) -> Vec<GraphDeltaOp> {
     (0..count)
         .map(|index| GraphDeltaOp {
             operation_uuid: Uuid::from_u128(0x1000 + index as u128),
-            kind: GraphDeltaOpKind::UpsertNode,
-            payload: GraphDeltaPayload::UpsertNodeV2 {
+            kind: GraphDeltaOpKind::SetNodeProperty,
+            payload: GraphDeltaPayload::SetNodeProperty {
                 node_uuid: Uuid::from_u128(0x2000 + index as u128).to_string(),
-                node_id: index as u64 + 1,
-                type_ids: vec![graphforge_value::EntityTypeId::decode(1).unwrap()],
-                created_at_micros: index as i64,
-                updated_at_micros: index as i64,
+                property_stem: "1".into(),
+                key: "rank".into(),
+                value: graphforge_storage::encode_graph_delta_value(
+                    &graphforge_ir::IrLiteral::Int(index as i64),
+                )
+                .unwrap(),
             },
         })
         .collect()
@@ -69,11 +71,11 @@ fn replay_merge_fingerprint(bencher: Bencher, operations: usize) {
     let mut second = fixture(operations);
     for (index, operation) in second.iter_mut().enumerate() {
         operation.operation_uuid = Uuid::from_u128(0x1_0000 + index as u128);
-        if let GraphDeltaPayload::UpsertNodeV2 {
-            updated_at_micros, ..
-        } = &mut operation.payload
-        {
-            *updated_at_micros += 1;
+        if let GraphDeltaPayload::SetNodeProperty { value, .. } = &mut operation.payload {
+            *value = graphforge_storage::encode_graph_delta_value(&graphforge_ir::IrLiteral::Int(
+                index as i64 + 1,
+            ))
+            .unwrap();
         }
     }
     let encoded_first = encode_delta_run(
@@ -92,13 +94,22 @@ fn replay_merge_fingerprint(bencher: Bencher, operations: usize) {
         GraphDeltaJournalLimits::default(),
     )
     .unwrap();
+    let mut base = ReconstructedGraphState::default();
+    for index in 0..operations {
+        let node = Uuid::from_u128(0x2000 + index as u128).to_string();
+        base.nodes.insert(
+            node.clone(),
+            vec![graphforge_value::EntityTypeId::decode(1).unwrap()],
+        );
+        base.node_ids.insert(node, index as u64 + 1);
+    }
     bencher.bench(|| {
         let limits = GraphDeltaJournalLimits::default();
         let runs = [
             decode_delta_run(&encoded_first, Some(1), limits).unwrap(),
             decode_delta_run(&encoded_second, Some(2), limits).unwrap(),
         ];
-        let mut state = ReconstructedGraphState::default();
+        let mut state = base.clone();
         let evidence = apply_delta_runs(&mut state, &runs, limits).unwrap();
         divan::black_box(evidence.state_fingerprint)
     });
@@ -111,7 +122,7 @@ fn transaction_classification(bencher: Bencher, count: usize) {
         divan::black_box(
             operations
                 .iter()
-                .filter(|op| matches!(op.kind, GraphDeltaOpKind::UpsertNode))
+                .filter(|op| matches!(op.kind, GraphDeltaOpKind::SetNodeProperty))
                 .count(),
         )
     });

--- a/crates/graphforge-storage/benches/m6_storage_io.rs
+++ b/crates/graphforge-storage/benches/m6_storage_io.rs
@@ -81,13 +81,15 @@ fn publish_delta(root: &std::path::Path) {
             run_uuid: Uuid::now_v7(),
             operations: vec![GraphDeltaOp {
                 operation_uuid: Uuid::now_v7(),
-                kind: GraphDeltaOpKind::UpsertNode,
-                payload: GraphDeltaPayload::UpsertNodeV2 {
-                    node_uuid: Uuid::from_u128(2).to_string(),
-                    node_id: 2,
-                    type_ids: vec![graphforge_value::EntityTypeId::decode(1).unwrap()],
-                    created_at_micros: 2,
-                    updated_at_micros: 2,
+                kind: GraphDeltaOpKind::SetNodeProperty,
+                payload: GraphDeltaPayload::SetNodeProperty {
+                    node_uuid: Uuid::from_u128(1).to_string(),
+                    property_stem: "1".into(),
+                    key: "rank".into(),
+                    value: graphforge_storage::encode_graph_delta_value(
+                        &graphforge_ir::IrLiteral::Int(7),
+                    )
+                    .unwrap(),
                 },
             }],
             limits: GraphDeltaJournalLimits::default(),

--- a/crates/graphforge-storage/src/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/src/graph_delta_compaction.rs
@@ -896,6 +896,12 @@ mod crash_oracle_tests {
             1_700_000_000_000_000,
         )
         .unwrap();
+        writer
+            .create_node(
+                Uuid::from_u128(1221),
+                graphforge_value::EntityTypeId::decode(1).unwrap(),
+            )
+            .unwrap();
         writer.flush().unwrap();
         let (_, files) = capture_graph_files(workspace.path()).unwrap();
         let mut participants = empty_workspace_participants().unwrap();
@@ -953,13 +959,13 @@ mod crash_oracle_tests {
                 run_uuid: Uuid::now_v7(),
                 operations: vec![GraphDeltaOp {
                     operation_uuid: Uuid::now_v7(),
-                    kind: crate::GraphDeltaOpKind::UpsertNode,
-                    payload: crate::GraphDeltaPayload::UpsertNodeV2 {
-                        node_uuid: Uuid::now_v7().hyphenated().to_string(),
-                        node_id: 1,
-                        type_ids: vec![graphforge_value::EntityTypeId::decode(1).unwrap()],
-                        created_at_micros: 1,
-                        updated_at_micros: 1,
+                    kind: crate::GraphDeltaOpKind::SetNodeProperty,
+                    payload: crate::GraphDeltaPayload::SetNodeProperty {
+                        node_uuid: Uuid::from_u128(1221).to_string(),
+                        property_stem: "_untyped".into(),
+                        key: "score".into(),
+                        value: crate::encode_graph_delta_value(&graphforge_ir::IrLiteral::Int(1))
+                            .unwrap(),
                     },
                 }],
                 limits: GraphDeltaJournalLimits::default(),

--- a/crates/graphforge-storage/src/graph_delta_journal.rs
+++ b/crates/graphforge-storage/src/graph_delta_journal.rs
@@ -96,7 +96,8 @@ impl Default for GraphDeltaJournalLimits {
     }
 }
 
-/// Supported authoritative mutation kinds for current graph surfaces.
+/// Framed mutation discriminants. Only property mutations are admitted by GFDR.
+/// Topology discriminants are recognized solely to reject unsupported records.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[repr(u8)]
@@ -291,12 +292,26 @@ impl GraphDeltaPayload {
         Ok(payload)
     }
 
-    fn validate_typed_values(&self) -> Result<(), GfError> {
+    fn validate_journal_support(&self) -> Result<(), GfError> {
         match self {
-            Self::UpsertNode { .. } | Self::UpsertEdge { .. } => Err(GfError::Project {
+            Self::UpsertNode { .. }
+            | Self::UpsertNodeV2 { .. }
+            | Self::DeleteNode { .. }
+            | Self::UpsertEdge { .. }
+            | Self::UpsertEdgeV2 { .. }
+            | Self::DeleteEdge { .. } => Err(GfError::Project {
                 code: ProjectErrorCode::UnsupportedProjectFormat,
-                message: "unsupported lossless-metadata-free GFDR topology payload".into(),
+                message:
+                    "GFDR supports property mutations only; topology requires canonical publication"
+                        .into(),
             }),
+            _ => Ok(()),
+        }
+    }
+
+    fn validate_typed_values(&self) -> Result<(), GfError> {
+        self.validate_journal_support()?;
+        match self {
             Self::SetNodeProperty {
                 property_stem,
                 value,
@@ -989,6 +1004,7 @@ pub fn apply_delta_runs(
     runs: &[GraphDeltaRun],
     limits: GraphDeltaJournalLimits,
 ) -> Result<GraphDeltaReplayEvidence, GfError> {
+    validate_replay_payloads(runs)?;
     let mut evidence = GraphDeltaReplayEvidence::default();
     for run in runs {
         evidence.runs_replayed = evidence.runs_replayed.saturating_add(1);
@@ -1010,11 +1026,26 @@ pub fn apply_delta_runs(
     Ok(evidence)
 }
 
+// Runs can be supplied directly without decoding. Inspect the complete input
+// before touching caller state, including records whose operation UUID is known.
+fn validate_replay_payloads(runs: &[GraphDeltaRun]) -> Result<(), GfError> {
+    for record in runs.iter().flat_map(|run| &run.records) {
+        record.payload.validate_journal_support()?;
+        if record.payload.expected_kind() != record.kind {
+            return Err(validation(
+                "graph delta operation kind does not match payload",
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_lines)] // Exhaustive payload handling is one fail-closed state machine.
 fn build_replay_overlay(
     runs: &[GraphDeltaRun],
     limits: GraphDeltaJournalLimits,
 ) -> Result<(ReplayOverlay, GraphDeltaReplayEvidence), GfError> {
+    validate_replay_payloads(runs)?;
     let mut overlay = ReplayOverlay::default();
     let mut evidence = GraphDeltaReplayEvidence::default();
     let mut operations = BTreeMap::<Uuid, GraphDeltaPayload>::new();
@@ -1462,6 +1493,7 @@ fn prepare_graph_delta_inner(
     catalog: Option<&graphforge_ir::RuntimeCatalog>,
 ) -> Result<PreparedGraphDelta, GfError> {
     for op in &request.operations {
+        op.payload.validate_journal_support()?;
         if op.payload.expected_kind() != op.kind {
             return Err(validation(
                 "graph delta operation kind does not match payload",
@@ -1620,6 +1652,7 @@ fn publish_graph_delta_after_prepare(
     let admitted_root = admission.root().to_owned();
     let container_root = admitted_root.as_path();
     for op in &request.operations {
+        op.payload.validate_journal_support()?;
         if op.payload.expected_kind() != op.kind {
             return Err(validation(
                 "graph delta operation kind does not match payload",
@@ -2206,7 +2239,7 @@ mod crash_oracle_tests {
     fn publish_graph_base(root: &Path) {
         crate::open_or_initialize_project(root).unwrap();
         let workspace = tempfile::tempdir().unwrap();
-        let node_uuid = Uuid::now_v7().hyphenated().to_string();
+        let node_uuid = Uuid::from_u128(1221).hyphenated().to_string();
         let mut state = ReconstructedGraphState::default();
         state
             .nodes
@@ -2256,13 +2289,12 @@ mod crash_oracle_tests {
             run_uuid: Uuid::now_v7(),
             operations: vec![GraphDeltaOp {
                 operation_uuid: Uuid::now_v7(),
-                kind: GraphDeltaOpKind::UpsertNode,
-                payload: GraphDeltaPayload::UpsertNodeV2 {
-                    node_uuid: Uuid::now_v7().hyphenated().to_string(),
-                    node_id: 1,
-                    type_ids: vec![EntityTypeId::decode(1).unwrap()],
-                    created_at_micros: 1,
-                    updated_at_micros: 1,
+                kind: GraphDeltaOpKind::SetNodeProperty,
+                payload: GraphDeltaPayload::SetNodeProperty {
+                    node_uuid: Uuid::from_u128(1221).to_string(),
+                    property_stem: "_untyped".into(),
+                    key: "score".into(),
+                    value: encode_graph_delta_value(&IrLiteral::Int(1)).unwrap(),
                 },
             }],
             limits: GraphDeltaJournalLimits::default(),
@@ -2330,12 +2362,7 @@ mod crash_oracle_tests {
     fn prepared_delta_fails_busy_behind_a_live_current_writer() {
         let root = tempfile::tempdir().unwrap();
         publish_graph_base(root.path());
-        let mut prepared = one_node_request();
-        let GraphDeltaPayload::UpsertNodeV2 { node_id, .. } = &mut prepared.operations[0].payload
-        else {
-            unreachable!();
-        };
-        *node_id = 2;
+        let prepared = one_node_request();
         let (concurrent_generation, concurrent) = stage_graph_clone(root.path());
 
         let error = publish_graph_delta_after_prepare(
@@ -2386,7 +2413,8 @@ mod checked_identity_tests {
     fn v2_memberships_preserve_integer_bytes_and_reject_other_domains() {
         let wire = br#"{"kind":"upsert_node_v2","node_uuid":"node","node_id":1,"type_ids":[0,1073741823,1073741824,2147483647],"created_at_micros":1,"updated_at_micros":2}"#;
         assert_eq!(
-            GraphDeltaPayload::decode(wire).unwrap().encode().unwrap(),
+            serde_json::to_vec(&serde_json::from_slice::<GraphDeltaPayload>(wire).unwrap())
+                .unwrap(),
             wire
         );
         for invalid in [2147483648_u32, 3221225472, u32::MAX] {
@@ -2398,17 +2426,16 @@ mod checked_identity_tests {
     }
 
     #[test]
-    fn initial_absent_primary_survives_label_replay_and_canonical_compaction() {
+    fn absent_primary_round_trip_and_topology_replay_refusal_preserve_state() {
         let uuid = Uuid::now_v7().to_string();
-        let initial = node_record(&uuid, vec![]);
-        let update = node_record(&uuid, vec![EntityTypeId::decode(1073741825).unwrap()]);
+        let labels = vec![EntityTypeId::decode(1073741825).unwrap()];
         let mut state = ReconstructedGraphState::default();
-        apply_one(&mut state, &initial).unwrap();
-        apply_one(&mut state, &update).unwrap();
-        assert_eq!(
-            state.node_primary_types[&uuid],
-            PrimaryEntityTypeId::absent()
-        );
+        state.nodes.insert(uuid.clone(), labels);
+        state
+            .node_primary_types
+            .insert(uuid.clone(), PrimaryEntityTypeId::absent());
+        state.node_ids.insert(uuid.clone(), u64::from(u32::MAX) + 1);
+        state.node_timestamps.insert(uuid.clone(), (1, 2));
         let base = tempfile::tempdir().unwrap();
         crate::writer::write_reconstructed_graph(base.path(), &state).unwrap();
         let reopened = load_base_state(base.path()).unwrap();
@@ -2416,49 +2443,39 @@ mod checked_identity_tests {
             reopened.node_primary_types[&uuid],
             PrimaryEntityTypeId::absent()
         );
-        assert_eq!(reopened.nodes[&uuid], state.nodes[&uuid]);
+        assert_eq!(reopened.nodes, state.nodes);
+        assert_eq!(reopened.node_ids, state.node_ids);
 
+        let topology = node_record(&uuid, vec![]);
+        // Even a matching previously applied UUID cannot bypass admission.
+        state.applied_operations.insert(
+            topology.operation_uuid.to_string(),
+            topology.payload.clone(),
+        );
+        let before = state.clone();
+        let property = GraphDeltaRecord {
+            kind: GraphDeltaOpKind::SetNodeProperty,
+            payload: GraphDeltaPayload::SetNodeProperty {
+                node_uuid: uuid,
+                property_stem: "_untyped".into(),
+                key: "score".into(),
+                value: encode_graph_delta_value(&IrLiteral::Int(7)).unwrap(),
+            },
+            ..node_record("unused", vec![])
+        };
         let run = GraphDeltaRun {
             run_sequence: 1,
             run_uuid: Uuid::now_v7(),
             transaction_uuid: Uuid::now_v7(),
-            records: vec![initial, update.clone()],
+            records: vec![property, topology],
             bytes: vec![],
         };
-        let (overlay, _) =
-            build_replay_overlay(&[run], GraphDeltaJournalLimits::default()).unwrap();
-        assert_eq!(
-            overlay.nodes[&uuid].as_ref().unwrap().primary_type,
-            PrimaryEntityTypeId::absent()
-        );
-
-        // A standalone update has no primary field. The canonical base remains
-        // authoritative even when the update's first membership is nonempty.
-        let run = GraphDeltaRun {
-            run_sequence: 1,
-            run_uuid: Uuid::now_v7(),
-            transaction_uuid: Uuid::now_v7(),
-            records: vec![update],
-            bytes: vec![],
-        };
-        let (overlay, _) =
-            build_replay_overlay(&[run], GraphDeltaJournalLimits::default()).unwrap();
-        let target = tempfile::tempdir().unwrap();
-        let (inventory, _) = capture_graph_files(base.path()).unwrap();
-        crate::graph_files::materialize_graph_tree(base.path(), &inventory, target.path()).unwrap();
-        crate::writer::write_replay_overlay_streaming(
-            base.path(),
-            &inventory,
-            target.path(),
-            &overlay,
-            GraphDeltaJournalLimits::default(),
-        )
-        .unwrap();
-        let compacted = load_base_state(target.path()).unwrap();
-        assert_eq!(
-            compacted.node_primary_types[&uuid],
-            PrimaryEntityTypeId::absent()
-        );
-        assert_eq!(compacted.nodes[&uuid], state.nodes[&uuid]);
+        let runs = [run];
+        let error =
+            apply_delta_runs(&mut state, &runs, GraphDeltaJournalLimits::default()).unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_PROJECT_FORMAT");
+        assert_eq!(state, before, "no earlier property mutation may leak");
+        let error = build_replay_overlay(&runs, GraphDeltaJournalLimits::default()).unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_PROJECT_FORMAT");
     }
 }

--- a/crates/graphforge-storage/src/project_portable_v2_import.rs
+++ b/crates/graphforge-storage/src/project_portable_v2_import.rs
@@ -2202,16 +2202,14 @@ mod tests {
     fn write_identity_delta(tree: &Path, raw: u32) {
         const RECORD_START: usize = 84;
         const PAYLOAD_LENGTH: usize = RECORD_START + 25;
-        const PAYLOAD_START: usize = PAYLOAD_LENGTH + 4;
         let op = crate::GraphDeltaOp {
             operation_uuid: Uuid::now_v7(),
-            kind: crate::GraphDeltaOpKind::UpsertNode,
-            payload: crate::GraphDeltaPayload::UpsertNodeV2 {
+            kind: crate::GraphDeltaOpKind::SetNodeProperty,
+            payload: crate::GraphDeltaPayload::SetNodeProperty {
                 node_uuid: Uuid::now_v7().to_string(),
-                node_id: 2,
-                type_ids: vec![graphforge_value::EntityTypeId::decode(0).unwrap()],
-                created_at_micros: 1,
-                updated_at_micros: 1,
+                property_stem: "_untyped".into(),
+                key: "score".into(),
+                value: crate::encode_graph_delta_value(&graphforge_ir::IrLiteral::Int(1)).unwrap(),
             },
         };
         let bytes = crate::encode_delta_run(
@@ -2222,13 +2220,16 @@ mod tests {
             crate::GraphDeltaJournalLimits::default(),
         )
         .unwrap();
-        let length =
-            u32::from_le_bytes(bytes[PAYLOAD_LENGTH..PAYLOAD_START].try_into().unwrap()) as usize;
-        let mut payload: serde_json::Value =
-            serde_json::from_slice(&bytes[PAYLOAD_START..PAYLOAD_START + length]).unwrap();
-        payload["type_ids"] = serde_json::json!([raw]);
+        // Forge a checksum-valid but unsupported topology record without using
+        // the publisher's rejected topology encoder.
+        let payload = serde_json::json!({
+            "kind": "upsert_node_v2", "node_uuid": Uuid::now_v7().to_string(),
+            "node_id": 2, "type_ids": [raw],
+            "created_at_micros": 1, "updated_at_micros": 1
+        });
         let payload = serde_json::to_vec(&payload).unwrap();
         let mut framed = bytes[..PAYLOAD_LENGTH].to_vec();
+        framed[RECORD_START + 22] = crate::GraphDeltaOpKind::UpsertNode as u8;
         framed.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
         framed.extend_from_slice(&payload);
         let checksum = Sha256::digest(&framed[RECORD_START..]);
@@ -2242,11 +2243,35 @@ mod tests {
 
     #[test]
     fn invalid_delta_identity_package_preserves_pristine_target_authority() {
-        for raw in [u32::MAX, 0x8000_0000, 0xc000_0000] {
+        for raw in [0, u32::MAX, 0x8000_0000, 0xc000_0000] {
             let (_owner, package) = identity_package(|tree| write_identity_delta(tree, raw));
             assert_identity_package_rejected(&package);
         }
-        let (_owner, package) = identity_package(|tree| write_identity_delta(tree, 0));
+        let (_owner, package) = identity_package(|tree| {
+            let state = crate::graph_delta_journal::load_base_state(tree).unwrap();
+            let op = crate::GraphDeltaOp {
+                operation_uuid: Uuid::now_v7(),
+                kind: crate::GraphDeltaOpKind::SetNodeProperty,
+                payload: crate::GraphDeltaPayload::SetNodeProperty {
+                    node_uuid: state.nodes.keys().next().unwrap().clone(),
+                    property_stem: "_untyped".into(),
+                    key: "score".into(),
+                    value: crate::encode_graph_delta_value(&graphforge_ir::IrLiteral::Int(7))
+                        .unwrap(),
+                },
+            };
+            let bytes = crate::encode_delta_run(
+                1,
+                Uuid::now_v7(),
+                Uuid::now_v7(),
+                &[op],
+                Default::default(),
+            )
+            .unwrap();
+            let path = tree.join(crate::delta_run_relative_path(1));
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, bytes).unwrap();
+        });
         let target = tempfile::tempdir().unwrap();
         import_complete_portable_v2(
             &package,

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -324,6 +324,14 @@ pub(crate) fn write_replay_overlay_streaming(
     overlay: &crate::graph_delta_journal::ReplayOverlay,
     limits: crate::graph_delta_journal::GraphDeltaJournalLimits,
 ) -> Result<ReplayNodeSpoolEvidence, GfError> {
+    if !overlay.nodes.is_empty() || !overlay.edges.is_empty() {
+        return Err(GfError::Project {
+            code: graphforge_core::ProjectErrorCode::UnsupportedProjectFormat,
+            message:
+                "GFDR supports property mutations only; topology requires canonical publication"
+                    .into(),
+        });
+    }
     let mut target_routes = crate::route_component::owned::admit_owned_workspace(target)?;
     let property_inventory = crate::AuthenticatedPropertyInventory::from_inventory_at_root(
         source,
@@ -7054,7 +7062,7 @@ mod tests {
     }
 
     #[test]
-    fn exploratory_replay_preserves_routes_and_full_width_ids_for_edge_changes() {
+    fn topology_overlay_refusal_preserves_routes_and_full_width_ids() {
         use crate::graph_delta_journal::{GraphDeltaJournalLimits, ReplayEdgeRow, ReplayOverlay};
         let base = TempDir::new().unwrap();
         let left = new_v7();
@@ -7115,63 +7123,43 @@ mod tests {
             )?;
             Ok(target)
         };
-        let target = apply(base.path(), &overlay).unwrap();
-        let actual = crate::graph_delta_journal::load_base_state(target.path()).unwrap();
-        assert_eq!(actual.node_ids, original.node_ids);
-        assert_eq!(actual.node_ids[&left.to_string()], left_id);
-        assert_eq!(actual.node_ids[&right.to_string()], right_id);
-        assert_eq!(
-            actual.edge_ids[&first.to_string()],
-            (first_id, right_id, left_id)
-        );
-        assert_eq!(
-            actual.edge_ids[&added.to_string()],
-            (first_id + 2, left_id, right_id)
-        );
-        assert_eq!(
-            actual.edges[&first.to_string()],
-            (right.to_string(), left.to_string(), "LIKES".into())
-        );
-        assert_eq!(
-            actual.edges[&added.to_string()],
-            (left.to_string(), right.to_string(), "KNOWS".into())
-        );
-        assert!(!actual.edges.contains_key(&deleted.to_string()));
-        let again = apply(target.path(), &ReplayOverlay::default()).unwrap();
-        assert_eq!(
-            crate::graph_delta_journal::load_base_state(again.path()).unwrap(),
-            actual
-        );
+        let error = apply(base.path(), &overlay).unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_PROJECT_FORMAT");
         assert_eq!(
             crate::graph_delta_journal::load_base_state(base.path()).unwrap(),
             original
         );
-        let mut changed = overlay.clone();
-        changed
+        assert_eq!(original.node_ids[&left.to_string()], left_id);
+        assert_eq!(original.node_ids[&right.to_string()], right_id);
+        assert_eq!(
+            original.edge_ids[&first.to_string()],
+            (first_id, left_id, right_id)
+        );
+        assert_eq!(
+            original.edges[&deleted.to_string()],
+            (left.to_string(), right.to_string(), "LIKES".into())
+        );
+        // A hand-built topology overlay must fail before creating any target
+        // authority, including for an existing edge with a changed surrogate.
+        overlay
             .edges
             .get_mut(&first.to_string())
             .unwrap()
             .as_mut()
             .unwrap()
             .edge_id += 1;
-        assert!(
-            apply(base.path(), &changed)
-                .unwrap_err()
-                .to_string()
-                .contains("edge surrogate changed")
-        );
-        let duplicate = new_v7();
-        let mut duplicated = overlay;
-        duplicated.edges.insert(
-            duplicate.to_string(),
-            Some(edge(duplicate, first_id + 2, "LIKES", false)),
-        );
-        assert!(
-            apply(base.path(), &duplicated)
-                .unwrap_err()
-                .to_string()
-                .contains("new edge surrogate is not monotonic")
-        );
+        let untouched = TempDir::new().unwrap();
+        let (inventory, _) = crate::capture_graph_files(base.path()).unwrap();
+        let error = write_replay_overlay_streaming(
+            base.path(),
+            &inventory,
+            untouched.path(),
+            &overlay,
+            Default::default(),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "GF_UNSUPPORTED_PROJECT_FORMAT");
+        assert_eq!(fs::read_dir(untouched.path()).unwrap().count(), 0);
     }
 
     #[test]

--- a/crates/graphforge-storage/tests/graph_delta_compaction.rs
+++ b/crates/graphforge-storage/tests/graph_delta_compaction.rs
@@ -21,47 +21,21 @@ use graphforge_value::EntityTypeId;
 use uuid::Uuid;
 
 fn sample_ops() -> Vec<GraphDeltaOp> {
-    let edge = Uuid::now_v7();
-    let src = Uuid::now_v7();
-    let dst = Uuid::now_v7();
-    vec![
-        GraphDeltaOp {
+    (1..=3)
+        .map(|id| GraphDeltaOp {
             operation_uuid: Uuid::now_v7(),
-            kind: GraphDeltaOpKind::UpsertNode,
-            payload: GraphDeltaPayload::UpsertNodeV2 {
-                node_uuid: src.hyphenated().to_string(),
-                node_id: 2,
-                type_ids: vec![EntityTypeId::decode(1).unwrap()],
-                created_at_micros: 1,
-                updated_at_micros: 1,
+            kind: GraphDeltaOpKind::SetNodeProperty,
+            payload: GraphDeltaPayload::SetNodeProperty {
+                node_uuid: Uuid::from_u128(id).to_string(),
+                property_stem: "Person".into(),
+                key: "value".into(),
+                value: graphforge_storage::encode_graph_delta_value(
+                    &graphforge_ir::IrLiteral::Str(Uuid::now_v7().to_string()),
+                )
+                .unwrap(),
             },
-        },
-        GraphDeltaOp {
-            operation_uuid: Uuid::now_v7(),
-            kind: GraphDeltaOpKind::UpsertNode,
-            payload: GraphDeltaPayload::UpsertNodeV2 {
-                node_uuid: dst.hyphenated().to_string(),
-                node_id: 3,
-                type_ids: vec![EntityTypeId::decode(1).unwrap()],
-                created_at_micros: 2,
-                updated_at_micros: 2,
-            },
-        },
-        GraphDeltaOp {
-            operation_uuid: Uuid::now_v7(),
-            kind: GraphDeltaOpKind::UpsertEdge,
-            payload: GraphDeltaPayload::UpsertEdgeV2 {
-                edge_uuid: edge.hyphenated().to_string(),
-                src_uuid: src.hyphenated().to_string(),
-                dst_uuid: dst.hyphenated().to_string(),
-                rel_type: "KNOWS".into(),
-                edge_id: 1,
-                src_id: 2,
-                dst_id: 3,
-                created_at_micros: 3,
-            },
-        },
-    ]
+        })
+        .collect()
 }
 
 fn publish_base(container: &std::path::Path) -> Uuid {
@@ -73,10 +47,17 @@ fn publish_base(container: &std::path::Path) -> Uuid {
         1_700_000_000_000_000,
     )
     .unwrap();
+    for id in 1..=3 {
+        writer
+            .create_node(Uuid::from_u128(id), EntityTypeId::decode(1).unwrap())
+            .unwrap();
+    }
     writer
-        .create_node(
-            Uuid::parse_str("00000000-0000-7000-8000-000000000001").unwrap(),
-            EntityTypeId::decode(1).unwrap(),
+        .create_edge(
+            Uuid::from_u128(4),
+            "KNOWS",
+            &Uuid::from_u128(1),
+            &Uuid::from_u128(2),
         )
         .unwrap();
     writer.flush().unwrap();
@@ -113,40 +94,7 @@ fn publish_base(container: &std::path::Path) -> Uuid {
     generation_uuid
 }
 
-fn publish_delta(container: &std::path::Path, mut ops: Vec<GraphDeltaOp>) -> [u8; 32] {
-    let resolved = resolve_project_generation(container).unwrap();
-    let inventory = resolved.graph_files_inventory().unwrap().unwrap();
-    let (state, _) = reconstruct_graph_state(
-        &resolved.graph_tree_root(),
-        &inventory,
-        GraphDeltaJournalLimits::default(),
-    )
-    .unwrap();
-    let src_id = state.node_ids.values().copied().max().unwrap_or(0) + 1;
-    let dst_id = src_id + 1;
-    if let GraphDeltaPayload::UpsertNodeV2 { node_id, .. } = &mut ops[0].payload {
-        *node_id = src_id;
-    }
-    if let GraphDeltaPayload::UpsertNodeV2 { node_id, .. } = &mut ops[1].payload {
-        *node_id = dst_id;
-    }
-    if let GraphDeltaPayload::UpsertEdgeV2 {
-        edge_id,
-        src_id: edge_src_id,
-        dst_id: edge_dst_id,
-        ..
-    } = &mut ops[2].payload
-    {
-        *edge_id = state
-            .edge_ids
-            .values()
-            .map(|(edge_id, _, _)| *edge_id)
-            .max()
-            .unwrap_or(0)
-            + 1;
-        *edge_src_id = src_id;
-        *edge_dst_id = dst_id;
-    }
+fn publish_delta(container: &std::path::Path, ops: Vec<GraphDeltaOp>) -> [u8; 32] {
     let receipt = publish_graph_delta(
         container,
         &GraphDeltaPublishRequest {

--- a/crates/graphforge-storage/tests/graph_delta_journal.rs
+++ b/crates/graphforge-storage/tests/graph_delta_journal.rs
@@ -87,51 +87,42 @@ fn assert_small_write_property_evidence(view: &std::path::Path, src_uuid: &str) 
 }
 
 fn sample_ops() -> Vec<GraphDeltaOp> {
-    let edge = Uuid::now_v7();
-    let src = Uuid::now_v7();
-    let dst = Uuid::now_v7();
+    let src = Uuid::from_u128(5).to_string();
+    let edge = "00000000-0000-7000-8000-000000000003".to_owned();
     vec![
         GraphDeltaOp {
             operation_uuid: Uuid::now_v7(),
-            kind: GraphDeltaOpKind::UpsertNode,
-            payload: GraphDeltaPayload::UpsertNodeV2 {
-                node_uuid: src.hyphenated().to_string(),
-                node_id: 3,
-                type_ids: vec![EntityTypeId::decode(1).unwrap()],
-                created_at_micros: 1_700_000_000_000_001,
-                updated_at_micros: 1_700_000_000_000_001,
+            kind: GraphDeltaOpKind::RemoveNodeProperty,
+            payload: GraphDeltaPayload::RemoveNodeProperty {
+                node_uuid: src.clone(),
+                property_stem: "_untyped".into(),
+                key: "absent".into(),
             },
         },
         GraphDeltaOp {
             operation_uuid: Uuid::now_v7(),
-            kind: GraphDeltaOpKind::UpsertNode,
-            payload: GraphDeltaPayload::UpsertNodeV2 {
-                node_uuid: dst.hyphenated().to_string(),
-                node_id: 4,
-                type_ids: vec![EntityTypeId::decode(1).unwrap()],
-                created_at_micros: 1_700_000_000_000_002,
-                updated_at_micros: 1_700_000_000_000_002,
+            kind: GraphDeltaOpKind::RemoveEdgeProperty,
+            payload: GraphDeltaPayload::RemoveEdgeProperty {
+                edge_uuid: edge.clone(),
+                property_stem: "KNOWS".into(),
+                key: "absent".into(),
             },
         },
         GraphDeltaOp {
             operation_uuid: Uuid::now_v7(),
-            kind: GraphDeltaOpKind::UpsertEdge,
-            payload: GraphDeltaPayload::UpsertEdgeV2 {
-                edge_uuid: edge.hyphenated().to_string(),
-                src_uuid: src.hyphenated().to_string(),
-                dst_uuid: dst.hyphenated().to_string(),
-                rel_type: "KNOWS".into(),
-                edge_id: 2,
-                src_id: 3,
-                dst_id: 4,
-                created_at_micros: 1_700_000_000_000_003,
+            kind: GraphDeltaOpKind::SetEdgeProperty,
+            payload: GraphDeltaPayload::SetEdgeProperty {
+                edge_uuid: edge,
+                property_stem: "KNOWS".into(),
+                key: "weight".into(),
+                value: encode_graph_delta_value(&IrLiteral::Float(0.5)).unwrap(),
             },
         },
         GraphDeltaOp {
             operation_uuid: Uuid::now_v7(),
             kind: GraphDeltaOpKind::SetNodeProperty,
             payload: GraphDeltaPayload::SetNodeProperty {
-                node_uuid: src.hyphenated().to_string(),
+                node_uuid: src,
                 property_stem: "_untyped".into(),
                 key: "rank".into(),
                 value: encode_graph_delta_value(&IrLiteral::Int(7)).unwrap(),
@@ -163,6 +154,20 @@ fn publish_base_with_extra_nodes(container: &std::path::Path, extra_nodes: usize
         .create_node(second, EntityTypeId::decode(1).unwrap())
         .unwrap();
     writer.create_edge(edge, "KNOWS", &first, &second).unwrap();
+    writer
+        .create_node(Uuid::from_u128(5), EntityTypeId::decode(1).unwrap())
+        .unwrap();
+    writer
+        .create_node(Uuid::from_u128(6), EntityTypeId::decode(1).unwrap())
+        .unwrap();
+    writer
+        .create_edge(
+            Uuid::from_u128(7),
+            "KNOWS",
+            &Uuid::from_u128(5),
+            &Uuid::from_u128(6),
+        )
+        .unwrap();
     for _ in 0..extra_nodes {
         writer
             .create_node(Uuid::now_v7(), EntityTypeId::decode(1).unwrap())
@@ -225,26 +230,7 @@ fn streaming_resource_ladder_is_independent_of_base_rows() {
     for extra_nodes in [256, 512, 1_024] {
         let root = tempfile::tempdir().unwrap();
         publish_base_with_extra_nodes(root.path(), extra_nodes);
-        let mut operations = sample_ops();
-        let src_id = extra_nodes as u64 + 3;
-        let dst_id = src_id + 1;
-        if let GraphDeltaPayload::UpsertNodeV2 { node_id, .. } = &mut operations[0].payload {
-            *node_id = src_id;
-        }
-        if let GraphDeltaPayload::UpsertNodeV2 { node_id, .. } = &mut operations[1].payload {
-            *node_id = dst_id;
-        }
-        if let GraphDeltaPayload::UpsertEdgeV2 {
-            edge_id,
-            src_id: edge_src_id,
-            dst_id: edge_dst_id,
-            ..
-        } = &mut operations[2].payload
-        {
-            *edge_id = 2;
-            *edge_src_id = src_id;
-            *edge_dst_id = dst_id;
-        }
+        let operations = sample_ops();
         publish_graph_delta(
             root.path(),
             &GraphDeltaPublishRequest {
@@ -276,25 +262,25 @@ fn streaming_resource_ladder_is_independent_of_base_rows() {
         if extra_nodes == 1024 {
             assert!(
                 replay.temporary_decode_stream_bytes > 0,
-                "the 2 MiB phase-separated strategy must be exercised"
-            );
-            let direct = tempfile::tempdir().unwrap();
-            let (_, direct_evidence) = materialize_replayed_graph_tree(
-                &resolved.graph_tree_root(),
-                &inventory,
-                direct.path(),
-                GraphDeltaJournalLimits {
-                    max_batch_rows: 7,
-                    ..GraphDeltaJournalLimits::default()
-                },
-            )
-            .unwrap();
-            assert_eq!(direct_evidence.temporary_decode_stream_bytes, 0);
-            assert_eq!(
-                fs::read(target.path().join("topology/nodes.parquet")).unwrap(),
-                fs::read(direct.path().join("topology/nodes.parquet")).unwrap()
+                "the 2 MiB phase-separated topology scan must be exercised even for property replay"
             );
         }
+        let direct = tempfile::tempdir().unwrap();
+        let (_, direct_evidence) = materialize_replayed_graph_tree(
+            &resolved.graph_tree_root(),
+            &inventory,
+            direct.path(),
+            GraphDeltaJournalLimits {
+                max_batch_rows: 7,
+                ..GraphDeltaJournalLimits::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(direct_evidence.temporary_decode_stream_bytes, 0);
+        assert_eq!(
+            fs::read(target.path().join("topology/nodes.parquet")).unwrap(),
+            fs::read(direct.path().join("topology/nodes.parquet")).unwrap()
+        );
         println!(
             "REPLAY_STREAM_BUDGET nodes={} stream_bytes={} stream_allocated={}",
             extra_nodes + 4,
@@ -332,7 +318,7 @@ fn streaming_resource_ladder_is_independent_of_base_rows() {
 }
 
 #[test]
-fn topology_replay_admission_is_path_specific_and_never_creates_rejected_output() {
+fn property_replay_topology_writer_admission_preserves_rejected_output() {
     let root = tempfile::tempdir().unwrap();
     publish_base(root.path());
     publish_graph_delta(
@@ -429,6 +415,190 @@ fn topology_replay_admission_is_path_specific_and_never_creates_rejected_output(
             .sum::<usize>(),
         2
     );
+}
+
+#[test]
+fn topology_payloads_reject_before_encoding_preparation_or_publication() {
+    let root = tempfile::tempdir().unwrap();
+    publish_base(root.path());
+    let parent = resolve_project_generation(root.path()).unwrap();
+    let before = snapshot_committed_files(root.path());
+    for operation in topology_ops() {
+        assert_eq!(
+            encode_delta_run(
+                1,
+                Uuid::now_v7(),
+                Uuid::now_v7(),
+                std::slice::from_ref(&operation),
+                GraphDeltaJournalLimits::default()
+            )
+            .unwrap_err()
+            .code(),
+            "GF_UNSUPPORTED_PROJECT_FORMAT"
+        );
+        let request = GraphDeltaPublishRequest {
+            transaction_uuid: Uuid::now_v7(),
+            generation_uuid: Uuid::now_v7(),
+            run_uuid: Uuid::now_v7(),
+            operations: vec![sample_ops().pop().unwrap(), operation],
+            limits: GraphDeltaJournalLimits::default(),
+        };
+        assert_eq!(
+            graphforge_storage::prepare_graph_delta(&parent, &request)
+                .err()
+                .unwrap()
+                .code(),
+            "GF_UNSUPPORTED_PROJECT_FORMAT"
+        );
+        assert_eq!(
+            publish_graph_delta(root.path(), &request)
+                .unwrap_err()
+                .code(),
+            "GF_UNSUPPORTED_PROJECT_FORMAT"
+        );
+        assert_eq!(snapshot_committed_files(root.path()), before);
+    }
+}
+
+#[test]
+fn topology_cannot_bypass_published_retry_or_mutate_direct_replay_state() {
+    let root = tempfile::tempdir().unwrap();
+    publish_base(root.path());
+    let request = GraphDeltaPublishRequest {
+        transaction_uuid: Uuid::now_v7(),
+        generation_uuid: Uuid::now_v7(),
+        run_uuid: Uuid::now_v7(),
+        operations: sample_ops(),
+        limits: GraphDeltaJournalLimits::default(),
+    };
+    publish_graph_delta(root.path(), &request).unwrap();
+    let generation = resolve_project_generation(root.path()).unwrap();
+    let inventory = generation.graph_files_inventory().unwrap().unwrap();
+    let (base, _) =
+        reconstruct_graph_state(&generation.graph_tree_root(), &inventory, request.limits).unwrap();
+    let before = snapshot_committed_files(root.path());
+    for operation in topology_ops() {
+        let mut retry = request.clone();
+        retry.operations = vec![operation.clone()];
+        assert_eq!(
+            publish_graph_delta(root.path(), &retry).unwrap_err().code(),
+            "GF_UNSUPPORTED_PROJECT_FORMAT"
+        );
+        assert_eq!(snapshot_committed_files(root.path()), before);
+
+        let supported = sample_ops().pop().unwrap();
+        let encoded = encode_delta_run(
+            1,
+            Uuid::now_v7(),
+            Uuid::now_v7(),
+            &[supported],
+            request.limits,
+        )
+        .unwrap();
+        let mut run = decode_delta_run(&encoded, Some(1), request.limits).unwrap();
+        let mut record = run.records[0].clone();
+        record.operation_uuid = operation.operation_uuid;
+        record.op_sequence = 1;
+        record.kind = operation.kind;
+        record.payload = operation.payload.clone();
+        run.records.push(record);
+        for already_applied in [false, true] {
+            let mut state = base.clone();
+            if already_applied {
+                state.applied_operations.insert(
+                    operation.operation_uuid.to_string(),
+                    operation.payload.clone(),
+                );
+            }
+            let original = state.clone();
+            assert_eq!(
+                graphforge_storage::apply_delta_runs(
+                    &mut state,
+                    std::slice::from_ref(&run),
+                    request.limits
+                )
+                .unwrap_err()
+                .code(),
+                "GF_UNSUPPORTED_PROJECT_FORMAT"
+            );
+            assert_eq!(
+                state, original,
+                "a supported prefix must not be applied before topology refusal"
+            );
+        }
+        let bytes = run_with_mutated_payload(&sample_ops()[0], |payload| {
+            *payload = serde_json::to_value(&operation.payload).unwrap();
+        });
+        assert_eq!(
+            decode_delta_run(&bytes, Some(1), request.limits)
+                .unwrap_err()
+                .code(),
+            "GF_UNSUPPORTED_PROJECT_FORMAT"
+        );
+    }
+}
+
+fn topology_ops() -> Vec<GraphDeltaOp> {
+    let node = "00000000-0000-7000-8000-000000000001".to_owned();
+    let edge = "00000000-0000-7000-8000-000000000003".to_owned();
+    [
+        (
+            GraphDeltaOpKind::UpsertNode,
+            GraphDeltaPayload::UpsertNode {
+                node_uuid: node.clone(),
+                type_ids: vec![],
+            },
+        ),
+        (
+            GraphDeltaOpKind::UpsertNode,
+            GraphDeltaPayload::UpsertNodeV2 {
+                node_uuid: node.clone(),
+                node_id: u64::MAX - 1,
+                type_ids: vec![EntityTypeId::decode(1).unwrap()],
+                created_at_micros: 1,
+                updated_at_micros: 2,
+            },
+        ),
+        (
+            GraphDeltaOpKind::DeleteNode,
+            GraphDeltaPayload::DeleteNode {
+                node_uuid: node.clone(),
+            },
+        ),
+        (
+            GraphDeltaOpKind::UpsertEdge,
+            GraphDeltaPayload::UpsertEdge {
+                edge_uuid: edge.clone(),
+                src_uuid: node.clone(),
+                dst_uuid: node.clone(),
+                rel_type: "OTHER".into(),
+            },
+        ),
+        (
+            GraphDeltaOpKind::UpsertEdge,
+            GraphDeltaPayload::UpsertEdgeV2 {
+                edge_uuid: edge.clone(),
+                src_uuid: node.clone(),
+                dst_uuid: node.clone(),
+                rel_type: "OTHER".into(),
+                edge_id: 1,
+                src_id: 1,
+                dst_id: 1,
+                created_at_micros: 1,
+            },
+        ),
+        (
+            GraphDeltaOpKind::DeleteEdge,
+            GraphDeltaPayload::DeleteEdge { edge_uuid: edge },
+        ),
+    ]
+    .into_iter()
+    .map(|(kind, payload)| GraphDeltaOp {
+        operation_uuid: Uuid::now_v7(),
+        kind,
+        payload,
+    })
+    .collect()
 }
 
 #[test]
@@ -533,11 +703,11 @@ fn small_write_preserves_unchanged_parquet_and_reopen_replays() {
 
     let ops = sample_ops();
     let edge_uuid = match &ops[2].payload {
-        GraphDeltaPayload::UpsertEdgeV2 { edge_uuid, .. } => edge_uuid.clone(),
+        GraphDeltaPayload::SetEdgeProperty { edge_uuid, .. } => edge_uuid.clone(),
         _ => unreachable!(),
     };
     let src_uuid = match &ops[0].payload {
-        GraphDeltaPayload::UpsertNodeV2 { node_uuid, .. } => node_uuid.clone(),
+        GraphDeltaPayload::RemoveNodeProperty { node_uuid, .. } => node_uuid.clone(),
         _ => unreachable!(),
     };
     let receipt = publish_graph_delta(
@@ -635,37 +805,11 @@ fn small_write_preserves_unchanged_parquet_and_reopen_replays() {
 }
 
 #[test]
-fn entity_delete_rewrites_each_affected_property_route_with_tombstones() {
+fn canonical_entity_delete_rewrites_each_affected_property_route_with_tombstones() {
     let root = tempfile::tempdir().unwrap();
     publish_base(root.path());
     let node = Uuid::parse_str("00000000-0000-7000-8000-000000000001").unwrap();
     let edge = Uuid::parse_str("00000000-0000-7000-8000-000000000003").unwrap();
-    publish_graph_delta(
-        root.path(),
-        &GraphDeltaPublishRequest {
-            transaction_uuid: Uuid::now_v7(),
-            generation_uuid: Uuid::now_v7(),
-            run_uuid: Uuid::now_v7(),
-            operations: vec![
-                GraphDeltaOp {
-                    operation_uuid: Uuid::now_v7(),
-                    kind: GraphDeltaOpKind::DeleteEdge,
-                    payload: GraphDeltaPayload::DeleteEdge {
-                        edge_uuid: edge.hyphenated().to_string(),
-                    },
-                },
-                GraphDeltaOp {
-                    operation_uuid: Uuid::now_v7(),
-                    kind: GraphDeltaOpKind::DeleteNode,
-                    payload: GraphDeltaPayload::DeleteNode {
-                        node_uuid: node.hyphenated().to_string(),
-                    },
-                },
-            ],
-            limits: GraphDeltaJournalLimits::default(),
-        },
-    )
-    .unwrap();
     let generation = resolve_project_generation(root.path()).unwrap();
     let inventory = generation.graph_files_inventory().unwrap().unwrap();
     let view = tempfile::tempdir().unwrap();
@@ -677,6 +821,15 @@ fn entity_delete_rewrites_each_affected_property_route_with_tombstones() {
     )
     .unwrap();
 
+    assert_eq!(
+        graphforge_storage::delete_nodes_and_edges(
+            view.path(),
+            &std::collections::HashSet::from([*node.as_bytes()]),
+            &std::collections::HashSet::from([*edge.as_bytes()])
+        )
+        .unwrap(),
+        (1, 1)
+    );
     let scratch = tempfile::tempdir().unwrap();
     for (kind, route) in [
         (PropertyRouteKind::Node, "Person"),
@@ -870,8 +1023,8 @@ fn exact_retry_transaction_is_idempotent_and_conflict_is_typed() {
     );
 
     let mut conflicting = ops;
-    if let GraphDeltaPayload::UpsertEdgeV2 { rel_type, .. } = &mut conflicting[2].payload {
-        *rel_type = "OTHER".into();
+    if let GraphDeltaPayload::SetEdgeProperty { value, .. } = &mut conflicting[2].payload {
+        *value = encode_graph_delta_value(&IrLiteral::Float(3.5)).unwrap();
     }
     let err = publish_graph_delta(
         root.path(),
@@ -891,7 +1044,7 @@ fn exact_retry_transaction_is_idempotent_and_conflict_is_typed() {
 // rather than failing an unrelated checksum or inventory check.
 fn run_with_raw_membership(raw: u32) -> Vec<u8> {
     run_with_mutated_payload(&sample_ops()[0], |payload| {
-        payload["type_ids"] = serde_json::json!([raw]);
+        *payload = serde_json::json!({"kind":"upsert_node_v2", "node_uuid":Uuid::from_u128(5).to_string(), "node_id":3, "type_ids":[raw], "created_at_micros":1, "updated_at_micros":1});
     })
 }
 
@@ -921,6 +1074,14 @@ fn run_with_mutated_payload(
     let mut framed = bytes[..PAYLOAD_LENGTH].to_vec();
     framed.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
     framed.extend_from_slice(&payload);
+    let kind: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+    framed[RECORD_START + 22] = match kind["kind"].as_str().unwrap() {
+        "upsert_node" | "upsert_node_v2" => GraphDeltaOpKind::UpsertNode as u8,
+        "delete_node" => GraphDeltaOpKind::DeleteNode as u8,
+        "upsert_edge" | "upsert_edge_v2" => GraphDeltaOpKind::UpsertEdge as u8,
+        "delete_edge" => GraphDeltaOpKind::DeleteEdge as u8,
+        _ => operation.kind as u8,
+    };
     let checksum = Sha256::digest(&framed[RECORD_START..]);
     framed.extend_from_slice(&checksum);
     let checksum = Sha256::digest(&framed);
@@ -953,14 +1114,18 @@ fn snapshot_committed_files(root: &std::path::Path) -> BTreeMap<std::path::PathB
 
 #[test]
 fn committed_checksum_valid_invalid_memberships_reject_without_authority_mutation() {
-    // Control proves the hand-built frame is accepted before changing its identity.
-    decode_delta_run(
-        &run_with_raw_membership(1),
-        Some(1),
-        GraphDeltaJournalLimits::default(),
-    )
-    .unwrap();
-    for raw in [0x8000_0000, 0xc000_0000, u32::MAX] {
+    // Valid topology frames are unsupported; invalid identity domains still fail closed during decoding.
+    assert_eq!(
+        decode_delta_run(
+            &run_with_raw_membership(1),
+            Some(1),
+            GraphDeltaJournalLimits::default()
+        )
+        .unwrap_err()
+        .code(),
+        "GF_UNSUPPORTED_PROJECT_FORMAT"
+    );
+    for raw in [1, 0x8000_0000, 0xc000_0000, u32::MAX] {
         let root = tempfile::tempdir().unwrap();
         open_or_initialize_project(root.path()).unwrap();
         let graph = tempfile::tempdir().unwrap();
@@ -1006,11 +1171,25 @@ fn committed_checksum_valid_invalid_memberships_reject_without_authority_mutatio
             GraphDeltaJournalLimits::default(),
         )
         .unwrap_err();
-        assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
-        assert!(
-            error.to_string().contains("payload decode failed"),
-            "{error}"
-        );
+        if raw == 1 {
+            assert_eq!(error.code(), "GF_UNSUPPORTED_PROJECT_FORMAT");
+        } else {
+            assert_eq!(error.code(), "GF_PROJECT_CORRUPT");
+            assert!(
+                error.to_string().contains("payload decode failed"),
+                "{error}"
+            );
+        }
+        let view = tempfile::tempdir().unwrap();
+        let replay_error = materialize_replayed_graph_tree(
+            &resolved.graph_tree_root(),
+            &inventory,
+            view.path(),
+            GraphDeltaJournalLimits::default(),
+        )
+        .unwrap_err();
+        assert_eq!(replay_error.code(), error.code());
+        assert_eq!(fs::read_dir(view.path()).unwrap().count(), 0);
         assert_eq!(
             snapshot_committed_files(root.path()),
             before,
@@ -1116,10 +1295,10 @@ fn legacy_v1_project_without_deltas_remains_readable() {
         .unwrap(),
         IrLiteral::Int(42)
     );
-    assert_eq!(state.node_ids.len(), 2);
-    assert_eq!(state.node_timestamps.len(), 2);
-    assert_eq!(state.edge_ids.len(), 1);
-    assert_eq!(state.edge_created_at.len(), 1);
+    assert_eq!(state.node_ids.len(), 4);
+    assert_eq!(state.node_timestamps.len(), 4);
+    assert_eq!(state.edge_ids.len(), 2);
+    assert_eq!(state.edge_created_at.len(), 2);
 }
 
 #[test]

--- a/docs/adr/0019-authoritative-graph-delta-journal.md
+++ b/docs/adr/0019-authoritative-graph-delta-journal.md
@@ -1,5 +1,14 @@
 # ADR 0019: Authoritative durable graph delta journal
 
+> Current contract amendment (#1221): GFDR supports only node/edge property
+> set/remove. Topology upserts/deletes are rejected before publication and by
+> decoding/replay, even when identity metadata is present. Public topology uses
+> canonical publication. Earlier topology/compatibility descriptions below are
+> historical; pre-v1 backward readers and migrations are not provided. The
+> [current publishing contract](../book/architecture/storage.md#current-publishing-contract)
+> is authoritative for supported operation kinds and conformance.
+
+
 **Status:** Accepted
 **Date:** 2026-08-15
 **Build target:** v0.5.x (M6)

--- a/docs/book/architecture/concurrency-recovery.md
+++ b/docs/book/architecture/concurrency-recovery.md
@@ -228,7 +228,12 @@ There are four CI surfaces for concurrency and durability contracts:
    behavior; the oracle is reusable by recovery, delta, compaction, and final
    certification. Authoritative graph delta runs (#752 / ADR 0019) publish only
    through the same `CURRENT` contract; they never recover by scanning newest
-   logs. After CURRENT selects a generation, normal and checkpoint opens verify
+   logs. GFDR supports property operations only. Request admission precedes
+   idempotent transaction shortcuts; persisted decoding and direct-run
+   prevalidation reject topology records. Journal recovery repairs selected or
+   abandoned publication attempts and never applies an arbitrary uncommitted
+   topology record to CURRENT. See the [publishing boundary](storage.md#current-publishing-contract).
+   After CURRENT selects a generation, normal and checkpoint opens verify
    its inventory and complete GFDR chain, replay canonical Parquet plus typed
    records inside a private workspace, and publish no partial read view on
    corruption, unsupported versions, or resource-limit failure. Recovery-on-open

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -405,15 +405,23 @@ immutable generation (`compact_graph_delta`) and reclaims unreachable inputs
 only through the shared retention/GC oracle. They are
 distinct from rebuildable `indexes/adjacency/deltas/` accelerators.
 
-Replay materializes only UUIDs touched by property operations or entity
-deletions; unchanged UUIDs remain in prior immutable fragments. During overlay
+GFDR admits only node/edge property set and removal. All node/edge topology
+upserts and deletes, including records with full-width identity metadata, fail
+with `GF_UNSUPPORTED_PROJECT_FORMAT`. Canonical publication owns topology.
+Admission checks precede preparation and transaction-retry shortcuts; decoding
+rejects persisted topology records, and direct in-memory replay prevalidates the
+complete input before changing caller state. Internal overlay writers refuse
+topology before creating target authority. No backward reader or migration is
+provided. See the [current publishing contract](#current-publishing-contract).
+
+Replay materializes only UUIDs touched by property operations; unchanged UUIDs remain in prior immutable fragments. During overlay
 construction the memory ceiling charges decoded runs, idempotency payloads,
 typed operation values, and the overlay simultaneously. Runs are released
 before materialization. Materialization then charges the retained overlay,
 node endpoint/identity authority, target references, baseline and output rows,
 Arrow arrays, and schema-width × row-group column metadata plus the active
-Parquet writer buffer. Replay writers disable dictionary encoding and
-compression variability and bound row groups by `max_batch_rows`. Legacy flat
+Parquet writer buffer. Replay writers use the shared permanent Zstd policy, retain their justified
+dictionary-off setting, and bound row groups by `max_batch_rows`. Flat
 generation-zero properties enter this same authenticated, sparse-fragment
 materialization path. `max_records_per_run` and `max_work_rows` independently
 bound mutation and physical work. Limit failures use the typed
@@ -967,3 +975,75 @@ The storage layer is transparent to all API surfaces.
 - [Architecture Refactor v0.5](refactor-v0.5.md) — UUID identity model, typed edge tables, project structure
 - [Execution Model](execution-model.md) — how providers connect to DataFusion
 - [ADR 0001: Rust Core](../../adr/0001-rust-core.md) — Parquet-as-primary and provider strategy
+
+
+## Current publishing contract
+
+Rust owns publication behavior. The public facade selects the operation path;
+storage owns authenticated representations and atomic generation selection.
+A publishing path is complete only when the selected generation and the facade's
+readers agree. Table-valued data remains Arrow at the API and Parquet at rest;
+versioned GFDR is the explicit property-journal exception.
+
+Every applicable graph publisher preserves these authorities together:
+
+- Exact node/edge UUIDs, full-width surrogates, endpoint identity, global edge
+  identity uniqueness, and persistent consumed-ID high-water marks. Deletion
+  cannot make an ID available to a subsequent ordinary CREATE.
+- Complete typed or exploratory schemas, null/concrete property types, latest
+  values and tombstones; immutable primary routes and label memberships remain
+  distinct. Physical path components never substitute for semantic route names.
+- Authenticated graph-file ownership, route authorities, UUID membership,
+  ordinal receipts and applicable adjacency/search generations. Staging reads
+  the admitted inventory rather than discovering authority from filenames.
+- All graph, catalog, ontology/composition and other declared publication
+  participants. A graph-only update retains unrelated participants; changing
+  ontology cannot strand retained semantic bindings or reinterpret numeric IDs.
+- Parent conflict, operation identity, cancellation, active reader leases and
+  crash/returned-error recovery. CURRENT selects the complete old or new
+  generation. A returned error after selection must reconcile actual selected
+  authority; retries cannot install an unrelated private candidate.
+- `permanent_parquet::writer_properties` for every verified permanent Parquet
+  publisher. Per-path dictionary, row-group, streaming and memory settings remain
+  local. Replay and compaction retain the accepted codec; private IPC/spill,
+  portable containers and query sinks have separate contracts.
+
+| Producer → publisher → consumer | Operation boundary and applicable proof |
+| --- | --- |
+| Public construction → canonical graph generation → facade/reopen | Typed/exploratory topology and properties, sharded nodes, routes, all graph identity authorities and continuation tails. Construction, CAS ownership and publishing-budget facade regressions cover exact reopening and portable interchange. |
+| Ordinary Cypher/analyst mutation → MutationTransaction/GraphWriter → generation readers | Canonical topology and property mutation; complete participant publication. Public CREATE/DELETE/SET, active streams, fault recovery and next-ID tests apply. |
+| Composite property mutation → GFDR preparation → verified replay/compaction | Only the four property operations are admitted. Qualified/constructed ownership fixtures cover sparse latest values, removals, nulls, route identity and shared immutable base payloads. Canonical property publication remains available when eligibility requires it. |
+| Composite topology mutation → canonical GraphWriter publication → facade | Never GFDR. Qualified create and owner-routing regressions cover identities and subsequent property mutation. |
+| Storage GFDR APIs → framed runs → direct replay, open, checkpoint, compaction/import | All topology operations are unsupported, including checksum-valid records, duplicate operation IDs and matching transaction retries. Refusal precedes authority changes; direct replay leaves the entire supplied state unchanged. |
+| Public compaction → complete new generation → refreshed facade | Full verified property chain, same-facade subsequent mutation, exact retry, retained streams and imported continuation. Private hydration and selected permanent ownership are measured separately. |
+| Ontology adoption/clear and retained semantic transformations → workspace generation → prepared readers | Same-name promotion stages graph and ontology together; disjoint metadata-only adoption reuses payloads. Unsupported clear/type-ID reinterpretation refuses before selection. Existing semantic transformation and promotion lifecycle tests own applicable retained-data proofs. |
+| Graph/belief/portable projection → selected artifact → verifier/import | Exact selection and endpoint closure, schemas, routes and rebuilt applicable controls. An exported artifact is not a selected live generation; clean import must validate it before subsequent mutation. |
+| Portable clean import/checkpoint restoration → complete generation → facade | Complete participant authentication and corruption refusal, exact identities/properties and continuation. Persisted unsupported topology GFDR cannot be imported as supported current state. |
+| Catalog/vector/knowledge/epistemic/provenance/restore markers → declared participant → domain reader | Domain schemas, references, authentication and atomic participant ownership apply. These writers do not allocate graph topology IDs; graph ordering/tails are inapplicable to the participant payload itself. |
+
+Private accepted construction/merge streams, decoder spools, standalone ontology
+persistence without a graph publisher, external query sinks, and test/benchmark
+fixtures are not permanent graph publishers. They cannot establish production
+support for a topology journal operation.
+
+`permanent_storage_budgets::publishing_contract_alternates_supported_paths_and_refuses_topology_journals`
+checks flat/sharded, exploratory/ontology-promoted, two-route construction,
+actual property GFDR, compaction, canonical topology mutation, reopening,
+export/full verification, clean import and subsequent mutation. It compares
+UUIDs, routes, endpoints, nullable typed values and node allocation continuity.
+The neighboring compaction/promotion/owner fixtures add active snapshots,
+interrupted publication, cancellation, retries and full-width identity coverage.
+Storage journal tests additionally cover forged persisted records, direct-run
+bypasses, byte-preserving refusal, corruption and exact resource thresholds.
+
+The conformance work reuses the source-bound measurements and deterministic
+budgets from the [permanent-storage assessment](permanent-storage-assessment.md),
+including #1213 encoding, #1219 CAS replay, #1224 property ownership, #1231 facade
+refresh and #1229 promotion. Rejection creates no graph payload or publication;
+its fixture compares every retained file digest and allocation before/after.
+The added preflight is a constant-work discriminant check per operation and
+retains no second graph or decoded value collection. Existing replay work,
+metadata, batch and memory limits remain enforced. Logical counters do not
+claim process/native RSS bounds; sampled overlapping allocation is not a hard
+peak bound. Source-bound integrated S20/S22 accounting remains the epic's later
+measurement, not an outcome inferred from this contract test.

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -1026,11 +1026,16 @@ persistence without a graph publisher, external query sinks, and test/benchmark
 fixtures are not permanent graph publishers. They cannot establish production
 support for a topology journal operation.
 
-`permanent_storage_budgets::publishing_contract_alternates_supported_paths_and_refuses_topology_journals`
-checks flat/sharded, exploratory/ontology-promoted, two-route construction,
-actual property GFDR, compaction, canonical topology mutation, reopening,
+The four `permanent_storage_budgets` tests
+`publishing_contract_alternates_supported_paths_and_refuses_topology_journals`,
+`publishing_contract_flat_ontology`, `publishing_contract_sharded_exploratory`
+and `publishing_contract_sharded_ontology` use `exercise_publishing_contract`
+to check flat/sharded, exploratory/ontology-promoted, two-route graphs. The flat
+cases use public composite CREATE on an empty project; the sharded cases use
+public construction sessions. All four exercise actual property GFDR,
+compaction, canonical topology mutation, reopening,
 export/full verification, clean import and subsequent mutation. It compares
-UUIDs, routes, endpoints, nullable typed values and node allocation continuity.
+UUIDs, routes, endpoints, nullable typed values and node/edge allocation continuity.
 The neighboring compaction/promotion/owner fixtures add active snapshots,
 interrupted publication, cancellation, retries and full-width identity coverage.
 Storage journal tests additionally cover forged persisted records, direct-run

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -1052,3 +1052,28 @@ metadata, batch and memory limits remain enforced. Logical counters do not
 claim process/native RSS bounds; sampled overlapping allocation is not a hard
 peak bound. Source-bound integrated S20/S22 accounting remains the epic's later
 measurement, not an outcome inferred from this contract test.
+
+### Publishing-contract acceptance evidence
+
+[The frozen four-case measurement](../../development/evidence/publishing-contract-1221.json)
+records 55.58 s user CPU, 5.36 s system CPU and 162,652 KiB observed process
+peak RSS. Separate syscall tracing recorded 882,417,829 bytes read and
+157,666,163 bytes written; separate pathname sampling observed 21,864,448
+allocated bytes at its largest sample, deduplicating shared inodes across
+retained, private and portable files. These are complete lifecycle observations,
+not isolated rejection costs or hard temporary-disk limits. The evidence records
+OS block counters, sample gaps, overlapping validation activity and failed
+superseded fixture attempts. No incomparable baseline improvement is claimed.
+
+| Contract outcome | Direct evidence |
+| --- | --- |
+| Supported producers, complete authorities and encoding selection | The producer matrix above; shared-policy and per-path budgets in the permanent-storage assessment. Participant-only paths explicitly exclude topology allocation. |
+| Unsupported topology refuses before authority changes | `topology_payloads_reject_before_encoding_preparation_or_publication`, `topology_cannot_bypass_published_retry_or_mutate_direct_replay_state`, `committed_checksum_valid_invalid_memberships_reject_without_authority_mutation`, and `topology_overlay_refusal_preserves_routes_and_full_width_ids`. These cover all topology variants, retry/direct-replay bypasses, authenticated persisted records and unchanged target bytes. |
+| Flat/sharded and exploratory/ontology public lifecycle | The four `publishing_contract_*` cases above assert the selected topology layout after optional adoption. They preserve exact node/edge UUIDs, endpoints, nullable values, route counts and consumed node/edge IDs across deletion, reopen, CREATE, export/full verification, clean import and subsequent mutation. |
+| Authentication and recovery remain enforced | Existing journal checksum/order/missing-run tests; compaction cancellation, checkpoint retention, cleanup and exact retry; portable import crash windows and pristine-target corruption refusal. Merged #1219, #1224, #1229 and #1231 supply public active-snapshot and returned-error lifecycle coverage. |
+| Resource bounds remain meaningful | `streaming_resource_ladder_is_independent_of_base_rows` uses 260/516/1,028 nodes, seven-row batches, 2 MiB replay admission and at most 256 KiB logical/allocated decoder spool. It compares exact output with the non-spooling path and limits logical replay-state growth to 128 bytes. Public conformance enforces 2 MiB compaction output and 8 KiB logical replay-state ceilings. These counters exclude process/native memory. |
+| Portable current-format identity correctness | `valid_identity_package_keeps_absent_primary_and_runtime_catalog_bytes`, `invalid_delta_identity_package_preserves_pristine_target_authority`, and `absent_primary_round_trip_and_topology_replay_refusal_preserve_state` distinguish valid full-width identities from unsupported topology replay. |
+
+This ledger maps ordinary implementation criteria to their existing tests. It
+adds no release-certification requirement and does not claim final capacity
+completion; integrated S20/S22 evidence remains under #1194.

--- a/docs/development/evidence/publishing-contract-1221.json
+++ b/docs/development/evidence/publishing-contract-1221.json
@@ -127,5 +127,29 @@
     "Filesystem sampling deduplicates hardlinked inodes across retained generations, private staging and portable artifacts. It excludes directory blocks and can miss unlinked open files or shorter-lived peaks; it is not a hard temporary-only disk bound.",
     "Preflight adds one constant-work operation-discriminant check per operation and a complete direct-run support/kind scan before changing supplied state; it creates no second decoded graph collection.",
     "Initial small construction fixtures were actually single-shard and failed the new flat assertion. Superseded flat setup attempts used invalid composite UUID versions and then explicit tagged Null properties. Those failed runs are not acceptance or performance evidence; final flat cases use deterministic UUIDv7 and absent nullable properties."
-  ]
+  ],
+  "validation": {
+    "public_conformance_cases": {
+      "passed": 4,
+      "failed": 0,
+      "measurement_runs": 3
+    },
+    "storage_unit_suite": {
+      "passed": 1086,
+      "failed": 1,
+      "ignored": 2,
+      "failure": "project_generation::tests::wave9_participant_inventory_rejects_links_and_special_files hardcodes /tmp; open_or_initialize_project refuses the host filesystem with GF_UNSUPPORTED_FILESYSTEM cause=filesystem_class_unproven before the test assertions. The full suite is not green."
+    },
+    "fast_checks": "passed",
+    "gate_registry": "passed",
+    "independent_source_and_evidence_review": "no outstanding verified finding",
+    "journal_integration": {
+      "passed": 18,
+      "failed": 0
+    },
+    "compaction_integration": {
+      "passed": 10,
+      "failed": 0
+    }
+  }
 }

--- a/docs/development/evidence/publishing-contract-1221.json
+++ b/docs/development/evidence/publishing-contract-1221.json
@@ -1,0 +1,131 @@
+{
+  "issue": 1221,
+  "source_commit": "2a1eb8b48cf1eed6525feb307261f2fbebc53d77",
+  "executable_sha256": "3de8dec2401d4355caef7a5929dcecef2a1d5c380a71148abe2649b3f10cfd67",
+  "workload": "Four public Rust-facade cases: 33 nodes via flat composite CREATE and 4097 nodes via sharded construction; 129 edges and two routes; exploratory and ontology-promoted. Unsupported topology GFDR refusal preserves published files, followed by actual property GFDR, compaction, canonical node/edge CREATE/DELETE/reopen/CREATE with consumed-ID continuity, exact query, export/full verify, clean import and subsequent mutation.",
+  "command": [
+    "permanent_storage_budgets",
+    "publishing_contract_",
+    "--nocapture",
+    "--test-threads=1"
+  ],
+  "runtime": {
+    "elapsed_seconds": 56.61,
+    "user_seconds": 55.58,
+    "system_seconds": 5.36,
+    "peak_rss_kib": 162652,
+    "filesystem_input_512_byte_blocks": 92088,
+    "filesystem_output_512_byte_blocks": 363200,
+    "exit_status": 0
+  },
+  "case_counters": [
+    {
+      "compaction_output_bytes": 33615,
+      "logical_replay_peak_bytes": 3014,
+      "nodes": 33,
+      "routes": 2,
+      "typed": false
+    },
+    {
+      "compaction_output_bytes": 46780,
+      "logical_replay_peak_bytes": 3005,
+      "nodes": 33,
+      "routes": 2,
+      "typed": true
+    },
+    {
+      "compaction_output_bytes": 575998,
+      "logical_replay_peak_bytes": 3062,
+      "nodes": 4097,
+      "routes": 2,
+      "typed": false
+    },
+    {
+      "compaction_output_bytes": 875986,
+      "logical_replay_peak_bytes": 3005,
+      "nodes": 4097,
+      "routes": 2,
+      "typed": true
+    }
+  ],
+  "syscall_io": {
+    "syscalls": {
+      "read": {
+        "calls": 212291,
+        "bytes": 729715862
+      },
+      "pread64": {
+        "calls": 264063,
+        "bytes": 107527816
+      },
+      "write": {
+        "calls": 20541,
+        "bytes": 112492012
+      },
+      "fsync": {
+        "calls": 16978,
+        "bytes": 0
+      },
+      "copy_file_range": {
+        "calls": 8254,
+        "bytes": 45174151
+      }
+    },
+    "read_bytes": 882417829,
+    "write_bytes": 157666163,
+    "errors": [],
+    "elapsed_seconds": 145.89
+  },
+  "workspace_observation": {
+    "command": [
+      "/tmp/gf1221-contract-measure-bin",
+      "publishing_contract_",
+      "--nocapture",
+      "--test-threads=1"
+    ],
+    "sampled_unique_inode_allocated_peak_bytes": 21864448,
+    "sampled_path_logical_peak_bytes": 18537409,
+    "sampled_file_count_peak": 1393,
+    "samples": 4610,
+    "requested_poll_interval_seconds": 0.005,
+    "maximum_observed_sample_interval_seconds": 0.03055325400782749,
+    "vanished_files_during_scan": 68,
+    "exit_status": 0,
+    "limitations": [
+      "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+      "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+      "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+      "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+    ]
+  },
+  "deterministic_budgets": {
+    "public_compaction_output_bytes": 2097152,
+    "public_compaction_logical_replay_peak_bytes": 8192,
+    "storage_resource_ladder_nodes": [
+      260,
+      516,
+      1028
+    ],
+    "storage_replay_batch_rows": 7,
+    "storage_replay_memory_admission_bytes": 2097152,
+    "storage_decoder_spool_logical_and_allocated_ceiling_bytes": 262144,
+    "storage_logical_replay_state_growth_ceiling_bytes": 128,
+    "unsupported_topology_published_file_changes": 0
+  },
+  "reused_measurements": [
+    "permanent-storage assessment: #1213 encoding",
+    "#1219 CAS replay/compaction",
+    "#1224 authenticated property ownership",
+    "#1229 atomic ontology promotion",
+    "#1231 complete facade refresh"
+  ],
+  "limitations": [
+    "No valid comparable complete pre-repair lifecycle baseline is claimed. This contract change enforces unsupported topology refusal and preserves existing supported paths; material optimization evidence is owned by the linked repairs.",
+    "Runtime, syscall and filesystem sampling are separate serial executions of the same frozen binary. Unrelated merged-tree validation was running concurrently; wall time is not an isolated benchmark.",
+    "Whole-process RSS includes overlapping native/Arrow/engine owners but is an observed peak, not a hard bound. Logical replay estimates exclude those owners.",
+    "Syscall byte totals count successful application transfers including copy_file_range in both directions, not physical device traffic. OS filesystem block counters are reported separately.",
+    "Filesystem sampling deduplicates hardlinked inodes across retained generations, private staging and portable artifacts. It excludes directory blocks and can miss unlinked open files or shorter-lived peaks; it is not a hard temporary-only disk bound.",
+    "Preflight adds one constant-work operation-discriminant check per operation and a complete direct-run support/kind scan before changing supplied state; it creates no second decoded graph collection.",
+    "Initial small construction fixtures were actually single-shard and failed the new flat assertion. Superseded flat setup attempts used invalid composite UUID versions and then explicit tagged Null properties. Those failed runs are not acceptance or performance evidence; final flat cases use deterministic UUIDv7 and absent nullable properties."
+  ]
+}


### PR DESCRIPTION
GFDR admitted topology operations even though replay did not maintain every current-format topology authority. This change enforces the existing public routing contract: property mutations may use GFDR; topology mutations publish canonically. Admission, persisted decoding, retry shortcuts and direct replay reject unsupported topology before changing authority.

Four Rust-facade cases prove actual flat composite CREATE and sharded construction, each exploratory and ontology-promoted, through property replay, compaction, node/edge deletion and allocation continuation, reopen, exact query, export/full verification, clean import and subsequent mutation. Existing journal, recovery and benchmark fixtures now seed canonical topology and exercise supported property operations. No compatibility reader or migration is added.

The publishing matrix and acceptance ledger document producer/consumer ownership, applicable authorities, rejection and reused recovery/snapshot evidence. Frozen-executable CPU, I/O, RSS and overlapping-allocation observations accompany deterministic replay/compaction budgets, with explicit limitations and no incomparable baseline claim.

Validation: all 45 publishing-budget cases pass in release coverage, including the four conformance cases; all four also pass each of three frozen measurement runs. The 18 journal and 10 compaction integration tests, workspace Clippy (`-D warnings`), formatting, fast checks and gate-registry checks pass. Independent source and evidence review found no outstanding finding.

`make pre-push` completed its Rust test stage with one known host failure: `project_generation::tests::wave9_participant_inventory_rejects_links_and_special_files` hardcodes `/tmp`, where filesystem admission refuses this host before reaching its assertions. Release storage units report 1,085 passed / 1 failed / 2 pre-existing ignored; the separate debug storage suite reports 1,086 passed / the same failure / 2 ignored. The full local run is failed, not green. Before that failure, 737 API units, all 118 BDD scenarios, all 45 publishing-budget cases and the changed CLI compaction test passed. No tests were skipped or weakened. Required CI must pass at the exact head before merge.

Closes #1221
