### PR TITLE
Bound authenticated manifest buckets and incremental updates

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -771,7 +771,7 @@ fn bucket_manifest_experiment(source: &Path) -> Value {
                     .values()
                     .map(|child| child.as_str().unwrap().to_owned()),
             ),
-            "leaf" => {}
+            "bucket" => {}
             other => panic!("unsupported assessment manifest node {other}"),
         }
         original.insert(digest, bytes);
@@ -808,7 +808,7 @@ fn bucket_manifest_experiment(source: &Path) -> Value {
     json!({"source_manifest_objects":original.len(),"source_manifest_allocated_bytes":original_allocated,
         "candidate_bucket_capacity":8,"candidate_objects":candidate.len(),"candidate_logical_bytes":candidate_logical,
         "candidate_estimated_allocated_bytes_at_4096":candidate_quantized,"authenticated_lookups_checked":entries.len(),
-        "production_format_changed":false})
+        "production_format_changed":true,"source_manifest_logical_bytes":original.values().map(Vec::len).sum::<usize>()})
 }
 
 fn validate_storage_budgets(f: Fixture, storage: &graphforge_storage::StorageAttributionSnapshot) {
@@ -889,6 +889,45 @@ fn validate_storage_budgets(f: Fixture, storage: &graphforge_storage::StorageAtt
     );
 }
 
+fn whole_project_file_census(root: &Path) -> Value {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let mut pending = vec![root.to_path_buf()];
+        let mut seen = BTreeSet::new();
+        let (mut files, mut logical, mut allocated, mut directory_allocated) =
+            (0_u64, 0_u64, 0_u64, 0_u64);
+        while let Some(path) = pending.pop() {
+            let metadata = std::fs::symlink_metadata(&path).unwrap();
+            assert!(!metadata.file_type().is_symlink());
+            if !seen.insert((metadata.dev(), metadata.ino())) {
+                continue;
+            }
+            if metadata.is_dir() {
+                directory_allocated += metadata.blocks() * 512;
+                pending.extend(
+                    std::fs::read_dir(path)
+                        .unwrap()
+                        .map(|entry| entry.unwrap().path()),
+                );
+            } else {
+                assert!(metadata.is_file());
+                files += 1;
+                logical += metadata.len();
+                allocated += metadata.blocks() * 512;
+            }
+        }
+        json!({"unique_files":files,"file_logical_bytes":logical,"file_allocated_bytes":allocated,
+            "directory_allocated_bytes":directory_allocated,"deduplication":"device/inode",
+            "scope":"recursive project including retained generations, caches and private state; point-in-time, not peak"})
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = root;
+        json!({"measured":false,"reason":"native inode census requires Unix"})
+    }
+}
+
 fn assess(f: Fixture) {
     let root = tempfile::tempdir().unwrap();
     let source = root.path().join("source");
@@ -924,6 +963,16 @@ fn assess(f: Fixture) {
     }
     let identity_experiment = identity_padding_experiment(&source);
     let manifest_experiment = bucket_manifest_experiment(&source);
+    if f.heterogeneous {
+        assert_eq!(manifest_experiment["authenticated_lookups_checked"], 352);
+        assert!(
+            manifest_experiment["source_manifest_allocated_bytes"]
+                .as_u64()
+                .unwrap()
+                <= 1_536_000,
+            "production manifest must halve the 3,072,000-byte #1196 native allocation baseline: {manifest_experiment}"
+        );
+    }
     if f.adjacency {
         graph.rebuild_adjacency(None).unwrap();
     }
@@ -937,11 +986,12 @@ fn assess(f: Fixture) {
         "unbuilt and built adjacency are distinct measured capabilities"
     );
     drop(graph);
+    let whole_project = whole_project_file_census(&source);
     let fingerprint = round_trip(root.path(), &source, f, &nodes, &edges);
     println!(
         "PERMANENT_STORAGE_ASSESSMENT {}",
         json!({"fixture":f.name,"nodes":f.nodes,"edges":f.edges,"routes":f.routes,"random_ids":matches!(f.identifiers, Identifiers::Random),"properties":f.properties,"heterogeneous_schemas":f.heterogeneous,"adjacency_built":f.adjacency,"unindexed_allocated_bytes":unindexed.allocated_bytes,"unindexed_categories":unindexed.categories,
-            "construction_elapsed_ns":construction_ns,"semantic_fingerprint":fingerprint,
+            "construction_elapsed_ns":construction_ns,"semantic_fingerprint":fingerprint,"whole_project":whole_project,
             "permanent": {"logical_bytes":storage.logical_bytes,"physical_logical_bytes":storage.physical_logical_bytes,"allocated_bytes":storage.allocated_bytes,"physical_objects":storage.physical_objects,"categories":storage.categories},
             "adjacency_codec_experiment":adjacency_experiment,"parquet_experiment":experiment,"identity_padding_experiment":identity_experiment,"manifest_bucket_experiment":manifest_experiment})
     );
@@ -995,6 +1045,24 @@ fn public_mutation_replaces_shared_constructed_payloads() {
     );
     drop(graph);
     round_trip(root.path(), &source, fixture, &nodes, &edges);
+    // Exercise the imported current-format manifest through a new publication,
+    // then reopen and authenticate the subsequently mutated graph.
+    let imported_path = root.path().join("imported");
+    let imported = GraphForge::new(imported_path.to_str()).unwrap();
+    imported
+        .execute("MATCH (n) WHERE n.score IS NOT NULL SET n.score = n.score + 1")
+        .unwrap();
+    for node in &mut nodes {
+        node.2 = node.2.map(|score| score + 1);
+    }
+    verify_graph(&imported, fixture, &nodes, &edges);
+    drop(imported);
+    verify_graph(
+        &GraphForge::new(imported_path.to_str()).unwrap(),
+        fixture,
+        &nodes,
+        &edges,
+    );
 }
 
 #[test]

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -5773,10 +5773,11 @@ fn validate_fresh_cas_control_bound(
         return Err("CAS growth proof requires one fresh publication with every changed path in the canonical inventory".into());
     }
     // A radix update consumes at least one of 64 nibbles per recursive branch.
-    // A split installs at most three nodes; a collapse can load one extra child.
+    // A nine-entry bucket split installs at most 17 nodes (2 * 9 - 1).
+    // This fresh-publication bound has no deletions or collapse probes.
     // The fresh empty root adds one install before the P updates.
     let installs = paths
-        .checked_mul(67)
+        .checked_mul(81)
         .and_then(|value| value.checked_add(1))
         .ok_or("CAS manifest install bound overflows")?;
     let reads = paths
@@ -5791,7 +5792,8 @@ fn validate_fresh_cas_control_bound(
         .checked_mul(graphforge_storage::GRAPH_MANIFEST_ENTRY_ENCODING_OVERHEAD_BYTES)
         .and_then(|value| value.checked_add(inventory_bytes))
         .and_then(|value| value.checked_add(graphforge_storage::GRAPH_MANIFEST_BRANCH_MAX_BYTES))
-        .ok_or("CAS manifest encoded-node bound overflows")?;
+        .ok_or("CAS manifest encoded-node bound overflows")?
+        .min(graphforge_storage::GRAPH_MANIFEST_NODE_MAX_BYTES);
     let requests = io
         .manifest
         .installed_objects

--- a/crates/graphforge-api/tests/scale_g500_ladder.rs
+++ b/crates/graphforge-api/tests/scale_g500_ladder.rs
@@ -6778,7 +6778,10 @@ fn cas_control_proof_accepts_path_variation_and_rejects_coherent_overcounts() {
             .contains("mandatory bootstrap")
     );
     let mut excessive = observations[0].clone();
-    let installed = 67 * excessive.canonical_artifact_objects + 2;
+    // Exceed the current 64-nibble path + 17-node local bucket split bound,
+    // including the one empty-root installation. Keep the negative case
+    // coherent with its I/O totals so it fails the structural ceiling itself.
+    let installed = 81 * excessive.canonical_artifact_objects + 2;
     let manifest = &mut excessive.cas_publication_io.manifest;
     manifest.installed_objects = installed;
     manifest.install_attempts = installed;

--- a/crates/graphforge-storage/src/graph_construction.rs
+++ b/crates/graphforge-storage/src/graph_construction.rs
@@ -292,7 +292,7 @@ fn compact_parent_inventory(
             crate::graph_object_store::read_graph_object_counted(
                 parent.container_root(),
                 digest,
-                64 * 1024 * 1024,
+                crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
                 &mut io,
             )
         })?;

--- a/crates/graphforge-storage/src/graph_construction_encoding.rs
+++ b/crates/graphforge-storage/src/graph_construction_encoding.rs
@@ -929,7 +929,7 @@ fn construction_parent_routes(
                     crate::graph_object_store::read_graph_object_counted(
                         parent.container_root(),
                         digest,
-                        64 * 1024 * 1024,
+                        crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
                         &mut io,
                     )
                 },

--- a/crates/graphforge-storage/src/graph_manifest.rs
+++ b/crates/graphforge-storage/src/graph_manifest.rs
@@ -13,7 +13,16 @@ pub const GRAPH_FILES_V2_VERSION: u32 = 2;
 /// Canonical radix-node format identifier.
 pub const GRAPH_MANIFEST_NODE_FORMAT: &str = "graphforge-graph-manifest-radix-node";
 /// Supported radix-node format version.
-pub const GRAPH_MANIFEST_NODE_VERSION: u32 = 2;
+pub const GRAPH_MANIFEST_NODE_VERSION: u32 = 3;
+/// Maximum exact entries in one current-format bucket.
+pub const GRAPH_MANIFEST_BUCKET_CAPACITY: usize = 8;
+/// Maximum canonical relative-path bytes in a manifest entry.
+pub const GRAPH_MANIFEST_PATH_MAX_BYTES: usize = 4096;
+/// Per-node encoded admission, checked before storage reads and JSON parsing.
+pub const GRAPH_MANIFEST_NODE_MAX_BYTES: u64 = 256 * 1024;
+/// Conservative decoded field/collection-slot charge, excluding allocator
+/// overhead and parser/canonical-encoding buffers (not a native RSS limit).
+pub const GRAPH_MANIFEST_NODE_MAX_DECODED_BYTES: u64 = 64 * 1024;
 /// Number of SHA-256 nibbles consumed by the Patricia trie.
 pub const GRAPH_RADIX_DEPTH: u8 = 64;
 /// Largest canonical branch: 16 references, a 63-nibble prefix, JSON header and newline.
@@ -39,7 +48,7 @@ pub struct GraphFilesRootV2 {
 }
 
 /// One immutable, canonically encoded radix node.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct GraphManifestNode {
     /// Node contract identifier.
     pub format: String,
@@ -50,12 +59,12 @@ pub struct GraphManifestNode {
     /// Lowercase hex path compressed between `depth` and this node's payload.
     pub prefix: String,
     #[serde(flatten)]
-    /// Branch or collision-leaf payload.
+    /// Branch or bounded-bucket payload.
     pub kind: GraphManifestNodeKind,
 }
 
 /// Canonical radix-node payload.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum GraphManifestNodeKind {
     /// Hex-nibble child references.
@@ -63,13 +72,142 @@ pub enum GraphManifestNodeKind {
         /// Canonically ordered nibble to child-object digest map.
         children: BTreeMap<String, String>,
     },
-    /// Terminal exact-path collision bucket.
-    Leaf {
-        /// Full SHA-256 digest shared by every colliding exact path.
-        path_sha256: String,
+    /// At most eight exact paths sharing the node's compressed route.
+    Bucket {
         /// Exact logical entries ordered by relative path.
         entries: Vec<GraphFileEntry>,
     },
+}
+
+// Do not deserialize the flattened public representation through Serde's
+// intermediate Content tree: that buffers arbitrary entries before an entry
+// visitor can enforce its limit. This wire type parses bounded fields directly.
+struct BoundedText<const MAX: usize>(String);
+impl<'de, const MAX: usize> Deserialize<'de> for BoundedText<MAX> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct TextVisitor<const MAX: usize>;
+        impl<const MAX: usize> serde::de::Visitor<'_> for TextVisitor<MAX> {
+            type Value = BoundedText<MAX>;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("bounded manifest text")
+            }
+            fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                if value.len() > MAX {
+                    return Err(E::custom("manifest text exceeds byte limit"));
+                }
+                Ok(BoundedText(value.to_owned()))
+            }
+        }
+        deserializer.deserialize_str(TextVisitor::<MAX>)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BoundedEntry {
+    relative_path: BoundedText<GRAPH_MANIFEST_PATH_MAX_BYTES>,
+    byte_length: u64,
+    content_sha256: BoundedText<64>,
+    role: GraphFileRole,
+}
+struct BoundedEntries(Vec<GraphFileEntry>);
+impl<'de> Deserialize<'de> for BoundedEntries {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct EntriesVisitor;
+        impl<'de> serde::de::Visitor<'de> for EntriesVisitor {
+            type Value = BoundedEntries;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("at most eight manifest entries")
+            }
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut input: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut entries = Vec::with_capacity(GRAPH_MANIFEST_BUCKET_CAPACITY);
+                for _ in 0..GRAPH_MANIFEST_BUCKET_CAPACITY {
+                    let Some(entry) = input.next_element::<BoundedEntry>()? else {
+                        return Ok(BoundedEntries(entries));
+                    };
+                    entries.push(GraphFileEntry {
+                        relative_path: entry.relative_path.0,
+                        byte_length: entry.byte_length,
+                        content_sha256: entry.content_sha256.0,
+                        role: entry.role,
+                    });
+                }
+                if input.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "manifest bucket entry limit exceeded",
+                    ));
+                }
+                Ok(BoundedEntries(entries))
+            }
+        }
+        deserializer.deserialize_seq(EntriesVisitor)
+    }
+}
+struct BoundedChildren(BTreeMap<String, String>);
+impl<'de> Deserialize<'de> for BoundedChildren {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ChildrenVisitor;
+        impl<'de> serde::de::Visitor<'de> for ChildrenVisitor {
+            type Value = BoundedChildren;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("at most sixteen manifest children")
+            }
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut input: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut children = BTreeMap::new();
+                for _ in 0..16 {
+                    let Some((key, value)) =
+                        input.next_entry::<BoundedText<1>, BoundedText<64>>()?
+                    else {
+                        return Ok(BoundedChildren(children));
+                    };
+                    if children.insert(key.0, value.0).is_some() {
+                        return Err(serde::de::Error::custom("duplicate manifest child"));
+                    }
+                }
+                if input.next_key::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::custom("manifest child limit exceeded"));
+                }
+                Ok(BoundedChildren(children))
+            }
+        }
+        deserializer.deserialize_map(ChildrenVisitor)
+    }
+}
+impl<'de> Deserialize<'de> for GraphManifestNode {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Wire {
+            format: BoundedText<64>,
+            format_version: u32,
+            depth: u8,
+            prefix: BoundedText<64>,
+            kind: BoundedText<8>,
+            children: Option<BoundedChildren>,
+            entries: Option<BoundedEntries>,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        let kind = match (wire.kind.0.as_str(), wire.children, wire.entries) {
+            ("branch", Some(children), None) => GraphManifestNodeKind::Branch {
+                children: children.0,
+            },
+            ("bucket", None, Some(entries)) => GraphManifestNodeKind::Bucket { entries: entries.0 },
+            _ => return Err(serde::de::Error::custom("unsupported manifest node shape")),
+        };
+        Ok(Self {
+            format: wire.format.0,
+            format_version: wire.format_version,
+            depth: wire.depth,
+            prefix: wire.prefix.0,
+            kind,
+        })
+    }
 }
 
 /// Admission bounds for resolving an untrusted radix manifest.
@@ -129,10 +267,21 @@ pub(crate) struct GraphManifestTargetedState {
 /// Encode one validated node as canonical JSON-line bytes.
 pub fn encode_node(node: &GraphManifestNode) -> Result<Vec<u8>, GfError> {
     validate_node(node)?;
-    canonical_line(node, "graph manifest radix node")
+    let bytes = canonical_line(node, "graph manifest radix node")?;
+    if bytes.len() as u64 > GRAPH_MANIFEST_NODE_MAX_BYTES {
+        return Err(validation(
+            "graph manifest encoded node byte limit exceeded",
+        ));
+    }
+    Ok(bytes)
 }
 /// Decode and validate canonical JSON-line node bytes.
 pub fn decode_node(bytes: &[u8]) -> Result<GraphManifestNode, GfError> {
+    if bytes.len() as u64 > GRAPH_MANIFEST_NODE_MAX_BYTES {
+        return Err(validation(
+            "graph manifest encoded node byte limit exceeded",
+        ));
+    }
     decode_canonical_line(bytes, "graph manifest radix node", validate_node)
 }
 /// Encode one validated compact root as canonical JSON-line bytes.
@@ -265,21 +414,17 @@ where
                     stack.push((child, payload_depth + 1, child_route));
                 }
             }
-            GraphManifestNodeKind::Leaf {
-                path_sha256,
-                entries,
-            } => {
-                if payload_depth != GRAPH_RADIX_DEPTH || node_route != path_sha256 {
-                    return Err(validation("graph manifest leaf is not terminal"));
-                }
+            GraphManifestNodeKind::Bucket { entries } => {
                 admit_work(
                     &mut evidence,
                     limits,
                     u64::try_from(entries.len()).unwrap_or(u64::MAX),
                 )?;
                 for entry in entries {
-                    if hex_digest(logical_path_digest(&entry.relative_path)) != path_sha256 {
-                        return Err(validation("graph manifest leaf path digest mismatch"));
+                    if !hex_digest(logical_path_digest(&entry.relative_path))
+                        .starts_with(&node_route)
+                    {
+                        return Err(validation("graph manifest bucket ancestral route mismatch"));
                     }
                     evidence.entries_examined = evidence.entries_examined.saturating_add(1);
                     if files.insert(entry.relative_path.clone(), entry).is_some() {
@@ -375,6 +520,30 @@ where
         if node.depth != depth {
             return Err(validation("graph manifest radix depth mismatch"));
         }
+        if let GraphManifestNodeKind::Bucket { entries } = &node.kind {
+            state.entries_examined = state
+                .entries_examined
+                .checked_add(entries.len())
+                .ok_or_else(|| validation("graph manifest targeted entry total overflow"))?;
+            if state.entries_examined > limits.max_entries {
+                return Err(validation("graph manifest targeted entry limit exceeded"));
+            }
+            state.work_units = state
+                .work_units
+                .checked_add(u64::try_from(entries.len()).unwrap_or(u64::MAX))
+                .ok_or_else(|| validation("graph manifest targeted work overflow"))?;
+            if state.work_units > limits.max_work_units {
+                return Err(validation("graph manifest targeted work limit exceeded"));
+            }
+            let ancestral_route = &route[..usize::from(depth)];
+            for entry in entries {
+                if !hex_digest(logical_path_digest(&entry.relative_path))
+                    .starts_with(ancestral_route)
+                {
+                    return Err(validation("graph manifest bucket ancestral route mismatch"));
+                }
+            }
+        }
         let prefix_end = usize::from(depth)
             .checked_add(node.prefix.len())
             .ok_or_else(|| validation("graph manifest prefix overflow"))?;
@@ -407,36 +576,10 @@ where
                 digest.clone_from(child);
                 depth = depth.saturating_add(1);
             }
-            GraphManifestNodeKind::Leaf {
-                path_sha256,
-                entries,
-            } => {
-                state.entries_examined = state
-                    .entries_examined
-                    .checked_add(entries.len())
-                    .ok_or_else(|| validation("graph manifest targeted entry total overflow"))?;
-                if state.entries_examined > limits.max_entries {
-                    return Err(validation("graph manifest targeted entry limit exceeded"));
-                }
-                state.work_units = state
-                    .work_units
-                    .checked_add(u64::try_from(entries.len()).unwrap_or(u64::MAX))
-                    .ok_or_else(|| validation("graph manifest targeted work overflow"))?;
-                if state.work_units > limits.max_work_units {
-                    return Err(validation("graph manifest targeted work limit exceeded"));
-                }
-                if depth != GRAPH_RADIX_DEPTH || path_sha256 != route {
-                    return Err(validation("graph manifest leaf is not terminal"));
-                }
-                for entry in entries {
-                    if hex_digest(logical_path_digest(&entry.relative_path)) != path_sha256 {
-                        return Err(validation("graph manifest leaf path digest mismatch"));
-                    }
-                    if entry.relative_path == relative_path {
-                        return Ok(Some(entry));
-                    }
-                }
-                return Ok(None);
+            GraphManifestNodeKind::Bucket { entries } => {
+                return Ok(entries
+                    .into_iter()
+                    .find(|entry| entry.relative_path == relative_path));
             }
         }
     }
@@ -475,6 +618,9 @@ fn validate_node(node: &GraphManifestNode) -> Result<(), GfError> {
     {
         return Err(validation("unsupported graph manifest radix node contract"));
     }
+    if node.prefix.len() > usize::from(GRAPH_RADIX_DEPTH) {
+        return Err(validation("graph manifest prefix byte limit exceeded"));
+    }
     validate_prefix(&node.prefix)?;
     let payload_depth = node
         .depth
@@ -487,8 +633,11 @@ fn validate_node(node: &GraphManifestNode) -> Result<(), GfError> {
     }
     match &node.kind {
         GraphManifestNodeKind::Branch { children } => {
+            if children.len() > 16 {
+                return Err(validation("graph manifest child limit exceeded"));
+            }
             if payload_depth >= GRAPH_RADIX_DEPTH {
-                return Err(validation("terminal graph manifest node must be a leaf"));
+                return Err(validation("terminal graph manifest node must be a bucket"));
             }
             if children.len() == 1 {
                 return Err(validation("graph manifest unary branch is not canonical"));
@@ -507,32 +656,80 @@ fn validate_node(node: &GraphManifestNode) -> Result<(), GfError> {
                 }
             }
         }
-        GraphManifestNodeKind::Leaf {
-            path_sha256,
-            entries,
-        } => {
-            if payload_depth != GRAPH_RADIX_DEPTH || entries.is_empty() {
-                return Err(validation("graph manifest leaf shape is invalid"));
-            }
-            validate_digest(path_sha256)?;
-            if node.prefix != path_sha256[usize::from(node.depth)..] {
-                return Err(validation("graph manifest leaf compressed route mismatch"));
+        GraphManifestNodeKind::Bucket { entries } => {
+            if entries.is_empty() || entries.len() > GRAPH_MANIFEST_BUCKET_CAPACITY {
+                return Err(validation("graph manifest bucket shape is invalid"));
             }
             let mut previous: Option<&str> = None;
             for entry in entries {
                 validate_entry(entry)?;
                 if previous.is_some_and(|p| p >= entry.relative_path.as_str()) {
-                    return Err(validation("graph manifest collision leaf is not canonical"));
-                }
-                if hex_digest(logical_path_digest(&entry.relative_path)) != *path_sha256 {
-                    return Err(validation("graph manifest leaf path digest mismatch"));
+                    return Err(validation(
+                        "graph manifest bucket entry order is not canonical",
+                    ));
                 }
                 previous = Some(&entry.relative_path);
             }
+            if node.prefix != bucket_prefix(node.depth, entries)? {
+                return Err(validation(
+                    "graph manifest bucket compressed route mismatch",
+                ));
+            }
         }
+    }
+    let decoded_charge = std::mem::size_of::<GraphManifestNode>() as u64
+        + node.format.len() as u64
+        + node.prefix.len() as u64
+        + match &node.kind {
+            GraphManifestNodeKind::Bucket { entries } => {
+                (GRAPH_MANIFEST_BUCKET_CAPACITY * std::mem::size_of::<GraphFileEntry>()) as u64
+                    + entries
+                        .iter()
+                        .map(|entry| {
+                            (entry.relative_path.len() + entry.content_sha256.len()) as u64
+                        })
+                        .sum::<u64>()
+            }
+            GraphManifestNodeKind::Branch { children } => {
+                (16 * std::mem::size_of::<(String, String)>()) as u64
+                    + children
+                        .iter()
+                        .map(|(key, value)| (key.len() + value.len()) as u64)
+                        .sum::<u64>()
+            }
+        };
+    if decoded_charge > GRAPH_MANIFEST_NODE_MAX_DECODED_BYTES {
+        return Err(validation(
+            "graph manifest decoded node byte limit exceeded",
+        ));
     }
     Ok(())
 }
+/// Maximal common digest suffix for a bounded entry set at the given depth.
+pub(crate) fn bucket_prefix(depth: u8, entries: &[GraphFileEntry]) -> Result<String, GfError> {
+    if depth > GRAPH_RADIX_DEPTH || entries.is_empty() {
+        return Err(validation("invalid manifest bucket prefix input"));
+    }
+    let first = hex_digest(logical_path_digest(&entries[0].relative_path));
+    let mut end = usize::from(GRAPH_RADIX_DEPTH);
+    for entry in &entries[1..] {
+        let digest = hex_digest(logical_path_digest(&entry.relative_path));
+        end = end.min(
+            first
+                .bytes()
+                .zip(digest.bytes())
+                .take_while(|(a, b)| a == b)
+                .count(),
+        );
+    }
+    if end < usize::from(depth) {
+        return Err(validation(
+            "graph manifest bucket entries cross ancestral routes",
+        ));
+    }
+    Ok(first[usize::from(depth)..end].to_owned())
+}
+
 fn validate_entry(entry: &GraphFileEntry) -> Result<(), GfError> {
     validate_path(&entry.relative_path)?;
     validate_digest(&entry.content_sha256)?;
@@ -548,7 +745,8 @@ fn validate_entry(entry: &GraphFileEntry) -> Result<(), GfError> {
 }
 fn validate_path(value: &str) -> Result<(), GfError> {
     let path = std::path::Path::new(value);
-    if path.as_os_str().is_empty()
+    if value.len() > GRAPH_MANIFEST_PATH_MAX_BYTES
+        || path.as_os_str().is_empty()
         || path.is_absolute()
         || path
             .components()
@@ -690,8 +888,7 @@ mod tests {
                         format_version: GRAPH_MANIFEST_NODE_VERSION,
                         depth: 0,
                         prefix: digest.clone(),
-                        kind: GraphManifestNodeKind::Leaf {
-                            path_sha256: digest,
+                        kind: GraphManifestNodeKind::Bucket {
                             entries: vec![entry],
                         },
                     };
@@ -736,8 +933,7 @@ mod tests {
                 format_version: GRAPH_MANIFEST_NODE_VERSION,
                 depth: GRAPH_RADIX_DEPTH,
                 prefix: String::new(),
-                kind: GraphManifestNodeKind::Leaf {
-                    path_sha256: digest.clone(),
+                kind: GraphManifestNodeKind::Bucket {
                     entries: vec![GraphFileEntry {
                         relative_path: path.into(),
                         byte_length: 0,
@@ -874,8 +1070,7 @@ mod tests {
             format_version: GRAPH_MANIFEST_NODE_VERSION,
             depth: 0,
             prefix: path_sha256.clone(),
-            kind: GraphManifestNodeKind::Leaf {
-                path_sha256,
+            kind: GraphManifestNodeKind::Bucket {
                 entries: vec![entry],
             },
         };
@@ -952,8 +1147,7 @@ mod tests {
                 format_version: GRAPH_MANIFEST_NODE_VERSION,
                 depth: 1,
                 prefix: route[1..].into(),
-                kind: GraphManifestNodeKind::Leaf {
-                    path_sha256: route,
+                kind: GraphManifestNodeKind::Bucket {
                     entries: vec![GraphFileEntry {
                         relative_path: path.clone(),
                         byte_length: 1,
@@ -1008,5 +1202,158 @@ mod tests {
         assert!(results.next().unwrap().unwrap().is_some());
         let error = results.next().unwrap().unwrap_err();
         assert!(error.to_string().contains("segment limit"), "{error}");
+    }
+    fn test_bucket(depth: u8, paths: &[String]) -> GraphManifestNode {
+        let mut entries = paths
+            .iter()
+            .map(|path| GraphFileEntry {
+                relative_path: path.clone(),
+                byte_length: u64::MAX,
+                content_sha256: "a".repeat(64),
+                role: GraphFileRole::Properties,
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+        GraphManifestNode {
+            format: GRAPH_MANIFEST_NODE_FORMAT.into(),
+            format_version: GRAPH_MANIFEST_NODE_VERSION,
+            depth,
+            prefix: bucket_prefix(depth, &entries).unwrap(),
+            kind: GraphManifestNodeKind::Bucket { entries },
+        }
+    }
+
+    #[test]
+    fn bounded_bucket_decoder_admits_maximum_fields_and_refuses_before_ninth_entry() {
+        let paths = (0..GRAPH_MANIFEST_BUCKET_CAPACITY)
+            .map(|index| {
+                let prefix = format!("p/{index}/");
+                format!(
+                    "{prefix}{}",
+                    "\u{0001}".repeat(GRAPH_MANIFEST_PATH_MAX_BYTES - prefix.len())
+                )
+            })
+            .collect::<Vec<_>>();
+        let node = test_bucket(0, &paths);
+        let encoded = encode_node(&node).unwrap();
+        assert!(encoded.len() as u64 <= GRAPH_MANIFEST_NODE_MAX_BYTES);
+        assert!(
+            encoded.len() > 192 * 1024,
+            "escaped maximum paths must exercise the encoded bound"
+        );
+        assert_eq!(decode_node(&encoded).unwrap(), node);
+
+        let mut too_long = paths.clone();
+        too_long[0].push('x');
+        assert!(encode_node(&test_bucket(0, &too_long)).is_err());
+        let mut wire = serde_json::to_value(&node).unwrap();
+        wire["entries"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "relative_path": "x".repeat(GRAPH_MANIFEST_PATH_MAX_BYTES + 1)
+            }));
+        let mut bytes = serde_json::to_vec(&wire).unwrap();
+        bytes.push(b'\n');
+        let error = decode_node(&bytes).unwrap_err();
+        assert!(
+            error.to_string().contains("entry limit"),
+            "ninth entry must not be decoded: {error}"
+        );
+
+        let bytes = vec![b'x'; GRAPH_MANIFEST_NODE_MAX_BYTES as usize + 1];
+        assert!(
+            decode_node(&bytes)
+                .unwrap_err()
+                .to_string()
+                .contains("encoded node byte limit")
+        );
+        let mut old = node;
+        old.format_version = 2;
+        let bytes = canonical_line(&old, "test").unwrap();
+        assert!(
+            decode_node(&bytes)
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported")
+        );
+    }
+
+    #[test]
+    fn bucket_duplicate_order_and_nonmaximal_prefix_are_rejected() {
+        let paths = vec!["a.parquet".into(), "b.parquet".into()];
+        let mut node = test_bucket(0, &paths);
+        let GraphManifestNodeKind::Bucket { entries } = &mut node.kind else {
+            unreachable!()
+        };
+        entries.reverse();
+        assert!(encode_node(&node).is_err());
+        let mut node = test_bucket(0, &paths);
+        let GraphManifestNodeKind::Bucket { entries } = &mut node.kind else {
+            unreachable!()
+        };
+        entries[1] = entries[0].clone();
+        assert!(encode_node(&node).is_err());
+        let mut node = test_bucket(0, &paths[..1]);
+        node.prefix.pop();
+        assert!(encode_node(&node).is_err());
+    }
+
+    #[test]
+    fn targeted_absence_rejects_bucket_under_wrong_ancestor() {
+        let actual = "topology/actual.parquet".to_owned();
+        let actual_route = hex_digest(logical_path_digest(&actual));
+        let wrong_edge = if actual_route.starts_with('0') {
+            "1"
+        } else {
+            "0"
+        };
+        let absent = (0..10_000)
+            .map(|index| format!("topology/absent-{index}.parquet"))
+            .find(|path| hex_digest(logical_path_digest(path)).starts_with(wrong_edge))
+            .unwrap();
+        let misplaced = test_bucket(1, std::slice::from_ref(&actual));
+        let bytes = encode_node(&misplaced).unwrap();
+        let digest = object_digest(&bytes);
+        // A distinct well-formed sibling avoids relying on unary-branch refusal.
+        let sibling = test_bucket(1, &[actual.clone() + ".sibling"]);
+        let sibling_route = hex_digest(logical_path_digest(&(actual.clone() + ".sibling")));
+        let sibling_edge = &sibling_route[..1];
+        assert_ne!(sibling_edge, wrong_edge);
+        let sibling_bytes = encode_node(&sibling).unwrap();
+        let sibling_digest = object_digest(&sibling_bytes);
+        let root_node = branch(
+            0,
+            BTreeMap::from([
+                (wrong_edge.into(), digest.clone()),
+                (sibling_edge.into(), sibling_digest.clone()),
+            ]),
+        );
+        let root_bytes = encode_node(&root_node).unwrap();
+        let root_digest = object_digest(&root_bytes);
+        let objects = BTreeMap::from([
+            (digest, bytes),
+            (sibling_digest, sibling_bytes),
+            (root_digest.clone(), root_bytes),
+        ]);
+        let root = GraphFilesRootV2 {
+            format: GRAPH_FILES_V2_FORMAT.into(),
+            format_version: GRAPH_FILES_V2_VERSION,
+            root_node_sha256: root_digest,
+            logical_file_count: 2,
+            logical_byte_length: 0,
+        };
+        let error =
+            resolve_manifest_entry(&root, &absent, GraphManifestLimits::default(), |digest| {
+                Ok(objects[digest].clone())
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("ancestral route"), "{error}");
+        assert!(
+            resolve_manifest(&root, GraphManifestLimits::default(), |digest| Ok(objects
+                [digest]
+                .clone()))
+            .is_err()
+        );
     }
 }

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -802,7 +802,7 @@ impl GraphManifestState {
             let (bytes, io) = read_graph_object_by_digest_file_counted(
                 lease.cas.open_digest(digest)?,
                 digest,
-                64 * 1024 * 1024,
+                crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
                 &lease.cas.diagnostic_root,
             )?;
             read_calls = read_calls
@@ -1081,7 +1081,11 @@ pub(crate) fn gc_graph_objects_guarded(
         let mut segment_digests = Vec::new();
         let (files, _) = crate::resolve_graph_manifest(graph_root, limits, |digest| {
             segment_digests.push(digest.to_owned());
-            read_graph_object_by_digest_from_cas(&guard.cas, digest, 64 * 1024 * 1024)
+            read_graph_object_by_digest_from_cas(
+                &guard.cas,
+                digest,
+                crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
+            )
         })?;
         marked.extend(segment_digests);
         marked.extend(files.into_iter().map(|entry| entry.content_sha256));
@@ -1794,7 +1798,7 @@ fn load_manifest_node(
     let (bytes, io) = read_graph_object_by_digest_file_counted(
         lease.cas.open_digest(digest)?,
         digest,
-        64 * 1024 * 1024,
+        crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
         &lease.cas.diagnostic_root,
     )?;
     publication_io.manifest_reads.add_read(io)?;
@@ -1839,21 +1843,45 @@ fn update_manifest_digest(
 ) -> Result<Option<String>, GfError> {
     let Some(current_digest) = current_digest else {
         return replacement
-            .map(|entry| {
-                install_manifest_node(
-                    lease,
-                    &leaf_node(
-                        depth,
-                        &path_digest[usize::from(depth)..],
-                        path_digest,
-                        vec![entry],
-                    ),
-                    publication_io,
-                )
-            })
+            .map(|entry| install_bucket_entries(lease, depth, vec![entry], publication_io))
             .transpose();
     };
     let mut node = load_manifest_node(lease, current_digest, depth, publication_io)?;
+    // A small bucket absorbs a divergent path before any prefix split. Both
+    // replacement and deletion recompute its maximal compressed prefix.
+    if let GraphManifestNodeKind::Bucket { mut entries } = node.kind {
+        for entry in &entries {
+            if !hex_digest(crate::graph_manifest::logical_path_digest(
+                &entry.relative_path,
+            ))
+            .starts_with(&path_digest[..usize::from(depth)])
+            {
+                return Err(validation(
+                    "manifest bucket ancestral route mismatch during update",
+                ));
+            }
+        }
+        match entries.binary_search_by(|entry| entry.relative_path.as_str().cmp(path)) {
+            Ok(index) => match replacement {
+                Some(entry) => entries[index] = entry,
+                None => {
+                    entries.remove(index);
+                }
+            },
+            Err(index) => {
+                if let Some(entry) = replacement {
+                    entries.insert(index, entry);
+                } else {
+                    return Ok(Some(current_digest.to_owned()));
+                }
+            }
+        }
+        return if entries.is_empty() {
+            Ok(None)
+        } else {
+            install_bucket_entries(lease, depth, entries, publication_io).map(Some)
+        };
+    }
     let start = usize::from(depth);
     let common = node
         .prefix
@@ -1878,12 +1906,7 @@ fn update_manifest_digest(
         }
         let new_digest = install_manifest_node(
             lease,
-            &leaf_node(
-                split_depth + 1,
-                &path_digest[usize::from(split_depth) + 1..],
-                path_digest,
-                vec![entry],
-            ),
+            &bucket_node(split_depth + 1, vec![entry])?,
             publication_io,
         )?;
         let children = BTreeMap::from([(old_edge, old_digest), (new_edge, new_digest)]);
@@ -1900,38 +1923,8 @@ fn update_manifest_digest(
         )
         .ok_or_else(|| validation("Patricia depth overflow"))?;
     match node.kind {
-        GraphManifestNodeKind::Leaf {
-            path_sha256,
-            mut entries,
-        } => {
-            if path_sha256 != path_digest {
-                return Err(validation("Patricia leaf route mismatch"));
-            }
-            match entries.binary_search_by(|entry| entry.relative_path.as_str().cmp(path)) {
-                Ok(index) => match replacement {
-                    Some(entry) => entries[index] = entry,
-                    None => {
-                        entries.remove(index);
-                    }
-                },
-                Err(index) => {
-                    if let Some(entry) = replacement {
-                        entries.insert(index, entry);
-                    } else {
-                        return Ok(Some(current_digest.to_owned()));
-                    }
-                }
-            }
-            if entries.is_empty() {
-                Ok(None)
-            } else {
-                install_manifest_node(
-                    lease,
-                    &leaf_node(depth, &node.prefix, path_digest, entries),
-                    publication_io,
-                )
-                .map(Some)
-            }
+        GraphManifestNodeKind::Bucket { .. } => {
+            unreachable!("buckets handled before prefix splitting")
         }
         GraphManifestNodeKind::Branch { mut children } => {
             if payload_depth >= GRAPH_RADIX_DEPTH {
@@ -1939,6 +1932,7 @@ fn update_manifest_digest(
             }
             let edge =
                 path_digest[usize::from(payload_depth)..=usize::from(payload_depth)].to_owned();
+            let deleting = replacement.is_none();
             let child = update_manifest_digest(
                 lease,
                 children.get(&edge).map(String::as_str),
@@ -1970,12 +1964,26 @@ fn update_manifest_digest(
                     child.prefix = format!("{}{}{}", node.prefix, edge, child.prefix);
                     install_manifest_node(lease, &child, publication_io).map(Some)
                 }
-                _ => install_manifest_node(
-                    lease,
-                    &branch_node(depth, &node.prefix, children),
-                    publication_io,
-                )
-                .map(Some),
+                _ => {
+                    if deleting
+                        && let Some(entries) = collect_small_subtree(
+                            lease,
+                            &children,
+                            payload_depth + 1,
+                            &path_digest[..usize::from(payload_depth)],
+                            publication_io,
+                        )?
+                    {
+                        return install_bucket_entries(lease, depth, entries, publication_io)
+                            .map(Some);
+                    }
+                    install_manifest_node(
+                        lease,
+                        &branch_node(depth, &node.prefix, children),
+                        publication_io,
+                    )
+                    .map(Some)
+                }
             }
         }
     }
@@ -1991,22 +1999,128 @@ fn branch_node(depth: u8, prefix: &str, children: BTreeMap<String, String>) -> G
     }
 }
 
-fn leaf_node(
+fn bucket_node(
     depth: u8,
-    prefix: &str,
-    path_sha256: &str,
     entries: Vec<crate::GraphFileEntry>,
-) -> GraphManifestNode {
-    GraphManifestNode {
+) -> Result<GraphManifestNode, GfError> {
+    Ok(GraphManifestNode {
         format: GRAPH_MANIFEST_NODE_FORMAT.into(),
         format_version: GRAPH_MANIFEST_NODE_VERSION,
         depth,
-        prefix: prefix.to_owned(),
-        kind: GraphManifestNodeKind::Leaf {
-            path_sha256: path_sha256.to_owned(),
-            entries,
-        },
+        prefix: crate::graph_manifest::bucket_prefix(depth, &entries)?,
+        kind: GraphManifestNodeKind::Bucket { entries },
+    })
+}
+
+// Only a formerly bounded bucket (at most nine entries after insertion) reaches
+// this builder. It never reconstructs the surrounding manifest.
+fn install_bucket_entries(
+    lease: &GraphObjectPublicationLease,
+    depth: u8,
+    entries: Vec<crate::GraphFileEntry>,
+    publication_io: &mut GraphPublicationIo,
+) -> Result<String, GfError> {
+    let capacity = crate::graph_manifest::GRAPH_MANIFEST_BUCKET_CAPACITY;
+    if entries.is_empty() || entries.len() > capacity + 1 {
+        return Err(validation("manifest bucket split input exceeds bound"));
     }
+    if entries.len() <= capacity {
+        return install_manifest_node(lease, &bucket_node(depth, entries)?, publication_io);
+    }
+    let prefix = crate::graph_manifest::bucket_prefix(depth, &entries)?;
+    let split_depth = usize::from(depth) + prefix.len();
+    if split_depth >= usize::from(GRAPH_RADIX_DEPTH) {
+        return Err(validation(
+            "manifest hash collision exceeds bucket capacity",
+        ));
+    }
+    let mut groups = BTreeMap::<String, Vec<crate::GraphFileEntry>>::new();
+    for entry in entries {
+        let digest = hex_digest(crate::graph_manifest::logical_path_digest(
+            &entry.relative_path,
+        ));
+        groups
+            .entry(digest[split_depth..=split_depth].to_owned())
+            .or_default()
+            .push(entry);
+    }
+    let mut children = BTreeMap::new();
+    for (edge, entries) in groups {
+        children.insert(
+            edge,
+            install_bucket_entries(lease, (split_depth + 1) as u8, entries, publication_io)?,
+        );
+    }
+    install_manifest_node(
+        lease,
+        &branch_node(depth, &prefix, children),
+        publication_io,
+    )
+}
+
+// Collect a small child forest without assuming that an authenticated branch
+// necessarily has more than eight descendants. Each pending nonempty node
+// contributes at least one entry. Stop as soon as that lower bound exceeds
+// eight; non-unary branches therefore permit at most sixteen node visits.
+fn collect_small_subtree(
+    lease: &GraphObjectPublicationLease,
+    children: &BTreeMap<String, String>,
+    depth: u8,
+    parent_route: &str,
+    publication_io: &mut GraphPublicationIo,
+) -> Result<Option<Vec<crate::GraphFileEntry>>, GfError> {
+    let capacity = crate::graph_manifest::GRAPH_MANIFEST_BUCKET_CAPACITY;
+    if children.len() > capacity {
+        return Ok(None);
+    }
+    let mut pending = children
+        .iter()
+        .map(|(edge, digest)| (digest.clone(), depth, format!("{parent_route}{edge}")))
+        .collect::<Vec<_>>();
+    let mut entries = Vec::with_capacity(capacity);
+    let mut visited = BTreeSet::new();
+    while let Some((digest, expected_depth, route)) = pending.pop() {
+        if visited.len() >= 2 * capacity || !visited.insert(digest.clone()) {
+            return Err(validation(
+                "manifest collapse node bound or uniqueness violated",
+            ));
+        }
+        let node = load_manifest_node(lease, &digest, expected_depth, publication_io)?;
+        let node_route = format!("{route}{}", node.prefix);
+        match node.kind {
+            GraphManifestNodeKind::Bucket { entries: bucket } => {
+                if entries.len() + pending.len() + bucket.len() > capacity {
+                    return Ok(None);
+                }
+                for entry in bucket {
+                    if !hex_digest(crate::graph_manifest::logical_path_digest(
+                        &entry.relative_path,
+                    ))
+                    .starts_with(&node_route)
+                    {
+                        return Err(validation(
+                            "manifest collapse bucket ancestral route mismatch",
+                        ));
+                    }
+                    entries.push(entry);
+                }
+            }
+            GraphManifestNodeKind::Branch { children } => {
+                if entries.len() + pending.len() + children.len() > capacity {
+                    return Ok(None);
+                }
+                let child_depth = u8::try_from(node_route.len() + 1)
+                    .map_err(|_| validation("manifest collapse depth overflow"))?;
+                pending.extend(
+                    children
+                        .into_iter()
+                        .map(|(edge, digest)| (digest, child_depth, format!("{node_route}{edge}"))),
+                );
+            }
+        }
+    }
+    entries.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    Ok(Some(entries))
 }
 
 /// Resolve a digest to its admitted project-level object path.
@@ -5568,6 +5682,167 @@ mod tests {
             .unwrap();
         assert_eq!(resolved.len(), 7);
         assert!(!resolved.iter().any(|entry| entry.relative_path == deleted));
+    }
+
+    #[test]
+    fn bounded_bucket_update_and_lookup_budgets_do_not_scale_with_inventory() {
+        for count in [128_usize, 256, 512] {
+            let container = tempfile::tempdir().unwrap();
+            let workspace = tempfile::tempdir().unwrap();
+            let lease = begin_graph_object_publication(container.path()).unwrap();
+            let paths = (0..count)
+                .map(|index| PathBuf::from(format!("payload-{index:06}.parquet")))
+                .collect::<Vec<_>>();
+            for path in &paths {
+                fs::write(workspace.path().join(path), b"initial").unwrap();
+            }
+            let mut state = GraphManifestState::empty();
+            let (original, _) =
+                append_graph_files_v2(&lease, workspace.path(), &mut state, &paths, &[]).unwrap();
+            fs::write(workspace.path().join(&paths[count / 2]), b"replacement").unwrap();
+            let (replaced, update) = append_graph_files_v2(
+                &lease,
+                workspace.path(),
+                &mut state,
+                &paths[count / 2..count / 2 + 1],
+                &[],
+            )
+            .unwrap();
+            assert_eq!(update.prior_entries_examined, 0);
+            assert_eq!(update.changed_entries_examined, 1);
+            // This deterministic representative ladder requires at most four radix
+            // reads/writes per replacement, independent of inventory doubling.
+            assert!(update.publication_io.manifest_reads.read_calls <= 4);
+            assert!(update.publication_io.manifest.installed_objects <= 4);
+            for root in [&original, &replaced] {
+                for path in [paths[count / 2].to_str().unwrap(), "absent-payload.parquet"] {
+                    let mut reads = 0;
+                    let found = crate::graph_manifest::resolve_manifest_entry(
+                        root,
+                        path,
+                        crate::GraphManifestLimits::default(),
+                        |digest| {
+                            reads += 1;
+                            read_graph_object_by_digest(
+                                container.path(),
+                                digest,
+                                crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
+                            )
+                        },
+                    )
+                    .unwrap();
+                    assert!(reads <= 4);
+                    assert_eq!(found.is_some(), path != "absent-payload.parquet");
+                    if let Some(entry) = found {
+                        assert_eq!(entry.byte_length, if root == &original { 7 } else { 11 });
+                    }
+                }
+            }
+            let removed = paths[count / 2].to_str().unwrap().to_owned();
+            let (_, deletion) =
+                append_graph_files_v2(&lease, workspace.path(), &mut state, &[], &[removed])
+                    .unwrap();
+            assert_eq!(deletion.prior_entries_examined, 0);
+            // Four ancestors plus at most sixteen bounded collapse probes each;
+            // this is logical application I/O, not process memory or OS I/O.
+            assert!(deletion.publication_io.manifest_reads.read_calls <= 68);
+            assert!(deletion.publication_io.manifest.installed_objects <= 4);
+            println!(
+                "BUCKET_UPDATE_BUDGET entries={count} replacement_reads={} replacement_installs={} deletion_reads={}",
+                update.publication_io.manifest_reads.read_calls,
+                update.publication_io.manifest.installed_objects,
+                deletion.publication_io.manifest_reads.read_calls
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_bucket_split_collapse_and_replacement_preserve_old_roots() {
+        let container = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let lease = begin_graph_object_publication(container.path()).unwrap();
+        let paths = (0..9)
+            .map(|index| PathBuf::from(format!("payload-{index}.parquet")))
+            .collect::<Vec<_>>();
+        for (index, path) in paths.iter().enumerate() {
+            fs::write(workspace.path().join(path), [index as u8]).unwrap();
+        }
+        let mut state = GraphManifestState::empty();
+        let (eight, _) =
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &paths[..8], &[]).unwrap();
+        let read = |root: &GraphFilesRootV2| {
+            let bytes = read_graph_object_by_digest(
+                container.path(),
+                &root.root_node_sha256,
+                crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
+            )
+            .unwrap();
+            crate::decode_graph_manifest_node(&bytes).unwrap()
+        };
+        assert!(
+            matches!(read(&eight).kind, GraphManifestNodeKind::Bucket { entries } if entries.len() == 8)
+        );
+        let (nine, split) =
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &paths[8..], &[]).unwrap();
+        assert!(matches!(
+            read(&nine).kind,
+            GraphManifestNodeKind::Branch { .. }
+        ));
+        assert_eq!(split.prior_entries_examined, 0);
+        assert_eq!(split.changed_entries_examined, 1);
+        assert!(split.publication_io.manifest.installed_objects <= 17);
+        assert_eq!(split.publication_io.manifest_reads.read_calls, 1);
+
+        let removed = paths[8].to_str().unwrap().to_owned();
+        let (collapsed, deletion) =
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &[], &[removed]).unwrap();
+        assert_eq!(collapsed, eight);
+        assert_eq!(deletion.prior_entries_examined, 0);
+        assert!(deletion.publication_io.manifest_reads.read_calls <= 18);
+        fs::write(workspace.path().join(&paths[0]), b"replacement").unwrap();
+        let (replaced, _) =
+            append_graph_files_v2(&lease, workspace.path(), &mut state, &paths[..1], &[]).unwrap();
+        assert_ne!(replaced.root_node_sha256, eight.root_node_sha256);
+        for (root, expected_count, first_length) in
+            [(&eight, 8, 1), (&nine, 9, 1), (&replaced, 8, 11)]
+        {
+            let (files, work) = crate::resolve_graph_manifest(
+                root,
+                crate::GraphManifestLimits::default(),
+                |digest| {
+                    read_graph_object_by_digest(
+                        container.path(),
+                        digest,
+                        crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
+                    )
+                },
+            )
+            .unwrap();
+            assert_eq!(files.len(), expected_count);
+            assert_eq!(files[0].byte_length, first_length);
+            assert!(work.segments_examined <= 17);
+            for entry in &files {
+                verify_graph_object(container.path(), &entry.content_sha256, entry.byte_length)
+                    .unwrap();
+                assert_eq!(
+                    crate::graph_manifest::resolve_manifest_entry(
+                        root,
+                        &entry.relative_path,
+                        crate::GraphManifestLimits::default(),
+                        |digest| {
+                            read_graph_object_by_digest(
+                                container.path(),
+                                digest,
+                                crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
+                            )
+                        }
+                    )
+                    .unwrap()
+                    .as_ref(),
+                    Some(entry)
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/graphforge-storage/src/graph_object_store.rs
+++ b/crates/graphforge-storage/src/graph_object_store.rs
@@ -2044,11 +2044,13 @@ fn install_bucket_entries(
             .or_default()
             .push(entry);
     }
+    let child_depth = u8::try_from(split_depth + 1)
+        .map_err(|_| validation("manifest bucket split depth overflow"))?;
     let mut children = BTreeMap::new();
     for (edge, entries) in groups {
         children.insert(
             edge,
-            install_bucket_entries(lease, (split_depth + 1) as u8, entries, publication_io)?,
+            install_bucket_entries(lease, child_depth, entries, publication_io)?,
         );
     }
     install_manifest_node(
@@ -5765,7 +5767,7 @@ mod tests {
             .map(|index| PathBuf::from(format!("payload-{index}.parquet")))
             .collect::<Vec<_>>();
         for (index, path) in paths.iter().enumerate() {
-            fs::write(workspace.path().join(path), [index as u8]).unwrap();
+            fs::write(workspace.path().join(path), [u8::try_from(index).unwrap()]).unwrap();
         }
         let mut state = GraphManifestState::empty();
         let (eight, _) =

--- a/crates/graphforge-storage/src/lib.rs
+++ b/crates/graphforge-storage/src/lib.rs
@@ -99,6 +99,7 @@ pub(crate) use graph_manifest::{
 #[cfg(any(test, feature = "test-support"))]
 pub use graph_manifest::{
     GRAPH_MANIFEST_BRANCH_MAX_BYTES, GRAPH_MANIFEST_ENTRY_ENCODING_OVERHEAD_BYTES,
+    GRAPH_MANIFEST_NODE_MAX_BYTES,
 };
 
 #[allow(

--- a/crates/graphforge-storage/src/project_generation.rs
+++ b/crates/graphforge-storage/src/project_generation.rs
@@ -140,7 +140,7 @@ impl ResolvedProjectGeneration {
                         crate::read_graph_object_by_digest(
                             self.container_root(),
                             digest,
-                            64 * 1024 * 1024,
+                            crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
                         )
                     },
                 )?;
@@ -247,7 +247,7 @@ impl ResolvedProjectGeneration {
                         crate::graph_object_store::read_graph_object_counted(
                             self.container_root(),
                             digest,
-                            4 * 1024 * 1024,
+                            crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
                             io,
                         )
                     },
@@ -337,7 +337,7 @@ impl ResolvedProjectGeneration {
                         crate::read_graph_object_by_digest(
                             self.container_root(),
                             digest,
-                            MAX_SEGMENT_BYTES,
+                            crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
                         )
                     },
                 )?;

--- a/crates/graphforge-storage/src/project_publication.rs
+++ b/crates/graphforge-storage/src/project_publication.rs
@@ -1177,7 +1177,7 @@ fn verify_compact_graph_root(
             crate::read_graph_object_by_digest(
                 container_root,
                 digest,
-                MAX_GRAPH_MANIFEST_SEGMENT_BYTES,
+                crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
             )
         })?;
     crate::route_component::authenticate_manifest_routes(root.format_version, &files, |entry| {
@@ -1202,7 +1202,7 @@ fn verify_compact_graph_root_with_lease(
             crate::graph_object_store::read_graph_object_by_digest_with_lease(
                 lease,
                 digest,
-                MAX_GRAPH_MANIFEST_SEGMENT_BYTES,
+                crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
             )
         })?;
     crate::route_component::authenticate_manifest_routes(root.format_version, &files, |entry| {

--- a/crates/graphforge-storage/src/storage_attribution.rs
+++ b/crates/graphforge-storage/src/storage_attribution.rs
@@ -970,7 +970,7 @@ pub fn capture_storage_attribution(
                     let bytes = crate::read_graph_object_by_digest(
                         generation.container_root(),
                         digest,
-                        64 * 1024 * 1024,
+                        crate::graph_manifest::GRAPH_MANIFEST_NODE_MAX_BYTES,
                     )?;
                     manifest_objects.insert((
                         digest.to_owned(),

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -377,14 +377,39 @@ materialization, lease cleanup, and GC use the distinct mutable open-or-create
 capability; materialization remains there because installing hard links mutates
 the source inode's link state.
 
-The node-v2 canonical shape has no unary branches: maximal lowercase-hex digest
-prefixes are compressed into nodes, branches have at least two distinct nibble
-children, and leaves contain the full-digest collision bucket in logical-path
-order. Empty inventory is the sole one-node empty-branch exception. Therefore
-`F > 0` distinct path digests require at most `2F - 1` manifest objects instead
-of one object per hash nibble. Resolver admission derives its structural bound
-from the authenticated root totals and rejects v1/mixed/future nodes, malformed
-or nonmaximal shapes, wrong routes, duplicate references, and corrupt objects.
+The node-v3 canonical shape uses bounded buckets of one to eight exact-path
+entries. Maximal lowercase-hex SHA-256 prefixes are compressed into nodes;
+branches have at least two distinct nibble children. Empty inventory is the
+sole one-node empty-branch exception. Each entry authenticates its logical
+path, byte length, role and payload SHA-256. Bucket order, unique paths and the
+entire ancestral hash route are checked, including when a targeted lookup is
+absent. For `F > 0` entries, the structural bound remains `2F - 1` nodes.
+Node v1/v2 and mixed/future formats are refused; this node-format change does
+not change the separate graph-files root version and adds no compatibility
+reader or migration machinery.
+
+Every production manifest-object read admits at most 256 KiB before allocating
+the encoded buffer. Decoding admits at most eight entries, 4096 UTF-8 bytes per
+path, 64 bytes per digest, and sixteen branch children. The explicit field
+visitor avoids an unbounded flattened JSON intermediate and rejects the ninth
+entry. A 64-KiB decoded representation charge covers the node, bounded entry or
+child slots and their string contents. This is a logical charge, **not a hard
+native-memory bound**: parser scratch, canonical re-encoding, allocator overhead,
+read caches, and retained copy-on-write ancestors can overlap. Process RSS and
+filesystem peaks must be measured separately; route-table payload limits are
+independent of these manifest-node limits.
+
+Insertion into a bucket is local; a ninth entry partitions at its first
+SHA-256 divergence into at most seventeen nodes. An unsplittable ninth
+full-digest collision is refused. Replacement copies only the selected path.
+Deletion removes empty nodes, collapses unary branches, and coalesces a small
+subtree using a probe limited to sixteen nodes and eight entries. A lower bound
+from pending nonempty children stops oversized probes without scanning the
+subtree. Published roots and payloads remain immutable, so retained generations
+and active snapshots keep their exact authenticated inventory. The 128/256/512
+entry regression ladder bounds representative successful and absent lookups and
+replacements to four reads, and checks deletion work separately. These are
+application I/O counters, not OS I/O or native memory measurements.
 
 Authoritative small-write delta runs, when present, live under
 `graph/deltas/` inside the same generation and are inventory-verified
@@ -790,11 +815,11 @@ under `.graphforge-cache/` and are rejected as graph authority. Parquet write
 sites share `RewriteBatch` plus `commit_topology_aware`; the three control-file
 writers record their descriptor before making replacement bytes visible.
 
-Terminal leaves retain a sorted exact-path bucket for the theoretical case in
-which distinct path bytes have the same SHA-256 digest. Producing a real
-SHA-256 collision is cryptographically infeasible and is not a test fixture.
-Tests instead cover exact-path replacement/deletion and reject malformed leaf
-digests, ordering, duplicate references, wrong depth, and corrupt objects.
+Terminal buckets retain sorted exact paths even when distinct path bytes share
+a SHA-256 digest, up to the eight-entry bound. A real SHA-256 collision is not a
+test fixture. Tests cover exact-path replacement/deletion, bucket split/collapse,
+maximum escaped path fields, oversized encodings, duplicate paths, malformed
+routes, unsupported versions and authenticated old-root reads.
 
 ### Properties layer (warm path)
 

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -793,10 +793,10 @@ authenticated open and never falls back to v3 when malformed or substituted.
 
 New mapped publications use a compact version-4 `graph/files` root, retaining
 the version-2 radix representation with explicit mapped-route authority. Payloads and
-fixed-depth radix nodes live once in the project content-addressed object
+compressed node-v3 radix nodes live once in the project content-addressed object
 store; a generation stores only its root reference and logical totals. Updates
-copy at most one bounded SHA-256 nibble path and retain exact-path collision
-leaves, so publication never scans or recopies prior file metadata. The private
+copy a bounded SHA-256 nibble path and split or collapse bounded buckets,
+so publication never scans or recopies the entire prior file inventory. The private
 workspace commit boundary records revision-identified sealed and tombstone
 descriptors before mutations become visible; they are acknowledged only after
 CURRENT advances. Reopen traverses the authenticated radix and hashes every
@@ -1102,3 +1102,36 @@ superseded fixture attempts. No incomparable baseline improvement is claimed.
 This ledger maps ordinary implementation criteria to their existing tests. It
 adds no release-certification requirement and does not claim final capacity
 completion; integrated S20/S22 evidence remains under #1194.
+
+### Bounded manifest allocation evidence (#1204)
+
+The fixed heterogeneous #1196 workload (4,097 nodes, 65,537 edges, four routes)
+now publishes 352 exact manifest entries as 209 production objects occupying
+856,064 native allocated bytes. The immediately preceding current-format
+baseline used 483 objects and 1,978,368 bytes for the same entries: a
+1,122,304-byte (56.7%) reduction. Attributed permanent allocation falls from
+9,814,016 to 8,691,712 bytes. The historical #1196 baseline remains separately
+recorded at 544 entries / 750 objects / 3,072,000 bytes; its additional 192 edge
+payload references were removed by earlier work, not by bucket encoding.
+The deterministic acceptance ceiling is 1,536,000 manifest bytes on native
+4-KiB allocation storage.
+
+Frozen executable source `36360cb8` preserves the exact semantic fingerprint
+through real public construction, reopen/query, export, full verification and
+clean import. The publishing suite additionally exercises immediate mutation,
+retained streams, subsequent imported mutation, recovery, cancellation and
+retry. Maximum-field and corruption tests, exact eight-to-nine split/collapse
+and retained-root checks, and the 128/256/512-entry update ladder cover the
+manifest boundary directly.
+
+The source-bound resource record is
+[`bounded-manifest-1204.json`](../../development/evidence/bounded-manifest-1204.json).
+Its full-fixture CPU observations include the existing codec experiments and
+portable lifecycle; they are not a query-speed benchmark. Application syscall
+reads are 1,303,689,747 baseline versus 1,301,114,860 candidate bytes; writes are
+267,812,449 versus 267,870,503 bytes. Thus the physical allocation saving does
+not imply reduced write traffic in this workload. Process RSS, OS block I/O,
+and separately sampled overlapping filesystem owners are reported with their
+measurement limits. The candidate point-in-time whole-project census includes
+21,979,136 allocated file bytes plus 1,257,472 directory bytes; no equivalent
+baseline census or whole-project reduction is claimed.

--- a/docs/development/evidence/bounded-manifest-1204.json
+++ b/docs/development/evidence/bounded-manifest-1204.json
@@ -359,5 +359,8 @@
     "Candidate whole-project census separately includes directory blocks, all retained/private/cache files and deduplicated inodes. No equivalent point-in-time baseline census exists, so no whole-project before/after claim is made.",
     "The retained test-only candidate model has 138,698 logical bytes, distinct from the actual production manifest 140,370 logical bytes. Acceptance uses actual native allocation, not prototype estimates.",
     "Historical #1196 and current baseline inventories differ due to prior merged payload fragmentation changes; the direct #1204 storage comparison uses identical current 352-entry inventories."
+  ],
+  "post_measurement_changes": [
+    "Clippy-driven checked usize-to-u8 conversion for split depth, after the existing split_depth < 64 refusal; and a checked test-fixture ordinal conversion. No admitted-format or measured-workload behavior changes. Measurements remain attributed to the frozen source, not relabeled as final-head runs."
   ]
 }

--- a/docs/development/evidence/bounded-manifest-1204.json
+++ b/docs/development/evidence/bounded-manifest-1204.json
@@ -362,5 +362,15 @@
   ],
   "post_measurement_changes": [
     "Clippy-driven checked usize-to-u8 conversion for split depth, after the existing split_depth < 64 refusal; and a checked test-fixture ordinal conversion. No admitted-format or measured-workload behavior changes. Measurements remain attributed to the frozen source, not relabeled as final-head runs."
-  ]
+  ],
+  "build_profile": "Cargo test profile: unoptimized + debuginfo (both frozen executables)",
+  "candidate_build_command": "TMPDIR=/home/ubuntu/graphforge-native-tmp-1195 CARGO_TARGET_DIR=/home/ubuntu/code/graphforge-target-1195 CARGO_BUILD_JOBS=4 cargo test -p graphforge-api --test permanent_storage_budgets --no-run",
+  "host": {
+    "architecture": "x86_64",
+    "cpu_model": "AMD Ryzen 7 3800X 8-Core Processor",
+    "logical_cpus": 16,
+    "memory_total": "131786392 kB",
+    "native_allocation_block_bytes": 4096,
+    "rustc": "rustc 1.96.0 (ac68faa20 2026-05-25)"
+  }
 }

--- a/docs/development/evidence/bounded-manifest-1204.json
+++ b/docs/development/evidence/bounded-manifest-1204.json
@@ -361,7 +361,8 @@
     "Historical #1196 and current baseline inventories differ due to prior merged payload fragmentation changes; the direct #1204 storage comparison uses identical current 352-entry inventories."
   ],
   "post_measurement_changes": [
-    "Clippy-driven checked usize-to-u8 conversion for split depth, after the existing split_depth < 64 refusal; and a checked test-fixture ordinal conversion. No admitted-format or measured-workload behavior changes. Measurements remain attributed to the frozen source, not relabeled as final-head runs."
+    "Clippy-driven checked usize-to-u8 conversion for split depth, after the existing split_depth < 64 refusal; and a checked test-fixture ordinal conversion. No admitted-format or measured-workload behavior changes. Measurements remain attributed to the frozen source, not relabeled as final-head runs.",
+    "The scale-accounting negative fixture now exceeds the 81-node per-path bound already present in the measured source, rather than the superseded 67-node bound. Its overcount rejection remains required."
   ],
   "build_profile": "Cargo test profile: unoptimized + debuginfo (both frozen executables)",
   "candidate_build_command": "TMPDIR=/home/ubuntu/graphforge-native-tmp-1195 CARGO_TARGET_DIR=/home/ubuntu/code/graphforge-target-1195 CARGO_BUILD_JOBS=4 cargo test -p graphforge-api --test permanent_storage_budgets --no-run",

--- a/docs/development/evidence/bounded-manifest-1204.json
+++ b/docs/development/evidence/bounded-manifest-1204.json
@@ -1,0 +1,363 @@
+{
+  "issue": 1204,
+  "source_commit": "36360cb871583b83b721bdb320275e6c7d110556",
+  "executable_sha256": "b9fec8831c309e62274229485f01180f5fb89537e7bbd8993ba1e2c906086177",
+  "baseline_source": {
+    "source_commit": "2a1eb8b48cf1eed6525feb307261f2fbebc53d77",
+    "executable": "/tmp/gf1221-contract-measure-bin",
+    "executable_sha256": "3de8dec2401d4355caef7a5929dcecef2a1d5c380a71148abe2649b3f10cfd67",
+    "command": "TMPDIR=/home/ubuntu/graphforge-native-tmp-1195 /usr/bin/time -v /tmp/gf1221-contract-measure-bin --exact permanent_heterogeneous_property_schemas --nocapture --test-threads=1",
+    "result": "passed",
+    "note": "Read-only existing public fixture before #1204 implementation. Current sameinput inventory352entries483nodes1978368allocatedbytes; historical #1196 inventory544entries750nodes3072000bytes is not silently equated. Test-only candidate209objects856064estimated4KiBallocatedbytes, not production outcome. Full fixture runtime includes other assessment experiments and portable semantic checks; not an isolated manifest speed claim."
+  },
+  "command": [
+    "permanent_storage_budgets",
+    "--exact",
+    "permanent_heterogeneous_property_schemas",
+    "--nocapture",
+    "--test-threads=1"
+  ],
+  "fixture": {
+    "nodes": 4097,
+    "edges": 65537,
+    "routes": 4,
+    "heterogeneous_properties": true,
+    "random_identifiers": true,
+    "semantic_fingerprint": "5c704d8bf7e1851e1631e6f36bc37495f9d9d9e1e9b94950e84310b545824ec2"
+  },
+  "historical_1196": {
+    "manifest_entries": 544,
+    "manifest_objects": 750,
+    "manifest_allocated_bytes": 3072000,
+    "difference_from_current_baseline": "192 fewer edge payload references in current baseline (257 to 65), caused by already-merged fragment changes; not attributed to #1204."
+  },
+  "baseline": {
+    "manifest": {
+      "authenticated_lookups_checked": 352,
+      "candidate_bucket_capacity": 8,
+      "candidate_estimated_allocated_bytes_at_4096": 856064,
+      "candidate_logical_bytes": 138698,
+      "candidate_objects": 209,
+      "production_format_changed": false,
+      "source_manifest_allocated_bytes": 1978368,
+      "source_manifest_objects": 483
+    },
+    "permanent": {
+      "allocated_bytes": 9814016,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 2011136,
+          "logical_bytes": 241380,
+          "logical_references": 491,
+          "physical_logical_bytes": 241380,
+          "physical_objects": 491
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 2265088,
+          "logical_bytes": 1877949,
+          "logical_references": 266,
+          "physical_logical_bytes": 1877949,
+          "physical_objects": 266
+        },
+        "topology_edges": {
+          "allocated_bytes": 3923968,
+          "logical_bytes": 3717678,
+          "logical_references": 65,
+          "physical_logical_bytes": 3717678,
+          "physical_objects": 65
+        },
+        "topology_nodes": {
+          "allocated_bytes": 102400,
+          "logical_bytes": 88869,
+          "logical_references": 5,
+          "physical_logical_bytes": 88869,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 1511424,
+          "logical_bytes": 1482397,
+          "logical_references": 12,
+          "physical_logical_bytes": 1482397,
+          "physical_objects": 9
+        }
+      },
+      "logical_bytes": 7408273,
+      "physical_logical_bytes": 7408273,
+      "physical_objects": 836
+    },
+    "runtime": {
+      "elapsed_seconds": 85.99,
+      "user_seconds": 77.32,
+      "system_seconds": 6.26,
+      "peak_rss_kib": 235020,
+      "filesystem_input_512_byte_blocks": 1284984,
+      "filesystem_output_512_byte_blocks": 572544,
+      "exit_status": 0
+    },
+    "syscall_io": {
+      "syscalls": {
+        "read": {
+          "calls": 159329,
+          "bytes": 966417054
+        },
+        "pread64": {
+          "calls": 557556,
+          "bytes": 337272693
+        },
+        "write": {
+          "calls": 13945,
+          "bytes": 267812449
+        },
+        "fsync": {
+          "calls": 20787,
+          "bytes": 0
+        }
+      },
+      "read_bytes": 1303689747,
+      "write_bytes": 267812449,
+      "errors": [],
+      "elapsed_seconds": 184.77
+    },
+    "workspace_observation": {
+      "command": [
+        "/tmp/gf1221-contract-measure-bin",
+        "--exact",
+        "permanent_heterogeneous_property_schemas",
+        "--nocapture",
+        "--test-threads=1"
+      ],
+      "sampled_unique_inode_allocated_peak_bytes": 52088832,
+      "sampled_path_logical_peak_bytes": 43485049,
+      "sampled_file_count_peak": 4564,
+      "samples": 3671,
+      "requested_poll_interval_seconds": 0.005,
+      "maximum_observed_sample_interval_seconds": 0.06228423898573965,
+      "vanished_files_during_scan": 793,
+      "exit_status": 0,
+      "limitations": [
+        "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+        "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+        "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+        "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+      ]
+    }
+  },
+  "candidate": {
+    "manifest": {
+      "authenticated_lookups_checked": 352,
+      "candidate_bucket_capacity": 8,
+      "candidate_estimated_allocated_bytes_at_4096": 856064,
+      "candidate_logical_bytes": 138698,
+      "candidate_objects": 209,
+      "production_format_changed": true,
+      "source_manifest_allocated_bytes": 856064,
+      "source_manifest_logical_bytes": 140370,
+      "source_manifest_objects": 209
+    },
+    "permanent": {
+      "allocated_bytes": 8691712,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 888832,
+          "logical_bytes": 145328,
+          "logical_references": 217,
+          "physical_logical_bytes": 145328,
+          "physical_objects": 217
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 2265088,
+          "logical_bytes": 1877949,
+          "logical_references": 266,
+          "physical_logical_bytes": 1877949,
+          "physical_objects": 266
+        },
+        "topology_edges": {
+          "allocated_bytes": 3923968,
+          "logical_bytes": 3717678,
+          "logical_references": 65,
+          "physical_logical_bytes": 3717678,
+          "physical_objects": 65
+        },
+        "topology_nodes": {
+          "allocated_bytes": 102400,
+          "logical_bytes": 88869,
+          "logical_references": 5,
+          "physical_logical_bytes": 88869,
+          "physical_objects": 5
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 1511424,
+          "logical_bytes": 1482397,
+          "logical_references": 12,
+          "physical_logical_bytes": 1482397,
+          "physical_objects": 9
+        }
+      },
+      "logical_bytes": 7312221,
+      "physical_logical_bytes": 7312221,
+      "physical_objects": 562
+    },
+    "whole_project": {
+      "deduplication": "device/inode",
+      "directory_allocated_bytes": 1257472,
+      "file_allocated_bytes": 21979136,
+      "file_logical_bytes": 15913545,
+      "scope": "recursive project including retained generations, caches and private state; point-in-time, not peak",
+      "unique_files": 2173
+    },
+    "runtime": {
+      "elapsed_seconds": 85.7,
+      "user_seconds": 76.17,
+      "system_seconds": 5.24,
+      "peak_rss_kib": 219820,
+      "filesystem_input_512_byte_blocks": 1284984,
+      "filesystem_output_512_byte_blocks": 567536,
+      "exit_status": 0
+    },
+    "syscall_io": {
+      "syscalls": {
+        "read": {
+          "calls": 141457,
+          "bytes": 963842167
+        },
+        "pread64": {
+          "calls": 557556,
+          "bytes": 337272693
+        },
+        "write": {
+          "calls": 13316,
+          "bytes": 267870503
+        },
+        "fsync": {
+          "calls": 18909,
+          "bytes": 0
+        }
+      },
+      "read_bytes": 1301114860,
+      "write_bytes": 267870503,
+      "errors": [],
+      "elapsed_seconds": 165.56
+    },
+    "workspace_observation": {
+      "command": [
+        "/tmp/gf1204-manifest-measure-bin",
+        "--exact",
+        "permanent_heterogeneous_property_schemas",
+        "--nocapture",
+        "--test-threads=1"
+      ],
+      "sampled_unique_inode_allocated_peak_bytes": 49524736,
+      "sampled_path_logical_peak_bytes": 43542815,
+      "sampled_file_count_peak": 3938,
+      "samples": 3770,
+      "requested_poll_interval_seconds": 0.005,
+      "maximum_observed_sample_interval_seconds": 0.05482088297139853,
+      "vanished_files_during_scan": 762,
+      "exit_status": 0,
+      "limitations": [
+        "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+        "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+        "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+        "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+      ]
+    }
+  },
+  "deterministic_budgets": {
+    "manifest_native_allocated_bytes": 1536000,
+    "bucket_entries": 8,
+    "path_utf8_bytes": 4096,
+    "node_encoded_bytes": 262144,
+    "node_decoded_logical_charge_bytes": 65536,
+    "representative_inventory_entries": [
+      128,
+      256,
+      512
+    ],
+    "representative_replacement_reads_and_installs_each": 4,
+    "representative_successful_and_absent_lookup_reads": 4,
+    "representative_deletion_reads": 68,
+    "local_ninth_entry_split_installs": 17,
+    "local_collapse_probe_nodes": 16
+  },
+  "limitations": [
+    "The same fixed-input assessment includes codec experiments, construction, queries, reopen and portable full verification/import. CPU observations are not an isolated manifest benchmark or proof of a query-speed improvement.",
+    "The candidate additionally performs a point-in-time recursive filesystem census and production budget assertions. Runtime observations include that extra work; no statistically significant latency or CPU gain is claimed.",
+    "Both executables were frozen before subprocess measurements. Runtime, syscall tracing and filesystem sampling are separate executions; tracing and sampling overhead are excluded from the CPU/RSS runtime observation.",
+    "The 64-KiB decoded charge describes bounded fields/slots, not native peak memory. Encoded input, JSON scratch, canonical output, cached decoded nodes and COW ancestors may overlap. Process RSS includes native owners but is an observed peak, not a hard bound.",
+    "Syscall bytes count successful application transfers, with copy_file_range/sendfile in both read and write totals. Filesystem block counters are separate OS observations, not inferred physical device traffic.",
+    "Workspace sampling counts overlapping retained generations, private state, portable output and clean import, deduplicating shared inodes for allocated bytes. It excludes directory allocation and can miss unlinked files or brief peaks; it is not a hard temporary-only disk bound.",
+    "Candidate whole-project census separately includes directory blocks, all retained/private/cache files and deduplicated inodes. No equivalent point-in-time baseline census exists, so no whole-project before/after claim is made.",
+    "The retained test-only candidate model has 138,698 logical bytes, distinct from the actual production manifest 140,370 logical bytes. Acceptance uses actual native allocation, not prototype estimates.",
+    "Historical #1196 and current baseline inventories differ due to prior merged payload fragmentation changes; the direct #1204 storage comparison uses identical current 352-entry inventories."
+  ]
+}


### PR DESCRIPTION
## Problem and result

The current heterogeneous construction fixture stores 352 authenticated payload entries in 483 manifest objects using 1,978,368 allocated bytes. Bounded eight-entry buckets reduce the actual production manifest to 209 objects / 856,064 bytes (56.7% less), below #1204's 1,536,000-byte budget. The exact public semantic fingerprint is unchanged.

Node format v3 adds explicit encoded and decoded-field admission, bounded parsing, full ancestral-route validation, incremental ninth-entry splitting and bounded deletion collapse. Production manifest readers share the encoded-node limit; independent route-table limits remain. Current roots are immutable and old node versions are refused without a compatibility reader or migration layer.

## Evidence

- Maximum escaped fields, oversized/duplicate/misplaced nodes, absent lookup, corruption and version refusal; exact eight-to-nine split/collapse and retained roots.
- 128/256/512-entry deterministic update ladder: three replacement reads/installs and three deletion reads at each size, with successful/absent lookup ceilings.
- Frozen source-bound public construction/reopen/query/export/full-verify/clean-import measurements, separate CPU/RSS, application/OS I/O, deduplicated disk sampling and total-project census: `docs/development/evidence/bounded-manifest-1204.json`.
- Full-workload write traffic rises by 58,054 bytes; no query-speed or hard native-memory claim. Historical #1196's different 544-entry inventory is reported separately.

Local checks: `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `make pre-push-fast`, and `make gate-registry-check` pass. The public fixture suite passes all 45 cases; the workspace run also passed 737 API unit tests, 118 BDD scenarios / 443 steps, and 17 fixed-hop regressions. Storage validation passes 1,091 unit and 74 integration cases; its sole failure is the existing hard-coded `/tmp` admission test (`GF_UNSUPPORTED_FILESYSTEM`, `filesystem_class_unproven`). No skip or assertion change was made for that environment constraint.

The workspace run exposed an outdated scale negative fixture using the old 67-node ceiling. It now exceeds the new 81-node structural ceiling and its rejection test passes; independent review verified the gate remains strict. `make pre-push` reached Rust coverage and failed only at that same `/tmp` test (1,090 storage unit tests passed); its final-source facade suite passed 45/45 and scale-accounting suite passed 30/30. Python/Node prerequisites were provisioned from the locked dependencies before that run. Full local validation is not claimed green. Required exact-head CI remains the merge gate.

Closes #1204

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791657358&installation_model_id=20486&pr_number=1239&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1239&signature=804ba6a1c559821f0bc6823d5c97565973287bc2472df3502292efbbdd908c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->