### PR TITLE
fix(cypher): preserve nullable COUNT arguments

### DIFF
--- a/crates/graphforge-api/tests/fixed_hop_limit.rs
+++ b/crates/graphforge-api/tests/fixed_hop_limit.rs
@@ -428,6 +428,14 @@ fn regression1094_property_free_shortcuts() {
         let mut failures = Vec::new();
         for (query, expected) in [
             ("MATCH ()-[r]->() RETURN count(r) AS n", 4),
+            ("MATCH ()-[r]->() RETURN count(DISTINCT r) AS n", 4),
+            ("MATCH ()-[r]->() RETURN count(r.missing) AS n", 0),
+            ("MATCH ()-[r]->() WITH r AS link RETURN count(link) AS n", 4),
+            (
+                "MATCH (a) OPTIONAL MATCH (a)-[r]->() RETURN count(r) AS n",
+                4,
+            ),
+            ("MATCH ()-[r:Missing]->() RETURN count(r) AS n", 0),
             ("MATCH ()-[r]->() RETURN count(NULL) AS n", 0),
             ("MATCH ()-[r]->() RETURN count(1) AS n", 4),
             ("MATCH (a:Missing)-[r]->() RETURN count(r) AS n", 0),
@@ -443,9 +451,24 @@ fn regression1094_property_free_shortcuts() {
         ] {
             let plan = forge.explain(query).unwrap();
             let should_optimize = query == "MATCH ()-[r]->() RETURN count(r) AS n"
-                || query == "MATCH ()-[r]->() RETURN count(1) AS n";
-            assert_eq!(plan.contains("EdgeCountExec"), should_optimize, "{plan}");
-            let result = forge.execute(query).unwrap();
+                || query == "MATCH ()-[r]->() RETURN count(1) AS n"
+                || query == "MATCH ()-[r:Missing]->() RETURN count(r) AS n"
+                || query == "MATCH ()-[r]->() WITH r AS link RETURN count(link) AS n";
+            assert_eq!(
+                plan.contains("EdgeCountExec"),
+                should_optimize,
+                "{query}: {plan}"
+            );
+            let (result, evidence) = demand::capture(|| forge.execute(query));
+            let result = result.unwrap();
+            assert_eq!(
+                evidence
+                    .operator_rss
+                    .iter()
+                    .any(|operator| operator.operator == "edge_count"),
+                should_optimize,
+                "{query}: actual execution must match shortcut eligibility"
+            );
             let actual = int64_values(&result, "n");
             if actual != vec![expected] {
                 failures.push(format!("{query}: {actual:?} != {expected}; {plan}"));

--- a/crates/graphforge-api/tests/with_aggregation.rs
+++ b/crates/graphforge-api/tests/with_aggregation.rs
@@ -255,11 +255,16 @@ fn count_preserves_nullable_variables_and_row_cardinality() {
         ),
         ("MATCH ()-[r:R]->() RETURN count(*) AS total", vec![1]),
         ("MATCH ()-[r:R*1..2]->() RETURN count(*) AS total", vec![1]),
+        ("MATCH ()-[r:R*1..2]->() RETURN count(r) AS total", vec![1]),
+        ("MATCH ()-[r:R*0..2]->() RETURN count(r) AS total", vec![4]),
         (
             "MATCH (a)-[:R]->() WHERE a.score = 999 RETURN count(*) AS total",
             vec![0],
         ),
     ] {
+        if query.contains("R*") {
+            assert!(!graph.explain(query).unwrap().contains("EdgeCountExec"));
+        }
         let result = graph.execute(query).unwrap();
         assert_eq!(
             result
@@ -298,7 +303,7 @@ fn count_preserves_nullable_variables_and_row_cardinality() {
         0
     );
     let grouped = graph
-        .execute("UNWIND [null,1,2] AS x RETURN null AS k, count(*) AS total")
+        .execute("UNWIND [null,1,2] AS x RETURN null AS k, count(*) AS total, count(x) AS present")
         .unwrap();
     assert_eq!(
         grouped
@@ -314,6 +319,15 @@ fn count_preserves_nullable_variables_and_row_cardinality() {
         .find(|batch| batch.num_rows() == 1)
         .unwrap();
     assert_eq!(batch.column(0).logical_null_count(), 1);
+    assert_eq!(
+        batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0),
+        2
+    );
     assert_eq!(
         batch
             .column(1)

--- a/crates/graphforge-api/tests/with_aggregation.rs
+++ b/crates/graphforge-api/tests/with_aggregation.rs
@@ -216,3 +216,111 @@ fn nested_with_aggregation_rewrites_predicates_and_rejects_nested_aggregates() {
     )
     .expect_err("aggregation in a pattern-comprehension body must remain invalid");
 }
+
+#[test]
+fn count_preserves_nullable_variables_and_row_cardinality() {
+    use arrow::array::Array;
+    let graph = GraphForge::new(None).unwrap();
+    graph.execute("CREATE (a:CountProbe {score:1,z:1}), (b:CountProbe {z:'text'}), (c:CountProbe {score:3,z:true}), (a)-[:R]->(b)").unwrap();
+    for (query, expected) in [
+        (
+            "MATCH (n) OPTIONAL MATCH (n)-[r:R]->(m) RETURN count(*) AS total, count(r) AS present",
+            vec![3, 1],
+        ),
+        ("MATCH (n) WITH n AS x RETURN count(*) AS total", vec![3]),
+        (
+            "MATCH (n) RETURN count(n.z) AS present, count(n.score) AS scored",
+            vec![3, 2],
+        ),
+        (
+            "UNWIND [null,1,2] AS x WITH x AS y RETURN count(*) AS total, count(y) AS present",
+            vec![3, 2],
+        ),
+        ("UNWIND [] AS x RETURN count(*) AS total", vec![0]),
+        (
+            "UNWIND [null,null] AS x RETURN count(*) AS total, count(x) AS present, count(DISTINCT x) AS unique",
+            vec![2, 0, 0],
+        ),
+        (
+            "UNWIND [] AS x RETURN count(*) AS total, count(x) AS present",
+            vec![0, 0],
+        ),
+        (
+            "UNWIND [null,1,1] AS x RETURN count(*) AS total, count(x) AS present, count(DISTINCT x) AS unique",
+            vec![3, 2, 1],
+        ),
+        (
+            "MATCH (n) OPTIONAL MATCH (n)-[r:R]->(m) RETURN count(m) AS present, count(DISTINCT r) AS unique",
+            vec![1, 1],
+        ),
+        ("MATCH ()-[r:R]->() RETURN count(*) AS total", vec![1]),
+        ("MATCH ()-[r:R*1..2]->() RETURN count(*) AS total", vec![1]),
+        (
+            "MATCH (a)-[:R]->() WHERE a.score = 999 RETURN count(*) AS total",
+            vec![0],
+        ),
+    ] {
+        let result = graph.execute(query).unwrap();
+        assert_eq!(
+            result
+                .batches
+                .iter()
+                .map(|batch| batch.num_rows())
+                .sum::<usize>(),
+            1,
+            "{query}"
+        );
+        let batch = result
+            .batches
+            .iter()
+            .find(|batch| batch.num_rows() == 1)
+            .unwrap();
+        assert_eq!(batch.num_columns(), expected.len(), "{query}");
+        for (column, expected) in expected.iter().enumerate() {
+            let array = batch
+                .column(column)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            assert!(!array.is_null(0), "{query}");
+            assert_eq!(array.value(0), *expected, "{query}");
+        }
+    }
+    let empty = graph
+        .execute("UNWIND [] AS x RETURN null AS k, count(*) AS total")
+        .unwrap();
+    assert_eq!(
+        empty
+            .batches
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum::<usize>(),
+        0
+    );
+    let grouped = graph
+        .execute("UNWIND [null,1,2] AS x RETURN null AS k, count(*) AS total")
+        .unwrap();
+    assert_eq!(
+        grouped
+            .batches
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum::<usize>(),
+        1
+    );
+    let batch = grouped
+        .batches
+        .iter()
+        .find(|batch| batch.num_rows() == 1)
+        .unwrap();
+    assert_eq!(batch.column(0).logical_null_count(), 1);
+    assert_eq!(
+        batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0),
+        3
+    );
+}

--- a/crates/graphforge-exec/src/edge_count.rs
+++ b/crates/graphforge-exec/src/edge_count.rs
@@ -3,7 +3,8 @@
 //! `MATCH ()-[r]->() RETURN count(r)` otherwise expands every adjacency entry
 //! into Arrow batches before aggregating. That retains process RSS ~linear in
 //! edge count and fails the progressive S18→S19 plateau gate. When the physical
-//! plan is a global nonnull literal / compiler row-marker count over a single
+//! plan is a global nonnull literal, compiler row-marker, or matched edge-identity
+//! count over a single
 //! unconstrained outward Expand (including a validated Partial/Final pair),
 //! replace it with the adjacency view's edge-entry count.
 
@@ -121,6 +122,33 @@ pub(crate) fn has_complete_frontier(expand: &ExpandExec) -> bool {
     expand.fetch.is_none() && trace(&expand.input, expand.src_col_idx)
 }
 
+/// An emitted fixed-hop edge has an identity even when its properties are null.
+/// Follow exact column lineage; names and schema nullability alone are not proof.
+fn is_matched_edge_identity(plan: &Arc<dyn ExecutionPlan>, index: usize) -> bool {
+    if let Some(projection) = plan.downcast_ref::<ProjectionExec>() {
+        return projection
+            .expr()
+            .get(index)
+            .and_then(|expr| expr.expr.downcast_ref::<Column>())
+            .is_some_and(|column| is_matched_edge_identity(projection.input(), column.index()));
+    }
+    if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
+        return is_matched_edge_identity(coalesce.input(), index);
+    }
+    if let Some(repartition) = plan.downcast_ref::<RepartitionExec>() {
+        return is_matched_edge_identity(repartition.input(), index);
+    }
+    let Some(expand) = plan.downcast_ref::<ExpandExec>() else {
+        return false;
+    };
+    index == expand.input_width
+        && expand.schema.fields().get(index).is_some_and(|field| {
+            field.name() == "edge_uuid"
+                && field.data_type() == &arrow::datatypes::DataType::FixedSizeBinary(16)
+                && !field.is_nullable()
+        })
+}
+
 fn is_row_count(aggregate: &AggregateExec) -> bool {
     aggregate.group_expr().is_empty()
         && !aggregate.aggr_expr().is_empty()
@@ -140,6 +168,9 @@ fn is_row_count(aggregate: &AggregateExec) -> bool {
                 if let Some(literal) = arg.downcast_ref::<Literal>() {
                     return !literal.value().is_null();
                 }
+                if let Some(column) = arg.downcast_ref::<Column>() {
+                    return is_matched_edge_identity(aggregate.input(), column.index());
+                }
                 arg.downcast_ref::<ScalarFunctionExpr>()
                     .is_some_and(|function| {
                         graphforge_rel::expr::is_cypher_row_marker(function.fun())
@@ -153,15 +184,18 @@ fn is_row_count(aggregate: &AggregateExec) -> bool {
 fn detect_edge_count(plan: &Arc<dyn ExecutionPlan>) -> Option<EdgeCountSpec> {
     let plan = peel_transport(plan);
     let aggregate = plan.downcast_ref::<AggregateExec>()?;
-    if !is_row_count(aggregate) {
-        return None;
-    }
     let input = match aggregate.mode() {
-        AggregateMode::Single => Arc::clone(aggregate.input()),
+        AggregateMode::Single if is_row_count(aggregate) => Arc::clone(aggregate.input()),
         AggregateMode::Final => {
             let input = peel_expand_input_without_projection(aggregate.input());
             let partial = input.downcast_ref::<AggregateExec>()?;
             if *partial.mode() != AggregateMode::Partial
+                || !aggregate.group_expr().is_empty()
+                || aggregate.filter_expr().iter().any(Option::is_some)
+                // DataFusion aggregate equality does not compare these flags.
+                || aggregate.aggr_expr().iter().any(|expr| {
+                    expr.is_distinct() || !expr.order_bys().is_empty()
+                })
                 || !is_row_count(partial)
                 || aggregate.aggr_expr() != partial.aggr_expr()
             {

--- a/crates/graphforge-ir/src/binder.rs
+++ b/crates/graphforge-ir/src/binder.rs
@@ -3159,14 +3159,11 @@ impl Binder {
         bindings
     }
 
-    /// Build one [`AggExpr`] from an aggregate call. `count(*)` has no argument;
-    /// `count(n)` over a bare variable counts bound rows (equivalent to `count(*)`
-    /// — a MATCH variable is always bound — and avoids referencing the bare
-    /// `var_N`, which is not a real column). Distinct aggregates keep the
-    /// argument so optional/unbound values can be filtered correctly. Distinct
-    /// aggregate calls are preserved in the IR so lowering can pick the matching
-    /// DataFusion/Cypher implementation. `out_var`, when set, binds the result
-    /// column for a following `Project` (#599 nested aggregates).
+    /// Build one [`AggExpr`] from an aggregate call. Only `count(*)` has no
+    /// argument: explicit variables may be null after OPTIONAL MATCH or scalar
+    /// projection and must retain their null-sensitive count semantics.
+    /// Distinct aggregate calls are preserved for lowering. `out_var`, when set,
+    /// binds the result column for a following `Project` (#599 nested aggregates).
     fn build_agg(
         &self,
         call: &graphforge_ast::FunctionCall,
@@ -3175,7 +3172,6 @@ impl Binder {
         out_var: Option<VarId>,
         s: &mut BinderState,
     ) -> AggExpr {
-        let bare_var_arg = matches!(call.args.first(), Some(Expr::Var(_)));
         let is_percentile = matches!(func, AggFunc::PercentileDisc | AggFunc::PercentileCont);
         if is_percentile {
             if call.star || call.args.len() != 2 {
@@ -3193,9 +3189,7 @@ impl Binder {
                 ));
             }
         }
-        let arg = if !is_percentile
-            && (call.star || (func == AggFunc::Count && bare_var_arg && !call.distinct))
-        {
+        let arg = if !is_percentile && call.star {
             None
         } else {
             call.args.first().map(|a| {

--- a/crates/graphforge-ir/tests/golden.rs
+++ b/crates/graphforge-ir/tests/golden.rs
@@ -214,3 +214,33 @@ fn parameter() {
         insta::assert_json_snapshot!("parameter", plan);
     });
 }
+
+#[test]
+fn count_retains_explicit_nullable_arguments() {
+    use graphforge_ir::{AggFunc, GraphOp, IrExpr};
+    for query in [
+        "MATCH (a:Employee) OPTIONAL MATCH (a)-[r:REPORTS_TO]->(b) RETURN count(*), count(r), count(DISTINCT r)",
+        "UNWIND [null,1,1] AS x WITH x AS y RETURN count(*), count(y), count(DISTINCT y)",
+    ] {
+        let plan = bind_query(query);
+        let aggs = plan
+            .ops
+            .iter()
+            .find_map(|op| match op {
+                GraphOp::Aggregate { aggs, .. } => Some(aggs),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(aggs.len(), 3);
+        assert_eq!(aggs[0].func, AggFunc::Count);
+        assert!(aggs[0].arg.is_none());
+        assert_eq!(aggs[1].func, AggFunc::Count);
+        assert_eq!(aggs[2].func, AggFunc::CountDistinct);
+        for agg in &aggs[1..] {
+            assert!(matches!(
+                plan.exprs.get(agg.arg.unwrap()),
+                IrExpr::VarRef(_)
+            ));
+        }
+    }
+}

--- a/crates/graphforge-ir/tests/ir_goldens/golden__aggregation.snap
+++ b/crates/graphforge-ir/tests/ir_goldens/golden__aggregation.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/graphforge-ir/tests/golden.rs
+assertion_line: 179
 ---
 {
   "ir_version": {
@@ -24,7 +25,7 @@ source: crates/graphforge-ir/tests/golden.rs
         "aggs": [
           {
             "func": "Count",
-            "arg": null,
+            "arg": 0,
             "alias": "total",
             "out_var": 1
           }
@@ -33,6 +34,10 @@ source: crates/graphforge-ir/tests/golden.rs
     }
   ],
   "exprs": {
-    "nodes": []
+    "nodes": [
+      {
+        "VarRef": 0
+      }
+    ]
   }
 }


### PR DESCRIPTION
`count(r)` incorrectly counted unmatched OPTIONAL rows, and `count(x)` counted null scalar values, because binding discarded every non-distinct bare-variable argument. Preserve explicit arguments so null-sensitive counting reaches the engine; reserve an absent argument for COUNT(*).

Retain the existing edge-count shortcut by tracing a projected column to the matched fixed Expand's own edge UUID. Keep the complete-frontier, direction, grouping, filter, DISTINCT and ordering gates, validating raw arguments at the partial aggregate rather than against final accumulator columns.

Validation:
- The OPTIONAL regression fails on main 77e415e0 with (3,3) instead of (3,1); the repaired public matrix passes, including scalar aliases, all-null/empty input, DISTINCT, grouping and explicit fixed/variable-length counts.
- Broad debug validation: 17 fixed-hop tests pass (two existing release-only benchmarks ignored), plus all four aggregation tests.
- Binder suite passes with the intentional COUNT argument snapshot reviewed. Shortcut tests verify exact results and actual captured execution for matched/zero-edge counts and relationship aliases; nullable properties, OPTIONAL and DISTINCT stay on ordinary execution.
- `cargo clippy --workspace -- -D warnings`, `make pre-push-fast`, `make gate-registry-check`, final formatting and diff checks pass.

- `make pre-push` completed the instrumented workspace run with the existing #1192 host limitation: `wave9_participant_inventory_rejects_links_and_special_files` uses hardcoded `/tmp` and gets `UnsupportedFilesystem`. Storage: 1,096 passed, one failed, two pre-existing ignored. All 57 permanent-storage integration tests passed. Later local validation stages are not claimed green; the required CI gate remains authoritative.

Closes #1251

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791703319&installation_model_id=20486&pr_number=1252&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1252&signature=cb3bb516af8cb0295a9f913d17f59f4b9f667d778a9a4ffd36670d42865cd673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->