### PR TITLE
fix(rel): push safe input predicates before fixed expansion

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -5785,6 +5785,20 @@ fn csr_cold_public_query_probe() {
             query_efficiency_diagnostics(&graph, query, &expected);
             return;
         }
+        if mode == "all" {
+            for (_, case) in query_efficiency_cases(query) {
+                let (result, work) = graphforge_exec::demand::capture(|| graph.execute(case));
+                assert_eq!(csr_two_hop_rows(&result.unwrap().batches), expected);
+                let hops: Vec<_> = work.hops.values().collect();
+                assert_eq!(hops.len(), 2);
+                assert_eq!((hops[0].input_rows, hops[0].candidates_generated), (1, 16));
+                assert_eq!(
+                    (hops[1].input_rows, hops[1].candidates_generated),
+                    (16, 256)
+                );
+                assert!(hops.iter().map(|hop| hop.edge_rows_scanned).sum::<u64>() <= 80_898);
+            }
+        }
         let selected_case =
             std::env::var("GF_CSR_PROBE_QUERY").unwrap_or_else(|_| "original".into());
         let (_, query) = query_efficiency_cases(query)
@@ -5852,4 +5866,123 @@ fn query_efficiency_diagnostics(graph: &GraphForge, original: &str, expected: &[
             "plan":plan.replace("-2047", "<fixture literal>")})
         );
     }
+}
+
+fn verify_selective_fixed_paths(graph: &GraphForge, nodes: &[Node], edges: &[Edge]) {
+    let score = nodes[1].2.unwrap();
+    let by_id: BTreeMap<_, _> = nodes.iter().map(|node| (node.0, node.2)).collect();
+    for case in 0..5 {
+        let predicate = match case {
+            0 => format!("a.score = {score}"),
+            1 => format!("a.score >= {score} AND a.score <= {score}"),
+            2 => "a.score IS NULL".into(),
+            3 => format!("a.score = {score} AND b.score IS NOT NULL"),
+            _ => format!("a.score = {score} OR b.score IS NULL"),
+        };
+        let mut expected = Vec::new();
+        for first in edges {
+            let start = by_id[&first.1];
+            let middle = by_id[&first.2];
+            let eligible = match case {
+                0 | 1 => start == Some(score),
+                2 => start.is_none(),
+                3 => start == Some(score) && middle.is_some(),
+                _ => start == Some(score) || middle.is_none(),
+            };
+            if !eligible {
+                continue;
+            }
+            for second in edges
+                .iter()
+                .filter(|second| second.1 == first.2 && second.0 != first.0)
+            {
+                expected.push([first.1, first.0, first.2, second.0, second.2]);
+            }
+        }
+        expected.sort();
+        let query = format!(
+            "MATCH (a)-[r]->(b)-[s]->(c) WHERE {predicate} RETURN a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid"
+        );
+        assert_eq!(
+            csr_two_hop_rows(&graph.execute(&query).unwrap().batches),
+            expected,
+            "case {case}"
+        );
+        let ordered = format!(
+            "{query} ORDER BY a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid LIMIT 7"
+        );
+        expected.truncate(7);
+        let result = graph.execute(&ordered).unwrap();
+        let actual: Vec<[Uuid; 5]> = result
+            .batches
+            .iter()
+            .flat_map(|batch| {
+                (0..batch.num_rows())
+                    .map(|row| std::array::from_fn(|column| uuid_at(batch, column, row)))
+            })
+            .collect();
+        assert_eq!(actual, expected, "ordered case {case}");
+    }
+}
+
+#[test]
+fn selective_fixed_paths_preserve_public_mutation_and_portable_lifecycle() {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "selective_fixed_paths",
+        nodes: 33,
+        edges: 129,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: true,
+        heterogeneous: false,
+    };
+    let (mut nodes, edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    verify_selective_fixed_paths(&graph, &nodes, &edges);
+    use futures::TryStreamExt as _;
+    let snapshot_query = "MATCH (a)-[r]->(b)-[s]->(c) WHERE a.score = -2047 RETURN a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid";
+    let snapshot_expected = csr_two_hop_rows(&graph.execute(snapshot_query).unwrap().batches);
+    let snapshot = graph.execute_stream(snapshot_query).unwrap();
+    graph
+        .execute("MATCH (n) WHERE n.score = -2046 SET n.score = -2047")
+        .unwrap();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let retained: Vec<RecordBatch> = runtime.block_on(snapshot.try_collect()).unwrap();
+    assert_eq!(csr_two_hop_rows(&retained), snapshot_expected);
+
+    for node in &mut nodes {
+        if node.2 == Some(-2046) {
+            node.2 = Some(-2047);
+        }
+    }
+    verify_selective_fixed_paths(&graph, &nodes, &edges);
+    verify_graph(&graph, fixture, &nodes, &edges);
+    drop(graph);
+    round_trip_checked(root.path(), &source, |graph| {
+        verify_selective_fixed_paths(graph, &nodes, &edges);
+        verify_graph(graph, fixture, &nodes, &edges)
+    });
+    let imported_path = root.path().join("imported");
+    let imported = GraphForge::new(imported_path.to_str()).unwrap();
+    imported
+        .execute("MATCH (n) WHERE n.score = -2045 REMOVE n.score")
+        .unwrap();
+    for node in &mut nodes {
+        if node.2 == Some(-2045) {
+            node.2 = None;
+        }
+    }
+    verify_selective_fixed_paths(&imported, &nodes, &edges);
+    verify_graph(&imported, fixture, &nodes, &edges);
+    drop(imported);
+    let reopened = GraphForge::new(imported_path.to_str()).unwrap();
+    verify_selective_fixed_paths(&reopened, &nodes, &edges);
+    verify_graph(&reopened, fixture, &nodes, &edges);
 }

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -5781,6 +5781,16 @@ fn csr_cold_public_query_probe() {
         let graph = GraphForge::new(source.to_str()).unwrap();
         let open_ns = opened.elapsed().as_nanos();
         let query = "MATCH (a)-[r]->(b)-[s]->(c) WHERE a.score = -2047 RETURN a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid";
+        if std::env::var_os("GF_CSR_PROBE_DIAGNOSTICS").is_some() {
+            query_efficiency_diagnostics(&graph, query, &expected);
+            return;
+        }
+        let selected_case =
+            std::env::var("GF_CSR_PROBE_QUERY").unwrap_or_else(|_| "original".into());
+        let (_, query) = query_efficiency_cases(query)
+            .into_iter()
+            .find(|(name, _)| *name == selected_case)
+            .expect("known probe query case");
         let mut query_ns = Vec::new();
         for _ in 0..5 {
             let started = Instant::now();
@@ -5791,10 +5801,55 @@ fn csr_cold_public_query_probe() {
         println!(
             "CSR_COLD_PUBLIC_QUERY {}",
             json!({
-                "mode":mode,"open_elapsed_ns":open_ns,"query_elapsed_ns":query_ns,
+                "mode":mode,"case":selected_case,"open_elapsed_ns":open_ns,"query_elapsed_ns":query_ns,
                 "rows":expected.len(),"fingerprint":digest_hex(&serde_json::to_vec(&expected).unwrap()),
                 "cache_scope":"first query is application-cold only in separate read process; subsequent queries reuse the same facade; OS cache advice is external and separately recorded"
             })
+        );
+    }
+}
+
+// Aggregate-only diagnostics for #1207. Run this exact probe in a dedicated
+// process; query-scoped demand capture excludes concurrent unbound executions.
+fn query_efficiency_cases(original: &str) -> [(&'static str, &str); 3] {
+    let prefiltered = "MATCH (a) WHERE a.score = -2047 WITH a MATCH (a)-[r]->(b)-[s]->(c) RETURN a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid";
+    let range = "MATCH (a)-[r]->(b)-[s]->(c) WHERE a.score >= -2047 AND a.score <= -2047 RETURN a.node_uuid, r.edge_uuid, b.node_uuid, s.edge_uuid, c.node_uuid";
+    [
+        ("original", original),
+        ("prefiltered", prefiltered),
+        ("range", range),
+    ]
+}
+
+fn query_efficiency_diagnostics(graph: &GraphForge, original: &str, expected: &[[Uuid; 5]]) {
+    for (name, query) in query_efficiency_cases(original) {
+        let plan = graph
+            .explain_stage(query, graphforge_api::ExplainStage::PhysicalPlan)
+            .unwrap();
+        let started = Instant::now();
+        let (result, captured) = graphforge_exec::demand::capture(|| graph.execute(query));
+        let elapsed_ns = started.elapsed().as_nanos();
+        let result = result.unwrap();
+        assert_eq!(csr_two_hop_rows(&result.batches), expected);
+        let hops: Vec<_> = captured.hops.iter().map(|(id, hop)| json!({
+            "hop":id,"input_rows":hop.input_rows,"input_batches":hop.input_batches,
+            "candidates":hop.candidates_generated,"emitted":hop.rows_emitted,
+            "edge_reads":hop.edge_reads_completed,"edge_full_reads":hop.edge_full_reads,
+            "edge_rows_scanned":hop.edge_rows_scanned,"edge_rows_returned":hop.edge_rows_returned,
+            "node_reads":hop.node_reads_completed,"node_full_reads":hop.node_full_reads,
+            "node_rows_scanned":hop.node_rows_scanned,"node_rows_returned":hop.node_rows_returned,
+            "edge_projected_columns":hop.edge_projected_columns,"node_projected_columns":hop.node_projected_columns
+        })).collect();
+        let filters: Vec<_> = captured.filters.values().map(|f| json!({"ordinal":f.ordinal,
+            "relationship_uniqueness":f.relationship_uniqueness,"input_rows":f.input_rows,"output_rows":f.output_rows})).collect();
+        println!(
+            "QUERY_EFFICIENCY_DIAGNOSTICS {}",
+            json!({"case":name,"rows":expected.len(),
+            "fingerprint":digest_hex(&serde_json::to_vec(expected).unwrap()),"elapsed_ns":elapsed_ns,
+            "hops":hops,"filters":filters,"hydration":captured.hydration,
+            "memory_reserved_before":captured.memory_reserved_before,"memory_reserved_after":captured.memory_reserved_after,
+            "returned_batch_bytes":captured.returned_batch_bytes,"execution_batch_rows":captured.execution_batch_rows,
+            "plan":plan.replace("-2047", "<fixture literal>")})
         );
     }
 }

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5417,14 +5417,21 @@ impl ExecutionSession {
                 .expect("DataFusion RuntimeEnv construction"),
         );
 
+        let mut optimizer_rules = datafusion::optimizer::Optimizer::new().rules;
+        let predicate_position = optimizer_rules
+            .iter()
+            .position(|rule| rule.name() == "push_down_filter")
+            .expect("pinned DataFusion optimizer includes filter pushdown");
+        optimizer_rules.insert(
+            predicate_position + 1,
+            Arc::new(graphforge_rel::input_predicates::FixedExpandInputPredicates),
+        );
         let state = SessionStateBuilder::new()
             .with_default_features()
             .with_config(config)
             .with_runtime_env(runtime_env)
             .with_query_planner(Arc::new(GraphForgeQueryPlanner))
-            .with_optimizer_rule(Arc::new(
-                graphforge_rel::input_predicates::FixedExpandInputPredicates,
-            ))
+            .with_optimizer_rules(optimizer_rules)
             // Runs after DataFusion's default rules, when terminal fetches and
             // eager round-robin exchanges are visible (#1269).
             .with_physical_optimizer_rule(Arc::new(demand::FixedHopDemandRule))

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5417,21 +5417,12 @@ impl ExecutionSession {
                 .expect("DataFusion RuntimeEnv construction"),
         );
 
-        let mut optimizer_rules = datafusion::optimizer::Optimizer::new().rules;
-        let predicate_position = optimizer_rules
-            .iter()
-            .position(|rule| rule.name() == "push_down_filter")
-            .expect("pinned DataFusion optimizer includes filter pushdown");
-        optimizer_rules.insert(
-            predicate_position + 1,
-            Arc::new(graphforge_rel::input_predicates::FixedExpandInputPredicates),
-        );
         let state = SessionStateBuilder::new()
             .with_default_features()
             .with_config(config)
             .with_runtime_env(runtime_env)
             .with_query_planner(Arc::new(GraphForgeQueryPlanner))
-            .with_optimizer_rules(optimizer_rules)
+            .with_optimizer_rules(graphforge_rel::input_predicates::optimizer_rules())
             // Runs after DataFusion's default rules, when terminal fetches and
             // eager round-robin exchanges are visible (#1269).
             .with_physical_optimizer_rule(Arc::new(demand::FixedHopDemandRule))

--- a/crates/graphforge-exec/src/lib.rs
+++ b/crates/graphforge-exec/src/lib.rs
@@ -5422,6 +5422,9 @@ impl ExecutionSession {
             .with_config(config)
             .with_runtime_env(runtime_env)
             .with_query_planner(Arc::new(GraphForgeQueryPlanner))
+            .with_optimizer_rule(Arc::new(
+                graphforge_rel::input_predicates::FixedExpandInputPredicates,
+            ))
             // Runs after DataFusion's default rules, when terminal fetches and
             // eager round-robin exchanges are visible (#1269).
             .with_physical_optimizer_rule(Arc::new(demand::FixedHopDemandRule))

--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -3814,6 +3814,24 @@ pub(crate) fn relationship_disjoint(left: DfExpr, right: DfExpr) -> DfExpr {
     CYPHER_RELATIONSHIP_DISJOINT.call(vec![left, right])
 }
 
+// Exact fixed-hop residual admitted by the input-predicate optimizer. Do not
+// identify UDFs by name: another implementation may use the same name.
+pub(crate) fn is_fixed_relationship_disjoint(
+    expr: &DfExpr,
+    schema: &datafusion::common::DFSchema,
+) -> bool {
+    use datafusion::logical_expr::ExprSchemable;
+    let DfExpr::ScalarFunction(function) = expr else {
+        return false;
+    };
+    function.func.inner().downcast_ref::<CypherRelationshipDisjoint>().is_some()
+        && function.args.len() == 2
+        && function.args.iter().all(|arg| {
+            matches!(arg, DfExpr::Column(column) if column.relation.is_some() && column.name == "edge_id")
+                && arg.get_type(schema).ok() == Some(DataType::UInt64)
+        })
+}
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 struct CypherRelationshipDisjoint {
     signature: Signature,

--- a/crates/graphforge-rel/src/expr.rs
+++ b/crates/graphforge-rel/src/expr.rs
@@ -42,6 +42,12 @@ use value_semantics::{
 };
 pub(crate) use value_semantics::{CYPHER_ORDER_KEY, needs_cypher_order_key_type};
 
+pub(crate) fn is_comparison_predicate(
+    function: &datafusion::logical_expr::expr::ScalarFunction,
+) -> bool {
+    value_semantics::is_comparison_predicate(function)
+}
+
 pub(crate) use aggregates::{
     CYPHER_COLLECT, CYPHER_COLLECT_DISTINCT, CYPHER_MAX, CYPHER_MIN, CYPHER_PERCENTILE_CONT,
     CYPHER_PERCENTILE_DISC,

--- a/crates/graphforge-rel/src/expr/value_semantics.rs
+++ b/crates/graphforge-rel/src/expr/value_semantics.rs
@@ -112,6 +112,16 @@ fn scalar_as_bool(s: &ScalarValue) -> datafusion::error::Result<Option<bool>> {
 pub(super) static CYPHER_CMP_PRED: LazyLock<ScalarUDF> =
     LazyLock::new(|| ScalarUDF::new_from_impl(CypherCmpPred::new()));
 
+pub(super) fn is_comparison_predicate(
+    function: &datafusion::logical_expr::expr::ScalarFunction,
+) -> bool {
+    function
+        .func
+        .inner()
+        .downcast_ref::<CypherCmpPred>()
+        .is_some()
+}
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 struct CypherCmpPred {
     signature: Signature,

--- a/crates/graphforge-rel/src/input_predicates.rs
+++ b/crates/graphforge-rel/src/input_predicates.rs
@@ -66,6 +66,21 @@ fn total_predicate(expr: &Expr, schema: &DFSchema) -> bool {
         Expr::BinaryExpr(binary) if binary.op == Operator::And => {
             total_predicate(&binary.left, schema) && total_predicate(&binary.right, schema)
         }
+        Expr::ScalarFunction(function) if crate::expr::is_comparison_predicate(function) => {
+            function.args.len() == 3
+                && matches!(
+                    &function.args[2],
+                    Expr::Literal(
+                        datafusion::common::ScalarValue::Int8(Some(0..=3))
+                            | datafusion::common::ScalarValue::Int64(Some(0..=3)),
+                        _
+                    )
+                )
+                && atom_type(&function.args[0], schema)
+                    .as_ref()
+                    .is_some_and(primitive)
+                && atom_type(&function.args[0], schema) == atom_type(&function.args[1], schema)
+        }
         _ => crate::expr::is_fixed_relationship_disjoint(expr, schema),
     }
 }
@@ -127,5 +142,134 @@ impl OptimizerRule for FixedExpandInputPredicates {
             None => replacement,
         };
         Ok(Transformed::yes(replacement))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::Field;
+    use datafusion::common::{Column, TableReference};
+    use datafusion::logical_expr::{EmptyRelation, Extension, col, lit};
+    use datafusion::optimizer::OptimizerContext;
+    use graphforge_ir::Direction;
+
+    fn expanded() -> LogicalPlan {
+        let schema = DFSchema::new_with_metadata(
+            vec![(
+                Some(TableReference::bare("var_0")),
+                Arc::new(Field::new("score", DataType::Int64, true)),
+            )],
+            Default::default(),
+        )
+        .unwrap();
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(schema),
+        });
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(ExpandNode::new(
+                Arc::new(input),
+                "*",
+                0,
+                1,
+                2,
+                Direction::Out,
+                None,
+                vec![Arc::new(Field::new("edge_id", DataType::UInt64, false))],
+                vec![],
+                vec![Arc::new(Field::new("score", DataType::Int64, true))],
+            )),
+        })
+    }
+
+    fn column(var: &str) -> Expr {
+        Expr::Column(Column::new(Some(TableReference::bare(var)), "score"))
+    }
+
+    fn rewrite(predicate: Expr) -> Transformed<LogicalPlan> {
+        FixedExpandInputPredicates
+            .rewrite(
+                LogicalPlan::Filter(Filter::try_new(predicate, Arc::new(expanded())).unwrap()),
+                &OptimizerContext::new(),
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn same_named_destination_stays_residual() {
+        let result = rewrite(
+            column("var_0")
+                .eq(lit(7_i64))
+                .and(column("var_1").gt(lit(2_i64))),
+        );
+        assert!(result.transformed);
+        let LogicalPlan::Filter(residual) = result.data else {
+            panic!("destination predicate must remain");
+        };
+        assert_eq!(residual.predicate, column("var_1").gt(lit(2_i64)));
+        let LogicalPlan::Extension(extension) = residual.input.as_ref() else {
+            panic!();
+        };
+        let expand = extension
+            .node
+            .as_any()
+            .downcast_ref::<ExpandNode>()
+            .unwrap();
+        let LogicalPlan::Filter(input) = expand.input.as_ref() else {
+            panic!("input predicate must precede expansion");
+        };
+        assert_eq!(input.predicate, column("var_0").eq(lit(7_i64)));
+    }
+
+    #[test]
+    fn potentially_failing_residual_blocks_entire_filter() {
+        let predicate = column("var_0")
+            .eq(lit(7_i64))
+            .and((column("var_1") / lit(0_i64)).gt(lit(0_i64)));
+        assert!(!rewrite(predicate).transformed);
+    }
+
+    #[test]
+    fn unqualified_or_mixed_disjunction_is_not_moved() {
+        assert!(!total_predicate(
+            &col("score").eq(lit(7_i64)),
+            expanded().schema()
+        ));
+        assert!(
+            !rewrite(
+                column("var_0")
+                    .eq(lit(7_i64))
+                    .or(column("var_1").eq(lit(7_i64)))
+            )
+            .transformed
+        );
+        assert!(!rewrite(column("var_1").eq(lit(7_i64))).transformed);
+    }
+
+    #[test]
+    fn volatile_residual_blocks_entire_filter() {
+        let random = datafusion::functions::math::random().call(vec![]);
+        assert!(!rewrite(column("var_0").eq(lit(7_i64)).and(random.gt(lit(0.5)))).transformed);
+    }
+
+    #[test]
+    fn input_column_comparison_preserves_qualified_membership() {
+        assert!(rewrite(column("var_0").eq(column("var_0"))).transformed);
+        assert!(!rewrite(column("var_0").eq(column("var_1"))).transformed);
+    }
+
+    #[test]
+    fn nullable_input_checks_can_precede_expansion() {
+        assert!(rewrite(column("var_0").is_null()).transformed);
+        assert!(rewrite(column("var_0").is_not_null()).transformed);
+        assert!(
+            rewrite(
+                column("var_0")
+                    .gt_eq(lit(-7_i64))
+                    .and(column("var_0").lt_eq(lit(7_i64)))
+            )
+            .transformed
+        );
     }
 }

--- a/crates/graphforge-rel/src/input_predicates.rs
+++ b/crates/graphforge-rel/src/input_predicates.rs
@@ -17,6 +17,18 @@ use graphforge_plan::ExpandNode;
 #[derive(Debug)]
 pub struct FixedExpandInputPredicates;
 
+/// Preserve DataFusion defaults and place graph input filtering before projection pruning.
+#[must_use]
+pub fn optimizer_rules() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
+    let mut rules = datafusion::optimizer::Optimizer::new().rules;
+    let position = rules
+        .iter()
+        .position(|rule| rule.name() == "push_down_filter")
+        .expect("pinned DataFusion optimizer includes filter pushdown");
+    rules.insert(position + 1, Arc::new(FixedExpandInputPredicates));
+    rules
+}
+
 fn atom_type(expr: &Expr, schema: &DFSchema) -> Option<DataType> {
     match expr {
         Expr::Column(column) if column.relation.is_some() => expr.get_type(schema).ok(),
@@ -86,7 +98,7 @@ fn total_predicate(expr: &Expr, schema: &DFSchema) -> bool {
 }
 
 impl OptimizerRule for FixedExpandInputPredicates {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "graphforge_fixed_expand_input_predicates"
     }
 

--- a/crates/graphforge-rel/src/input_predicates.rs
+++ b/crates/graphforge-rel/src/input_predicates.rs
@@ -1,0 +1,131 @@
+//! Conservative predicate movement across required fixed graph expansion.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::{DFSchema, Result, tree_node::Transformed};
+use datafusion::logical_expr::utils::{conjunction, split_conjunction};
+use datafusion::logical_expr::{Expr, ExprSchemable, Filter, LogicalPlan, Operator};
+use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
+use graphforge_plan::ExpandNode;
+
+/// Move total, deterministic input predicates before required fixed expansion.
+///
+/// DataFusion's extension hook uses unqualified column names. This rule instead
+/// requires qualified references to unchanged input fields and never moves an
+/// expression that can introduce row-dependent errors or volatile evaluation.
+#[derive(Debug)]
+pub struct FixedExpandInputPredicates;
+
+fn atom_type(expr: &Expr, schema: &DFSchema) -> Option<DataType> {
+    match expr {
+        Expr::Column(column) if column.relation.is_some() => expr.get_type(schema).ok(),
+        Expr::Literal(value, _) if !value.is_null() => Some(value.data_type()),
+        _ => None,
+    }
+}
+
+fn primitive(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Boolean
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Utf8View
+            | DataType::FixedSizeBinary(_)
+    )
+}
+
+fn total_predicate(expr: &Expr, schema: &DFSchema) -> bool {
+    match expr {
+        Expr::BinaryExpr(binary)
+            if matches!(
+                binary.op,
+                Operator::Eq
+                    | Operator::NotEq
+                    | Operator::Lt
+                    | Operator::LtEq
+                    | Operator::Gt
+                    | Operator::GtEq
+            ) =>
+        {
+            let left = atom_type(&binary.left, schema);
+            left.as_ref().is_some_and(primitive) && left == atom_type(&binary.right, schema)
+        }
+        Expr::IsNull(value) | Expr::IsNotNull(value) => atom_type(value, schema).is_some(),
+        Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+            total_predicate(&binary.left, schema) && total_predicate(&binary.right, schema)
+        }
+        _ => crate::expr::is_fixed_relationship_disjoint(expr, schema),
+    }
+}
+
+impl OptimizerRule for FixedExpandInputPredicates {
+    fn name(&self) -> &str {
+        "graphforge_fixed_expand_input_predicates"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>> {
+        let LogicalPlan::Filter(filter) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        let LogicalPlan::Extension(extension) = filter.input.as_ref() else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(expand) = extension.node.as_any().downcast_ref::<ExpandNode>() else {
+            return Ok(Transformed::no(plan));
+        };
+        // Do not alter which rows reach a potentially failing or volatile
+        // residual expression in the same filter.
+        if !total_predicate(&filter.predicate, filter.input.schema()) {
+            return Ok(Transformed::no(plan));
+        }
+        let (push, keep): (Vec<_>, Vec<_>) = split_conjunction(&filter.predicate)
+            .into_iter()
+            .cloned()
+            .partition(|expr| {
+                let columns = expr.column_refs();
+                !crate::expr::is_fixed_relationship_disjoint(expr, filter.input.schema())
+                    && !columns.is_empty()
+                    && columns.iter().all(|column| {
+                        column.relation.is_some() && expand.input.schema().has_column(column)
+                    })
+            });
+        let Some(predicate) = conjunction(push) else {
+            return Ok(Transformed::no(plan));
+        };
+        let mut replacement = expand.clone();
+        replacement.input = Arc::new(LogicalPlan::Filter(Filter::try_new(
+            predicate,
+            Arc::clone(&expand.input),
+        )?));
+        let replacement = LogicalPlan::Extension(datafusion::logical_expr::Extension {
+            node: Arc::new(replacement),
+        });
+        let replacement = match conjunction(keep) {
+            Some(predicate) => {
+                LogicalPlan::Filter(Filter::try_new(predicate, Arc::new(replacement))?)
+            }
+            None => replacement,
+        };
+        Ok(Transformed::yes(replacement))
+    }
+}

--- a/crates/graphforge-rel/src/lib.rs
+++ b/crates/graphforge-rel/src/lib.rs
@@ -20,6 +20,8 @@ pub use expr::{ExprLowerer, LoweringError, VarMap, ir_literal_to_scalar, scalar_
 pub mod lowerer;
 pub use lowerer::GraphPlanLowerer;
 
+pub mod input_predicates;
+
 pub mod calendar;
 
 pub mod temporal;

--- a/docs/book/architecture/execution-model.md
+++ b/docs/book/architecture/execution-model.md
@@ -77,6 +77,32 @@ GraphPlan (Graph IR)
 
 ---
 
+## Predicates before fixed expansion
+
+The Rust execution session runs `FixedExpandInputPredicates` immediately after
+DataFusion's filter pushdown and before projection pruning. It moves eligible
+predicates across required fixed `ExpandNode` boundaries only when every
+referenced qualified column is preserved by the input. Comparisons of matching
+primitive types and null checks retain their existing evaluation semantics;
+recognized Cypher range comparisons retain their UDF implementation. Property
+joins remain in the plan and subsequent standard optimizer passes place the
+inserted filters through those joins.
+
+An unrecognized, volatile, potentially failing, or mixed-OR expression blocks
+movement of the entire filter. Fixed-hop relationship-disjoint checks are
+recognized by implementation type and exact UInt64 operands and remain residual.
+Destination/edge references cannot cross their producing expansion. Optional,
+variable-length and path operators have no new pushdown permission. This rule
+changes neither persisted representations nor authentication and recovery paths.
+
+The public eight-route fixture asserts 16 first-hop and 256 second-hop candidates
+for its selective equality and range queries, with an independent exact UUID
+oracle. Mutation, active snapshots, reopen and portable round trips exercise the
+same predicates. Source-bound CPU, syscall I/O, process RSS and sampled disk
+comparisons are recorded in
+[the #1241 evidence](../../development/evidence/input-predicates-1241.json).
+Timing observations are not CI assertions; sampled peaks are not hard bounds.
+
 ## List expression execution
 
 `graphforge-rel` keeps quantifier and list-comprehension UDF execution in the

--- a/docs/development/evidence/input-predicates-1241.json
+++ b/docs/development/evidence/input-predicates-1241.json
@@ -1,0 +1,750 @@
+{
+  "status": "Implemented candidate meets measured selection budgets; repository regression and exact-head CI gate are recorded separately before merge.",
+  "baseline": {
+    "source": "5fc68e568893110cca97b0eb2c797d306b264e27",
+    "probe": {
+      "source": "9ca395d3785ce9ede9c34b539d1e3479d0d08d05",
+      "integrated_core_source": "5fc68e568893110cca97b0eb2c797d306b264e27",
+      "sha256": "d695553c3e0ebb22cc4ae0db09466843689636159179fb9f478170183ae19505",
+      "profile": "release optimized; RUSTFLAGS,CARGO_ENCODED_RUSTFLAGS,LLVM_PROFILE_FILE unset",
+      "command": "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
+      "limitations": "Diagnostic mode explains before execution and enables work counters; those timings are not uninstrumented latency observations. Normal mode remains the five-query latency probe."
+    },
+    "observations": {
+      "first_ns": [
+        3964624405,
+        3839940110,
+        4636086101
+      ],
+      "first_median_ns": 3964624405,
+      "warm_min_ns": 3582274212,
+      "warm_max_ns": 4016911263,
+      "warm_median_ns": 3850297525.0,
+      "process": [
+        {
+          "user_seconds": 22.76,
+          "system_seconds": 8.71,
+          "rss_kib": 153640.0,
+          "input_blocks": 22680.0,
+          "output_blocks": 410264.0
+        },
+        {
+          "user_seconds": 22.49,
+          "system_seconds": 8.59,
+          "rss_kib": 152332.0,
+          "input_blocks": 22680.0,
+          "output_blocks": 410264.0
+        },
+        {
+          "user_seconds": 22.56,
+          "system_seconds": 8.77,
+          "rss_kib": 152848.0,
+          "input_blocks": 22680.0,
+          "output_blocks": 410264.0
+        }
+      ]
+    },
+    "work": [
+      {
+        "case": "original",
+        "rows": 256,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+        "hops": [
+          {
+            "candidates": 65537,
+            "edge_full_reads": 521,
+            "edge_projected_columns": 11,
+            "edge_reads": 585,
+            "edge_rows_returned": 65537,
+            "edge_rows_scanned": 531465,
+            "emitted": 65537,
+            "hop": 1,
+            "input_batches": 2,
+            "input_rows": 4097,
+            "node_full_reads": 41,
+            "node_projected_columns": 6,
+            "node_reads": 45,
+            "node_rows_returned": 28923,
+            "node_rows_scanned": 32784
+          },
+          {
+            "candidates": 1048352,
+            "edge_full_reads": 8321,
+            "edge_projected_columns": 2,
+            "edge_reads": 8385,
+            "edge_rows_returned": 994175,
+            "edge_rows_scanned": 8401025,
+            "emitted": 1048352,
+            "hop": 3,
+            "input_batches": 9,
+            "input_rows": 65537,
+            "node_full_reads": 641,
+            "node_projected_columns": 2,
+            "node_reads": 645,
+            "node_rows_returned": 459368,
+            "node_rows_scanned": 524433
+          }
+        ],
+        "memory_reserved_before": 0,
+        "memory_reserved_after": 747880,
+        "returned_batch_bytes": 21040,
+        "execution_batch_rows": 8192
+      },
+      {
+        "case": "prefiltered",
+        "rows": 256,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+        "hops": [
+          {
+            "candidates": 16,
+            "edge_full_reads": 1,
+            "edge_projected_columns": 11,
+            "edge_reads": 65,
+            "edge_rows_returned": 16,
+            "edge_rows_scanned": 15361,
+            "emitted": 16,
+            "hop": 2,
+            "input_batches": 1,
+            "input_rows": 1,
+            "node_full_reads": 1,
+            "node_projected_columns": 6,
+            "node_reads": 5,
+            "node_rows_returned": 16,
+            "node_rows_scanned": 17
+          },
+          {
+            "candidates": 256,
+            "edge_full_reads": 1,
+            "edge_projected_columns": 2,
+            "edge_reads": 65,
+            "edge_rows_returned": 256,
+            "edge_rows_scanned": 65537,
+            "emitted": 256,
+            "hop": 4,
+            "input_batches": 1,
+            "input_rows": 16,
+            "node_full_reads": 1,
+            "node_projected_columns": 2,
+            "node_reads": 5,
+            "node_rows_returned": 256,
+            "node_rows_scanned": 257
+          }
+        ],
+        "memory_reserved_before": 0,
+        "memory_reserved_after": 747880,
+        "returned_batch_bytes": 21040,
+        "execution_batch_rows": 8192
+      },
+      {
+        "case": "range",
+        "rows": 256,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+        "hops": [
+          {
+            "candidates": 65537,
+            "edge_full_reads": 521,
+            "edge_projected_columns": 11,
+            "edge_reads": 585,
+            "edge_rows_returned": 65537,
+            "edge_rows_scanned": 531465,
+            "emitted": 65537,
+            "hop": 1,
+            "input_batches": 2,
+            "input_rows": 4097,
+            "node_full_reads": 41,
+            "node_projected_columns": 6,
+            "node_reads": 45,
+            "node_rows_returned": 28923,
+            "node_rows_scanned": 32784
+          },
+          {
+            "candidates": 1048352,
+            "edge_full_reads": 8321,
+            "edge_projected_columns": 2,
+            "edge_reads": 8385,
+            "edge_rows_returned": 994175,
+            "edge_rows_scanned": 8401025,
+            "emitted": 1048352,
+            "hop": 3,
+            "input_batches": 9,
+            "input_rows": 65537,
+            "node_full_reads": 641,
+            "node_projected_columns": 2,
+            "node_reads": 645,
+            "node_rows_returned": 459368,
+            "node_rows_scanned": 524433
+          }
+        ],
+        "memory_reserved_before": 0,
+        "memory_reserved_after": 747880,
+        "returned_batch_bytes": 21040,
+        "execution_batch_rows": 8192
+      }
+    ],
+    "syscalls": {
+      "read_bytes": 8149233916,
+      "write_bytes": 130790402,
+      "syscalls": {
+        "read": {
+          "calls": 1901324,
+          "bytes": 6447918794,
+          "errors": 0
+        },
+        "pread64": {
+          "calls": 3320189,
+          "bytes": 1692100676,
+          "errors": 0
+        },
+        "write": {
+          "calls": 25039,
+          "bytes": 121575956,
+          "errors": 0
+        },
+        "fsync": {
+          "calls": 1347,
+          "bytes": 0,
+          "errors": 0
+        },
+        "copy_file_range": {
+          "calls": 1330,
+          "bytes": 9214446,
+          "errors": 0
+        },
+        "readv": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "preadv": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "sendfile": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "pwrite64": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "writev": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "pwritev": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        }
+      },
+      "csr_direct_read_bytes": 9577462,
+      "csr_copy_bytes": 1324020,
+      "csr_syscalls": {
+        "read": {
+          "calls": 310,
+          "bytes": 9577462,
+          "errors": 0
+        },
+        "copy_file_range": {
+          "calls": 36,
+          "bytes": 1324020,
+          "errors": 0
+        },
+        "fsync": {
+          "calls": 36,
+          "bytes": 0,
+          "errors": 0
+        },
+        "pread64": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "readv": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "preadv": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "sendfile": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        }
+      },
+      "unresolved_calls": 0,
+      "scope": "successful syscall return bytes across process tree, including non-file descriptors; copy/sendfile counted once as read and once as write; CSR classification from -yy descriptor paths including resumed calls; not physical I/O"
+    },
+    "sampled_workspace": [
+      {
+        "case": "original",
+        "baseline": [
+          {
+            "allocated_bytes": 41250816,
+            "logical_bytes": 27783012,
+            "unique_files": 4248
+          },
+          {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "unique_files": 0
+          }
+        ],
+        "sampled_overlapping_allocated_peak_bytes": 53239808,
+        "sampled_private_temporary_allocated_peak_bytes": 11988992,
+        "samples": 437,
+        "maximum_sample_gap_seconds": 0.07780275004915893,
+        "vanished_files": 9,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d"
+      },
+      {
+        "case": "prefiltered",
+        "baseline": [
+          {
+            "allocated_bytes": 41250816,
+            "logical_bytes": 27783012,
+            "unique_files": 4248
+          },
+          {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "unique_files": 0
+          }
+        ],
+        "sampled_overlapping_allocated_peak_bytes": 53882880,
+        "sampled_private_temporary_allocated_peak_bytes": 12632064,
+        "samples": 42,
+        "maximum_sample_gap_seconds": 0.07283752399962395,
+        "vanished_files": 1,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d"
+      }
+    ]
+  },
+  "candidate": {
+    "probe": {
+      "source": "6cc56556827bdfd5bce63b58579cbed47758d426",
+      "integrated_core_source": "5fc68e568893110cca97b0eb2c797d306b264e27",
+      "sha256": "68c7ec667f823ec8d070ccddefef02dccf247c5b3445fb8e323904914e4a8da4",
+      "profile": "release optimized; RUSTFLAGS,CARGO_ENCODED_RUSTFLAGS,LLVM_PROFILE_FILE unset",
+      "command": "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
+      "limitations": "Diagnostic mode explains before execution and enables work counters; those timings are not uninstrumented latency observations. Normal mode remains the five-query latency probe."
+    },
+    "observations": {
+      "original": {
+        "first_ns": [
+          268168064,
+          269601562,
+          264391772
+        ],
+        "first_median_ns": 268168064,
+        "reused_ns": [
+          256217495,
+          255659085,
+          254264148,
+          254255888,
+          254400760,
+          253479983,
+          252756220,
+          253081245,
+          242510623,
+          259105711,
+          261547517,
+          253803049
+        ],
+        "reused_median_ns": 254260018.0,
+        "process_open_plus_five_queries": [
+          {
+            "user_seconds": 1.08,
+            "system_seconds": 1.05,
+            "maximum_rss_kib": 101544
+          },
+          {
+            "user_seconds": 1.07,
+            "system_seconds": 1.02,
+            "maximum_rss_kib": 100236
+          },
+          {
+            "user_seconds": 1.11,
+            "system_seconds": 1.01,
+            "maximum_rss_kib": 101504
+          }
+        ]
+      },
+      "range": {
+        "first_ns": [
+          275802051,
+          252652357,
+          268054983
+        ],
+        "first_median_ns": 268054983,
+        "reused_ns": [
+          256771166,
+          255975641,
+          256053443,
+          255408270,
+          259751853,
+          256282897,
+          255515382,
+          256683264,
+          256596533,
+          255216947,
+          255265838,
+          254861980
+        ],
+        "reused_median_ns": 256014542.0,
+        "process_open_plus_five_queries": [
+          {
+            "user_seconds": 1.12,
+            "system_seconds": 1.02,
+            "maximum_rss_kib": 100652
+          },
+          {
+            "user_seconds": 1.1,
+            "system_seconds": 1.01,
+            "maximum_rss_kib": 100560
+          },
+          {
+            "user_seconds": 1.1,
+            "system_seconds": 1.01,
+            "maximum_rss_kib": 100956
+          }
+        ]
+      }
+    },
+    "work": [
+      {
+        "case": "original",
+        "rows": 256,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+        "hops": [
+          {
+            "candidates": 16,
+            "edge_full_reads": 1,
+            "edge_projected_columns": 11,
+            "edge_reads": 65,
+            "edge_rows_returned": 16,
+            "edge_rows_scanned": 15361,
+            "emitted": 16,
+            "hop": 1,
+            "input_batches": 1,
+            "input_rows": 1,
+            "node_full_reads": 1,
+            "node_projected_columns": 6,
+            "node_reads": 5,
+            "node_rows_returned": 16,
+            "node_rows_scanned": 17
+          },
+          {
+            "candidates": 256,
+            "edge_full_reads": 1,
+            "edge_projected_columns": 2,
+            "edge_reads": 65,
+            "edge_rows_returned": 256,
+            "edge_rows_scanned": 65537,
+            "emitted": 256,
+            "hop": 3,
+            "input_batches": 1,
+            "input_rows": 16,
+            "node_full_reads": 1,
+            "node_projected_columns": 2,
+            "node_reads": 5,
+            "node_rows_returned": 256,
+            "node_rows_scanned": 257
+          }
+        ],
+        "memory_reserved_before": 0,
+        "memory_reserved_after": 747880,
+        "returned_batch_bytes": 21040,
+        "execution_batch_rows": 8192
+      },
+      {
+        "case": "prefiltered",
+        "rows": 256,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+        "hops": [
+          {
+            "candidates": 16,
+            "edge_full_reads": 1,
+            "edge_projected_columns": 11,
+            "edge_reads": 65,
+            "edge_rows_returned": 16,
+            "edge_rows_scanned": 15361,
+            "emitted": 16,
+            "hop": 2,
+            "input_batches": 1,
+            "input_rows": 1,
+            "node_full_reads": 1,
+            "node_projected_columns": 6,
+            "node_reads": 5,
+            "node_rows_returned": 16,
+            "node_rows_scanned": 17
+          },
+          {
+            "candidates": 256,
+            "edge_full_reads": 1,
+            "edge_projected_columns": 2,
+            "edge_reads": 65,
+            "edge_rows_returned": 256,
+            "edge_rows_scanned": 65537,
+            "emitted": 256,
+            "hop": 4,
+            "input_batches": 1,
+            "input_rows": 16,
+            "node_full_reads": 1,
+            "node_projected_columns": 2,
+            "node_reads": 5,
+            "node_rows_returned": 256,
+            "node_rows_scanned": 257
+          }
+        ],
+        "memory_reserved_before": 0,
+        "memory_reserved_after": 747880,
+        "returned_batch_bytes": 21040,
+        "execution_batch_rows": 8192
+      },
+      {
+        "case": "range",
+        "rows": 256,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d",
+        "hops": [
+          {
+            "candidates": 16,
+            "edge_full_reads": 1,
+            "edge_projected_columns": 11,
+            "edge_reads": 65,
+            "edge_rows_returned": 16,
+            "edge_rows_scanned": 15361,
+            "emitted": 16,
+            "hop": 1,
+            "input_batches": 1,
+            "input_rows": 1,
+            "node_full_reads": 1,
+            "node_projected_columns": 6,
+            "node_reads": 5,
+            "node_rows_returned": 16,
+            "node_rows_scanned": 17
+          },
+          {
+            "candidates": 256,
+            "edge_full_reads": 1,
+            "edge_projected_columns": 2,
+            "edge_reads": 65,
+            "edge_rows_returned": 256,
+            "edge_rows_scanned": 65537,
+            "emitted": 256,
+            "hop": 3,
+            "input_batches": 1,
+            "input_rows": 16,
+            "node_full_reads": 1,
+            "node_projected_columns": 2,
+            "node_reads": 5,
+            "node_rows_returned": 256,
+            "node_rows_scanned": 257
+          }
+        ],
+        "memory_reserved_before": 0,
+        "memory_reserved_after": 747880,
+        "returned_batch_bytes": 21040,
+        "execution_batch_rows": 8192
+      }
+    ],
+    "syscalls": {
+      "read_bytes": 232779339,
+      "write_bytes": 32998388,
+      "syscalls": {
+        "read": {
+          "calls": 22016,
+          "bytes": 97815647,
+          "errors": 0
+        },
+        "pread64": {
+          "calls": 377229,
+          "bytes": 125749246,
+          "errors": 0
+        },
+        "write": {
+          "calls": 4333,
+          "bytes": 23783942,
+          "errors": 0
+        },
+        "fsync": {
+          "calls": 1347,
+          "bytes": 0,
+          "errors": 0
+        },
+        "copy_file_range": {
+          "calls": 1330,
+          "bytes": 9214446,
+          "errors": 0
+        },
+        "readv": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "preadv": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "sendfile": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "pwrite64": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "writev": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "pwritev": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        }
+      },
+      "csr_direct_read_bytes": 9577462,
+      "csr_copy_bytes": 1324020,
+      "csr_syscalls": {
+        "read": {
+          "calls": 310,
+          "bytes": 9577462,
+          "errors": 0
+        },
+        "copy_file_range": {
+          "calls": 36,
+          "bytes": 1324020,
+          "errors": 0
+        },
+        "fsync": {
+          "calls": 36,
+          "bytes": 0,
+          "errors": 0
+        },
+        "pread64": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "readv": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "preadv": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        },
+        "sendfile": {
+          "calls": 0,
+          "bytes": 0,
+          "errors": 0
+        }
+      },
+      "unresolved_calls": 0,
+      "scope": "successful syscall return bytes across process tree, including non-file descriptors; copy/sendfile counted once as read and once as write; CSR classification from -yy descriptor paths including resumed calls; not physical I/O"
+    },
+    "sampled_workspace": [
+      {
+        "case": "original",
+        "baseline": [
+          {
+            "allocated_bytes": 41250816,
+            "logical_bytes": 27783012,
+            "unique_files": 4248
+          },
+          {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "unique_files": 0
+          }
+        ],
+        "sampled_overlapping_allocated_peak_bytes": 52596736,
+        "sampled_private_temporary_allocated_peak_bytes": 11345920,
+        "samples": 42,
+        "maximum_sample_gap_seconds": 0.07846011302899569,
+        "vanished_files": 0,
+        "fingerprint": "e0c6639970436d9b74acdb9f94f7c9eff85d4de4e169004655427a46b921565d"
+      }
+    ]
+  },
+  "selection_protocol": {
+    "workload": "Existing deterministic eight-route 4097-node/65537-edge public two-hop fixture, selective start property, exact 256-path oracle; equality and equivalent range; explicit WITH is a control only.",
+    "exploratory_baseline": "Query-scoped diagnostic run: original 65537+1048352 candidates and 8932490 edge rows scanned; explicit prefilter 16+256 candidates and 80898 edge rows scanned. Diagnostic timings do not establish accepted latency benefit.",
+    "minimum_useful_work_improvement": "Eliminate expansion of the 4096 rejected start nodes: first-hop input 1 and candidates16, second-hop input16 and candidates256 on this fixture. The repair must optimize the original public query; changing users' query text is not implementation.",
+    "minimum_latency_benefit": "Repeated uninstrumented original versus explicit-prefilter controls must show separated first-query and reused-facade ranges. A selected implementation should reach control maximum plus the original observed range, for each category; fill absolute nanosecond thresholds after baseline collection and before implementation evaluation.",
+    "maximum_query_costs": "Successful syscall read/write bytes and sampled overlapping private-file allocation must not exceed the corresponding original baseline. Observed process RSS ceiling is original maximum plus its observed range; this is an investigation threshold, not a hard memory bound.",
+    "maximum_maintenance_costs": "No added persistent artifacts or mutation/rebuild/replay/compaction work for a planner-only repair. Verify unchanged persisted files and existing lifecycle/cancellation/error contracts.",
+    "measurement": "Three separate read processes per case, five queries per facade, alternating case order across repetitions; fsync+POSIX_FADV_DONTNEED private files only. Separate syscall tracing and workspace sampling. Freeze and hash executables before all subprocesses; no overlapping builds.",
+    "correctness_boundary": "Required fixed expansion; qualified unchanged input references and explicitly eligible deterministic non-erroring predicates. Preserve residual predicates, optional scopes, edge/destination references, volatility/errors, nulls, duplicates, order/LIMIT and property joins. No broad unqualified-name-only hook.",
+    "derived_thresholds_before_implementation": {
+      "maximum_first_query_median_ns": 1062367774,
+      "maximum_reused_facade_median_ns": 698343326,
+      "maximum_process_cpu_seconds_open_plus_five_queries": 2.51,
+      "maximum_observed_process_rss_kib": 154948,
+      "first_and_reused_ranges_separate": true,
+      "maximum_successful_syscall_read_bytes": 8149233916,
+      "maximum_successful_syscall_write_bytes": 130790402,
+      "maximum_sampled_overlapping_allocated_bytes": 53239808,
+      "maximum_sampled_private_temporary_allocated_bytes": 11988992
+    },
+    "temporary_control_constraint": "Equivalent control sampled peak 53882880 overlapping/12632064 temporary exceeds initial no-increase ceiling by643072 bytes. Selected repair must resolve or quantify this cost before acceptance. No threshold revision made.",
+    "selected_repair_issue": 1241
+  },
+  "method": {
+    "host": "OVHC-AGENCY",
+    "cpu": "AMD Ryzen 7 3800X, 16 logical CPUs",
+    "memory_kib": 131786392,
+    "filesystem": "native ext4, 4096-byte allocation blocks",
+    "rustc": "1.96.0 (ac68faa20 2026-05-25)",
+    "datafusion": "54.1.0",
+    "arrow_parquet": "58.4.0",
+    "fixture": "4097 nodes, 65537 edges, eight routes, deterministic random UUIDs and nullable properties; independent sorted full-path oracle, 256 result rows",
+    "latency": "Three fresh processes per case, five queries per facade, alternating case order. fsync+POSIX_FADV_DONTNEED on private fixture before each process; advisory, not proof of physically cold media.",
+    "traces": "Separate complete strace -f -qq -yy -s 0 with read/pread/vector/write/copy_file_range/sendfile/fsync/fdatasync. Parse completed and resumed syscall returns, count copy once read and once write. Zero unresolved calls and errors. Not physical I/O.",
+    "workspace": "Separate 5-ms requested scans of fixture plus private TMPDIR. Deduplicate globally by device/inode, shared files attributed first to fixture. Regular files only, directories and unlinked-open files excluded. Maximum observed gaps 77.8 ms baseline, 78.5 ms candidate. Non-atomic sampled observations, not hard bounds.",
+    "freeze": "Copy successful release executable and verify SHA256 before/after every measurement; no builds overlapped measured runs. Test-only lifecycle additions after measured commit do not change production code or read-mode probe."
+  },
+  "reproduction": [
+    "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
+    "GF_CSR_PROBE_ROOT=<private admitted root> GF_CSR_PROBE_MODE=prepare <frozen executable> --exact csr_cold_public_query_probe --nocapture --test-threads=1",
+    "GF_CSR_PROBE_ROOT=<same root> GF_CSR_PROBE_MODE=read GF_CSR_PROBE_QUERY=original <frozen executable> --exact csr_cold_public_query_probe --nocapture --test-threads=1",
+    "Use GF_CSR_PROBE_QUERY=range for equivalent range; GF_CSR_PROBE_DIAGNOSTICS=1 only for separate work-counter runs.",
+    "cargo test --release -p graphforge-api --test permanent_storage_budgets",
+    "cargo test -p graphforge-rel input_predicates --lib"
+  ],
+  "honest_failures": [
+    {
+      "source": "506106581b92b573bc78ea7246f99cb7ca787696",
+      "binary_sha256": "712ef13b4de5b98604c6495654e98f45e789ae62957aca724a560811bc4c9b13",
+      "result": "First prototype appended after projection pruning preserved exact results but reduced no original/range work; superseded, never claimed as improvement."
+    },
+    {
+      "result": "Initial lifecycle fixture used nonexistent property values and exposed empty REMOVE frontier panic. Corrected fixture now performs actual mutations; independent panic is tracked as epic blocker #1242, not suppressed or fixed in this PR."
+    }
+  ],
+  "limitations": [
+    "Explicit-WITH baseline control temporary sample exceeded initial ceiling by643072 bytes. Actual original-query candidate sampled52596736 overlapping/11345920 temporary versus baseline53239808/11988992, meeting the unchanged observation ceiling; no hard peak guarantee or precise disk saving is inferred from sampling.",
+    "Nonzero747880 logical reserved bytes after query is a retained session accounting observation, not proof of a leak or total process memory. Process/native RSS is measured separately.",
+    "No new persisted artifact or writer path; no storage compression gain is attributed to this planner repair.",
+    "All five #1207 decisions and integrated S20/S22 remain outstanding; no S24/S26 run is authorized."
+  ],
+  "official_sources": [
+    "https://docs.rs/datafusion/54.1.0/datafusion/",
+    "https://docs.rs/parquet/58.4.0/parquet/"
+  ]
+}

--- a/docs/development/evidence/input-predicates-1241.json
+++ b/docs/development/evidence/input-predicates-1241.json
@@ -717,7 +717,7 @@
     "latency": "Three fresh processes per case, five queries per facade, alternating case order. fsync+POSIX_FADV_DONTNEED on private fixture before each process; advisory, not proof of physically cold media.",
     "traces": "Separate complete strace -f -qq -yy -s 0 with read/pread/vector/write/copy_file_range/sendfile/fsync/fdatasync. Parse completed and resumed syscall returns, count copy once read and once write. Zero unresolved calls and errors. Not physical I/O.",
     "workspace": "Separate 5-ms requested scans of fixture plus private TMPDIR. Deduplicate globally by device/inode, shared files attributed first to fixture. Regular files only, directories and unlinked-open files excluded. Maximum observed gaps 77.8 ms baseline, 78.5 ms candidate. Non-atomic sampled observations, not hard bounds.",
-    "freeze": "Copy successful release executable and verify SHA256 before/after every measurement; no builds overlapped measured runs. Test-only lifecycle additions after measured commit do not change production code or read-mode probe."
+    "freeze": "Copy successful release executable and verify SHA256 before/after every measurement; no builds overlapped measured runs. Later changes add tests/documentation, a static rule-name lifetime and relocation of the identical optimizer-rule factory; the recorded executable/source remain the measured artifact, not an unmeasured final-head timing claim."
   },
   "reproduction": [
     "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
@@ -741,10 +741,20 @@
     "Explicit-WITH baseline control temporary sample exceeded initial ceiling by643072 bytes. Actual original-query candidate sampled52596736 overlapping/11345920 temporary versus baseline53239808/11988992, meeting the unchanged observation ceiling; no hard peak guarantee or precise disk saving is inferred from sampling.",
     "Nonzero747880 logical reserved bytes after query is a retained session accounting observation, not proof of a leak or total process memory. Process/native RSS is measured separately.",
     "No new persisted artifact or writer path; no storage compression gain is attributed to this planner repair.",
-    "All five #1207 decisions and integrated S20/S22 remain outstanding; no S24/S26 run is authorized."
+    "Completion of the five-candidate #1207 assessment and integrated S20/S22 remain outstanding; no S24/S26 run is authorized."
   ],
   "official_sources": [
     "https://docs.rs/datafusion/54.1.0/datafusion/",
     "https://docs.rs/parquet/58.4.0/parquet/"
-  ]
+  ],
+  "normalized_work": {
+    "baseline_expansion_candidates_per_result_row": 4351.12890625,
+    "candidate_expansion_candidates_per_result_row": 1.0625,
+    "baseline_edge_rows_scanned_per_result_row": 34892.5390625,
+    "candidate_edge_rows_scanned_per_result_row": 316.0078125,
+    "baseline_syscall_read_bytes_amortized_per_query_including_open": 1629846783.2,
+    "candidate_syscall_read_bytes_amortized_per_query_including_open": 46555867.8,
+    "query_count": 5,
+    "result_rows_per_query": 256
+  }
 }

--- a/docs/development/evidence/input-predicates-1241.json
+++ b/docs/development/evidence/input-predicates-1241.json
@@ -364,17 +364,23 @@
           {
             "user_seconds": 1.08,
             "system_seconds": 1.05,
-            "maximum_rss_kib": 101544
+            "maximum_rss_kib": 101544,
+            "filesystem_inputs_counter": 22680,
+            "filesystem_outputs_counter": 87384
           },
           {
             "user_seconds": 1.07,
             "system_seconds": 1.02,
-            "maximum_rss_kib": 100236
+            "maximum_rss_kib": 100236,
+            "filesystem_inputs_counter": 22680,
+            "filesystem_outputs_counter": 87384
           },
           {
             "user_seconds": 1.11,
             "system_seconds": 1.01,
-            "maximum_rss_kib": 101504
+            "maximum_rss_kib": 101504,
+            "filesystem_inputs_counter": 22680,
+            "filesystem_outputs_counter": 87384
           }
         ]
       },
@@ -404,17 +410,23 @@
           {
             "user_seconds": 1.12,
             "system_seconds": 1.02,
-            "maximum_rss_kib": 100652
+            "maximum_rss_kib": 100652,
+            "filesystem_inputs_counter": 22680,
+            "filesystem_outputs_counter": 87384
           },
           {
             "user_seconds": 1.1,
             "system_seconds": 1.01,
-            "maximum_rss_kib": 100560
+            "maximum_rss_kib": 100560,
+            "filesystem_inputs_counter": 22680,
+            "filesystem_outputs_counter": 87384
           },
           {
             "user_seconds": 1.1,
             "system_seconds": 1.01,
-            "maximum_rss_kib": 100956
+            "maximum_rss_kib": 100956,
+            "filesystem_inputs_counter": 22680,
+            "filesystem_outputs_counter": 87384
           }
         ]
       }
@@ -717,7 +729,8 @@
     "latency": "Three fresh processes per case, five queries per facade, alternating case order. fsync+POSIX_FADV_DONTNEED on private fixture before each process; advisory, not proof of physically cold media.",
     "traces": "Separate complete strace -f -qq -yy -s 0 with read/pread/vector/write/copy_file_range/sendfile/fsync/fdatasync. Parse completed and resumed syscall returns, count copy once read and once write. Zero unresolved calls and errors. Not physical I/O.",
     "workspace": "Separate 5-ms requested scans of fixture plus private TMPDIR. Deduplicate globally by device/inode, shared files attributed first to fixture. Regular files only, directories and unlinked-open files excluded. Maximum observed gaps 77.8 ms baseline, 78.5 ms candidate. Non-atomic sampled observations, not hard bounds.",
-    "freeze": "Copy successful release executable and verify SHA256 before/after every measurement; no builds overlapped measured runs. Later changes add tests/documentation, a static rule-name lifetime and relocation of the identical optimizer-rule factory; the recorded executable/source remain the measured artifact, not an unmeasured final-head timing claim."
+    "freeze": "Copy successful release executable and verify SHA256 before/after every measurement; no builds overlapped measured runs. Later changes add tests/documentation, a static rule-name lifetime and relocation of the identical optimizer-rule factory; the recorded executable/source remain the measured artifact, not an unmeasured final-head timing claim.",
+    "os_io": "GNU time -v filesystem input/output resource counters are retained alongside syscall bytes; input counter22680 is unchanged across baseline and candidate. Do not infer a physical disk-read reduction from the much lower syscall-read totals."
   },
   "reproduction": [
     "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",

--- a/docs/development/evidence/input-predicates-1241.json
+++ b/docs/development/evidence/input-predicates-1241.json
@@ -1,5 +1,5 @@
 {
-  "status": "Implemented candidate meets measured selection budgets; repository regression and exact-head CI gate are recorded separately before merge.",
+  "status": "Implemented candidate meets measured selection budgets. Changed-surface local tests passed; full local gates retain existing #1192 failure. Authoritative exact-head PR CI is the merge gate.",
   "baseline": {
     "source": "5fc68e568893110cca97b0eb2c797d306b264e27",
     "probe": {
@@ -769,5 +769,55 @@
     "candidate_syscall_read_bytes_amortized_per_query_including_open": 46555867.8,
     "query_count": 5,
     "result_rows_per_query": 256
+  },
+  "validation": {
+    "environment": "TMPDIR=<native ext4 private temporary directory>; CARGO_TARGET_DIR=<isolated target>; CARGO_BUILD_JOBS=4",
+    "commands": [
+      {
+        "command": "cargo test -p graphforge-rel input_predicates --lib",
+        "result": "PASS: six boundary tests"
+      },
+      {
+        "command": "cargo test --release -p graphforge-api --test permanent_storage_budgets",
+        "result": "PASS: 48 tests"
+      },
+      {
+        "command": "cargo test --release -p graphforge-api --test fixed_hop_limit --test e2e_baseline --test value_semantics",
+        "result": "PASS: 17 fixed-hop tests (two existing ignored), 187 end-to-end tests, 11 value-semantics tests"
+      },
+      {
+        "command": "cargo clippy --workspace -- -D warnings",
+        "result": "PASS"
+      },
+      {
+        "command": "cargo fmt --all -- --check",
+        "result": "PASS after final Rust edit"
+      },
+      {
+        "command": "make pre-push-fast",
+        "result": "PASS"
+      },
+      {
+        "command": "make gate-registry-check",
+        "result": "PASS, including 14 registry tests"
+      },
+      {
+        "command": "cargo test --workspace",
+        "result": "Exit101: sole failure in storage unit suite is existing #1192 wave9_participant_inventory_rejects_links_and_special_files; 1097 storage tests passed, two existing ignored. Earlier changed-surface tests passed, including six optimizer boundaries, 48 permanent facade tests, 17 fixed-hop tests, 118 BDD scenarios and 3897/3897 TCK scenarios with zero regressions. This is not a green workspace claim."
+      },
+      {
+        "command": "make pre-push",
+        "result": "Exit2: rust-tests-coverage-native stops at the same existing #1192 test; storage suite1096 passed, one failed, two existing ignored. The instrumented run passed 118BDD/3897TCK scenarios, 48permanent facade tests and17fixed-hop tests. Python/Node wrapper coverage and final threshold stages did not run after this prerequisite failed; full pre-push is not claimed green."
+      }
+    ],
+    "known_local_failure": {
+      "issue": 1192,
+      "file": "crates/graphforge-storage/src/project_generation.rs",
+      "line": 2576,
+      "cause": "Test uses tempdir_in(\"/tmp\"), overriding TMPDIR. /tmp is tmpfs; native project admission rejects it with UnsupportedFilesystem / filesystem_class_unproven before the test assertion. Production and test code in this path are unchanged from main.",
+      "disposition": "Preserve failure evidence and the existing issue; do not weaken filesystem admission, skip the test or include an unrelated repair in #1241."
+    },
+    "preflight_repairs": "Installed missing worktree development dependencies with uv sync --locked --all-extras --inexact and pnpm install --frozen-lockfile; subsequent preflight and Rust quality stages passed.",
+    "ci_gate": "Authoritative merge requirement: required exact-head CI and github-status/CI Gate must pass on the GitHub PR, with CLEAN merge state, no unresolved review threads and closing reference exactly #1241."
   }
 }


### PR DESCRIPTION
Selective predicates on an already-bound node previously stayed above required fixed expansions. Move eligible qualified input predicates before expansion, retaining property joins and refusing unsafe or volatile filters. On the public eight-route fixture, the original equality and range queries return the same 256 exact paths while expansion candidates fall from 1,113,889 to 272.

Frozen release measurements show first-query median 3.965→0.268 s, successful read-syscall bytes 8.15 GB→233 MB, and observed process RSS maximum 153,640→101,544 KiB. OS read counters are unchanged; sampled disk peaks are observations, not hard bounds. The committed evidence preserves the failed first prototype and all selection thresholds.

Validation includes six optimizer boundary tests, 48 permanent-storage/public lifecycle tests, 187 end-to-end queries, 17 fixed-hop tests, 11 value-semantics tests, 118 BDD scenarios and all 3,897 TCK scenarios. Public coverage includes exact identities/nulls/duplicates/order, mutation, a retained filtered snapshot, reopen, export/full verification/clean import and subsequent mutation. Clippy, formatting, fast checks and gate-registry validation pass. Full workspace and pre-push runs fail only at the existing #1192 socket-inventory test: it hardcodes `/tmp` (tmpfs on this host), causing filesystem admission to reject setup. Storage totals are 1,097 passed / 1 failed in the workspace run and 1,096 / 1 in coverage. Downstream wrapper coverage did not run after that failure. No test or admission check was weakened.

The independently reproduced empty-REMOVE panic is tracked separately in #1242. This implements the predicate-placement repair selected by #1207; the remaining assessment and S20/S22 work remain under #1194.

Closes #1241

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791671486&installation_model_id=20486&pr_number=1243&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1243&signature=c163fdcfeed76fe62817e33857bb1bba12a03f42cf632e25f844b5b345bd6110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->