### PR TITLE
fix(storage): rebase stale property authority during optimistic publication

### DIFF
--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -511,6 +511,8 @@ impl GraphForge {
             };
             let property_inventory =
                 crate::property_inventory_for_hydrated_generation(parent, &self.dir)?;
+            #[cfg(test)]
+            after_property_inventory_capture_for_test();
             apply_graph_mutations(
                 self,
                 request,
@@ -665,6 +667,21 @@ impl GraphForge {
                 Err(error)
             }
         }
+    }
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static AFTER_PROPERTY_INVENTORY_CAPTURE: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn after_property_inventory_capture_for_test() {
+    // Take before invoking: the competing publisher enters this boundary too.
+    let hook = AFTER_PROPERTY_INVENTORY_CAPTURE.with(|slot| slot.borrow_mut().take());
+    if let Some(hook) = hook {
+        hook();
     }
 }
 
@@ -2753,6 +2770,122 @@ mod tests {
                 .sum::<usize>(),
             2
         );
+    }
+
+    fn assert_exact_people(graph: &GraphForge, mut expected: Vec<(Uuid, String)>) {
+        let result = graph
+            .execute("MATCH (n:Person) RETURN n.node_uuid AS id, n.name AS name")
+            .unwrap();
+        let mut actual = Vec::new();
+        for batch in result.batches {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+                .unwrap();
+            let names = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            for row in 0..batch.num_rows() {
+                actual.push((
+                    Uuid::from_slice(ids.value(row)).unwrap(),
+                    names.value(row).to_owned(),
+                ));
+            }
+        }
+        actual.sort();
+        expected.sort();
+        assert_eq!(actual, expected);
+    }
+
+    fn exercise_property_authority_rebase(max_rebases: u32) {
+        let _serial = OPTIMISTIC_PUBLISH_SERIAL
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        struct ClearHook;
+        impl Drop for ClearHook {
+            fn drop(&mut self) {
+                AFTER_PROPERTY_INVENTORY_CAPTURE.with(|slot| slot.borrow_mut().take());
+            }
+        }
+        let _clear_hook = ClearHook;
+        let directory = TempDir::new().unwrap();
+        let graph = GraphForge::new_with_options(
+            directory.path().to_str(),
+            optimistic_options(max_rebases),
+        )
+        .unwrap();
+        let competitor =
+            GraphForge::new_with_options(directory.path().to_str(), optimistic_options(1)).unwrap();
+        let before = graphforge_storage::resolve_project_generation(directory.path())
+            .unwrap()
+            .generation_uuid();
+        let captured = std::rc::Rc::new(std::cell::Cell::new(None));
+        let observed = captured.clone();
+        let root = directory.path().to_path_buf();
+        AFTER_PROPERTY_INVENTORY_CAPTURE.with(|slot| {
+            *slot.borrow_mut() = Some(Box::new(move || {
+                assert!(observed.get().is_none(), "hook must run once");
+                competitor
+                    .publish_composite_transaction(graph_request(153, 154, "Grace"))
+                    .unwrap();
+                let winner = graphforge_storage::resolve_project_generation(&root)
+                    .unwrap()
+                    .generation_uuid();
+                assert_ne!(winner, before);
+                observed.set(Some(winner));
+            }));
+        });
+        let request = graph_request(151, 152, "Ada");
+        let result = graph.publish_composite_transaction(request.clone());
+        let winner = captured
+            .get()
+            .expect("competitor published after inventory capture");
+        let after = graphforge_storage::resolve_project_generation(directory.path())
+            .unwrap()
+            .generation_uuid();
+        let mut expected = vec![(uuid7(154), "Grace".to_owned())];
+        if max_rebases == 0 {
+            assert_eq!(result.unwrap_err().code(), "GF_REBASE_EXHAUSTED");
+            assert_eq!(after, winner);
+        } else {
+            let receipt = result.unwrap();
+            assert_ne!(after, winner);
+            expected.push((uuid7(152), "Ada".to_owned()));
+            assert_exact_people(&graph, expected.clone());
+            assert_eq!(
+                graph.publish_composite_transaction(request).unwrap(),
+                receipt
+            );
+            assert_eq!(
+                graph
+                    .publish_composite_transaction(graph_request(151, 152, "changed"))
+                    .unwrap_err()
+                    .code(),
+                "GF_IDEMPOTENCY_CONFLICT"
+            );
+            assert_eq!(
+                graphforge_storage::resolve_project_generation(directory.path())
+                    .unwrap()
+                    .generation_uuid(),
+                after
+            );
+        }
+        drop(graph);
+        let reopened = GraphForge::new(directory.path().to_str()).unwrap();
+        assert_exact_people(&reopened, expected);
+    }
+
+    #[test]
+    fn optimistic_property_authority_race_rebases_exactly_once() {
+        exercise_property_authority_rebase(1);
+    }
+
+    #[test]
+    fn optimistic_property_authority_race_obeys_rebase_budget() {
+        exercise_property_authority_rebase(0);
     }
 
     #[test]

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -6750,7 +6750,7 @@ pub(crate) fn seal_property_windows(
             let current = crate::resolve_project_generation(container_root)?;
             if current.generation_uuid() != *expected {
                 return Err(GfError::Project {
-                    code: ProjectErrorCode::TransactionConflict,
+                    code: ProjectErrorCode::WriteConflict,
                     message: format!(
                         "property mutation authority changed: expected={} current={}",
                         expected,

--- a/crates/graphforge-storage/src/writer.rs
+++ b/crates/graphforge-storage/src/writer.rs
@@ -9248,7 +9248,7 @@ mod tests {
         assert!(matches!(
             error,
             GfError::Project {
-                code: ProjectErrorCode::TransactionConflict,
+                code: ProjectErrorCode::WriteConflict,
                 ..
             }
         ));

--- a/docs/development/evidence/optimistic-authority-290.json
+++ b/docs/development/evidence/optimistic-authority-290.json
@@ -1,0 +1,163 @@
+{
+  "issue": 290,
+  "purpose": "Correct bounded optimistic rebase when property authority changes before staging",
+  "production_base": "5fc68e568893110cca97b0eb2c797d306b264e27",
+  "regression_revision": "03a39348848037caac8480aba0d187002b1ee952",
+  "repair_revision": "36a386b20d8432b254cbb34f49461c4620ff9f0e",
+  "ci_failure": {
+    "pr": 1243,
+    "head": "547ec4c98bbfdc6764ba642f9d71b28eeb73b34b",
+    "run": 34537860496,
+    "job": 103073636722,
+    "lane": "Node Binding",
+    "tests": 277,
+    "passed": 276,
+    "failed": 1,
+    "test": "write-mode options validate and optimistic agents publish exactly once",
+    "error": "GF_IDEMPOTENCY_CONFLICT: property mutation authority changed",
+    "census": "All independent applicable lanes completed. Bazel, Python binding, Windows locks, macOS durability, native aggregate and quality/policy lanes passed. CI Gate failed as aggregate. Concurrency Matrix and Bazel Diagnostics skipped under existing conditions."
+  },
+  "cause": "seal_property_windows classified CURRENT-generation drift as TransactionConflict; the composite publisher rebases only WriteConflict.",
+  "repair": "Classify only that stale authority boundary as WriteConflict. Existing bounded optimistic rebase and rollback perform the recovery. Genuine operation identity conflicts remain unchanged.",
+  "fixture": {
+    "mechanism": "One-shot thread-local test hook after authenticated property inventory capture. A separate optimistic facade synchronously publishes a distinct node before the original stages its property window. No timing race, sleep, or retry loop is used by the test.",
+    "assertions": [
+      "Competitor advances CURRENT and hook runs once",
+      "One allowed rebase publishes both exact UUID/name pairs once",
+      "Immediate query and reopen preserve both pairs",
+      "Exact receipt retry and conflicting-content refusal do not advance CURRENT",
+      "Zero rebase budget returns GF_REBASE_EXHAUSTED with only the competitor published"
+    ],
+    "isolation": "Hook is taken before invoking the competitor, cleared by a drop guard, and serialized with the existing optimistic publication fixtures."
+  },
+  "environment": {
+    "TMPDIR": "/home/ubuntu/graphforge-native-tmp-1195",
+    "CARGO_TARGET_DIR": "/home/ubuntu/code/graphforge-target-1195",
+    "CARGO_BUILD_JOBS": "4"
+  },
+  "validation": [
+    {
+      "command": "cargo test -p graphforge-api --lib optimistic_property_authority_race",
+      "revision": "03a39348",
+      "exit_code": 101,
+      "passed": 0,
+      "failed": 2,
+      "ignored": 0,
+      "observed": "Both fail with GF_IDEMPOTENCY_CONFLICT; successful-rebase case reports the exact property authority drift message."
+    },
+    {
+      "command": "cargo test -p graphforge-api --lib composite_publish::tests",
+      "revision": "36a386b20d8432b254cbb34f49461c4620ff9f0e",
+      "exit_code": 0,
+      "passed": 22,
+      "failed": 0,
+      "ignored": 0
+    },
+    {
+      "command": "cargo clippy --workspace -- -D warnings",
+      "exit_code": 0
+    },
+    {
+      "command": "make pre-push-fast",
+      "exit_code": 0
+    },
+    {
+      "command": "make gate-registry-check",
+      "exit_code": 0
+    },
+    {
+      "command": "make pre-push-preflight",
+      "exit_code": 0
+    },
+    {
+      "command": "pnpm --filter @curatelabs/graphforge build",
+      "exit_code": 0,
+      "profile": "release"
+    },
+    {
+      "command": "TMPDIR=/home/ubuntu/graphforge-native-tmp-1195 pnpm --filter @curatelabs/graphforge test",
+      "exit_code": 0,
+      "passed": 277,
+      "failed": 0,
+      "skipped": 0,
+      "cancelled": 0,
+      "note": "Includes the exact optimistic agents acceptance test that failed CI."
+    },
+    {
+      "command": "cargo test --workspace",
+      "revision": "36a386b20d8432b254cbb34f49461c4620ff9f0e",
+      "exit_code": 101,
+      "api_unit_passed": 739,
+      "bdd_scenarios_passed": 118,
+      "opencypher_tck_passed": 3897,
+      "opencypher_tck_regressions": 0,
+      "fixed_hop_passed": 17,
+      "fixed_hop_existing_release_only_ignored": 2,
+      "permanent_storage_passed": 47,
+      "construction_ladder_small_fixture_passed": 30,
+      "storage_passed": 1096,
+      "storage_failed": 2,
+      "storage_existing_ignored": 2,
+      "failures": [
+        "Known #1192 hardcoded /tmp filesystem admission",
+        "Existing stale-authority storage test expected TransactionConflict; corrected below"
+      ]
+    },
+    {
+      "command": "make pre-push",
+      "revision": "36a386b20d8432b254cbb34f49461c4620ff9f0e",
+      "exit_code": 2,
+      "preflight": "passed",
+      "policy_static": "passed",
+      "rust_quality": "passed",
+      "api_unit_passed": 739,
+      "opencypher_tck_passed": 3897,
+      "opencypher_tck_regressions": 0,
+      "fixed_hop_passed": 17,
+      "permanent_storage_passed": 47,
+      "construction_ladder_small_fixture_passed": 30,
+      "storage_passed": 1095,
+      "storage_failed": 2,
+      "storage_existing_ignored": 2,
+      "failures": [
+        "Known #1192 hardcoded /tmp filesystem admission",
+        "Existing stale-authority storage test expected TransactionConflict; corrected below"
+      ],
+      "not_reached": [
+        "Python wrapper coverage",
+        "Node wrapper coverage",
+        "Final coverage thresholds"
+      ]
+    },
+    {
+      "command": "cargo test -p graphforge-storage --lib writer::tests::staged_property_mutation_conflicts_after_intervening_project_publication -- --exact",
+      "revision": "a12a5d73a16c14953cc2bacbd78d5c50a390f6d5",
+      "exit_code": 0,
+      "passed": 1,
+      "failed": 0,
+      "ignored": 0,
+      "scope": "Only the expected error variant changed; unchanged CURRENT bytes, generation and baseline property checks all execute and pass. Production code is unchanged from the broad and binding runs."
+    }
+  ],
+  "limits": "No storage, query-latency, memory or I/O improvement is claimed for this correctness repair.",
+  "node_provenance": {
+    "source_commit": "36a386b20d8432b254cbb34f49461c4620ff9f0e",
+    "artifacts": [
+      {
+        "path": "/home/ubuntu/code/graphforge-290/crates/graphforge-bindings-node/graphforge.linux-x64-gnu.node",
+        "sha256": "36df9743a03db279b178b7e99bf69019fa6a9eba571e9eaaba8b2a21126f19ef"
+      }
+    ]
+  },
+  "corrected_storage_expectation_revision": "a12a5d73a16c14953cc2bacbd78d5c50a390f6d5",
+  "known_local_limitation": {
+    "issue": 1192,
+    "state_at_verification": "OPEN",
+    "test": "project_generation::tests::wave9_participant_inventory_rejects_links_and_special_files",
+    "cause": "The test explicitly uses tempdir_in(\"/tmp\"), overriding the admitted TMPDIR. On this host /tmp is tmpfs, refused during native filesystem admission before the inventory assertions.",
+    "error": "GF_UNSUPPORTED_FILESYSTEM: phase=CLASSIFY outcome=rejected cause=filesystem_class_unproven",
+    "unchanged": "project_generation.rs is unchanged from the production base. No skip, assertion weakening or filesystem-admission change is included."
+  },
+  "local_gate_claim": "Full local gates were run and are not claimed green. Their failure census is retained, and the changed error expectation passed its focused regression. Exact-head required CI remains the merge gate.",
+  "merge_requirement": "Required CI and CI Gate must pass at the exact PR head before merge; this file records pre-PR local evidence."
+}


### PR DESCRIPTION
A concurrent publisher can advance CURRENT after an optimistic writer captures property authority but before it seals its property window. That drift was reported as `GF_IDEMPOTENCY_CONFLICT`, so valid distinct creates bypassed bounded rebase and failed Node acceptance. Classify this boundary as `GF_WRITE_CONFLICT` so the existing rebase path handles it; genuine operation-identity conflicts retain their current refusal.

A deterministic one-shot hook forces the competing publication at the previously uncovered boundary. Tests prove exact UUID/property results after immediate reads and reopen, unchanged CURRENT on exact receipt retry and conflicting-content refusal, and `GF_REBASE_EXHAUSTED` when the rebase budget is zero. Both new tests fail with the observed CI error on unchanged production behavior; all 22 composite-publication tests pass with the one-line repair.

Validation: formatting, workspace Clippy, fast checks, gate-registry checks, all 22 composite-publication tests, and all 277 rebuilt Node acceptance tests pass. The direct storage refusal regression also passes after updating its expected variant; unchanged CURRENT bytes, generation and property-value assertions remain intact.

Full workspace and pre-push runs passed 739 API units, 3,897 openCypher scenarios with zero regressions, 17 fixed-hop tests, 47 permanent-storage lifecycles and 30 small construction-ladder tests. Both ended with the now-corrected error expectation and existing #1192: its hardcoded `/tmp` overrides the admitted TMPDIR and fails filesystem admission on this host. Downstream wrapper coverage and final coverage thresholds were not reached. Full local gates are not claimed green. [Source-bound evidence](https://github.com/CurateLabs/graphforge/blob/79ea4e53754b2f791c10d7e6d2f81319b69ce0b7/docs/development/evidence/optimistic-authority-290.json) retains the complete census and native artifact hash.

The previous CI failure census is also retained: Node was the sole test failure in run 34537860496; authoritative Bazel and other applicable lanes passed. This focused repair unblocks #1243 under the repository's temporary WIP exception for a verified CI blocker.

Closes #290

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791675556&installation_model_id=20486&pr_number=1244&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1244&signature=8514e75ef17fa219a5e9c75ba327024974e1d8a4028efd358b6b6412c703b034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->