### PR TITLE
fix(storage): compress CSR shards with authenticated decode bounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ pre-push-fast:  ## Run fast checks only — format, lint, type, security, docstr
 	@echo "━━━ Bazelisk preflight + Cargo/Bazel drift ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@command -v bazelisk >/dev/null || (echo "bazelisk is required on PATH; see docs/development/bazel.md"; exit 1)
 	@python3 scripts/ci/cargo-bazel-drift-check.py
+	@cargo metadata --locked --manifest-path benchmarks/Cargo.toml --format-version 1 >/dev/null
 	@python3 scripts/ci/python-build-mode-check.py
 	@python3 scripts/ci/test-python-build-mode-check.py
 	@python3 scripts/ci/test-uuid-derivation-policy.py

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
  "tokio",
  "unicode-normalization",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "594b6ba3c63b9701d278637b815cac9903f9c34e2906b60fd6018eb89b58575b",
+  "checksum": "4b33b0ec957be7243e5c68d59d42863c4a0d8132f2d574b0a365c0a587ed9702",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -14056,6 +14056,10 @@
             {
               "id": "uuid 1.26.0",
               "target": "uuid"
+            },
+            {
+              "id": "zstd 0.13.3",
+              "target": "zstd"
             }
           ],
           "selects": {
@@ -14087,10 +14091,6 @@
             {
               "id": "wait-timeout 0.2.1",
               "target": "wait_timeout"
-            },
-            {
-              "id": "zstd 0.13.3",
-              "target": "zstd"
             }
           ],
           "selects": {}
@@ -34674,14 +34674,14 @@
     "ureq 3.4.0",
     "url 2.5.8",
     "uuid 1.26.0",
-    "windows-sys 0.61.2"
+    "windows-sys 0.61.2",
+    "zstd 0.13.3"
   ],
   "direct_dev_deps": [
     "codspeed-divan-compat 5.0.1",
     "cucumber 0.21.1",
     "insta 1.48.0",
-    "wait-timeout 0.2.1",
-    "zstd 0.13.3"
+    "wait-timeout 0.2.1"
   ],
   "unused_patches": []
 }

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -5728,3 +5728,73 @@ fn compressed_csr_public_mutation_snapshot_and_portable_queries() {
     verify_graph(&reopened, fixture, &nodes, &edges);
     verify_csr_two_hop_queries(&reopened, &edges, fixture.routes);
 }
+
+/// The default case proves the oracle in CI. Source-frozen measurement runs use
+/// separate `prepare` and `read` processes and a private GF_CSR_PROBE_ROOT.
+#[test]
+fn csr_cold_public_query_probe() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = std::env::var_os("GF_CSR_PROBE_ROOT")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| temporary.path().join("probe"));
+    let mode = std::env::var("GF_CSR_PROBE_MODE").unwrap_or_else(|_| "all".into());
+    assert!(matches!(mode.as_str(), "all" | "prepare" | "read"));
+    let source = root.join("source");
+    let oracle_path = root.join("oracle.json");
+    if mode != "read" {
+        assert!(
+            !source.exists(),
+            "probe preparation requires a fresh private root"
+        );
+        std::fs::create_dir_all(&root).unwrap();
+        let fixture = Fixture {
+            name: "csr_cold_public_query",
+            nodes: 4097,
+            edges: 65537,
+            routes: 8,
+            identifiers: Identifiers::Random,
+            properties: true,
+            adjacency: true,
+            heterogeneous: false,
+        };
+        let (nodes, edges) = rows(fixture);
+        let mut expected = Vec::new();
+        for first in edges.iter().filter(|edge| edge.1 == nodes[1].0) {
+            for second in edges
+                .iter()
+                .filter(|edge| edge.1 == first.2 && edge.0 != first.0)
+            {
+                expected.push([first.1, first.0, first.2, second.0, second.2]);
+            }
+        }
+        expected.sort();
+        assert!(!expected.is_empty());
+        std::fs::write(&oracle_path, serde_json::to_vec(&expected).unwrap()).unwrap();
+        construct(&source, fixture, &nodes, &edges);
+        let graph = GraphForge::new(source.to_str()).unwrap();
+        graph.rebuild_adjacency(None).unwrap();
+    }
+    if mode != "prepare" {
+        let expected: Vec<[Uuid; 5]> =
+            serde_json::from_slice(&std::fs::read(oracle_path).unwrap()).unwrap();
+        let opened = Instant::now();
+        let graph = GraphForge::new(source.to_str()).unwrap();
+        let open_ns = opened.elapsed().as_nanos();
+        let query = "MATCH (a)-[r]->(b)-[s]->(c) WHERE a.score = -2047 RETURN a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid";
+        let mut query_ns = Vec::new();
+        for _ in 0..5 {
+            let started = Instant::now();
+            let result = graph.execute(query).unwrap();
+            query_ns.push(started.elapsed().as_nanos());
+            assert_eq!(csr_two_hop_rows(&result.batches), expected);
+        }
+        println!(
+            "CSR_COLD_PUBLIC_QUERY {}",
+            json!({
+                "mode":mode,"open_elapsed_ns":open_ns,"query_elapsed_ns":query_ns,
+                "rows":expected.len(),"fingerprint":digest_hex(&serde_json::to_vec(&expected).unwrap()),
+                "cache_scope":"first query is application-cold only in separate read process; subsequent queries reuse the same facade; OS cache advice is external and separately recorded"
+            })
+        );
+    }
+}

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -474,6 +474,10 @@ fn adjacency_codec_experiment(source: &Path) -> Value {
     let mut encode_ns = [0_u128; 3];
     let mut decode_ns = [0_u128; 3];
     let mut source_bytes = 0_u64;
+    #[cfg(unix)]
+    let mut source_allocated_bytes = 0_u64;
+    #[cfg(not(unix))]
+    let source_allocated_bytes = 0_u64;
     let mut shards = 0_u64;
     let mut largest_decoded_batch = 0_usize;
     while let Some(directory) = pending.pop() {
@@ -493,7 +497,13 @@ fn adjacency_codec_experiment(source: &Path) -> Value {
             let reader = FileReader::try_new(File::open(entry.path()).unwrap(), None).unwrap();
             let schema = reader.schema();
             let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
-            source_bytes += entry.metadata().unwrap().len();
+            let metadata = entry.metadata().unwrap();
+            source_bytes += metadata.len();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::MetadataExt as _;
+                source_allocated_bytes += metadata.blocks() * 512;
+            }
             shards += 1;
             for batch in &batches {
                 largest_decoded_batch = largest_decoded_batch.max(batch.get_array_memory_size());
@@ -534,10 +544,19 @@ fn adjacency_codec_experiment(source: &Path) -> Value {
             }
         }
     }
-    assert!(shards > 0);
-    json!({"shards":shards,"source_bytes":source_bytes,"normalized_bytes_none_lz4_zstd":sizes,
+    assert_eq!(shards, 18, "fixed eight-route fixture shard boundaries");
+    assert!(
+        source_bytes * 10 <= 4_920_564 * 3,
+        "CSR payload exceeds the #1205 30% budget: {source_bytes}"
+    );
+    #[cfg(unix)]
+    assert!(
+        source_allocated_bytes * 10 <= 4_972_544 * 3,
+        "actual native CSR allocation exceeds the #1205 30% budget: {source_allocated_bytes}"
+    );
+    json!({"shards":shards,"source_bytes":source_bytes,"source_allocated_bytes_unix":source_allocated_bytes,"normalized_bytes_none_lz4_zstd":sizes,
         "estimated_allocated_bytes_at_4096":allocations,"encode_elapsed_ns":encode_ns,"decode_elapsed_ns":decode_ns,
-        "largest_decoded_batch_array_bytes":largest_decoded_batch,"production_format_changed":false})
+        "largest_decoded_batch_array_bytes":largest_decoded_batch,"production_format_changed":true})
 }
 
 fn identity_padding_experiment(source: &Path) -> Value {
@@ -5608,4 +5627,104 @@ fn publishing_edge_surrogates(source: &Path) -> BTreeMap<Uuid, u64> {
         }
     }
     ids
+}
+
+fn csr_two_hop_rows(batches: &[RecordBatch]) -> Vec<[Uuid; 5]> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            rows.push(std::array::from_fn(|column| uuid_at(batch, column, row)));
+        }
+    }
+    rows.sort();
+    rows
+}
+
+fn verify_csr_two_hop_queries(graph: &GraphForge, edges: &[Edge], routes: usize) {
+    for inbound in [false, true] {
+        for route in std::iter::once(None).chain((0..routes).map(Some)) {
+            let relation = route.map_or_else(String::new, |r| format!(":REL{r}"));
+            let pattern = if inbound {
+                format!("(a)<-[r{relation}]-(b)<-[s]-(c)")
+            } else {
+                format!("(a)-[r{relation}]->(b)-[s]->(c)")
+            };
+            let query = format!(
+                "MATCH {pattern} RETURN a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid"
+            );
+            let actual = csr_two_hop_rows(&graph.execute(&query).unwrap().batches);
+            let mut expected = Vec::new();
+            for first in edges {
+                if route.is_some_and(|r| first.3 != format!("REL{r}")) {
+                    continue;
+                }
+                for second in edges {
+                    if first.0 == second.0 {
+                        continue;
+                    }
+                    if inbound && first.1 == second.2 {
+                        expected.push([first.2, first.0, first.1, second.0, second.1]);
+                    } else if !inbound && first.2 == second.1 {
+                        expected.push([first.1, first.0, first.2, second.0, second.2]);
+                    }
+                }
+            }
+            expected.sort();
+            assert_eq!(actual, expected, "exact current CSR query: {query}");
+        }
+    }
+}
+
+#[test]
+fn compressed_csr_public_mutation_snapshot_and_portable_queries() {
+    use futures::TryStreamExt as _;
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "compressed_csr_lifecycle",
+        nodes: 33,
+        edges: 129,
+        routes: 4,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: true,
+        heterogeneous: false,
+    };
+    let (nodes, mut edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    graph.rebuild_adjacency(None).unwrap();
+    verify_graph(&graph, fixture, &nodes, &edges);
+    verify_csr_two_hop_queries(&graph, &edges, fixture.routes);
+    let query = "MATCH (a)-[r]->(b)-[s]->(c) RETURN a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid";
+    let before = csr_two_hop_rows(&graph.execute(query).unwrap().batches);
+    let snapshot = graph.execute_stream(query).unwrap();
+    graph.execute("MATCH ()-[r:REL0]->() DELETE r").unwrap();
+    edges.retain(|edge| edge.3 != "REL0");
+    verify_graph(&graph, fixture, &nodes, &edges);
+    verify_csr_two_hop_queries(&graph, &edges, fixture.routes);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let old: Vec<RecordBatch> = runtime.block_on(snapshot.try_collect()).unwrap();
+    assert_eq!(csr_two_hop_rows(&old), before);
+    graph.rebuild_adjacency(None).unwrap();
+    verify_csr_two_hop_queries(&graph, &edges, fixture.routes);
+    drop(graph);
+    round_trip_checked(root.path(), &source, |graph| {
+        verify_csr_two_hop_queries(graph, &edges, fixture.routes);
+        verify_graph(graph, fixture, &nodes, &edges)
+    });
+    let imported_path = root.path().join("imported");
+    let imported = GraphForge::new(imported_path.to_str()).unwrap();
+    imported.execute("MATCH ()-[r:REL1]->() DELETE r").unwrap();
+    edges.retain(|edge| edge.3 != "REL1");
+    verify_csr_two_hop_queries(&imported, &edges, fixture.routes);
+    imported.rebuild_adjacency(None).unwrap();
+    verify_graph(&imported, fixture, &nodes, &edges);
+    drop(imported);
+    let reopened = GraphForge::new(imported_path.to_str()).unwrap();
+    verify_graph(&reopened, fixture, &nodes, &edges);
+    verify_csr_two_hop_queries(&reopened, &edges, fixture.routes);
 }

--- a/crates/graphforge-exec/src/adjacency.rs
+++ b/crates/graphforge-exec/src/adjacency.rs
@@ -29,11 +29,9 @@ use arrow::record_batch::RecordBatch;
 use graphforge_core::{GfError, OntologyMode};
 use graphforge_ir::Direction;
 use graphforge_storage::adjacency::{
-    self as csr, ALL_RELATIONS_STEM, AdjacencyManifestRow, CsrIndex, CsrRow, ShardedCsrIndex,
+    self as csr, ALL_RELATIONS_STEM, AdjacencyManifestRow, ShardedCsrIndex,
 };
-use graphforge_storage::adjacency_delta::{
-    CsrDeltaOverlay, DeltaSegment, overlay_delta_segments, read_delta_chain,
-};
+use graphforge_storage::adjacency_delta::{DeltaSegment, read_delta_chain};
 use graphforge_storage::generation::read_topology_generation;
 
 use crate::ValueAt;
@@ -113,14 +111,12 @@ enum AdjacencyInner {
     #[default]
     Empty,
     Map(HashMap<u64, Vec<(u64, u64)>>),
-    Csr(Arc<CsrIndex>),
     Sharded(Arc<ShardedCsrIndex>),
     ShardedOverlay {
         base: Arc<ShardedCsrIndex>,
         replaced: HashMap<u64, Vec<(u64, u64)>>,
         node_extent: u64,
     },
-    Overlay(CsrDeltaOverlay),
     Undirected {
         out: Arc<AdjacencyInner>,
         inbound: Arc<AdjacencyInner>,
@@ -138,7 +134,6 @@ pub struct NeighborRow<'a> {
 #[derive(Clone, Debug)]
 enum NeighborRowKind<'a> {
     Pairs(&'a [(u64, u64)]),
-    Csr(CsrRow<'a>),
     Owned(Vec<(u64, u64)>),
 }
 
@@ -146,12 +141,6 @@ impl<'a> NeighborRow<'a> {
     fn pairs(entries: &'a [(u64, u64)]) -> Self {
         Self {
             kind: NeighborRowKind::Pairs(entries),
-        }
-    }
-
-    fn csr(row: CsrRow<'a>) -> Self {
-        Self {
-            kind: NeighborRowKind::Csr(row),
         }
     }
 
@@ -166,7 +155,6 @@ impl<'a> NeighborRow<'a> {
     pub fn len(&self) -> usize {
         match &self.kind {
             NeighborRowKind::Pairs(entries) => entries.len(),
-            NeighborRowKind::Csr(row) => row.len(),
             NeighborRowKind::Owned(entries) => entries.len(),
         }
     }
@@ -182,7 +170,6 @@ impl<'a> NeighborRow<'a> {
     pub fn get(&self, index: usize) -> Option<(u64, u64)> {
         match &self.kind {
             NeighborRowKind::Pairs(entries) => entries.get(index).copied(),
-            NeighborRowKind::Csr(row) => row.get(index),
             NeighborRowKind::Owned(entries) => entries.get(index).copied(),
         }
     }
@@ -192,7 +179,6 @@ impl<'a> NeighborRow<'a> {
     pub fn to_vec(&self) -> Vec<(u64, u64)> {
         match &self.kind {
             NeighborRowKind::Pairs(entries) => entries.to_vec(),
-            NeighborRowKind::Csr(row) => row.iter().collect(),
             NeighborRowKind::Owned(entries) => entries.clone(),
         }
     }
@@ -351,19 +337,11 @@ impl AdjacencyInner {
         Ok(match self {
             Self::Empty => 0,
             Self::Map(map) => map.values().map(|row| row.len() as u64).sum(),
-            Self::Csr(csr) => csr.edge_count(),
             Self::Sharded(csr) => csr.edge_count(),
             Self::ShardedOverlay { base, replaced, .. } => {
                 let mut total = base.edge_count();
                 for (node, row) in replaced {
                     total = total - base.row_len(*node)? + row.len() as u64;
-                }
-                total
-            }
-            Self::Overlay(overlay) => {
-                let mut total = overlay.base.edge_count();
-                for (node, row) in &overlay.replaced {
-                    total = total - overlay.base.row(*node).len() as u64 + row.len() as u64;
                 }
                 total
             }
@@ -377,15 +355,10 @@ impl AdjacencyInner {
         Ok(match self {
             Self::Empty => 0,
             Self::Map(map) => map.get(&node_id).map_or(0, |row| row.len() as u64),
-            Self::Csr(csr) => csr.row(node_id).len() as u64,
             Self::Sharded(csr) => csr.row_len(node_id)?,
             Self::ShardedOverlay { base, replaced, .. } => match replaced.get(&node_id) {
                 Some(row) => row.len() as u64,
                 None => base.row_len(node_id)?,
-            },
-            Self::Overlay(overlay) => match overlay.row(node_id) {
-                graphforge_storage::adjacency_delta::OverlayRow::Base(row) => row.len() as u64,
-                graphforge_storage::adjacency_delta::OverlayRow::Replaced(row) => row.len() as u64,
             },
             Self::Undirected { out, inbound } => out
                 .degree(node_id)?
@@ -397,13 +370,9 @@ impl AdjacencyInner {
         match self {
             Self::Empty => true,
             Self::Map(map) => map.is_empty(),
-            Self::Csr(csr) => csr.edge_count() == 0,
             Self::Sharded(csr) => csr.edge_count() == 0,
             Self::ShardedOverlay { base, replaced, .. } => {
                 base.edge_count() == 0 && replaced.values().all(Vec::is_empty)
-            }
-            Self::Overlay(overlay) => {
-                overlay.base.edge_count() == 0 && overlay.replaced.values().all(Vec::is_empty)
             }
             Self::Undirected { out, inbound } => out.is_empty() && inbound.is_empty(),
         }
@@ -413,7 +382,6 @@ impl AdjacencyInner {
         Ok(match self {
             Self::Empty => NeighborRow::pairs(&[]),
             Self::Map(map) => NeighborRow::pairs(map.get(&node_id).map_or(&[], Vec::as_slice)),
-            Self::Csr(csr) => NeighborRow::csr(csr.row(node_id)),
             Self::Sharded(csr) => NeighborRow::owned(csr.row(node_id)?),
             Self::ShardedOverlay { base, replaced, .. } => {
                 NeighborRow::owned(match replaced.get(&node_id) {
@@ -421,12 +389,6 @@ impl AdjacencyInner {
                     None => base.row(node_id)?,
                 })
             }
-            Self::Overlay(overlay) => match overlay.row(node_id) {
-                graphforge_storage::adjacency_delta::OverlayRow::Base(row) => NeighborRow::csr(row),
-                graphforge_storage::adjacency_delta::OverlayRow::Replaced(entries) => {
-                    NeighborRow::pairs(entries)
-                }
-            },
             Self::Undirected { out, inbound } => {
                 merge_undirected_row(&out.neighbors(node_id)?, &inbound.neighbors(node_id)?)
             }
@@ -436,19 +398,15 @@ impl AdjacencyInner {
     fn backing(&self) -> AdjacencyBacking {
         match self {
             Self::Empty | Self::Map(_) => AdjacencyBacking::ScanHashMap,
-            Self::Csr(_) | Self::Sharded(_) => AdjacencyBacking::CsrNative,
-            Self::Overlay(_) | Self::ShardedOverlay { .. } => AdjacencyBacking::CsrOverlay,
+            Self::Sharded(_) => AdjacencyBacking::CsrNative,
+            Self::ShardedOverlay { .. } => AdjacencyBacking::CsrOverlay,
             Self::Undirected { .. } => AdjacencyBacking::CsrUndirected,
         }
     }
 
     fn base_csr_entries_expanded(&self) -> u64 {
         match self {
-            Self::Empty
-            | Self::Csr(_)
-            | Self::Sharded(_)
-            | Self::Overlay(_)
-            | Self::ShardedOverlay { .. } => 0,
+            Self::Empty | Self::Sharded(_) | Self::ShardedOverlay { .. } => 0,
             Self::Map(map) => u64::try_from(map.values().map(Vec::len).sum::<usize>()).unwrap_or(0),
             Self::Undirected { out, inbound } => out
                 .base_csr_entries_expanded()
@@ -458,7 +416,6 @@ impl AdjacencyInner {
 
     fn overlay_row_count(&self) -> u64 {
         match self {
-            Self::Overlay(overlay) => overlay.overlay_row_count(),
             Self::ShardedOverlay { replaced, .. } => {
                 u64::try_from(replaced.len()).unwrap_or(u64::MAX)
             }
@@ -475,9 +432,7 @@ impl AdjacencyInner {
             Self::Map(map) => map.keys().next().map_or(0, |_| {
                 map.keys().copied().max().map_or(0, |m| m.saturating_add(1))
             }),
-            Self::Csr(csr) => csr.node_count(),
             Self::Sharded(csr) => csr.node_count(),
-            Self::Overlay(overlay) => overlay.node_extent,
             Self::ShardedOverlay { node_extent, .. } => *node_extent,
             Self::Undirected { out, inbound } => out.node_extent().max(inbound.node_extent()),
         }
@@ -491,18 +446,8 @@ impl AdjacencyInner {
                     visit(node_id, NeighborRow::pairs(entries.as_slice()));
                 }
             }
-            Self::Csr(csr) => {
-                for node_id in 0..csr.node_count() {
-                    visit(node_id, NeighborRow::csr(csr.row(node_id)));
-                }
-            }
             Self::Sharded(csr) => {
                 for node_id in 0..csr.node_count() {
-                    visit(node_id, self.neighbors(node_id)?);
-                }
-            }
-            Self::Overlay(overlay) => {
-                for node_id in 0..overlay.node_extent {
                     visit(node_id, self.neighbors(node_id)?);
                 }
             }
@@ -1167,32 +1112,9 @@ impl PersistentAdjacencyProvider {
                     node_extent,
                 });
             }
-            // Legacy single-batch CSR migration path. A successful rebuild
-            // publishes sharded v1 files; old projects remain readable until
-            // that rebuild occurs.
-            let base = Arc::new(csr::read_csr(&path)?);
-            if deltas.is_empty() {
-                return Ok(AdjacencyInner::Csr(base));
-            }
-            // Torn-read count guard (#765): the base CSR must match the manifest
-            // row it was loaded against. If a concurrent compaction rewrote the
-            // CSR under this snapshot, the recorded counts differ and applying
-            // the chain would double-count — bail to a rebuild instead.
-            if let Some(row) = rows
-                .iter()
-                .find(|r| r.relation_type == stem && r.direction == d)
-                && (base.node_count() != row.node_count || base.edge_count() != row.edge_count)
-            {
-                return Err(GfError::Storage(
-                    "adjacency base CSR disagrees with manifest counts (torn read)".into(),
-                ));
-            }
-            let overlay = overlay_delta_segments(base, stem, d, deltas);
-            if overlay.replaced.is_empty() {
-                Ok(AdjacencyInner::Csr(overlay.base))
-            } else {
-                Ok(AdjacencyInner::Overlay(overlay))
-            }
+            Err(GfError::Storage(
+                "unsupported or missing current CSR shard manifest".into(),
+            ))
         };
         match direction {
             Direction::Out => Ok(Adjacency {
@@ -1553,12 +1475,21 @@ impl AdjacencyProvider for PersistentAdjacencyProvider {
 
 /// Undirected CSR pair without materializing a merged hash map (#340).
 #[cfg(test)]
-fn merge_undirected(out: CsrIndex, inbound: CsrIndex) -> Adjacency {
+fn merge_undirected(out: csr::CsrIndex, inbound: csr::CsrIndex) -> Adjacency {
+    let root = Arc::new(tempfile::tempdir().unwrap());
+    let out_path = root.path().join("out.csr");
+    let in_path = root.path().join("in.csr");
+    csr::write_sharded_csr(&out_path, &out, 2).unwrap();
+    csr::write_sharded_csr(&in_path, &inbound, 2).unwrap();
     Adjacency {
-        retained_root: None,
+        retained_root: Some(RetainedAdjacencyRoot(root)),
         inner: AdjacencyInner::Undirected {
-            out: Arc::new(AdjacencyInner::Csr(Arc::new(out))),
-            inbound: Arc::new(AdjacencyInner::Csr(Arc::new(inbound))),
+            out: Arc::new(AdjacencyInner::Sharded(Arc::new(
+                ShardedCsrIndex::open(&out_path).unwrap(),
+            ))),
+            inbound: Arc::new(AdjacencyInner::Sharded(Arc::new(
+                ShardedCsrIndex::open(&in_path).unwrap(),
+            ))),
         },
     }
 }
@@ -1569,7 +1500,7 @@ fn merge_undirected(out: CsrIndex, inbound: CsrIndex) -> Adjacency {
 
 #[cfg(test)]
 mod tests {
-    use graphforge_storage::adjacency::build_adjacency_index;
+    use graphforge_storage::adjacency::{CsrIndex, build_adjacency_index};
     use std::path::Path;
 
     use graphforge_core::uuid::{Uuid, new_v7, to_bytes};
@@ -1869,7 +1800,9 @@ mod tests {
                 if path.extension().and_then(|ext| ext.to_str()) != Some("csr") {
                     continue;
                 }
-                std::fs::write(&path, b"corrupt-payload").unwrap();
+                let mut bytes = std::fs::read(&path).unwrap();
+                bytes[0] ^= 1;
+                std::fs::write(&path, bytes).unwrap();
                 overwritten += 1;
             }
         }

--- a/crates/graphforge-storage/Cargo.toml
+++ b/crates/graphforge-storage/Cargo.toml
@@ -40,6 +40,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 unicode-normalization = { workspace = true }
 uuid = { workspace = true }
+zstd = { version = "=0.13.3", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -49,7 +50,6 @@ rustix = { version = "1.1", features = ["fs"] }
 named-lock = "0.4.1"
 
 [dev-dependencies]
-zstd = { version = "=0.13.3", default-features = false }
 divan = { workspace = true }
 wait-timeout = "0.2"
 

--- a/crates/graphforge-storage/src/adjacency.rs
+++ b/crates/graphforge-storage/src/adjacency.rs
@@ -33,9 +33,10 @@
 //! offsets array; the struct child is the targets array. See
 //! [`ADJACENCY_CSR_SCHEMA`] and `docs/book/architecture/storage.md` §Derived
 //! Indexes. [`ShardedCsrIndex`] resolves only the shard(s) containing a requested
-//! row. Legacy single-batch [`CsrIndex`] files remain readable until rebuild.
+//! row. Only the current versioned shard representation is supported.
 
 mod builder;
+mod codec;
 pub use builder::{
     ADJACENCY_SPILL_DIR_NAME, AdjacencyBuildMetrics, AdjacencyBuildOptions,
     DEFAULT_ADJACENCY_CHUNK_ROWS, DEFAULT_ADJACENCY_MERGE_FAN_IN, build_adjacency_index,
@@ -73,22 +74,26 @@ pub const ALL_RELATIONS_STEM: &str = "_all";
 /// File name of the adjacency index manifest within `indexes/adjacency/`.
 pub const MANIFEST_FILE: &str = "index_manifest.parquet";
 
-const SHARDED_CSR_VERSION: u32 = 1;
+const SHARDED_CSR_VERSION: u32 = 2;
 /// Default maximum adjacency entries materialized in one persisted CSR shard.
 pub const DEFAULT_CSR_SHARD_EDGES: usize = 1_048_576;
 /// Default maximum local CSR rows (offset entries minus one) per shard.
 pub const DEFAULT_CSR_SHARD_NODES: usize = 1_048_576;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct CsrShardRecord {
     first_node: u64,
     node_count: u64,
     edge_count: u64,
     file: String,
     sha256: String,
+    encoded_bytes: u64,
+    decoded_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct CsrShardManifest {
     format: String,
     version: u32,
@@ -110,7 +115,7 @@ pub struct ShardedCsrIndex {
 }
 
 impl ShardedCsrIndex {
-    /// Open the shard manifest beside the legacy logical `.csr` path.
+    /// Open the current shard manifest beside the logical `.csr` path.
     pub fn open(path: &Path) -> Result<Self, GfError> {
         let manifest_path = path.with_extension("csr.json");
         let bytes = std::fs::read(&manifest_path).map_err(storage_err)?;
@@ -132,7 +137,10 @@ impl ShardedCsrIndex {
             .join(&manifest.shard_dir);
         for shard in &manifest.shards {
             if shard.node_count == 0
-                || shard.first_node.saturating_add(shard.node_count) > manifest.node_count
+                || shard
+                    .first_node
+                    .checked_add(shard.node_count)
+                    .is_none_or(|end| end > manifest.node_count)
                 || prior_first.is_some_and(|prior| shard.first_node < prior)
             {
                 return Err(GfError::Storage(
@@ -140,7 +148,16 @@ impl ShardedCsrIndex {
                 ));
             }
             prior_first = Some(shard.first_node);
-            edges = edges.saturating_add(shard.edge_count);
+            edges = edges
+                .checked_add(shard.edge_count)
+                .ok_or_else(|| GfError::Storage("CSR manifest edge count overflow".into()))?;
+            if shard.decoded_bytes != codec::decoded_bytes(shard.node_count, shard.edge_count)?
+                || shard.encoded_bytes > codec::encoded_limit(shard.node_count, shard.edge_count)?
+            {
+                return Err(GfError::Storage(
+                    "CSR shard admission metadata disagrees".into(),
+                ));
+            }
             if !is_normal_path_component(&shard.file) {
                 return Err(GfError::Storage("invalid CSR shard file name".into()));
             }
@@ -151,7 +168,7 @@ impl ShardedCsrIndex {
             let metadata = std::fs::metadata(&shard_path).map_err(|error| {
                 GfError::Storage(format!("missing CSR shard {}: {error}", shard.file))
             })?;
-            if !metadata.is_file() {
+            if !metadata.is_file() || metadata.len() != shard.encoded_bytes {
                 return Err(GfError::Storage(format!(
                     "missing CSR shard {}",
                     shard.file
@@ -290,22 +307,7 @@ impl ShardedCsrIndex {
             return Ok(map(csr.row(node_id - record.first_node)));
         }
         let path = self.root.join(&record.file);
-        let bytes = std::fs::read(&path).map_err(|error| {
-            GfError::Storage(format!("missing CSR shard {}: {error}", path.display()))
-        })?;
-        if sha256_hex(&bytes) != record.sha256 {
-            return Err(GfError::Storage(format!(
-                "CSR shard checksum mismatch: {}",
-                record.file
-            )));
-        }
-        let csr = read_csr_bytes(&bytes, &path)?;
-        if csr.node_count() != record.node_count || csr.edge_count() != record.edge_count {
-            return Err(GfError::Storage(format!(
-                "CSR shard count mismatch: {}",
-                record.file
-            )));
-        }
+        let csr = read_authenticated_shard(&path, record)?;
         let output = map(csr.row(node_id - record.first_node));
         *cache = Some((record.file.clone(), csr));
         Ok(output)
@@ -319,7 +321,7 @@ pub fn sharded_csr_exists(path: &Path) -> bool {
 }
 
 fn csr_artifact_exists(path: &Path) -> bool {
-    path.is_file() || sharded_csr_exists(path)
+    sharded_csr_exists(path)
 }
 
 fn is_normal_path_component(value: &str) -> bool {
@@ -329,7 +331,7 @@ fn is_normal_path_component(value: &str) -> bool {
 }
 
 /// Write a versioned checksummed shard set and publish its manifest last.
-/// This compatibility helper accepts an in-memory CSR; streaming builders use
+/// This writer accepts an in-memory CSR; streaming builders use
 /// the same shard writer while producing one bounded shard at a time.
 pub fn write_sharded_csr(path: &Path, csr: &CsrIndex, max_edges: usize) -> Result<(), GfError> {
     csr.validate()?;
@@ -375,8 +377,8 @@ impl ShardedCsrWriter {
             owned_root: Some(root.clone()),
             root,
             shard_dir,
-            max_edges: max_edges.max(1),
-            max_nodes: max_nodes.max(1),
+            max_edges: max_edges.clamp(1, DEFAULT_CSR_SHARD_EDGES),
+            max_nodes: max_nodes.clamp(1, DEFAULT_CSR_SHARD_NODES),
             records: Vec::new(),
             shard: CsrIndex {
                 offsets: vec![0],
@@ -443,7 +445,7 @@ impl ShardedCsrWriter {
 
         self.flush()?;
         let mut identity = Sha256::new();
-        identity.update(b"graphforge/csr-shards/v1\0");
+        identity.update(b"graphforge/csr-shards/v2\0");
         identity.update(node_count.to_le_bytes());
         identity.update(self.edge_count.to_le_bytes());
         for record in &self.records {
@@ -516,16 +518,7 @@ impl Drop for ShardedCsrWriter {
 fn shard_set_matches(root: &Path, records: &[CsrShardRecord]) -> bool {
     for record in records {
         let path = root.join(&record.file);
-        let Ok(bytes) = std::fs::read(&path) else {
-            return false;
-        };
-        if sha256_hex(&bytes) != record.sha256 {
-            return false;
-        }
-        let Ok(csr) = read_csr_bytes(&bytes, &path) else {
-            return false;
-        };
-        if csr.node_count() != record.node_count || csr.edge_count() != record.edge_count {
+        if read_authenticated_shard(&path, record).is_err() {
             return false;
         }
     }
@@ -540,14 +533,22 @@ fn write_csr_shard(
 ) -> Result<CsrShardRecord, GfError> {
     let file = format!("{ordinal:020}.csr");
     let path = root.join(&file);
-    write_csr(&path, shard)?;
-    let bytes = std::fs::read(&path).map_err(storage_err)?;
+    write_csr_shard_file(&path, shard)?;
+    let encoded_bytes = std::fs::metadata(&path).map_err(storage_err)?.len();
+    let bytes = codec::read(
+        &path,
+        encoded_bytes,
+        codec::encoded_limit(shard.node_count(), shard.edge_count())?,
+    )?;
+    codec::preflight(&bytes, shard.node_count(), shard.edge_count())?;
     Ok(CsrShardRecord {
         first_node,
         node_count: shard.node_count(),
         edge_count: shard.edge_count(),
         file,
         sha256: sha256_hex(&bytes),
+        encoded_bytes: bytes.len() as u64,
+        decoded_bytes: codec::decoded_bytes(shard.node_count(), shard.edge_count())?,
     })
 }
 
@@ -858,8 +859,9 @@ pub fn manifest_path(project_dir: &Path) -> PathBuf {
 /// # Errors
 /// Returns [`GfError::Storage`] if `csr` violates its invariants or on
 /// I/O/encode failure; on failure `path` is untouched.
-pub fn write_csr(path: &Path, csr: &CsrIndex) -> Result<(), GfError> {
+fn write_csr_shard_file(path: &Path, csr: &CsrIndex) -> Result<(), GfError> {
     csr.validate()?;
+    codec::decoded_bytes(csr.node_count(), csr.edge_count())?;
 
     let offsets: Vec<i64> = csr
         .offsets
@@ -904,68 +906,71 @@ pub fn write_csr(path: &Path, csr: &CsrIndex) -> Result<(), GfError> {
         .tempfile_in(parent)
         .map_err(storage_err)?;
 
+    let options = arrow::ipc::writer::IpcWriteOptions::default()
+        .try_with_compression(Some(arrow::ipc::CompressionType::ZSTD))
+        .map_err(storage_err)?;
     let mut writer =
-        FileWriter::try_new(tmp.as_file(), &ADJACENCY_CSR_SCHEMA).map_err(storage_err)?;
+        FileWriter::try_new_with_options(tmp.as_file(), &ADJACENCY_CSR_SCHEMA, options)
+            .map_err(storage_err)?;
     writer.write(&batch).map_err(storage_err)?;
     writer.finish().map_err(storage_err)?;
     persist_temp(tmp, path)?;
-    // Explicit legacy writes are a supported migration/testing seam. Make the
-    // representation choice unambiguous so a stale sharded manifest cannot
-    // shadow the newly published single-batch file.
-    let sharded_manifest = path.with_extension("csr.json");
-    if sharded_manifest.exists() {
-        let shard_root = std::fs::read(&sharded_manifest)
-            .ok()
-            .and_then(|bytes| serde_json::from_slice::<CsrShardManifest>(&bytes).ok())
-            .filter(|manifest| is_normal_path_component(&manifest.shard_dir))
-            .and_then(|manifest| path.parent().map(|parent| parent.join(manifest.shard_dir)));
-        std::fs::remove_file(sharded_manifest).map_err(storage_err)?;
-        if let Some(shard_root) = shard_root {
-            let _ = std::fs::remove_dir_all(shard_root);
-        }
-    }
     Ok(())
 }
 
-/// Read a CSR file written by [`write_csr`] back into a [`CsrIndex`].
+/// Materialize a current sharded CSR for explicit validation/inspection.
+/// Query row access uses [`ShardedCsrIndex`] and does not assemble the index.
 ///
 /// # Errors
-/// Returns [`GfError::Storage`] if the file is missing, is not an Arrow IPC
-/// file with [`ADJACENCY_CSR_SCHEMA`], or decodes to an invalid CSR.
+/// Refuses missing, unsupported or corrupt shards.
 pub fn read_csr(path: &Path) -> Result<CsrIndex, GfError> {
-    if sharded_csr_exists(path) {
-        let sharded = ShardedCsrIndex::open(path)?;
-        let mut csr = CsrIndex {
-            offsets: vec![0],
-            ..CsrIndex::default()
-        };
-        for node in 0..sharded.node_count() {
-            for (edge, neighbor) in sharded.row(node)? {
-                csr.edge_ids.push(edge);
-                csr.neighbor_ids.push(neighbor);
-            }
-            csr.offsets.push(csr.edge_count());
+    let sharded = ShardedCsrIndex::open(path)?;
+    let mut csr = CsrIndex {
+        offsets: vec![0],
+        ..CsrIndex::default()
+    };
+    for node in 0..sharded.node_count() {
+        for (edge, neighbor) in sharded.row(node)? {
+            csr.edge_ids.push(edge);
+            csr.neighbor_ids.push(neighbor);
         }
-        csr.validate()?;
-        return Ok(csr);
+        csr.offsets.push(csr.edge_count());
     }
-    let file = File::open(path)
-        .map_err(|e| GfError::Storage(format!("cannot open CSR file {}: {e}", path.display())))?;
-    let reader = FileReader::try_new(file, None)
-        .map_err(|e| GfError::Storage(format!("invalid CSR file {}: {e}", path.display())))?;
-    decode_csr(reader, path)
+    csr.validate()?;
+    Ok(csr)
 }
 
-fn read_csr_bytes(bytes: &[u8], path: &Path) -> Result<CsrIndex, GfError> {
-    let reader = FileReader::try_new(std::io::Cursor::new(bytes), None).map_err(|error| {
-        GfError::Storage(format!("invalid CSR shard {}: {error}", path.display()))
-    })?;
-    decode_csr(reader, path)
+fn read_authenticated_shard(path: &Path, record: &CsrShardRecord) -> Result<CsrIndex, GfError> {
+    if record.decoded_bytes != codec::decoded_bytes(record.node_count, record.edge_count)? {
+        return Err(GfError::Storage(
+            "CSR decoded-byte admission mismatch".into(),
+        ));
+    }
+    let bytes = codec::read(
+        path,
+        record.encoded_bytes,
+        codec::encoded_limit(record.node_count, record.edge_count)?,
+    )?;
+    if sha256_hex(&bytes) != record.sha256 {
+        return Err(GfError::Storage(format!(
+            "CSR shard checksum mismatch: {}",
+            record.file
+        )));
+    }
+    codec::preflight(&bytes, record.node_count, record.edge_count)?;
+    let reader = FileReader::try_new(std::io::Cursor::new(&bytes), None).map_err(storage_err)?;
+    let csr = decode_csr(reader, path, record.node_count, record.edge_count)?;
+    if csr.node_count() != record.node_count || csr.edge_count() != record.edge_count {
+        return Err(GfError::Storage("CSR shard count mismatch".into()));
+    }
+    Ok(csr)
 }
 
 fn decode_csr<R: std::io::Read + std::io::Seek>(
     reader: FileReader<R>,
     path: &Path,
+    admitted_nodes: u64,
+    admitted_edges: u64,
 ) -> Result<CsrIndex, GfError> {
     if reader.schema().fields() != ADJACENCY_CSR_SCHEMA.fields() {
         return Err(GfError::Storage(format!(
@@ -976,9 +981,11 @@ fn decode_csr<R: std::io::Read + std::io::Seek>(
     }
 
     let mut csr = CsrIndex {
-        offsets: vec![0],
-        ..CsrIndex::default()
+        offsets: Vec::with_capacity(usize::try_from(admitted_nodes + 1).map_err(storage_err)?),
+        edge_ids: Vec::with_capacity(usize::try_from(admitted_edges).map_err(storage_err)?),
+        neighbor_ids: Vec::with_capacity(usize::try_from(admitted_edges).map_err(storage_err)?),
     };
+    csr.offsets.push(0);
     for batch in reader {
         let batch = batch.map_err(storage_err)?;
         let adjacency = batch
@@ -1009,6 +1016,18 @@ fn decode_csr<R: std::io::Read + std::io::Seek>(
         // arrays wholesale: this stays correct for multi-batch files and for
         // list arrays whose offsets do not start at zero (slices).
         let value_offsets = adjacency.value_offsets();
+        if adjacency.null_count() != 0
+            || entries.null_count() != 0
+            || edge_ids.null_count() != 0
+            || neighbor_ids.null_count() != 0
+            || value_offsets.first() != Some(&0)
+            || value_offsets.last().copied() != i64::try_from(edge_ids.len()).ok()
+            || value_offsets.windows(2).any(|pair| pair[0] > pair[1])
+        {
+            return Err(GfError::Storage(
+                "invalid CSR offsets or null values".into(),
+            ));
+        }
         for row in 0..adjacency.len() {
             let start = usize::try_from(value_offsets[row]).map_err(storage_err)?;
             let end = usize::try_from(value_offsets[row + 1]).map_err(storage_err)?;
@@ -1808,7 +1827,9 @@ mod tests {
 
         let first = reader.root.join(&reader.manifest.shards[0].file);
         let original = std::fs::read(&first).unwrap();
-        std::fs::write(&first, b"corrupt").unwrap();
+        let mut corrupt = original.clone();
+        corrupt[0] ^= 1;
+        std::fs::write(&first, corrupt).unwrap();
         assert!(reader.row(0).unwrap_err().to_string().contains("checksum"));
         assert!(
             reader
@@ -1861,7 +1882,10 @@ mod tests {
             (expected.node_count(), expected.edge_count())
         );
         for record in &published.manifest.shards {
-            std::fs::write(published.root.join(&record.file), b"corrupt-payload").unwrap();
+            let payload = published.root.join(&record.file);
+            let mut bytes = std::fs::read(&payload).unwrap();
+            bytes[0] ^= 1;
+            std::fs::write(payload, bytes).unwrap();
         }
         let reader = ShardedCsrIndex::open(&path).expect("open must not decode shard payloads");
         assert_eq!(
@@ -1978,50 +2002,17 @@ mod tests {
     }
 
     #[test]
-    fn legacy_single_batch_csr_migrates_to_shards_on_rebuild() {
+    fn unsupported_csr_manifest_version_is_refused() {
         let directory = TempDir::new().unwrap();
         let path = directory.path().join("KNOWS.out.csr");
-        let expected = sample_csr();
-
-        write_csr(&path, &expected).unwrap();
-        assert!(!sharded_csr_exists(&path));
-        assert_eq!(read_csr(&path).unwrap(), expected);
-
-        write_sharded_csr(&path, &expected, 2).unwrap();
-        let shard_root = ShardedCsrIndex::open(&path).unwrap().root;
-        assert!(sharded_csr_exists(&path));
-        assert_eq!(read_csr(&path).unwrap(), expected);
-
-        write_csr(&path, &expected).unwrap();
-        assert!(!shard_root.exists());
-        assert!(!sharded_csr_exists(&path));
-        assert_eq!(read_csr(&path).unwrap(), expected);
-    }
-
-    #[test]
-    fn legacy_cleanup_rejects_parent_directory_manifest_paths() {
-        let directory = TempDir::new().unwrap();
-        let adjacency = directory.path().join("adjacency");
-        std::fs::create_dir(&adjacency).unwrap();
-        let sentinel = directory.path().join("must-remain");
-        std::fs::write(&sentinel, b"safe").unwrap();
-        let path = adjacency.join("KNOWS.out.csr");
-        let malicious = CsrShardManifest {
-            format: "graphforge.csr-shards".into(),
-            version: SHARDED_CSR_VERSION,
-            node_count: 0,
-            edge_count: 0,
-            shard_dir: "..".into(),
-            shards: Vec::new(),
-        };
-        std::fs::write(
-            path.with_extension("csr.json"),
-            serde_json::to_vec(&malicious).unwrap(),
-        )
-        .unwrap();
-
-        write_csr(&path, &sample_csr()).unwrap();
-        assert_eq!(std::fs::read(&sentinel).unwrap(), b"safe");
+        write_sharded_csr(&path, &sample_csr(), 2).unwrap();
+        let manifest_path = path.with_extension("csr.json");
+        let mut manifest: CsrShardManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        manifest.version = 1;
+        std::fs::write(manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+        assert!(ShardedCsrIndex::open(&path).is_err());
+        assert!(read_csr(&path).is_err());
     }
 
     #[test]
@@ -2104,7 +2095,12 @@ mod tests {
                 neighbor_ids: vec![],
             },
         ] {
-            assert_eq!(write_csr(&path, &malformed).unwrap_err().code(), "GF_IO");
+            assert_eq!(
+                write_sharded_csr(&path, &malformed, DEFAULT_CSR_SHARD_EDGES)
+                    .unwrap_err()
+                    .code(),
+                "GF_IO"
+            );
             assert!(!path.exists());
         }
     }
@@ -2114,7 +2110,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = csr_path(dir.path(), "KNOWS", Direction::Out);
         let csr = sample_csr();
-        write_csr(&path, &csr).unwrap();
+        write_sharded_csr(&path, &csr, DEFAULT_CSR_SHARD_EDGES).unwrap();
         assert_eq!(read_csr(&path).unwrap(), csr);
     }
 
@@ -2144,7 +2140,7 @@ mod tests {
             offsets: vec![0],
             ..CsrIndex::default()
         };
-        write_csr(&path, &csr).unwrap();
+        write_sharded_csr(&path, &csr, DEFAULT_CSR_SHARD_EDGES).unwrap();
         let back = read_csr(&path).unwrap();
         assert_eq!(back, csr);
         assert_eq!(back.node_count(), 0);
@@ -2156,7 +2152,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = csr_path(dir.path(), ALL_RELATIONS_STEM, Direction::Out);
         let csr = sample_csr(); // node 1 has an empty range
-        write_csr(&path, &csr).unwrap();
+        write_sharded_csr(&path, &csr, DEFAULT_CSR_SHARD_EDGES).unwrap();
         let back = read_csr(&path).unwrap();
         assert_eq!(back.offsets[1], back.offsets[2], "node 1 has no neighbors");
         assert_eq!(back.node_count(), 3);
@@ -2167,14 +2163,14 @@ mod tests {
     fn write_csr_replaces_existing_file_atomically() {
         let dir = TempDir::new().unwrap();
         let path = csr_path(dir.path(), "KNOWS", Direction::Out);
-        write_csr(&path, &sample_csr()).unwrap();
+        write_sharded_csr(&path, &sample_csr(), DEFAULT_CSR_SHARD_EDGES).unwrap();
 
         let newer = CsrIndex {
             offsets: vec![0, 1],
             edge_ids: vec![99],
             neighbor_ids: vec![0],
         };
-        write_csr(&path, &newer).unwrap();
+        write_sharded_csr(&path, &newer, DEFAULT_CSR_SHARD_EDGES).unwrap();
         assert_eq!(read_csr(&path).unwrap(), newer, "second write wins");
 
         let temps = std::fs::read_dir(adjacency_dir(dir.path()))
@@ -2212,7 +2208,7 @@ mod tests {
             neighbor_ids: vec![1],
         };
         assert!(matches!(
-            write_csr(&path, &non_monotone),
+            write_sharded_csr(&path, &non_monotone, DEFAULT_CSR_SHARD_EDGES),
             Err(GfError::Storage(_))
         ));
 
@@ -2223,14 +2219,14 @@ mod tests {
             neighbor_ids: vec![1],
         };
         assert!(matches!(
-            write_csr(&path, &length_mismatch),
+            write_sharded_csr(&path, &length_mismatch, DEFAULT_CSR_SHARD_EDGES),
             Err(GfError::Storage(_))
         ));
 
         // Empty offsets (the empty graph must be [0], not []).
         let empty_offsets = CsrIndex::default();
         assert!(matches!(
-            write_csr(&path, &empty_offsets),
+            write_sharded_csr(&path, &empty_offsets, DEFAULT_CSR_SHARD_EDGES),
             Err(GfError::Storage(_))
         ));
 
@@ -2241,7 +2237,7 @@ mod tests {
             neighbor_ids: vec![1],
         };
         assert!(matches!(
-            write_csr(&path, &ragged),
+            write_sharded_csr(&path, &ragged, DEFAULT_CSR_SHARD_EDGES),
             Err(GfError::Storage(_))
         ));
 
@@ -2605,7 +2601,12 @@ mod tests {
             edge_ids: vec![99],
             neighbor_ids: vec![1],
         };
-        write_csr(&csr_path(dir.path(), "KNOWS", Direction::Out), &bogus).unwrap();
+        write_sharded_csr(
+            &csr_path(dir.path(), "KNOWS", Direction::Out),
+            &bogus,
+            DEFAULT_CSR_SHARD_EDGES,
+        )
+        .unwrap();
 
         let issues = validate_adjacency_index(dir.path()).unwrap();
         assert_eq!(
@@ -2747,7 +2748,12 @@ mod tests {
         // (the diamond has only KNOWS, so the _all CSR is identical and would
         // not be a corruption).
         let knows_out = csr_path(dir.path(), "KNOWS", Direction::Out);
-        write_csr(&knows_out, &csr_from_entries(&[], Direction::Out)).unwrap();
+        write_sharded_csr(
+            &knows_out,
+            &csr_from_entries(&[], Direction::Out),
+            DEFAULT_CSR_SHARD_EDGES,
+        )
+        .unwrap();
 
         let issues = validate_adjacency_index(dir.path()).unwrap();
         assert!(
@@ -2773,7 +2779,7 @@ mod tests {
             edge_ids: vec![],
             neighbor_ids: vec![],
         };
-        assert!(write_csr(Path::new("/"), &empty).is_err());
+        assert!(write_sharded_csr(Path::new("/"), &empty, DEFAULT_CSR_SHARD_EDGES).is_err());
 
         let root = TempDir::new().unwrap();
         let path = root.path().join("wrong-schema.arrow");

--- a/crates/graphforge-storage/src/adjacency/builder/tests.rs
+++ b/crates/graphforge-storage/src/adjacency/builder/tests.rs
@@ -203,7 +203,7 @@ fn hostile_and_reserved_stems_are_skipped_but_counted_in_union() {
 fn build_failure_leaves_no_manifest() {
     let dir = TempDir::new().unwrap();
     write_diamond(dir.path());
-    // Pre-create indexes/adjacency as a READ-ONLY dir so write_csr fails.
+    // Pre-create indexes/adjacency as a READ-ONLY dir so shard publication fails.
     let adj = adjacency_dir(dir.path());
     std::fs::create_dir_all(&adj).unwrap();
     let mut perms = std::fs::metadata(&adj).unwrap().permissions();

--- a/crates/graphforge-storage/src/adjacency/codec.rs
+++ b/crates/graphforge-storage/src/adjacency/codec.rs
@@ -1,0 +1,414 @@
+//! Admission for the current bounded, single-batch CSR Arrow IPC format.
+
+use std::io::Read as _;
+use std::path::Path;
+
+use arrow::ipc::{CompressionType, MetadataVersion};
+use graphforge_core::GfError;
+
+use super::{DEFAULT_CSR_SHARD_EDGES, DEFAULT_CSR_SHARD_NODES, storage_err};
+
+// The fixed schema needs far less metadata. This is an admission limit, not an
+// estimate of Arrow's parser or allocator overhead.
+const METADATA_MAX_BYTES: usize = 16 * 1024;
+
+fn invalid() -> GfError {
+    GfError::Storage("invalid or oversized current CSR shard encoding".into())
+}
+
+fn buffer_lengths(nodes: u64, edges: u64) -> Result<[u64; 7], GfError> {
+    if nodes > DEFAULT_CSR_SHARD_NODES as u64 || edges > DEFAULT_CSR_SHARD_EDGES as u64 {
+        return Err(invalid());
+    }
+    Ok([
+        nodes.div_ceil(8),
+        8 * (nodes + 1),
+        edges.div_ceil(8),
+        edges.div_ceil(8),
+        8 * edges,
+        edges.div_ceil(8),
+        8 * edges,
+    ])
+}
+
+pub(super) fn decoded_bytes(nodes: u64, edges: u64) -> Result<u64, GfError> {
+    Ok(buffer_lengths(nodes, edges)?.iter().sum())
+}
+
+pub(super) fn encoded_limit(nodes: u64, edges: u64) -> Result<u64, GfError> {
+    // Arrow stores a raw buffer if compression would expand it. Include IPC
+    // prefixes, alignment, schema/message/footer and end markers separately.
+    Ok(decoded_bytes(nodes, edges)? + METADATA_MAX_BYTES as u64)
+}
+
+pub(super) fn read(path: &Path, encoded_bytes: u64, limit: u64) -> Result<Vec<u8>, GfError> {
+    if encoded_bytes > limit {
+        return Err(invalid());
+    }
+    let mut file = std::fs::File::open(path).map_err(|error| {
+        GfError::Storage(format!("missing CSR shard {}: {error}", path.display()))
+    })?;
+    if file.metadata().map_err(storage_err)?.len() != encoded_bytes {
+        return Err(invalid());
+    }
+    let mut bytes = vec![0; usize::try_from(encoded_bytes).map_err(storage_err)?];
+    file.read_exact(&mut bytes).map_err(storage_err)?;
+    let mut trailing = [0_u8; 1];
+    if file.read(&mut trailing).map_err(storage_err)? != 0 {
+        return Err(invalid());
+    }
+    Ok(bytes)
+}
+
+fn index(value: i64) -> Result<usize, GfError> {
+    usize::try_from(value).map_err(storage_err)
+}
+
+fn slice(bytes: &[u8], offset: usize, len: usize) -> Result<&[u8], GfError> {
+    bytes
+        .get(offset..offset.checked_add(len).ok_or_else(invalid)?)
+        .ok_or_else(invalid)
+}
+
+fn validate_zstd_frame(payload: &[u8], expected: u64) -> Result<(), GfError> {
+    if payload.get(..4) != Some(&[0x28, 0xb5, 0x2f, 0xfd])
+        || zstd::zstd_safe::find_frame_compressed_size(payload).map_err(storage_err)?
+            != payload.len()
+        || zstd::zstd_safe::get_frame_content_size(payload).map_err(storage_err)? != Some(expected)
+    {
+        return Err(invalid());
+    }
+    Ok(())
+}
+
+fn validate_schema(schema: arrow::ipc::Schema<'_>) -> Result<(), GfError> {
+    if schema.endianness() != arrow::ipc::Endianness::Little {
+        return Err(invalid());
+    }
+    let fields = schema.fields().ok_or_else(invalid)?;
+    if fields.len() != 1 {
+        return Err(invalid());
+    }
+    let adjacency = fields.get(0);
+    validate_field(adjacency, "adjacency")?;
+    if adjacency.type_as_large_list().is_none() {
+        return Err(invalid());
+    }
+    let items = adjacency.children().ok_or_else(invalid)?;
+    if items.len() != 1 {
+        return Err(invalid());
+    }
+    let item = items.get(0);
+    validate_field(item, "item")?;
+    if item.type_as_struct_().is_none() {
+        return Err(invalid());
+    }
+    let entries = item.children().ok_or_else(invalid)?;
+    if entries.len() != 2 {
+        return Err(invalid());
+    }
+    for (field, name) in entries.iter().zip(["edge_id", "neighbor_id"]) {
+        validate_field(field, name)?;
+        let integer = field.type_as_int().ok_or_else(invalid)?;
+        if integer.bitWidth() != 64
+            || integer.is_signed()
+            || field
+                .children()
+                .is_some_and(|children| !children.is_empty())
+        {
+            return Err(invalid());
+        }
+    }
+    Ok(())
+}
+
+fn validate_field(field: arrow::ipc::Field<'_>, name: &str) -> Result<(), GfError> {
+    if field.name() != Some(name) || field.nullable() || field.dictionary().is_some() {
+        return Err(invalid());
+    }
+    Ok(())
+}
+
+/// Check every allocation-bearing declaration before Arrow constructs arrays.
+pub(super) fn preflight(bytes: &[u8], nodes: u64, edges: u64) -> Result<(), GfError> {
+    let lengths = buffer_lengths(nodes, edges)?;
+    if bytes.len() as u64 > encoded_limit(nodes, edges)? || bytes.get(..6) != Some(b"ARROW1") {
+        return Err(invalid());
+    }
+    let trailer = bytes.len().checked_sub(10).ok_or_else(invalid)?;
+    let footer_len =
+        arrow::ipc::reader::read_footer_length(bytes[trailer..].try_into().map_err(storage_err)?)
+            .map_err(storage_err)?;
+    if footer_len > METADATA_MAX_BYTES {
+        return Err(invalid());
+    }
+    let footer_start = trailer.checked_sub(footer_len).ok_or_else(invalid)?;
+    let footer = arrow::ipc::root_as_footer(&bytes[footer_start..trailer]).map_err(storage_err)?;
+    if footer.version() != MetadataVersion::V5
+        || footer.dictionaries().is_some_and(|d| !d.is_empty())
+    {
+        return Err(invalid());
+    }
+    validate_schema(footer.schema().ok_or_else(invalid)?)?;
+    let batches = footer.recordBatches().ok_or_else(invalid)?;
+    if batches.len() != 1 {
+        return Err(invalid());
+    }
+    let block = batches.get(0);
+    let offset = index(block.offset())?;
+    let metadata_len = usize::try_from(block.metaDataLength()).map_err(storage_err)?;
+    let body_len = index(block.bodyLength())?;
+    if metadata_len > METADATA_MAX_BYTES || offset < 8 {
+        return Err(invalid());
+    }
+    let metadata = slice(&bytes[..footer_start], offset, metadata_len)?;
+    if metadata.get(..4) != Some(&[255; 4]) {
+        return Err(invalid());
+    }
+    let declared = i32::from_le_bytes(slice(metadata, 4, 4)?.try_into().map_err(storage_err)?);
+    if usize::try_from(declared).map_err(storage_err)?
+        != metadata_len.checked_sub(8).ok_or_else(invalid)?
+    {
+        return Err(invalid());
+    }
+    let message = arrow::ipc::root_as_message(&metadata[8..]).map_err(storage_err)?;
+    if message.version() != MetadataVersion::V5 || index(message.bodyLength())? != body_len {
+        return Err(invalid());
+    }
+    let batch = message.header_as_record_batch().ok_or_else(invalid)?;
+    let compression = batch.compression().ok_or_else(invalid)?;
+    if compression.codec() != CompressionType::ZSTD
+        || compression.method() != arrow::ipc::BodyCompressionMethod::BUFFER
+        || index(batch.length())? as u64 != nodes
+    {
+        return Err(invalid());
+    }
+    let fields = batch.nodes().ok_or_else(invalid)?;
+    if fields.len() != 4 {
+        return Err(invalid());
+    }
+    for (field, expected) in fields.iter().zip([nodes, edges, edges, edges]) {
+        if index(field.length())? as u64 != expected || field.null_count() != 0 {
+            return Err(invalid());
+        }
+    }
+    let buffers = batch.buffers().ok_or_else(invalid)?;
+    if buffers.len() != lengths.len() {
+        return Err(invalid());
+    }
+    let body = slice(
+        &bytes[..footer_start],
+        offset.checked_add(metadata_len).ok_or_else(invalid)?,
+        body_len,
+    )?;
+    let mut prior_end = 0;
+    for (buffer, expected) in buffers.iter().zip(lengths) {
+        let start = index(buffer.offset())?;
+        let len = index(buffer.length())?;
+        if start < prior_end {
+            return Err(invalid());
+        }
+        let encoded = slice(body, start, len)?;
+        prior_end = start.checked_add(len).ok_or_else(invalid)?;
+        if expected == 0 && encoded.is_empty() {
+            continue;
+        }
+        let declared = i64::from_le_bytes(slice(encoded, 0, 8)?.try_into().map_err(storage_err)?);
+        let payload = &encoded[8..];
+        if declared == -1 {
+            if payload.len() as u64 != expected {
+                return Err(invalid());
+            }
+        } else {
+            if u64::try_from(declared).map_err(storage_err)? != expected {
+                return Err(invalid());
+            }
+            validate_zstd_frame(payload, expected)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> (tempfile::TempDir, std::path::PathBuf, Vec<u8>) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shard.csr");
+        let csr = super::super::CsrIndex {
+            offsets: vec![0, 128],
+            edge_ids: vec![u64::MAX; 128],
+            neighbor_ids: vec![u64::MAX - 1; 128],
+        };
+        super::super::write_csr_shard_file(&path, &csr).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        (dir, path, bytes)
+    }
+
+    fn first_buffer_start(bytes: &[u8]) -> usize {
+        let trailer = bytes.len() - 10;
+        let len =
+            arrow::ipc::reader::read_footer_length(bytes[trailer..].try_into().unwrap()).unwrap();
+        let footer = arrow::ipc::root_as_footer(&bytes[trailer - len..trailer]).unwrap();
+        let block = footer.recordBatches().unwrap().get(0);
+        usize::try_from(block.offset()).unwrap() + usize::try_from(block.metaDataLength()).unwrap()
+    }
+
+    #[test]
+    fn current_writer_passes_exact_predecode_admission() {
+        let (_dir, path, bytes) = fixture();
+        preflight(&bytes, 1, 128).unwrap();
+        assert_eq!(
+            read(&path, bytes.len() as u64, encoded_limit(1, 128).unwrap()).unwrap(),
+            bytes
+        );
+        assert!(preflight(&bytes, 2, 128).is_err());
+        assert!(preflight(&bytes, 1, 127).is_err());
+        assert!(decoded_bytes(u64::MAX, 1).is_err());
+        assert!(decoded_bytes(1, u64::MAX).is_err());
+    }
+
+    #[test]
+    fn size_bomb_is_refused_before_arrow_decoding() {
+        let (_dir, path, mut bytes) = fixture();
+        let start = first_buffer_start(&bytes);
+        bytes[start..start + 8].copy_from_slice(&i64::MAX.to_le_bytes());
+        assert!(preflight(&bytes, 1, 128).is_err());
+        assert!(read(&path, u64::MAX, encoded_limit(1, 128).unwrap()).is_err());
+        assert!(
+            read(
+                &path,
+                bytes.len() as u64 + 1,
+                encoded_limit(1, 128).unwrap()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn malformed_footer_and_truncated_ipc_are_refused() {
+        let (_dir, _path, bytes) = fixture();
+        for len in [0, 5, 9, bytes.len() - 1] {
+            assert!(preflight(&bytes[..len], 1, 128).is_err());
+        }
+        let mut oversized = bytes;
+        let trailer = oversized.len() - 10;
+        oversized[trailer..trailer + 4].copy_from_slice(&i32::MAX.to_le_bytes());
+        assert!(preflight(&oversized, 1, 128).is_err());
+    }
+
+    #[test]
+    fn zstd_requires_one_exact_current_frame_and_size() {
+        let bytes = zstd::bulk::compress(&[7; 128], 1).unwrap();
+        validate_zstd_frame(&bytes, 128).unwrap();
+        assert!(validate_zstd_frame(&bytes, 127).is_err());
+        assert!(validate_zstd_frame(&[bytes.clone(), bytes.clone()].concat(), 256).is_err());
+        let mut trailing = bytes.clone();
+        trailing.push(0);
+        assert!(validate_zstd_frame(&trailing, 128).is_err());
+        assert!(validate_zstd_frame(&bytes[..bytes.len() - 1], 128).is_err());
+        assert!(validate_zstd_frame(&[0x50, 0x2a, 0x4d, 0x18, 0, 0, 0, 0], 0).is_err());
+    }
+
+    #[test]
+    fn bulk_decoder_context_does_not_grow_with_admitted_output() {
+        let mut context = zstd::zstd_safe::DCtx::create();
+        let context_bytes = context.sizeof();
+        assert!(context_bytes <= 256 * 1024);
+        for len in [1024, 1024 * 1024, 8 * 1024 * 1024] {
+            let input = vec![23; len];
+            let encoded = zstd::bulk::compress(&input, 1).unwrap();
+            validate_zstd_frame(&encoded, u64::try_from(len).unwrap()).unwrap();
+            let mut output = vec![0_u8; len];
+            assert_eq!(
+                context.decompress(output.as_mut_slice(), &encoded).unwrap(),
+                len
+            );
+            assert_eq!(output, input);
+            assert_eq!(context.sizeof(), context_bytes);
+            assert!(
+                context
+                    .decompress(&mut output[..len - 1], &encoded)
+                    .is_err()
+            );
+        }
+        println!("CSR_ZSTD_FIXED_CONTEXT_BYTES {context_bytes}");
+    }
+
+    #[test]
+    fn authenticated_size_bomb_is_refused_by_lookup_and_reuse() {
+        use super::super::{
+            CsrIndex, ShardedCsrIndex, sha256_hex, shard_set_matches, write_sharded_csr,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.csr");
+        let csr = CsrIndex {
+            offsets: vec![0, 128],
+            edge_ids: (0..128).collect(),
+            neighbor_ids: vec![u64::MAX; 128],
+        };
+        write_sharded_csr(&path, &csr, 128).unwrap();
+        let mut reader = ShardedCsrIndex::open(&path).unwrap();
+        let record = &mut reader.manifest.shards[0];
+        let payload = reader.root.join(&record.file);
+        let mut bytes = std::fs::read(&payload).unwrap();
+        let start = first_buffer_start(&bytes);
+        bytes[start..start + 8].copy_from_slice(&i64::MAX.to_le_bytes());
+        record.sha256 = sha256_hex(&bytes);
+        std::fs::write(payload, bytes).unwrap();
+        assert!(reader.row(0).is_err());
+        assert!(reader.row_len(0).is_err());
+        assert!(reader.row_chunk(0, 0, 1).is_err());
+        assert!(reader.cache.lock().unwrap().is_none());
+        assert!(!shard_set_matches(&reader.root, &reader.manifest.shards));
+    }
+
+    #[test]
+    fn structurally_valid_incomplete_or_invalid_schema_is_refused_without_conversion() {
+        let (_dir, _path, bytes) = fixture();
+        let trailer = bytes.len() - 10;
+        let len =
+            arrow::ipc::reader::read_footer_length(bytes[trailer..].try_into().unwrap()).unwrap();
+        let base = trailer - len;
+        let footer_bytes = &bytes[base..trailer];
+        let footer = arrow::ipc::root_as_footer(footer_bytes).unwrap();
+        let schema = footer.schema().unwrap();
+        let table = schema._tab.loc();
+        let vtable_delta = i32::from_le_bytes(footer_bytes[table..table + 4].try_into().unwrap());
+        let vtable =
+            usize::try_from(i64::try_from(table).unwrap() - i64::from(vtable_delta)).unwrap();
+        let slot = base + vtable + usize::from(arrow::ipc::Schema::VT_FIELDS);
+        let mut missing_fields = bytes.clone();
+        missing_fields[slot..slot + 2].fill(0);
+        assert!(
+            arrow::ipc::root_as_footer(&missing_fields[base..trailer])
+                .unwrap()
+                .schema()
+                .unwrap()
+                .fields()
+                .is_none()
+        );
+        assert!(preflight(&missing_fields, 1, 128).is_err());
+
+        let integer = schema
+            .fields()
+            .unwrap()
+            .get(0)
+            .children()
+            .unwrap()
+            .get(0)
+            .children()
+            .unwrap()
+            .get(0)
+            .type_as_int()
+            .unwrap();
+        let offset = integer._tab.vtable().get(arrow::ipc::Int::VT_BITWIDTH);
+        assert_ne!(offset, 0);
+        let width = base + integer._tab.loc() + usize::from(offset);
+        let mut invalid_width = bytes;
+        invalid_width[width..width + 4].copy_from_slice(&63_i32.to_le_bytes());
+        assert!(arrow::ipc::root_as_footer(&invalid_width[base..trailer]).is_ok());
+        assert!(preflight(&invalid_width, 1, 128).is_err());
+    }
+}

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -613,7 +613,8 @@ Within each shard this is the CSR structure in its idiomatic Arrow encoding — 
 two top-level columns because a RecordBatch requires equal column lengths. The list's offsets
 buffer **is** the CSR offsets array (length `node_count + 1`, `Int64`, starting at 0,
 monotone), and the flattened struct child **is** the targets array (length `edge_count`):
-neighbors of `node_id = i` are `targets[offsets[i]..offsets[i+1]]`, zero-copy on read.
+neighbors of `node_id = i` are `targets[offsets[i]..offsets[i+1]]`. The reader authenticates
+and decompresses one bounded Arrow batch, then copies its values into the shared shard cache.
 
 Conventions:
 
@@ -621,16 +622,47 @@ Conventions:
   array is never empty.
 - **Node with no neighbors**: an empty list (`offsets[i] == offsets[i+1]`).
 - The shard manifest records format/version, total node/edge counts, ordered boundaries,
-  per-shard counts, and SHA-256 checksums. A row may span consecutive shards when a
+  per-shard counts, encoded/decoded byte lengths, and SHA-256 checksums. A row may span consecutive shards when a
   high-degree vertex exceeds the configured hard edge cap; readers concatenate those
   fragments in deterministic `(key, edge_id)` order.
 - Logical CSR rows cover exactly `node_id ∈ 0..node_count`; surrogates beyond `node_count`
   have no entries. Empty interior rows need no physical shard bytes.
 - In-memory consumers (`graphforge_exec::AdjacencyProvider`) keep a
   `ShardedCsrIndex` on a persisted hit and materialize only the requested logical row
-  from its bounded shard fragments. Legacy single-batch `.csr` files remain readable
-  and migrate on rebuild.
+  from its bounded shard fragments. Only current version 2 manifests and Zstd IPC shards
+  are admitted. Version 1 manifests and standalone legacy files have no compatibility reader
+  or migration path.
   Scan-build fallback still materializes a hash map for oracle parity.
+
+### Bounded CSR compression
+
+Every production shard publisher uses Arrow IPC Zstd with the existing full-width
+`UInt64` IDs and `Int64` offsets. The standard IPC raw-buffer marker is permitted
+when compression would expand a buffer; it is part of the current codec, not a
+legacy file fallback. Configured shard limits remain upper bounds and are capped
+at 1,048,576 rows and 1,048,576 edges. High-degree rows continue across shards;
+smaller configured limits retain their existing behavior.
+
+For admitted shard counts `N` and `E`, the seven decoded buffers total
+`D = 8*(N+1) + 16*E + ceil(N/8) + 3*ceil(E/8)` bytes, including validity bitmaps.
+The encoded file is capped at `D + 16,384` bytes. The manifest carries both exact
+encoded length and `D`; lookup and stable-shard reuse validate these counts, bound
+reads, authenticate SHA-256, then check the IPC footer/message and every buffer
+before Arrow allocates decoded arrays. Preflight requires the exact fixed schema,
+one batch, no dictionaries, zero null counts, matching field lengths, Zstd buffer
+compression, and one exact current Zstd frame with matching content size. Invalid
+schema declarations return an error before Arrow's schema converter is invoked.
+Decoded offsets must start at zero, remain monotone, and end at the edge count.
+
+Opening checks shard metadata without reading payloads. Cloned readers share one
+cache. On a miss, the prior cached CSR stays alive until the replacement fully
+validates. Resource accounting must include that old cache, the encoded file,
+Arrow's body buffer and decoded arrays, the new CSR vectors, parser/alignment
+allocations and the fixed Zstd decoder context. The pinned bulk Zstd decoder uses
+the supplied bounded destination rather than a separate streaming window buffer.
+`D` is a deterministic buffer-content bound, **not** a process RSS bound. Allocator
+overhead and other graph/query owners remain separate. A whole logical hub row can
+span many shards; only `row_chunk` bounds the returned row portion by its limit.
 
 ### Rebuild and versioning semantics
 

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -636,7 +636,8 @@ Conventions:
 
 ### Bounded CSR compression
 
-Every production shard publisher uses Arrow IPC Zstd with the existing full-width
+Every production shard publisher uses Arrow IPC Zstd (the pinned Arrow default
+compression level 3) with the existing full-width
 `UInt64` IDs and `Int64` offsets. The standard IPC raw-buffer marker is permitted
 when compression would expand a buffer; it is part of the current codec, not a
 legacy file fallback. Configured shard limits remain upper bounds and are capped
@@ -1167,3 +1168,43 @@ and separately sampled overlapping filesystem owners are reported with their
 measurement limits. The candidate point-in-time whole-project census includes
 21,979,136 allocated file bytes plus 1,257,472 directory bytes; no equivalent
 baseline census or whole-project reduction is claimed.
+
+
+### Bounded CSR allocation and cost evidence (#1205)
+
+The fixed eight-route public lifecycle fixture uses 4,097 nodes, 65,537 edges,
+random full-width identities and nullable properties. Frozen release executables
+compare the uncompressed current baseline with the bounded compressed writer;
+both produce the same semantic fingerprint through reopen, export, full
+verification and clean import.
+
+| Measurement | Uncompressed baseline | Bounded Zstd |
+|---|---:|---:|
+| Actual CSR payload bytes (18 shards) | 4,920,564 | 1,324,020 |
+| Actual CSR allocated bytes | 4,972,544 | 1,363,968 |
+| CSR metadata logical bytes | 10,329 | 11,431 |
+| Attributed permanent allocated bytes | 15,151,104 | 11,542,528 |
+| Whole-project file allocation, point census | 44,806,144 | 41,197,568 |
+| Whole-lifecycle process peak RSS, KiB | 220,400 | 238,252 |
+| Whole-lifecycle syscall read bytes | 2,309,281,609 | 2,098,377,656 |
+| Whole-lifecycle syscall write bytes | 357,447,042 | 328,689,815 |
+| Sampled overlapping workspace allocated peak | 89,038,848 | 74,625,024 |
+| Cold-probe direct CSR read bytes | 35,552,246 | 9,577,462 |
+| Cold-probe first-query median, seconds | 3.855 | 3.891 |
+
+Payload and allocation both meet the deterministic 70% reduction budget. The
+whole-lifecycle RSS increase is a measured cost, not a decoded-memory improvement.
+The cold probe executes exact 256-row two-hop public queries in three fresh
+processes, with four subsequent queries per facade. Its predeclared timing, RSS
+and syscall-I/O investigation thresholds pass; this is not a latency improvement
+claim or a noisy CI timing gate. Private-file cache advice does not guarantee OS
+cache eviction. Syscall traffic is not physical I/O.
+
+The workspace sampler deduplicates overlapping file owners by device/inode and
+includes project, staging and portable state. It excludes directory blocks and
+open-unlinked files and can miss short peaks; the largest observed sampling gaps
+are approximately 62 ms and 59 ms. These are sampled workspace peaks, not hard
+temporary-disk bounds. The separate point census includes retained generations.
+See [`bounded-csr-1205.json`](../../development/evidence/bounded-csr-1205.json)
+for frozen source/executable hashes, exact observations, commands, decoded bounds,
+CPU/I/O costs and limitations, including the superseded incomplete baseline trace.

--- a/docs/development/evidence/bounded-csr-1205.json
+++ b/docs/development/evidence/bounded-csr-1205.json
@@ -998,5 +998,34 @@
     "cold_trace": "Use the same syscall set plus -yy descriptor paths on a separate cold_read process, without using its instrumented timing as latency evidence.",
     "cache_advice": "Before each of three read processes and the separate trace, fsync and POSIX_FADV_DONTNEED each unique regular file in the private fixture.",
     "workspace_sampling": "Separate lifecycle run: recursively stat the private temporary workspace, deduplicate file allocation by (st_dev, st_ino), sum st_blocks*512, record elapsed intervals and peak; requested interval 5ms."
+  },
+  "validation": {
+    "cargo_fmt_all_check": "passed after final implementation edit",
+    "cargo_clippy_workspace_deny_warnings": "passed, including full pre-push rust-quality stage",
+    "make_pre_push_fast": "passed",
+    "make_gate_registry_check": "passed: validation and14 registry tests",
+    "native_adjacency": "cargo test -p graphforge-storage -p graphforge-exec --lib adjacency:: -- --nocapture: storage58 passed/1 existing ignored, exec18 passed; subsequent final codec7/7 passed",
+    "cargo_test_workspace": {
+      "outcome": "failed on existing hardcoded /tmp filesystem admission setup",
+      "storage": "1097 passed, 1 failed, 2 existing ignored",
+      "public_permanent_storage": "47 passed",
+      "ladder_accounting": "30 passed",
+      "fixed_hop": "17 passed, 2 existing release-only ignored",
+      "public_api_unit": "737 passed",
+      "public_api_bdd": "118 scenarios passed",
+      "opencypher": "3897 passed, zero regressions"
+    },
+    "make_pre_push": {
+      "outcome": "failed at rust-tests-coverage-native on the same existing filesystem setup",
+      "storage": "1096 passed, 1 failed, 2 existing ignored",
+      "prior_stages": "preflight, policy-static and rust-quality passed"
+    },
+    "local_failure": {
+      "test": "project_generation::tests::wave9_participant_inventory_rejects_links_and_special_files",
+      "source": "crates/graphforge-storage/src/project_generation.rs:2576",
+      "cause": "The unchanged fixture explicitly creates its root with tempdir_in(\"/tmp\"); this host rejects that filesystem with GF_UNSUPPORTED_FILESYSTEM cause=filesystem_class_unproven before the link/socket assertions. TMPDIR points to admitted native storage for other tests.",
+      "policy": "No skip, weakened assertion or successful full-gate claim. Exact-head required CI remains the merge authority."
+    },
+    "independent_review": "Implementation and measurement evidence reviewed independently; no outstanding verified finding."
   }
 }

--- a/docs/development/evidence/bounded-csr-1205.json
+++ b/docs/development/evidence/bounded-csr-1205.json
@@ -1,0 +1,1002 @@
+{
+  "issue": 1205,
+  "measurement_date_utc": "2026-09-10",
+  "host": {
+    "name": "OVHC-AGENCY",
+    "filesystem": "native ext4 /dev/md3",
+    "cpu": "AMD Ryzen 7 3800X, 16 logical CPUs",
+    "memory_kib": 131786392
+  },
+  "format": {
+    "manifest_version": 2,
+    "codec": "Arrow IPC Zstd, Arrow default compression level 3",
+    "maximum_shard_rows": 1048576,
+    "maximum_shard_edges": 1048576,
+    "decoded_buffer_content_bound": "8*(N+1)+16*E+ceil(N/8)+3*ceil(E/8)",
+    "encoded_file_bound": "decoded buffer content bound + 16384",
+    "native_bulk_decoder_observed_bytes": 95976,
+    "native_bulk_decoder_test_ceiling_bytes": 262144
+  },
+  "whole_lifecycle": {
+    "baseline": {
+      "provenance": {
+        "source": "c74a529ac9c60997c1343b9f36a074bef39173d8",
+        "executable": "/tmp/gf1205-baseline-release-bin",
+        "sha256": "ebf3962a815698d1b16e886dc6738f64a829896874478a55bce5385ca56894f9",
+        "profile": "release optimized; RUSTFLAGS, CARGO_ENCODED_RUSTFLAGS and LLVM_PROFILE_FILE unset; no coverage instrumentation",
+        "command": "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
+        "toolchain": "rustc 1.96.0 (ac68faa20 2026-05-25)"
+      },
+      "command": "frozen executable --exact permanent_random_properties_eight_routes --nocapture --test-threads=1",
+      "fixture": {
+        "nodes": 4097,
+        "edges": 65537,
+        "routes": 8,
+        "random_ids": true,
+        "semantic_fingerprint": "1a4578d5b5d6c474b1fd9de5478fd2afe0f69e1456f3964d410bc6e0fd3e8b51"
+      },
+      "csr": {
+        "decode_elapsed_ns": [
+          468480,
+          6847344,
+          6241207
+        ],
+        "encode_elapsed_ns": [
+          844066,
+          7689554,
+          19788691
+        ],
+        "estimated_allocated_bytes_at_4096": [
+          4972544,
+          2351104,
+          1363968
+        ],
+        "largest_decoded_batch_array_bytes": 3322008,
+        "normalized_bytes_none_lz4_zstd": [
+          4920564,
+          2320564,
+          1324020
+        ],
+        "production_format_changed": false,
+        "shards": 18,
+        "source_bytes": 4920564
+      },
+      "permanent": {
+        "allocated_bytes": 15151104,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 5050368,
+            "logical_bytes": 4930893,
+            "logical_references": 37,
+            "physical_logical_bytes": 4930893,
+            "physical_objects": 37
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 212992,
+            "logical_bytes": 187022,
+            "logical_references": 8,
+            "physical_logical_bytes": 187022,
+            "physical_objects": 8
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 4337664,
+            "logical_bytes": 2576971,
+            "logical_references": 546,
+            "physical_logical_bytes": 2576971,
+            "physical_objects": 546
+          },
+          "topology_edges": {
+            "allocated_bytes": 3936256,
+            "logical_bytes": 3726446,
+            "logical_references": 65,
+            "physical_logical_bytes": 3726446,
+            "physical_objects": 65
+          },
+          "topology_nodes": {
+            "allocated_bytes": 102400,
+            "logical_bytes": 90021,
+            "logical_references": 5,
+            "physical_logical_bytes": 90021,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 1511424,
+            "logical_bytes": 1482397,
+            "logical_references": 12,
+            "physical_logical_bytes": 1482397,
+            "physical_objects": 12
+          }
+        },
+        "logical_bytes": 12993750,
+        "physical_logical_bytes": 12993750,
+        "physical_objects": 673
+      },
+      "whole_project": {
+        "deduplication": "device/inode",
+        "directory_allocated_bytes": 1466368,
+        "file_allocated_bytes": 44806144,
+        "file_logical_bytes": 31328040,
+        "scope": "recursive project including retained generations, caches and private state; point-in-time, not peak",
+        "unique_files": 4246
+      },
+      "process": {
+        "user_seconds": 9.63,
+        "system_seconds": 8.05,
+        "peak_rss_kib": 220400,
+        "filesystem_input_512byte_blocks": 1234328,
+        "filesystem_output_512byte_blocks": 816008
+      },
+      "syscall_io": {
+        "trace": "/tmp/gf1205-baseline-full.strace",
+        "read_bytes": 2309281609,
+        "write_bytes": 357447042,
+        "syscalls": {
+          "read": {
+            "calls": 216910,
+            "bytes": 1551382882,
+            "errors": 0
+          },
+          "pread64": {
+            "calls": 1335284,
+            "bytes": 693849287,
+            "errors": 0
+          },
+          "write": {
+            "calls": 19575,
+            "bytes": 293397602,
+            "errors": 0
+          },
+          "fsync": {
+            "calls": 24447,
+            "bytes": 0,
+            "errors": 0
+          },
+          "copy_file_range": {
+            "calls": 6650,
+            "bytes": 64049440,
+            "errors": 0
+          },
+          "readv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "preadv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "sendfile": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pwrite64": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "writev": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pwritev": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          }
+        },
+        "scope": "successful syscall return bytes across process tree, including non-file descriptors; not physical disk I/O; copy/sendfile charge one read and one write"
+      },
+      "sampled_workspace": {
+        "command": [
+          "/tmp/gf1205-baseline-release-bin",
+          "--exact",
+          "permanent_random_properties_eight_routes",
+          "--nocapture",
+          "--test-threads=1"
+        ],
+        "sampled_unique_inode_allocated_peak_bytes": 89038848,
+        "sampled_path_logical_peak_bytes": 71218161,
+        "sampled_file_count_peak": 5605,
+        "samples": 798,
+        "requested_poll_interval_seconds": 0.005,
+        "maximum_observed_sample_interval_seconds": 0.06176758895162493,
+        "vanished_files_during_scan": 567,
+        "exit_status": 0,
+        "limitations": [
+          "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+          "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+          "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+          "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+        ]
+      }
+    },
+    "candidate": {
+      "provenance": {
+        "source": "745f4a79cdbb4a6bcca09abdf50878d32006293b",
+        "executable": "/tmp/gf1205-candidate-release-bin",
+        "sha256": "8fd08dac0da8e0cb3a68a3e9eac928efa8f0fe1da5d0036f5d924bcb1db08dbb",
+        "profile": "release optimized; RUSTFLAGS, CARGO_ENCODED_RUSTFLAGS and LLVM_PROFILE_FILE unset; no coverage instrumentation",
+        "command": "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
+        "toolchain": "rustc 1.96.0 (ac68faa20 2026-05-25)"
+      },
+      "command": "frozen executable --exact permanent_random_properties_eight_routes --nocapture --test-threads=1",
+      "fixture": {
+        "nodes": 4097,
+        "edges": 65537,
+        "routes": 8,
+        "random_ids": true,
+        "semantic_fingerprint": "1a4578d5b5d6c474b1fd9de5478fd2afe0f69e1456f3964d410bc6e0fd3e8b51"
+      },
+      "csr": {
+        "decode_elapsed_ns": [
+          445098,
+          6568933,
+          5775071
+        ],
+        "encode_elapsed_ns": [
+          1548500,
+          7247341,
+          18837035
+        ],
+        "estimated_allocated_bytes_at_4096": [
+          4972544,
+          2351104,
+          1363968
+        ],
+        "largest_decoded_batch_array_bytes": 1081784,
+        "normalized_bytes_none_lz4_zstd": [
+          4920564,
+          2320564,
+          1324020
+        ],
+        "production_format_changed": true,
+        "shards": 18,
+        "source_allocated_bytes_unix": 1363968,
+        "source_bytes": 1324020
+      },
+      "permanent": {
+        "allocated_bytes": 11542528,
+        "categories": {
+          "adjacency": {
+            "allocated_bytes": 1441792,
+            "logical_bytes": 1335451,
+            "logical_references": 37,
+            "physical_logical_bytes": 1335451,
+            "physical_objects": 37
+          },
+          "catalog_and_manifests": {
+            "allocated_bytes": 212992,
+            "logical_bytes": 187003,
+            "logical_references": 8,
+            "physical_logical_bytes": 187003,
+            "physical_objects": 8
+          },
+          "clean_imported_project": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "construction_staging": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "other": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "portable_package": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          },
+          "properties": {
+            "allocated_bytes": 4337664,
+            "logical_bytes": 2576971,
+            "logical_references": 546,
+            "physical_logical_bytes": 2576971,
+            "physical_objects": 546
+          },
+          "topology_edges": {
+            "allocated_bytes": 3936256,
+            "logical_bytes": 3726446,
+            "logical_references": 65,
+            "physical_logical_bytes": 3726446,
+            "physical_objects": 65
+          },
+          "topology_nodes": {
+            "allocated_bytes": 102400,
+            "logical_bytes": 90021,
+            "logical_references": 5,
+            "physical_logical_bytes": 90021,
+            "physical_objects": 5
+          },
+          "uuid_and_surrogates": {
+            "allocated_bytes": 1511424,
+            "logical_bytes": 1482397,
+            "logical_references": 12,
+            "physical_logical_bytes": 1482397,
+            "physical_objects": 12
+          }
+        },
+        "logical_bytes": 9398289,
+        "physical_logical_bytes": 9398289,
+        "physical_objects": 673
+      },
+      "whole_project": {
+        "deduplication": "device/inode",
+        "directory_allocated_bytes": 1466368,
+        "file_allocated_bytes": 41197568,
+        "file_logical_bytes": 27732579,
+        "scope": "recursive project including retained generations, caches and private state; point-in-time, not peak",
+        "unique_files": 4246
+      },
+      "process": {
+        "user_seconds": 9.57,
+        "system_seconds": 7.84,
+        "peak_rss_kib": 238252,
+        "filesystem_input_512byte_blocks": 1234328,
+        "filesystem_output_512byte_blocks": 759664
+      },
+      "syscall_io": {
+        "trace": "/tmp/gf1205-candidate-full.strace",
+        "read_bytes": 2098377656,
+        "write_bytes": 328689815,
+        "syscalls": {
+          "read": {
+            "calls": 214544,
+            "bytes": 1358456139,
+            "errors": 0
+          },
+          "pread64": {
+            "calls": 1335284,
+            "bytes": 693849287,
+            "errors": 0
+          },
+          "write": {
+            "calls": 19572,
+            "bytes": 282617585,
+            "errors": 0
+          },
+          "fsync": {
+            "calls": 24447,
+            "bytes": 0,
+            "errors": 0
+          },
+          "copy_file_range": {
+            "calls": 6650,
+            "bytes": 46072230,
+            "errors": 0
+          },
+          "readv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "preadv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "sendfile": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pwrite64": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "writev": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pwritev": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          }
+        },
+        "scope": "successful syscall return bytes across process tree, including non-file descriptors; not physical disk I/O; copy/sendfile charge one read and one write"
+      },
+      "sampled_workspace": {
+        "command": [
+          "/tmp/gf1205-candidate-release-bin",
+          "--exact",
+          "permanent_random_properties_eight_routes",
+          "--nocapture",
+          "--test-threads=1"
+        ],
+        "sampled_unique_inode_allocated_peak_bytes": 74625024,
+        "sampled_path_logical_peak_bytes": 56842658,
+        "sampled_file_count_peak": 5605,
+        "samples": 827,
+        "requested_poll_interval_seconds": 0.005,
+        "maximum_observed_sample_interval_seconds": 0.0586216690717265,
+        "vanished_files_during_scan": 656,
+        "exit_status": 0,
+        "limitations": [
+          "Sampling can miss shorter-lived allocation peaks and unlinked open files.",
+          "Includes retained project generations, private hydration/staging and portable artifacts, not only temporary files.",
+          "Hardlinks are deduplicated for allocated bytes, not path logical bytes.",
+          "Separate run from CPU/RSS and syscall traces; scanner adds filesystem activity."
+        ]
+      }
+    }
+  },
+  "cold_public_query": {
+    "cost_thresholds": {
+      "scope": "Cold-read probe assessment only; recorded after baseline observations and before any candidate cold-read process. These are investigation thresholds, not noisy CI timing gates or hard RSS bounds. Whole-lifecycle measurements above were descriptive and are not retroactively preregistered.",
+      "storage_requirement": "existing issue #1205: payload and native allocated bytes at most 30% of historical uncompressed fixture",
+      "baseline_first_query_ns": [
+        3961126673,
+        3855093351,
+        3810072343
+      ],
+      "baseline_warm_query_ns": [
+        4135322267,
+        3740693056,
+        3634908329,
+        3865423498,
+        4114791613,
+        3730840427,
+        3675519561,
+        3659108425,
+        4099978418,
+        4112301295,
+        3609213194,
+        4440933975
+      ],
+      "baseline_max_rss_kib": 153296,
+      "largest_fixture_decoded_buffer_content_bytes": 1106468,
+      "maximum_first_query_median_ns": 4026147681,
+      "maximum_warm_query_median_ns": 4654779058.0,
+      "maximum_observed_rss_kib": 155714,
+      "read_write_syscall_ceiling_formula": "corresponding baseline trace bytes + 18 * 16,384 bytes",
+      "rationale": [
+        "Timing permits the observed baseline range plus20ms, over three times the existing all18-shard Zstd decode observation (~6ms), for decode/admission work. A larger change requires investigation.",
+        "RSS permits two additional largest admitted shard buffer sets plus the256KiB decoder-context test ceiling; it is an observed-cost threshold, not a proof about allocator or total process bounds.",
+        "I/O allows one full16KiB metadata allowance per18 shards; compression should reduce payload traffic.",
+        "Sampling, RSS and syscall counts retain their distinct scopes; no timing-only CI assertions are introduced."
+      ],
+      "maximum_read_bytes": 8176478393,
+      "maximum_write_bytes": 134680634
+    },
+    "baseline": {
+      "provenance": {
+        "source": "33a8570a47c3e10f13f39150a7631628518a3faf",
+        "core_source": "c74a529ac9c60997c1343b9f36a074bef39173d8",
+        "executable": "/tmp/gf1205-baseline-probe-bin",
+        "sha256": "a09778c74def1a17b4acffe9fb363afbbbf4dae200f3c72097629fce648c0879",
+        "harness_sha256": "ba23585ce246e3ad15c6137b25e3d20720ec4ab0f0b6b7bffc03e332634c0a10",
+        "profile": "release optimized, no coverage instrumentation; RUSTFLAGS/CARGO_ENCODED_RUSTFLAGS/LLVM_PROFILE_FILE unset",
+        "command": "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json"
+      },
+      "observations": [
+        {
+          "run": 0,
+          "cache_advice": {
+            "unique_files": 4248,
+            "logical_bytes": 31378473,
+            "operation": "fsync and POSIX_FADV_DONTNEED on this private fixture only; advisory, not proof of OS eviction; executable/libraries unchanged"
+          },
+          "query": {
+            "cache_scope": "first query is application-cold only in separate read process; subsequent queries reuse the same facade; OS cache advice is external and separately recorded",
+            "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+            "mode": "read",
+            "open_elapsed_ns": 741121046,
+            "query_elapsed_ns": [
+              3961126673,
+              4135322267,
+              3740693056,
+              3634908329,
+              3865423498
+            ],
+            "rows": 256
+          },
+          "time_file": "/tmp/gf1205-baseline-cold-0-time.txt"
+        },
+        {
+          "run": 1,
+          "cache_advice": {
+            "unique_files": 4248,
+            "logical_bytes": 31378473,
+            "operation": "fsync and POSIX_FADV_DONTNEED on this private fixture only; advisory, not proof of OS eviction; executable/libraries unchanged"
+          },
+          "query": {
+            "cache_scope": "first query is application-cold only in separate read process; subsequent queries reuse the same facade; OS cache advice is external and separately recorded",
+            "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+            "mode": "read",
+            "open_elapsed_ns": 702011283,
+            "query_elapsed_ns": [
+              3855093351,
+              4114791613,
+              3730840427,
+              3675519561,
+              3659108425
+            ],
+            "rows": 256
+          },
+          "time_file": "/tmp/gf1205-baseline-cold-1-time.txt"
+        },
+        {
+          "run": 2,
+          "cache_advice": {
+            "unique_files": 4248,
+            "logical_bytes": 31378473,
+            "operation": "fsync and POSIX_FADV_DONTNEED on this private fixture only; advisory, not proof of OS eviction; executable/libraries unchanged"
+          },
+          "query": {
+            "cache_scope": "first query is application-cold only in separate read process; subsequent queries reuse the same facade; OS cache advice is external and separately recorded",
+            "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+            "mode": "read",
+            "open_elapsed_ns": 757287137,
+            "query_elapsed_ns": [
+              3810072343,
+              4099978418,
+              4112301295,
+              3609213194,
+              4440933975
+            ],
+            "rows": 256
+          },
+          "time_file": "/tmp/gf1205-baseline-cold-2-time.txt"
+        }
+      ],
+      "trace_cache_advice": {
+        "unique_files": 4248,
+        "logical_bytes": 31378473,
+        "operation": "fsync and POSIX_FADV_DONTNEED on this private fixture only; advisory, not proof of OS eviction; executable/libraries unchanged"
+      },
+      "command": [
+        "/tmp/gf1205-baseline-probe-bin",
+        "--exact",
+        "csr_cold_public_query_probe",
+        "--nocapture",
+        "--test-threads=1"
+      ],
+      "limitations": [
+        "Three separate read processes; each opens the facade then runs one first query and four same-facade repeats.",
+        "Cache advice applies only to private fixture files and is not a guaranteed cold OS cache.",
+        "Timing observations are not CI timing gates; process RSS includes runtime/facade/query owners.",
+        "Tracing is a separate run and is not used for latency claims."
+      ],
+      "process_observations": [
+        {
+          "user_seconds": 22.82,
+          "system_seconds": 8.64,
+          "peak_rss_kib": 153296,
+          "filesystem_input_512byte_blocks": 29728,
+          "filesystem_output_512byte_blocks": 417312
+        },
+        {
+          "user_seconds": 22.58,
+          "system_seconds": 8.69,
+          "peak_rss_kib": 152316,
+          "filesystem_input_512byte_blocks": 29728,
+          "filesystem_output_512byte_blocks": 417312
+        },
+        {
+          "user_seconds": 22.62,
+          "system_seconds": 8.63,
+          "peak_rss_kib": 152404,
+          "filesystem_input_512byte_blocks": 29728,
+          "filesystem_output_512byte_blocks": 417312
+        }
+      ],
+      "syscall_io": {
+        "trace": "/tmp/gf1205-baseline-cold.strace",
+        "read_bytes": 8176183481,
+        "write_bytes": 134385722,
+        "syscalls": {
+          "read": {
+            "calls": 1900978,
+            "bytes": 6471272917,
+            "errors": 0
+          },
+          "pread64": {
+            "calls": 3320189,
+            "bytes": 1692100676,
+            "errors": 0
+          },
+          "write": {
+            "calls": 25026,
+            "bytes": 121575834,
+            "errors": 0
+          },
+          "fsync": {
+            "calls": 1347,
+            "bytes": 0,
+            "errors": 0
+          },
+          "copy_file_range": {
+            "calls": 1330,
+            "bytes": 12809888,
+            "errors": 0
+          },
+          "readv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "preadv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "sendfile": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pwrite64": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "writev": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pwritev": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          }
+        },
+        "csr_direct_read_bytes": 35552246,
+        "csr_copy_bytes": 4920564,
+        "csr_syscalls": {
+          "read": {
+            "calls": 702,
+            "bytes": 35552246,
+            "errors": 0
+          },
+          "copy_file_range": {
+            "calls": 36,
+            "bytes": 4920564,
+            "errors": 0
+          },
+          "fsync": {
+            "calls": 36,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pread64": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "readv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "preadv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "sendfile": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          }
+        },
+        "unresolved_calls": 0,
+        "scope": "successful syscall return bytes across process tree, including non-file descriptors; copy/sendfile counted once as read and once as write; CSR classification from -yy descriptor paths including resumed calls; not physical I/O"
+      },
+      "first_query_median_ns": 3855093351,
+      "reused_facade_query_median_ns": 3803058277.0
+    },
+    "candidate": {
+      "provenance": {
+        "source": "5bc79c60406b774323112a0efa294f04163ae1c1",
+        "core_source": "745f4a79cdbb4a6bcca09abdf50878d32006293b",
+        "executable": "/tmp/gf1205-candidate-probe-bin",
+        "sha256": "56ea2e9354f92722a587b1abce98387092bf7eba31bde5e6d158d3874f1cfc67",
+        "harness_sha256": "ba23585ce246e3ad15c6137b25e3d20720ec4ab0f0b6b7bffc03e332634c0a10",
+        "profile": "release optimized, no coverage instrumentation; RUSTFLAGS/CARGO_ENCODED_RUSTFLAGS/LLVM_PROFILE_FILE unset",
+        "command": "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json"
+      },
+      "observations": [
+        {
+          "run": 0,
+          "cache_advice": {
+            "unique_files": 4248,
+            "logical_bytes": 27783012,
+            "operation": "fsync and POSIX_FADV_DONTNEED on this private fixture only; advisory, not proof of OS eviction; executable/libraries unchanged"
+          },
+          "query": {
+            "cache_scope": "first query is application-cold only in separate read process; subsequent queries reuse the same facade; OS cache advice is external and separately recorded",
+            "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+            "mode": "read",
+            "open_elapsed_ns": 706412907,
+            "query_elapsed_ns": [
+              3949943567,
+              3608448999,
+              3870129140,
+              3812572610,
+              3637269764
+            ],
+            "rows": 256
+          },
+          "time_file": "/tmp/gf1205-candidate-cold-0-time.txt"
+        },
+        {
+          "run": 1,
+          "cache_advice": {
+            "unique_files": 4248,
+            "logical_bytes": 27783012,
+            "operation": "fsync and POSIX_FADV_DONTNEED on this private fixture only; advisory, not proof of OS eviction; executable/libraries unchanged"
+          },
+          "query": {
+            "cache_scope": "first query is application-cold only in separate read process; subsequent queries reuse the same facade; OS cache advice is external and separately recorded",
+            "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+            "mode": "read",
+            "open_elapsed_ns": 698168639,
+            "query_elapsed_ns": [
+              3672527253,
+              4008831941,
+              3603514454,
+              3589052965,
+              3828957506
+            ],
+            "rows": 256
+          },
+          "time_file": "/tmp/gf1205-candidate-cold-1-time.txt"
+        },
+        {
+          "run": 2,
+          "cache_advice": {
+            "unique_files": 4248,
+            "logical_bytes": 27783012,
+            "operation": "fsync and POSIX_FADV_DONTNEED on this private fixture only; advisory, not proof of OS eviction; executable/libraries unchanged"
+          },
+          "query": {
+            "cache_scope": "first query is application-cold only in separate read process; subsequent queries reuse the same facade; OS cache advice is external and separately recorded",
+            "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+            "mode": "read",
+            "open_elapsed_ns": 669666149,
+            "query_elapsed_ns": [
+              3890587544,
+              3986468360,
+              3695447714,
+              3612397305,
+              3620677994
+            ],
+            "rows": 256
+          },
+          "time_file": "/tmp/gf1205-candidate-cold-2-time.txt"
+        }
+      ],
+      "trace_cache_advice": {
+        "unique_files": 4248,
+        "logical_bytes": 27783012,
+        "operation": "fsync and POSIX_FADV_DONTNEED on this private fixture only; advisory, not proof of OS eviction; executable/libraries unchanged"
+      },
+      "command": [
+        "/tmp/gf1205-candidate-probe-bin",
+        "--exact",
+        "csr_cold_public_query_probe",
+        "--nocapture",
+        "--test-threads=1"
+      ],
+      "limitations": [
+        "Three separate read processes; each opens the facade then runs one first query and four same-facade repeats.",
+        "Cache advice applies only to private fixture files and is not a guaranteed cold OS cache.",
+        "Timing observations are not CI timing gates; process RSS includes runtime/facade/query owners.",
+        "Tracing is a separate run and is not used for latency claims."
+      ],
+      "process_observations": [
+        {
+          "user_seconds": 22.39,
+          "system_seconds": 8.78,
+          "peak_rss_kib": 152824,
+          "filesystem_input_512byte_blocks": 22680,
+          "filesystem_output_512byte_blocks": 410264
+        },
+        {
+          "user_seconds": 22.47,
+          "system_seconds": 8.86,
+          "peak_rss_kib": 152848,
+          "filesystem_input_512byte_blocks": 22680,
+          "filesystem_output_512byte_blocks": 410264
+        },
+        {
+          "user_seconds": 22.6,
+          "system_seconds": 8.73,
+          "peak_rss_kib": 153260,
+          "filesystem_input_512byte_blocks": 22680,
+          "filesystem_output_512byte_blocks": 410264
+        }
+      ],
+      "syscall_io": {
+        "trace": "/tmp/gf1205-candidate-cold.strace",
+        "read_bytes": 8149233915,
+        "write_bytes": 130790280,
+        "syscalls": {
+          "read": {
+            "calls": 1901324,
+            "bytes": 6447918793,
+            "errors": 0
+          },
+          "pread64": {
+            "calls": 3320189,
+            "bytes": 1692100676,
+            "errors": 0
+          },
+          "write": {
+            "calls": 25026,
+            "bytes": 121575834,
+            "errors": 0
+          },
+          "fsync": {
+            "calls": 1347,
+            "bytes": 0,
+            "errors": 0
+          },
+          "copy_file_range": {
+            "calls": 1330,
+            "bytes": 9214446,
+            "errors": 0
+          },
+          "readv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "preadv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "sendfile": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pwrite64": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "writev": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pwritev": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          }
+        },
+        "csr_direct_read_bytes": 9577462,
+        "csr_copy_bytes": 1324020,
+        "csr_syscalls": {
+          "read": {
+            "calls": 310,
+            "bytes": 9577462,
+            "errors": 0
+          },
+          "copy_file_range": {
+            "calls": 36,
+            "bytes": 1324020,
+            "errors": 0
+          },
+          "fsync": {
+            "calls": 36,
+            "bytes": 0,
+            "errors": 0
+          },
+          "pread64": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "readv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "preadv": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          },
+          "sendfile": {
+            "calls": 0,
+            "bytes": 0,
+            "errors": 0
+          }
+        },
+        "unresolved_calls": 0,
+        "scope": "successful syscall return bytes across process tree, including non-file descriptors; copy/sendfile counted once as read and once as write; CSR classification from -yy descriptor paths including resumed calls; not physical I/O"
+      },
+      "first_query_median_ns": 3890587544,
+      "reused_facade_query_median_ns": 3666358739.0
+    },
+    "threshold_results": {
+      "first_query_median": true,
+      "reused_facade_median": true,
+      "observed_rss": true,
+      "syscall_reads": true,
+      "syscall_writes": true
+    },
+    "baseline_reconstruction": "c74a529ac9c60997c1343b9f36a074bef39173d8 plus identical edge_query_identities helper and csr_cold_public_query_probe from candidate 5bc79c60406b774323112a0efa294f04163ae1c1; harness SHA256 is recorded in both provenance objects. Local baseline-only commit 33a8570 is not a production change."
+  },
+  "limitations": [
+    "Whole-lifecycle timings are one descriptive pair, not preregistered thresholds or a claimed latency improvement.",
+    "Whole-lifecycle peak process RSS increases by 17852 KiB; decoded buffer bounds do not imply lower total RSS.",
+    "Arrow get_array_memory_size can count shared backing buffers repeatedly; its decrease is not a native-memory saving.",
+    "Syscall bytes are successful return bytes including copy operations, not physical disk I/O. Instrumented run timing is excluded.",
+    "Workspace peaks are sampled overlapping project/staging/portable owners, deduplicated by device/inode for allocated files; not temporary-only or hard bounds. Directories and open-unlinked files are excluded.",
+    "An earlier baseline trace omitted vector/copy syscalls and is superseded for complete I/O claims; it passed but is not used in comparisons.",
+    "Three cold-probe processes use private-file fsync/POSIX_FADV_DONTNEED advice; OS eviction is not guaranteed. Four subsequent queries per process reuse the facade.",
+    "Measurements use frozen executables before subprocess execution; no heavy builds overlapped measured runs. Baseline trace attribution parsing overlapped only the separate candidate byte-count trace."
+  ],
+  "reproduction": {
+    "build_environment": {
+      "TMPDIR": "admitted native filesystem temporary directory",
+      "CARGO_TARGET_DIR": "isolated native build directory",
+      "CARGO_BUILD_JOBS": "4",
+      "unset": [
+        "RUSTFLAGS",
+        "CARGO_ENCODED_RUSTFLAGS",
+        "LLVM_PROFILE_FILE"
+      ]
+    },
+    "freeze": "Copy the built release test executable to a distinct immutable measurement path and record SHA256 before running any subprocess.",
+    "runtime": "/usr/bin/time -v FROZEN_EXECUTABLE --exact permanent_random_properties_eight_routes --nocapture --test-threads=1",
+    "syscall_trace": "strace -f -qq -s 0 -e trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync -o TRACE FROZEN_EXECUTABLE --exact permanent_random_properties_eight_routes --nocapture --test-threads=1",
+    "cold_prepare": "GF_CSR_PROBE_ROOT=PRIVATE_NATIVE_DIRECTORY GF_CSR_PROBE_MODE=prepare FROZEN_PROBE --exact csr_cold_public_query_probe --nocapture --test-threads=1",
+    "cold_read": "GF_CSR_PROBE_ROOT=PRIVATE_NATIVE_DIRECTORY GF_CSR_PROBE_MODE=read /usr/bin/time -v FROZEN_PROBE --exact csr_cold_public_query_probe --nocapture --test-threads=1",
+    "cold_trace": "Use the same syscall set plus -yy descriptor paths on a separate cold_read process, without using its instrumented timing as latency evidence.",
+    "cache_advice": "Before each of three read processes and the separate trace, fsync and POSIX_FADV_DONTNEED each unique regular file in the private fixture.",
+    "workspace_sampling": "Separate lifecycle run: recursively stat the private temporary workspace, deduplicate file allocation by (st_dev, st_ino), sum st_blocks*512, record elapsed intervals and peak; requested interval 5ms."
+  }
+}

--- a/docs/development/evidence/bounded-csr-1205.json
+++ b/docs/development/evidence/bounded-csr-1205.json
@@ -1037,7 +1037,17 @@
       "repair": "Regeneration adds only zstd to graphforge-storage dependencies in benchmarks/Cargo.lock. pre-push-fast now checks locked benchmark metadata before compilation.",
       "measurement_impact": "No production-code or measured executable change. Initial failed CI is retained; a corrected-head complete CI run is required.",
       "local_regression": "cargo test --locked --manifest-path benchmarks/Cargo.toml -p graphforge-benchmark-certify --lib tests::command_owned_cache_direct_files_preserve_read_only_inputs -- --exact --nocapture: 1 passed on native Linux; Windows execution remains a CI requirement.",
-      "fast_checks": "make pre-push-fast and make gate-registry-check pass after the repair."
+      "fast_checks": "make pre-push-fast and make gate-registry-check pass after the repair.",
+      "complete_census": {
+        "independent_causes": 1,
+        "failed_jobs": [
+          103038520770,
+          103038520763
+        ],
+        "downstream_gate": "CI Gate failed because these required jobs failed.",
+        "linux_failure": "Bazel Bootstrap completed its authoritative Rust test step, then the real tiny/ownership-growth lifecycle producer refused the same stale benchmarks/Cargo.lock under --locked.",
+        "other_lanes": "All other applicable independent lanes passed, including concurrency, both bindings and macOS durability."
+      }
     }
   }
 }

--- a/docs/development/evidence/bounded-csr-1205.json
+++ b/docs/development/evidence/bounded-csr-1205.json
@@ -1026,6 +1026,18 @@
       "cause": "The unchanged fixture explicitly creates its root with tempdir_in(\"/tmp\"); this host rejects that filesystem with GF_UNSUPPORTED_FILESYSTEM cause=filesystem_class_unproven before the link/socket assertions. TMPDIR points to admitted native storage for other tests.",
       "policy": "No skip, weakened assertion or successful full-gate claim. Exact-head required CI remains the merge authority."
     },
-    "independent_review": "Implementation and measurement evidence reviewed independently; no outstanding verified finding."
+    "independent_review": "Implementation and measurement evidence reviewed independently; no outstanding verified finding.",
+    "initial_ci_failure": {
+      "run": 34527042473,
+      "head": "f8703d2abba573ad577c7eb243512f5ce321bf37",
+      "job": 103038520770,
+      "failure": "Windows read-only certifier cache cleanup command refused stale benchmarks/Cargo.lock under --locked before executing the test.",
+      "cause": "Moving zstd from a storage dev dependency to a normal dependency also requires its entry in the separate benchmark workspace lockfile.",
+      "reproduction": "cargo metadata --locked --offline --manifest-path benchmarks/Cargo.toml --format-version 1 failed before repair; passed after regeneration.",
+      "repair": "Regeneration adds only zstd to graphforge-storage dependencies in benchmarks/Cargo.lock. pre-push-fast now checks locked benchmark metadata before compilation.",
+      "measurement_impact": "No production-code or measured executable change. Initial failed CI is retained; a corrected-head complete CI run is required.",
+      "local_regression": "cargo test --locked --manifest-path benchmarks/Cargo.toml -p graphforge-benchmark-certify --lib tests::command_owned_cache_direct_files_preserve_read_only_inputs -- --exact --nocapture: 1 passed on native Linux; Windows execution remains a CI requirement.",
+      "fast_checks": "make pre-push-fast and make gate-registry-check pass after the repair."
+    }
   }
 }

--- a/tools/bazel/drift/cargo_feature_fingerprint.json
+++ b/tools/bazel/drift/cargo_feature_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema": "graphforge.cargo-feature-fingerprint.v1",
-  "sha256": "3a90505cee03086fdc15ea2999389015255f7e47e1f03ecc5fd3eba978318b08",
+  "sha256": "f9b62cc0ac7943de81dcb2dc768bce66833a75ceea8d739640c5c178efcaa4c0",
   "entries": [
     {
       "name": "graphforge-api",
@@ -2346,7 +2346,7 @@
           "features": [],
           "optional": false,
           "uses_default_features": false,
-          "kind": "dev",
+          "kind": null,
           "target": null
         }
       ]


### PR DESCRIPTION
Closes #1205.

Production CSR shards now use bounded Arrow IPC Zstd with current-format authenticated encoded/decoded sizes. Lookup and stable-shard reuse reject invalid schemas, frames, lengths and offsets before exposing values. All publishing paths retain full-width IDs and bounded shards; the legacy standalone execution reader is removed.

The eight-route public lifecycle fixture reduces actual CSR allocation from 4,972,544 to 1,363,968 bytes (72.6%), with exact traversal, reopen, export/full verification, clean import and subsequent mutation. The committed evidence records frozen executables, storage/CPU/I/O costs and sampled overlapping workspace peaks. Whole-lifecycle RSS increases from 220,400 to 238,252 KiB; cold-query costs pass the predeclared investigation thresholds without claiming a latency improvement.

Validation: bounded codec/native adjacency tests and public mutation/snapshot/portable tests pass. Formatting, workspace clippy, pre-push-fast and gate-registry checks pass. Workspace validation passes all 47 permanent-storage facade tests, 30 ladder/accounting tests, 17 fixed-hop tests and 3,897 conformance scenarios. Both workspace and full pre-push stop only at the unchanged `wave9_participant_inventory_rejects_links_and_special_files` fixture: its hardcoded `/tmp` root is rejected by this host with `filesystem_class_unproven` before its assertions. Full local gates are therefore not claimed green; exact-head required CI remains the merge gate. Independent implementation review found no outstanding verified finding.


Initial CI exposed one dependency-resolution omission in the separate benchmark workspace: both Windows cache cleanup and Linux tiny lifecycle execution refused its stale lockfile. The corrected lock adds only the normal Zstd dependency. Fast validation now checks that workspace with `cargo metadata --locked`; the targeted cache regression passes locally. The failed run remains documented, and corrected-head CI is required.
