### PR TITLE
fix(storage): preserve structured property-reader errors

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -7252,3 +7252,149 @@ fn property_layout_bloom_assessment() {
         }
     }
 }
+
+fn construct_count_marker_fixture(source: &Path) -> (Vec<Node>, Vec<Option<String>>) {
+    let fixture = Fixture {
+        name: "count_marker",
+        nodes: 129,
+        edges: 0,
+        routes: 1,
+        identifiers: Identifiers::Random,
+        properties: true,
+        adjacency: false,
+        heterogeneous: false,
+    };
+    let (nodes, _) = rows(fixture);
+    let payloads = (0..nodes.len())
+        .map(|row| {
+            (row % 11 != 0).then(|| digest_hex(format!("count-marker/{row}").as_bytes()).repeat(4))
+        })
+        .collect::<Vec<_>>();
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let mut session = graph
+        .begin_graph_construction(GraphConstructionBudgets {
+            max_batch_rows: 1024,
+            max_run_records: 4096,
+            merge_fan_in: 2,
+            ..Default::default()
+        })
+        .unwrap();
+    let mut fields = CONSTRUCTION_NODE_SCHEMA.fields().to_vec();
+    fields.extend([
+        Arc::new(Field::new("score", DataType::Int64, true)),
+        Arc::new(Field::new("z_payload", DataType::Utf8, true)),
+    ]);
+    let arrays = vec![
+        uuids(nodes.iter().map(|node| node.0)),
+        Arc::new(StringArray::from(
+            nodes.iter().map(|node| node.1.as_str()).collect::<Vec<_>>(),
+        )) as ArrayRef,
+        Arc::new(Int64Array::from(
+            nodes.iter().map(|node| node.2).collect::<Vec<_>>(),
+        )) as ArrayRef,
+        Arc::new(StringArray::from(payloads.clone())) as ArrayRef,
+    ];
+    session
+        .append_nodes(
+            "count-marker",
+            &RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays).unwrap(),
+        )
+        .unwrap();
+    session.seal_and_publish().unwrap();
+    (nodes, payloads)
+}
+
+#[test]
+fn count_row_marker_rejects_property_corruption_after_facade_open() {
+    use std::io::{Read, Seek, SeekFrom, Write};
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    construct_count_marker_fixture(&source);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let selected = graphforge_storage::resolve_project_generation(&source).unwrap();
+    let generation_owned = selected.declared_graph_files_inventory().unwrap().is_some();
+    let inventory = selected.graph_files_inventory().unwrap().unwrap();
+    let path = inventory
+        .files
+        .iter()
+        .filter(|entry| entry.relative_path.ends_with(".parquet"))
+        .find_map(|entry| {
+            let path = if generation_owned {
+                selected.graph_tree_root().join(&entry.relative_path)
+            } else {
+                graphforge_storage::graph_object_path(&source, &entry.content_sha256).unwrap()
+            };
+            let reader =
+                ParquetRecordBatchReaderBuilder::try_new(File::open(&path).unwrap()).unwrap();
+            reader
+                .schema()
+                .index_of("z_payload")
+                .is_ok()
+                .then_some(path)
+        })
+        .unwrap();
+    // Deliberately damage this test-owned immutable object after opening the
+    // facade, so query authentication must detect the hostile in-place change.
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(permissions.mode() | 0o200);
+    }
+    #[cfg(not(unix))]
+    permissions.set_readonly(false);
+    std::fs::set_permissions(&path, permissions).unwrap();
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .unwrap();
+    file.seek(SeekFrom::Start(4)).unwrap();
+    let mut byte = [0_u8; 1];
+    file.read_exact(&mut byte).unwrap();
+    byte[0] ^= 1;
+    file.seek(SeekFrom::Start(4)).unwrap();
+    file.write_all(&byte).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+    // An unknown route is resolved without demanding this property's payload.
+    // A demanded route must authenticate even when its predicate yields no rows.
+    let absent = graph
+        .execute("MATCH (n:Missing) RETURN count(*) AS value")
+        .unwrap();
+    assert_eq!(
+        absent
+            .batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>(),
+        1
+    );
+    assert_eq!(absent.batches[0].column(0).logical_null_count(), 0);
+    assert_eq!(
+        absent.batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0),
+        0
+    );
+    for query in [
+        "MATCH (n) RETURN count(*) AS value",
+        "MATCH (n) WHERE n.score = 999 RETURN count(*) AS value",
+    ] {
+        let error = graph.execute(query).unwrap_err();
+        assert_eq!(error.code(), "GF_PROJECT_CORRUPT", "{query}: {error}");
+        assert!(
+            matches!(
+                error,
+                graphforge_core::GfError::Project {
+                    code: graphforge_core::ProjectErrorCode::ProjectCorrupt,
+                    ..
+                }
+            ),
+            "{query}: {error}"
+        );
+    }
+}

--- a/crates/graphforge-storage/src/catalog.rs
+++ b/crates/graphforge-storage/src/catalog.rs
@@ -1921,7 +1921,7 @@ where
     } else {
         captured =
             crate::property_overlay::authenticated_property_inventory_for_route(dir, kind, stem)
-                .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+                .map_err(|error| DataFusionError::External(Box::new(error)))?;
         &captured
     };
     let schema = inventory.route_schema(kind, stem);
@@ -1952,21 +1952,21 @@ where
                     let batch = normalize_property_batch(batch, schema.as_ref())?;
                     let batch =
                         project_property_batch(batch, kind.uuid_field(), selected_properties)?;
-                    stopped = !visit(&batch)
-                        .map_err(|error| graphforge_core::GfError::Storage(error.to_string()))?;
+                    stopped =
+                        !visit(&batch).map_err(graphforge_core::GfError::from_execution_error)?;
                 }
                 Ok(())
             },
         )
-        .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+        .map_err(|error| DataFusionError::External(Box::new(error)))?;
     if !stopped && !rows.is_empty() {
         let batch = crate::writer::property_snapshots_to_batch(stem, is_edge, rows)
-            .map_err(|error| DataFusionError::Execution(error.to_string()))?
+            .map_err(|error| DataFusionError::External(Box::new(error)))?
             .ok_or_else(|| DataFusionError::Execution("property batch disappeared".into()))?;
         let batch = normalize_property_batch(batch, schema.as_ref())
-            .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         let batch = project_property_batch(batch, kind.uuid_field(), selected_properties)
-            .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
         let _ = visit(&batch)?;
     }
     Ok(metrics)
@@ -4126,6 +4126,105 @@ mod tests {
                 .all(|batch| batch.schema() == batches[0].schema())
         );
         assert!(batches[0].column_by_name("year").is_some());
+    }
+
+    #[test]
+    fn property_overlay_adapter_preserves_error_sources() {
+        use graphforge_core::{GfError, ProjectErrorCode};
+        let dir = TempDir::new().unwrap();
+        let mut writer =
+            crate::GraphWriter::open_at(dir.path(), graphforge_core::OntologyMode::Strict, 1)
+                .unwrap();
+        let uuid = graphforge_core::uuid::new_v7();
+        writer
+            .create_node(
+                uuid,
+                graphforge_value::EntityTypeId::ontology(graphforge_core::TypeId(1)).unwrap(),
+            )
+            .unwrap();
+        writer
+            .set_properties(
+                &uuid,
+                Some("Person"),
+                HashMap::from([(
+                    "name".to_owned(),
+                    graphforge_ir::IrLiteral::Str("Ada".to_owned()),
+                )]),
+            )
+            .unwrap();
+        writer.flush().unwrap();
+        let inventory = crate::property_overlay::authenticated_property_inventory_for_route(
+            dir.path(),
+            crate::PropertyRouteKind::Node,
+            "Person",
+        )
+        .unwrap();
+        let original = GfError::Project {
+            code: ProjectErrorCode::ProjectCorrupt,
+            message: "typed visitor failure".into(),
+        };
+        // Exercise both callbacks inside the reader and the trailing batch.
+        for batch_size in [1, 1024] {
+            let error = visit_property_overlay_batched_projected(
+                dir.path(),
+                Some(&inventory),
+                "Person",
+                false,
+                batch_size,
+                None,
+                |_| Err(DataFusionError::External(Box::new(original.clone()))),
+            )
+            .unwrap_err();
+            let recovered = GfError::from_execution_error(error);
+            assert_eq!(recovered.code(), original.code());
+            assert_eq!(recovered.to_string(), original.to_string());
+            let error = visit_property_overlay_batched_projected(
+                dir.path(),
+                Some(&inventory),
+                "Person",
+                false,
+                batch_size,
+                None,
+                |_| {
+                    Err(DataFusionError::Execution(
+                        "GF_PROJECT_CORRUPT: diagnostic only".into(),
+                    ))
+                },
+            )
+            .unwrap_err();
+            assert_eq!(GfError::from_execution_error(error).code(), "GF_EXECUTION");
+        }
+        // Inventory acquisition and consumption of retained inventory must both
+        // preserve the reader's structured refusal, before delivering any rows.
+        let fragment = crate::property_overlay::enumerate_property_fragments(
+            dir.path(),
+            crate::PropertyRouteKind::Node,
+            &crate::route_component::component("Person"),
+        )
+        .unwrap()
+        .pop()
+        .unwrap()
+        .path;
+        std::fs::write(fragment, b"corrupt").unwrap();
+        for retained in [None, Some(&inventory)] {
+            let error = visit_property_overlay_batched_projected(
+                dir.path(),
+                retained,
+                "Person",
+                false,
+                1,
+                None,
+                |_| panic!("corrupt property data must not reach the visitor"),
+            )
+            .unwrap_err();
+            assert!(matches!(
+                GfError::from_execution_error(error),
+                GfError::Project {
+                    code: ProjectErrorCode::ProjectCorrupt,
+                    ..
+                }
+            ));
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
A property file modified after facade opening was correctly rejected, but the catalog adapter erased `GfError::Project(ProjectCorrupt)` and exposed generic `GF_EXECUTION` text. Preserve typed sources through DataFusion at the property-reader and callback boundaries so the existing facade conversion returns the original structured error.

Public construction regression proves typed refusal for ordinary COUNT and a demanded property predicate with an empty frontier. An unknown-label COUNT remains an exact non-null zero control, preserving on-demand access to unrelated routes. Adapter tests cover fresh/retained inventory, full/trailing callback batches, and diagnostic text that must remain generic.

Validation: baseline public failure reproduced on unmodified main; repaired public test and all 26 property-overlay tests pass, including mandatory-key and late-decoder refusal. `cargo clippy --workspace -- -D warnings`, `make pre-push-fast`, `make gate-registry-check`, final formatting and diff checks pass.

The full `make pre-push` run passed all 58 permanent-storage tests and 118 BDD scenarios, then finished storage with 1,097 passed, one failed and two pre-existing ignored. The sole failure is the existing #1192 hardcoded `/tmp` filesystem-admission limitation. Later local stages are not claimed green; required CI remains the merge gate.

Closes #1253

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791705811&installation_model_id=20486&pr_number=1254&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1254&signature=5d8769ed9d8133fa434eb1b544691fab47df23e2d5a02b3a2f5067e813fb61ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->