### PR TITLE
fix(exec): preserve empty REMOVE frontier schema

### DIFF
--- a/crates/graphforge-api/tests/e2e_baseline.rs
+++ b/crates/graphforge-api/tests/e2e_baseline.rs
@@ -5557,3 +5557,87 @@ fn fixed_hop_new_endpoint_property_survives_write_and_reopen() {
         }
     }
 }
+
+fn exercise_empty_remove_frontier(edge: bool) {
+    let gf = GraphForge::new(None).unwrap();
+    gf.execute(
+        "CREATE (a:Probe {name:'left', score:1})-[:LINK {score:1}]->(:Probe {name:'right'})",
+    )
+    .unwrap();
+    let (pattern, target, read) = if edge {
+        (
+            "()-[r:LINK]->()",
+            "r",
+            "MATCH ()-[r:LINK]->() RETURN r.edge_uuid, r.score",
+        )
+    } else {
+        (
+            "(n:Probe)",
+            "n",
+            "MATCH (n:Probe {name:'left'}) RETURN n.node_uuid, n.score",
+        )
+    };
+    let before = rows(&gf, read);
+    for predicate in [
+        format!("{target}.score = 999"),
+        format!("{target}.score IS NULL AND {target}.score = 1"),
+    ] {
+        let query = format!("MATCH {pattern} WHERE {predicate} REMOVE {target}.score");
+        let result = rows(&gf, &query);
+        let removed = result.batches[0]
+            .column_by_name("properties_removed")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(removed.value(0), 0);
+        assert_eq!(rows(&gf, read).batches, before.batches);
+    }
+    let empty_return = rows(
+        &gf,
+        &format!(
+            "MATCH {pattern} WHERE {target}.score = 999 REMOVE {target}.score RETURN {target}.score"
+        ),
+    );
+    assert_eq!(empty_return.stats.rows_produced, 0);
+    rows(
+        &gf,
+        &format!("MATCH {pattern} WHERE {target}.score = 1 SET {target}.score = 2"),
+    );
+    assert_eq!(
+        read_int(
+            &gf,
+            &format!("MATCH {pattern} WHERE {target}.score = 2 RETURN {target}.score")
+        ),
+        Some(2)
+    );
+    let removed = rows(
+        &gf,
+        &format!("MATCH {pattern} WHERE {target}.score = 2 REMOVE {target}.score"),
+    );
+    assert_eq!(
+        removed.batches[0]
+            .column_by_name("properties_removed")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap()
+            .value(0),
+        1
+    );
+    assert_eq!(read_int(&gf, "MATCH (n:Probe) RETURN count(n)"), Some(2));
+    assert_eq!(
+        read_int(&gf, "MATCH ()-[r:LINK]->() RETURN count(r)"),
+        Some(1)
+    );
+}
+
+#[test]
+fn empty_remove_node_frontier_preserves_graph_and_following_writes() {
+    exercise_empty_remove_frontier(false);
+}
+
+#[test]
+fn empty_remove_edge_frontier_preserves_graph_and_following_writes() {
+    exercise_empty_remove_frontier(true);
+}

--- a/crates/graphforge-api/tests/e2e_baseline.rs
+++ b/crates/graphforge-api/tests/e2e_baseline.rs
@@ -5591,7 +5591,21 @@ fn exercise_empty_remove_frontier(edge: bool) {
             .downcast_ref::<UInt64Array>()
             .unwrap();
         assert_eq!(removed.value(0), 0);
-        assert_eq!(rows(&gf, read).batches, before.batches);
+        let after = rows(&gf, read);
+        assert_eq!(after.schema.fields(), before.schema.fields());
+        let mut before_metadata = before.schema.metadata().clone();
+        let mut after_metadata = after.schema.metadata().clone();
+        // Query IDs identify executions, independently of the graph identities.
+        assert_ne!(
+            before_metadata.remove("graphforge.query_id"),
+            after_metadata.remove("graphforge.query_id")
+        );
+        assert_eq!(after_metadata, before_metadata);
+        assert_eq!(after.batches.len(), before.batches.len());
+        for (after, before) in after.batches.iter().zip(&before.batches) {
+            assert_eq!(after.num_rows(), before.num_rows());
+            assert_eq!(after.columns(), before.columns());
+        }
     }
     let empty_return = rows(
         &gf,
@@ -5600,6 +5614,15 @@ fn exercise_empty_remove_frontier(edge: bool) {
         ),
     );
     assert_eq!(empty_return.stats.rows_produced, 0);
+    assert_eq!(empty_return.schema.field(0).data_type(), &DataType::Int64);
+    let missing_return = rows(
+        &gf,
+        &format!(
+            "MATCH {pattern} WHERE {target}.score = 999 REMOVE {target}.missing RETURN {target}.missing"
+        ),
+    );
+    assert_eq!(missing_return.stats.rows_produced, 0);
+    assert_eq!(missing_return.schema.field(0).data_type(), &DataType::Null);
     rows(
         &gf,
         &format!("MATCH {pattern} WHERE {target}.score = 1 SET {target}.score = 2"),

--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -6366,3 +6366,89 @@ fn qualified_cypher_edge_owners_preserve_constructed_and_pending_values() {
     drop(imported);
     verify(&GraphForge::new(imported_path.to_str()).unwrap(), &expected);
 }
+
+#[test]
+fn empty_remove_preserves_durable_graph_snapshot_and_portable_mutation() {
+    use futures::TryStreamExt as _;
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let fixture = Fixture {
+        name: "empty_remove_lifecycle",
+        nodes: 33,
+        edges: 129,
+        routes: 2,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: true,
+        heterogeneous: false,
+    };
+    let (mut nodes, mut edges) = rows(fixture);
+    construct(&source, fixture, &nodes, &edges);
+    let original_ids = cas_uuid_node_surrogates(&source);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let expected_snapshot = nodes
+        .iter()
+        .map(|row| (row.0, row.2))
+        .collect::<BTreeMap<_, _>>();
+    let snapshot = graph
+        .execute_stream("MATCH (n) RETURN n.node_uuid, n.score")
+        .unwrap();
+    let check_noop = |graph: &GraphForge| {
+        for query in [
+            "MATCH (n) WHERE n.score = 999999 REMOVE n.score",
+            "MATCH ()-[r]->() WHERE r.weight = 999999 REMOVE r.weight",
+        ] {
+            let result = graph.execute(query).unwrap();
+            assert_eq!(result.side_effects.as_ref().unwrap().properties_removed, 0);
+        }
+    };
+    check_noop(&graph);
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let mutation = graph
+        .execute("MATCH (n) WHERE n.score = -2047 SET n.score = 4242")
+        .unwrap();
+    assert_eq!(mutation.side_effects.as_ref().unwrap().properties_set, 1);
+    nodes[1].2 = Some(4242);
+    verify_graph(&graph, fixture, &nodes, &edges);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let batches = runtime.block_on(snapshot.try_collect::<Vec<_>>()).unwrap();
+    let mut observed = BTreeMap::new();
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            assert!(
+                observed
+                    .insert(uuid_at(&batch, 0, row), int_at(&batch, 1, row))
+                    .is_none()
+            );
+        }
+    }
+    assert_eq!(observed, expected_snapshot);
+    drop(graph);
+    assert_eq!(cas_uuid_node_surrogates(&source), original_ids);
+    round_trip_checked(root.path(), &source, |graph| {
+        verify_graph(graph, fixture, &nodes, &edges)
+    });
+    let imported_path = root.path().join("imported");
+    let imported_ids = cas_uuid_node_surrogates(&imported_path);
+    assert_eq!(imported_ids, original_ids);
+    let imported = GraphForge::new(imported_path.to_str()).unwrap();
+    check_noop(&imported);
+    let mutation = imported
+        .execute("MATCH ()-[r]->() WHERE r.weight IS NOT NULL SET r.weight = r.weight + 1")
+        .unwrap();
+    assert_eq!(
+        mutation.side_effects.as_ref().unwrap().properties_set,
+        edges.iter().filter(|edge| edge.4.is_some()).count() as u64
+    );
+    for edge in &mut edges {
+        edge.4 = edge.4.map(|weight| weight + 1);
+    }
+    verify_graph(&imported, fixture, &nodes, &edges);
+    drop(imported);
+    let reopened = GraphForge::new(imported_path.to_str()).unwrap();
+    verify_graph(&reopened, fixture, &nodes, &edges);
+    assert_eq!(cas_uuid_node_surrogates(&imported_path), imported_ids);
+}

--- a/crates/graphforge-exec/src/write_driver.rs
+++ b/crates/graphforge-exec/src/write_driver.rs
@@ -3394,6 +3394,10 @@ fn run_remove_phase(
                 item.target.0
             ))
         })?;
+        // No matched batches means no mutation; retain the known property schema.
+        if frontier.batches.is_empty() {
+            continue;
+        }
         let existing = frontier.df_schema.index_of_column_by_name(
             Some(&datafusion::common::TableReference::bare(format!(
                 "var_{}",


### PR DESCRIPTION
REMOVE indexed the first batch to recover a property's type even when a preceding match produced no batches. Return from that item's mutation work after target validation when the frontier is empty, preserving the authoritative empty schema and nonempty behavior.

Direct Rust regressions cover node and edge no-ops, nullable predicates, existing Int64 and missing-property Null empty returns, exact state and subsequent SET/REMOVE. The durable fixture preserves identities and an active snapshot through immediate queries, reopen, export/full verification/clean import and subsequent imported-edge mutation. It now passes on the merged #1224 prerequisite.

Validation:
- `cargo test -p graphforge-api --test e2e_baseline empty_remove -- --nocapture`: 2 passed.
- `cargo test -p graphforge-api --test permanent_storage_budgets empty_remove_preserves_durable_graph_snapshot_and_portable_mutation -- --exact --nocapture`: 1 passed.
- Rebuilt Python native binding from `4231661be845744e1486908f51831021c5a1ce15` using `uv run maturin develop --release -m crates/graphforge-bindings-py/Cargo.toml`; node/edge public reproduction, typed empty results, exact identities and subsequent SET/REMOVE passed. Native SHA-256: `81417cf2ceab53b1a93af4fd655c43035fb748c0e0b8205de5ee37ab48695f33`.
- Formatting, `make gate-registry-check` (14 tests), and `make pre-push-fast` passed. Independent review found no code findings.
- Full `make pre-push` passed workspace Clippy/format and preceding instrumented suites, then failed only at the existing #1192 hardcoded `/tmp` filesystem-admission fixture (storage: 1,096 passed, 1 failed, 2 pre-existing ignored). This full command is not claimed green. Initial prerequisite check failed because this worktree lacked Node napi; frozen-lockfile dependency installation resolved it.

Closes #1242

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791688011&installation_model_id=20486&pr_number=1246&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1246&signature=abab9b4141d5cc750c460c6603c3cce3575552d8ab7f42a64a970084139cf5b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->