### PR TITLE
perf(query): avoid unused property hydration in row counts

### DIFF
--- a/crates/graphforge-api/tests/permanent_storage_budgets.rs
+++ b/crates/graphforge-api/tests/permanent_storage_budgets.rs
@@ -7398,3 +7398,164 @@ fn count_row_marker_rejects_property_corruption_after_facade_open() {
         );
     }
 }
+
+fn count_marker_rows(batches: &[RecordBatch]) -> Vec<(Uuid, Option<i64>, Option<String>)> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        assert_eq!(batch.num_columns(), 3);
+        let payload = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for row in 0..batch.num_rows() {
+            rows.push((
+                uuid_at(batch, 0, row),
+                int_at(batch, 1, row),
+                (!payload.is_null(row)).then(|| payload.value(row).to_owned()),
+            ));
+        }
+    }
+    rows.sort();
+    rows
+}
+
+fn verify_count_marker_graph(
+    graph: &GraphForge,
+    nodes: &[Node],
+    payloads: &[Option<String>],
+) -> String {
+    let result = graph
+        .execute("MATCH (n) RETURN n.node_uuid, n.score, n.z_payload")
+        .unwrap();
+    let actual = count_marker_rows(&result.batches);
+    let mut expected = nodes
+        .iter()
+        .zip(payloads)
+        .map(|(node, payload)| (node.0, node.2, payload.clone()))
+        .collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(actual, expected);
+    for (query, expected) in [
+        ("MATCH (n) RETURN count(*) AS value", nodes.len() as i64),
+        (
+            "MATCH (n) RETURN count(n.score) AS value",
+            nodes.iter().filter(|node| node.2.is_some()).count() as i64,
+        ),
+        (
+            "MATCH (n) RETURN sum(n.score) AS value",
+            nodes.iter().filter_map(|node| node.2).sum(),
+        ),
+        (
+            "MATCH (n) RETURN count(n.z_payload) AS value",
+            payloads.iter().filter(|payload| payload.is_some()).count() as i64,
+        ),
+    ] {
+        let result = graph.execute(query).unwrap();
+        assert_eq!(
+            result
+                .batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            1
+        );
+        let batch = result
+            .batches
+            .iter()
+            .find(|batch| batch.num_rows() == 1)
+            .unwrap();
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(int_at(batch, 0, 0), Some(expected), "{query}");
+    }
+    digest_hex(&serde_json::to_vec(&actual).unwrap())
+}
+
+#[test]
+fn count_row_marker_avoids_property_values_through_public_lifecycle() {
+    use futures::TryStreamExt as _;
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("source");
+    let (nodes, mut payloads) = construct_count_marker_fixture(&source);
+    let graph = GraphForge::new(source.to_str()).unwrap();
+    let initial = verify_count_marker_graph(&graph, &nodes, &payloads);
+    let capture = |query: &str, expected: i64| {
+        let (result, captured) = graphforge_exec::demand::capture(|| graph.execute(query));
+        let result = result.unwrap();
+        assert_eq!(
+            result
+                .batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            1
+        );
+        let batch = result
+            .batches
+            .iter()
+            .find(|batch| batch.num_rows() == 1)
+            .unwrap();
+        assert_eq!(int_at(batch, 0, 0), Some(expected));
+        assert_eq!(captured.property_overlays.len(), 1, "{query}");
+        captured.property_overlays[0].clone()
+    };
+    let counted = capture("MATCH (n) RETURN count(*) AS value", nodes.len() as i64);
+    let values = capture(
+        "MATCH (n) RETURN count(n.z_payload) AS value",
+        payloads.iter().filter(|payload| payload.is_some()).count() as i64,
+    );
+    assert!(counted.authentication_bytes > 0);
+    assert_eq!(counted.authentication_bytes, values.authentication_bytes);
+    assert!(counted.physical_rows > 0);
+    assert_eq!(counted.physical_rows, values.physical_rows);
+    let unrequested_bytes = payloads.iter().flatten().map(String::len).sum::<usize>() as u64;
+    assert!(counted.spill_bytes + unrequested_bytes <= values.spill_bytes);
+    assert!(counted.spill_bytes <= nodes.len() as u64 * 256);
+    assert!(counted.decoder_peak_bytes <= nodes.len() as u64 * 256);
+    assert!(counted.decoder_peak_bytes < values.decoder_peak_bytes);
+    println!(
+        "COUNT_MARKER_WORK {}",
+        json!({"rows":nodes.len(),"unrequested_value_bytes":unrequested_bytes,"count_spill_bytes":counted.spill_bytes,"value_spill_bytes":values.spill_bytes,"authentication_bytes_each":counted.authentication_bytes,"physical_rows_each":counted.physical_rows,"count_logical_decoder_peak_bytes":counted.decoder_peak_bytes,"value_logical_decoder_peak_bytes":values.decoder_peak_bytes})
+    );
+
+    let snapshot = graph
+        .execute_stream("MATCH (n) RETURN n.node_uuid, n.score, n.z_payload")
+        .unwrap();
+    graph
+        .execute("MATCH (n) WHERE n.score = -2047 SET n.z_payload = 'after-publish'")
+        .unwrap();
+    payloads[1] = Some("after-publish".into());
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let retained: Vec<RecordBatch> = runtime.block_on(snapshot.try_collect()).unwrap();
+    assert_eq!(
+        digest_hex(&serde_json::to_vec(&count_marker_rows(&retained)).unwrap()),
+        initial
+    );
+    let mutated = verify_count_marker_graph(&graph, &nodes, &payloads);
+    assert_ne!(mutated, initial);
+    drop(graph);
+    let portable = round_trip_checked(root.path(), &source, |graph| {
+        verify_count_marker_graph(graph, &nodes, &payloads)
+    });
+    assert_eq!(portable, mutated);
+    let imported_path = root.path().join("imported");
+    let imported = GraphForge::new(imported_path.to_str()).unwrap();
+    imported
+        .execute("MATCH (n) WHERE n.score = -2046 REMOVE n.z_payload")
+        .unwrap();
+    payloads[2] = None;
+    let after_import_mutation = verify_count_marker_graph(&imported, &nodes, &payloads);
+    assert_ne!(after_import_mutation, portable);
+    drop(imported);
+    assert_eq!(
+        verify_count_marker_graph(
+            &GraphForge::new(imported_path.to_str()).unwrap(),
+            &nodes,
+            &payloads
+        ),
+        after_import_mutation
+    );
+}

--- a/crates/graphforge-exec/src/demand.rs
+++ b/crates/graphforge-exec/src/demand.rs
@@ -190,6 +190,24 @@ pub struct JoinSnapshot {
     pub build_memory_bytes: u64,
 }
 
+/// Completed property-overlay work for one physical tree occurrence.
+/// Counters are logical work/admission observations, not process RSS or
+/// filesystem allocation; repeated shared-plan occurrences are not additive.
+#[doc(hidden)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PropertyOverlaySnapshot {
+    /// Physical tree encounter order among property overlays.
+    pub ordinal: usize,
+    /// Logical bytes written by the overlay spool and merge.
+    pub spill_bytes: u64,
+    /// Bytes authenticated by completed property reads.
+    pub authentication_bytes: u64,
+    /// Physical fragment rows validated by completed reads.
+    pub physical_rows: u64,
+    /// Maximum logical decoder admission estimate, not process/native RSS.
+    pub decoder_peak_bytes: u64,
+}
+
 /// Aggregate-only diagnostic snapshot for the most recently reset capture.
 #[doc(hidden)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -202,6 +220,8 @@ pub struct DemandSnapshot {
     pub sorts: Vec<SortSnapshot>,
     /// Executed hash-join estimates and aggregate work.
     pub joins: Vec<JoinSnapshot>,
+    /// Completed native property-overlay counters.
+    pub property_overlays: Vec<PropertyOverlaySnapshot>,
     /// Per-operator observational RSS lifetimes.
     pub operator_rss: Vec<OperatorRssSnapshot>,
     /// Number of query cancellation signals.
@@ -413,6 +433,7 @@ pub(crate) fn record_plan_completion(
         plan: &Arc<dyn ExecutionPlan>,
         sorts: &mut Vec<SortSnapshot>,
         joins: &mut Vec<JoinSnapshot>,
+        property_overlays: &mut Vec<PropertyOverlaySnapshot>,
     ) {
         if plan.downcast_ref::<SortExec>().is_some() {
             let metrics = plan.metrics().unwrap_or_default();
@@ -446,8 +467,18 @@ pub(crate) fn record_plan_completion(
                 build_memory_bytes: metric(&metrics, "build_mem_used"),
             });
         }
+        if plan.name() == "PropertyOverlayExec" {
+            let metrics = plan.metrics().unwrap_or_default();
+            property_overlays.push(PropertyOverlaySnapshot {
+                ordinal: property_overlays.len(),
+                spill_bytes: metric(&metrics, "property_spill_bytes"),
+                authentication_bytes: metric(&metrics, "property_authentication_bytes"),
+                physical_rows: metric(&metrics, "property_physical_rows"),
+                decoder_peak_bytes: metric(&metrics, "property_decoder_peak_bytes"),
+            });
+        }
         for child in plan.children() {
-            visit(child, sorts, joins);
+            visit(child, sorts, joins, property_overlays);
         }
     }
 
@@ -463,7 +494,8 @@ pub(crate) fn record_plan_completion(
 
     let mut sorts = Vec::new();
     let mut joins = Vec::new();
-    visit(plan, &mut sorts, &mut joins);
+    let mut property_overlays = Vec::new();
+    visit(plan, &mut sorts, &mut joins, &mut property_overlays);
     let completion_rss = current_rss_bytes();
     let mut state = CAPTURE
         .lock()
@@ -485,6 +517,7 @@ pub(crate) fn record_plan_completion(
     state.snapshot.hydration = hydration;
     state.snapshot.sorts = sorts;
     state.snapshot.joins = joins;
+    state.snapshot.property_overlays = property_overlays;
     state.snapshot.memory_reserved_before = memory_reserved_before as u64;
     state.snapshot.memory_reserved_after = memory_reserved_after as u64;
     state.snapshot.returned_batch_bytes = returned_batch_bytes as u64;

--- a/crates/graphforge-rel/src/lowerer.rs
+++ b/crates/graphforge-rel/src/lowerer.rs
@@ -2703,8 +2703,20 @@ fn lower_aggregate(
             let mut arg = a.arg.map(|id| lowerer.lower(id)).transpose()?;
             if a.func == AggFunc::Count
                 && arg.is_none()
-                && let Some((qualifier, field)) = input.schema().iter().last()
+                && let Some((qualifier, field)) = input
+                    .schema()
+                    .iter()
+                    .filter(|(_, field)| {
+                        matches!(
+                            field.name().as_str(),
+                            "node_uuid" | "edge_uuid" | "node_id" | "edge_id" | "src_id" | "dst_id"
+                        )
+                    })
+                    .last()
+                    .or_else(|| input.schema().iter().last())
             {
+                // The marker is true even for null OPTIONAL rows. Its value
+                // does not need a property payload when an identity is in scope.
                 let column = DfExpr::Column(datafusion::common::Column::new(
                     qualifier.cloned(),
                     field.name(),

--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -1348,6 +1348,56 @@ SUM and selective-property count remain controls. All measured RSS ceilings
 pass. The prototype is reverted from this assessment; #1249 owns production
 implementation and its direct correctness/CI close gate.
 
+### Qualified row-count marker — #1249
+
+The production marker now selects an existing qualified identity from the
+aggregate input, retaining the scalar-only fallback and true-for-null behavior.
+Explicit nullable counts keep their argument. The earlier prototype observations
+above remain historical; the [final paired evidence](../../development/evidence/count-row-marker-1249.json)
+uses baseline `6907d926` (tree-identical to merged `b9765e8e`) and candidate
+`e8cb7dcb`, frozen before any subprocess measurement.
+
+On the same 4,101-node fixture, count-all warm execution changes from 14.453 to
+10.926 ms, label count from 14.482 to 11.314 ms and empty-label count from
+14.701 to 11.064 ms. Median process CPU falls by 0.03/0.02/0.03 seconds,
+meeting those cases' original 0.02-second thresholds. Each avoids 923,911 syscall
+read bytes and approximately 308.8 KB writes over five queries. Process CPU
+includes facade opening and the oracle; warm timing covers execution only.
+Filesystem input blocks remain 3,328: these are not block-device read savings.
+
+All exact scalar oracles pass, and six of seven original RSS ceilings pass.
+The explicit identity-count control reaches 70,184 KiB against its unchanged
+69,952 KiB ceiling. That observation remains **failed**. A fixed eight-pair,
+alternating diagnostic crosses the same ceiling on the unchanged baseline
+three times and candidate once. Executed plans and work are identical for this
+control; sampled residence is dominated by executable mappings. This supports
+retaining the targeted improvement with a disclosed control-budget limitation,
+not claiming all ceilings pass, proving RSS equivalence, or conclusively
+attributing the original unsampled peak. No threshold or failed result is
+replaced by the diagnostic.
+
+The 129-row deterministic public regression writes 16,184 logical spill bytes
+for row counting versus 50,465 for nullable property counting, avoiding at least
+the 29,952 unrequested payload bytes. Both authenticate 8,850 bytes and validate
+129 physical rows. Logical decoder peaks are 38 versus 624 bytes; these are
+reader admission estimates, not process RSS. Completed diagnostic counters are
+reported per physical-plan occurrence and are not additive shared-plan totals.
+
+Exact UUIDs, nullable scores and payload hashes survive public construction,
+SET with an active old stream, immediate queries, reopen, export/full verification,
+clean import, subsequent REMOVE and another reopen. A property-file modification
+after facade admission returns structured `GF_PROJECT_CORRUPT` for demanded-route
+counts, including an empty-result predicate. Unknown labels return exact non-null
+zero without opening an unrelated payload, preserving the existing demand
+contract. The nullable-count and typed-error repairs in #1251/#1253, mandatory-key
+and late-decoder refusal tests remain in force.
+
+The permanent and whole-fixture physical inventories are unchanged. Descriptor
+samples include unlinked open files and globally deduplicate overlapping owners;
+both variants have a sampled whole-fixture maximum of 5,447,680 bytes. Individual
+samples and their scheduling gaps are not hard bounds. This repair changes no
+publishing, replay, compaction or permanent-format policy.
+
 The fragmentation test fixes topology cardinality at 4,101 live nodes across
 chain lengths; it repeatedly overwrites the same score and removes/restores an
 actually present nullable property. It asserts the verified run count rather

--- a/docs/development/evidence/count-row-marker-1249.json
+++ b/docs/development/evidence/count-row-marker-1249.json
@@ -11,11 +11,12 @@
     "profile": "release optimized, no coverage instrumentation",
     "cargo_lock_sha256": "d80355162144c38a02b5df9787cc1d81e7a0299dc385bde1f342d0bdb06e4ba1",
     "frozen_at_utc": "2026-09-11T08:08:44.495704+00:00",
-    "pending_merge_pr": 1254,
-    "measurement_state": "ready; exact source tree matches merged main; no measurement has run",
     "cache_invalidation": "cargo clean --profile release -p graphforge-api -p graphforge-exec -p graphforge-rel -p graphforge-ir -p graphforge-storage",
     "integrated_main": "b9765e8e1b3441503f07f8ac389892a1e7518406",
-    "merged_tree_equal": true
+    "merged_tree_equal": true,
+    "freeze_time_measurement_state": "ready; exact source tree matches merged main; no measurement has run",
+    "baseline_pr": 1254,
+    "measurement_state": "Completed paired measurements recorded below; freeze-time status is retained separately."
   },
   "candidate": {
     "source": "e8cb7dcb5d3f65e207df3edca72d7f2e7611d7a8",

--- a/docs/development/evidence/count-row-marker-1249.json
+++ b/docs/development/evidence/count-row-marker-1249.json
@@ -1,0 +1,12577 @@
+{
+  "issue": 1249,
+  "decision": "Accept identity anchoring for COUNT(*) with deterministic avoided property materialization and measured CPU/I/O gains in affected queries. Preserve the explicit identity control RSS cap failure and bounded residency diagnosis; do not claim all resource ceilings passed.",
+  "baseline": {
+    "source": "6907d9269188d19bf55804480afa86d2600bbd49",
+    "source_tree": "4e30782922febaab8c88be25e8324eda7c683c3e",
+    "executable": "/tmp/gf1249-statistics-baseline-bin",
+    "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+    "compiler_artifact": "/home/ubuntu/code/graphforge-target-1195/release/deps/permanent_storage_budgets-f7f9bbeb16a733b5",
+    "build_command": "TMPDIR=/home/ubuntu/graphforge-native-tmp-1195 CARGO_TARGET_DIR=/home/ubuntu/code/graphforge-target-1195 CARGO_BUILD_JOBS=4 cargo test --locked --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
+    "profile": "release optimized, no coverage instrumentation",
+    "cargo_lock_sha256": "d80355162144c38a02b5df9787cc1d81e7a0299dc385bde1f342d0bdb06e4ba1",
+    "frozen_at_utc": "2026-09-11T08:08:44.495704+00:00",
+    "pending_merge_pr": 1254,
+    "measurement_state": "ready; exact source tree matches merged main; no measurement has run",
+    "cache_invalidation": "cargo clean --profile release -p graphforge-api -p graphforge-exec -p graphforge-rel -p graphforge-ir -p graphforge-storage",
+    "integrated_main": "b9765e8e1b3441503f07f8ac389892a1e7518406",
+    "merged_tree_equal": true
+  },
+  "candidate": {
+    "source": "e8cb7dcb5d3f65e207df3edca72d7f2e7611d7a8",
+    "source_tree": "c1b3dc5fd319acb73565218bab87bd739f6a196c",
+    "executable": "/tmp/gf1249-statistics-candidate-bin",
+    "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+    "compiler_artifact": "/home/ubuntu/code/graphforge-target-1195/release/deps/permanent_storage_budgets-f7f9bbeb16a733b5",
+    "build_command": "TMPDIR=/home/ubuntu/graphforge-native-tmp-1195 CARGO_TARGET_DIR=/home/ubuntu/code/graphforge-target-1195 CARGO_BUILD_JOBS=4 cargo test --locked --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
+    "profile": "release optimized, no coverage instrumentation",
+    "cargo_lock_sha256": "d80355162144c38a02b5df9787cc1d81e7a0299dc385bde1f342d0bdb06e4ba1",
+    "frozen_at_utc": "2026-09-11T08:33:37.904534+00:00",
+    "cache_invalidation": "cargo clean --profile release -p graphforge-api -p graphforge-exec -p graphforge-rel -p graphforge-ir -p graphforge-storage"
+  },
+  "environment": {
+    "cpu": "AMD Ryzen 7 3800X, 16 logical CPUs",
+    "filesystem": "native ext4 /dev/md3 at process root, OVHC-AGENCY",
+    "rustc": "rustc 1.96.0 (ac68faa20 2026-05-25)",
+    "measurements": "No overlapping builds/tests. Frozen executables verified before/after. Three fresh processes per query, five execute-only samples, rotating case order; separate strace and descriptor-sampling runs."
+  },
+  "fixture": {
+    "path": "/home/ubuntu/graphforge-native-tmp-1195/gf1207-fragment-integrated-32",
+    "live_nodes": 4101,
+    "state": "Identical retained public-construction fixture from #1207, after compaction and explicit cleanup. oracle.json supplies independent exact UUID/label/nullable-score values. No durable file changed during the full comparison.",
+    "allocation_before": {
+      "source": {
+        "files": [
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/checkpoint.json",
+            "device": 2307,
+            "inode": 20344374,
+            "bytes": 10178,
+            "allocated_bytes": 12288,
+            "sha256": "a605c0cd50ab2c86f2cc2501b053b93c84181ece5d293498bd80873e77b04903",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20341881,
+            "bytes": 11343,
+            "allocated_bytes": 12288,
+            "sha256": "e3aa6efead5e8bce6f3cdc32d8a67e1f763617c2700db51dafad56e6c8512c51",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000001.parquet",
+            "device": 2307,
+            "inode": 20341885,
+            "bytes": 11548,
+            "allocated_bytes": 12288,
+            "sha256": "c3b419c9a1a713c5de9b75395e779ed7b3addc067380db6d0c2facd887611b42",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000002.parquet",
+            "device": 2307,
+            "inode": 20341886,
+            "bytes": 11629,
+            "allocated_bytes": 12288,
+            "sha256": "ea014b2b2803df6ca7872b767a19b9363d1bc9cf20967debbd9e8768e8c87d0f",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000003.parquet",
+            "device": 2307,
+            "inode": 20341888,
+            "bytes": 11339,
+            "allocated_bytes": 12288,
+            "sha256": "47b38adf23b203e58401e5ad0daa35194d62c4396b5ef8f542a999d5052f48a4",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000004.parquet",
+            "device": 2307,
+            "inode": 20341890,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "fd0b2013a7a356bb012ee3cbe23745073340a24b1ffe217103313820ddb3f856",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/semantic-routes.json",
+            "device": 2307,
+            "inode": 20342071,
+            "bytes": 173,
+            "allocated_bytes": 4096,
+            "sha256": "cb76eac12be5c052279f30e18f4d9e01e31dc6386c2d2678af9716b2b3186089",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/generation.json",
+            "device": 2307,
+            "inode": 20342070,
+            "bytes": 72,
+            "allocated_bytes": 4096,
+            "sha256": "83628bb4c0ac01773986d43b0bda4eaba2769c8330ca13757e5cde14a2289fae",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000000001-00000000000000001024.parquet",
+            "device": 2307,
+            "inode": 20341132,
+            "bytes": 21659,
+            "allocated_bytes": 24576,
+            "sha256": "94c0da4b221cc0735d685d6549cad01001e4e4aa795355391a135f6f07ac8b2d",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000001025-00000000000000002048.parquet",
+            "device": 2307,
+            "inode": 20341640,
+            "bytes": 21297,
+            "allocated_bytes": 24576,
+            "sha256": "ba6ff4ed453a2b3b0053a108944235f965ad7980694dacc3a1fc455a827e553c",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000002049-00000000000000003072.parquet",
+            "device": 2307,
+            "inode": 20341664,
+            "bytes": 21305,
+            "allocated_bytes": 24576,
+            "sha256": "681bea5f3af29b4cce5e82cb1782833b839fcab4d9f5fdc957a635f99a2f2def",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000003073-00000000000000004096.parquet",
+            "device": 2307,
+            "inode": 20341667,
+            "bytes": 21297,
+            "allocated_bytes": 24576,
+            "sha256": "c12bc155a3bda71953d16ffb936f77882be64d41614be3cc1b781ad408824f7a",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000004097-00000000000000004097.parquet",
+            "device": 2307,
+            "inode": 20341671,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "bf4761364f49453df22885b6552de5603d723300e5c0c6a4e8cb2e56b0eb272d",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/runtime_catalog.parquet",
+            "device": 2307,
+            "inode": 20340130,
+            "bytes": 2427,
+            "allocated_bytes": 4096,
+            "sha256": "b54ff73b637ba263fdf90d9372bba1b418f00667af00a0e5d347d5b9fb2a7efc",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/runtime_entity_label_encoding.json",
+            "device": 2307,
+            "inode": 20339908,
+            "bytes": 74,
+            "allocated_bytes": 4096,
+            "sha256": "a688960f0b7533d9b63091e0f3508bb309a31e01e5d849c2db2cd276e52c98bd",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/surrogate_tails.parquet",
+            "device": 2307,
+            "inode": 20342069,
+            "bytes": 812,
+            "allocated_bytes": 4096,
+            "sha256": "c903125bd7bc00c7ed372414b61ab339284f971a7b256de958b1b7a82f77198d",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/forward-v4-1-397fe6668042ca86.uuidx",
+            "device": 2307,
+            "inode": 20340350,
+            "bytes": 98328,
+            "allocated_bytes": 102400,
+            "sha256": "397fe6668042ca86f2bdea1ee6d56ec5275a440a8e61acb336869fed67e18a10",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/identities-v5-1-5f10c0faae23ecb0.uuidx",
+            "device": 2307,
+            "inode": 20340496,
+            "bytes": 102425,
+            "allocated_bytes": 106496,
+            "sha256": "5f10c0faae23ecb058e1008193beda76bdff849914a3d012a141107b654388d1",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/identities-v5-base-0-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20340544,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/manifest.json",
+            "device": 2307,
+            "inode": 20340887,
+            "bytes": 1436,
+            "allocated_bytes": 4096,
+            "sha256": "6a716bf40392cc96863eff972c0937b82b1e9ac2aee19ec48f8fa3335710d379",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/node-surrogates-v5-1-8246fb253b7adf63.uuidx",
+            "device": 2307,
+            "inode": 20340537,
+            "bytes": 98328,
+            "allocated_bytes": 102400,
+            "sha256": "8246fb253b7adf6313c7ff893b76908a09aaa3c9564b3f7e65ac25d06928af3d",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/node-surrogates-v5-base-0-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20340684,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/ordinal-v4-1-22814aa50d977547.uuidx",
+            "device": 2307,
+            "inode": 20340924,
+            "bytes": 65552,
+            "allocated_bytes": 69632,
+            "sha256": "22814aa50d977547982c0eaec854f8f739b0bd73f505d7e591a45d5925102f76",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/ordinal-v4-manifest.json",
+            "device": 2307,
+            "inode": 20342059,
+            "bytes": 932,
+            "allocated_bytes": 4096,
+            "sha256": "2058f8b86a238085b4a57be10d7c47454b364a2b29fc92252bdd31de6e939e64",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/ordinal-v4-receipt.json",
+            "device": 2307,
+            "inode": 20342057,
+            "bytes": 244,
+            "allocated_bytes": 4096,
+            "sha256": "152a1e0dbb705a75ad5ae580b076a8c68e3d6184e789d8cdfd2fb639561f31b2",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/ordinal-v4.lock",
+            "device": 2307,
+            "inode": 20342061,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/tombstones-v4-1-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20341856,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/inventory.json",
+            "device": 2307,
+            "inode": 20342075,
+            "bytes": 6057,
+            "allocated_bytes": 8192,
+            "sha256": "b1aea5af3f28471b5d850f10221503b9fe121bfdea52347f88beac796cf4911e",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-1f520e03912dcc0852eb390d584e1265b387db1270646fed89b0071e1c43d43c.json",
+            "device": 2307,
+            "inode": 20340113,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "9fb4bd4742f261ed8f23ef034c2e5d2087f86fbf61cdf05d331d543cbe290085",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-23973f7603084e0f04952225034ddf4badf604772a4112475e73d7df2013129f.json",
+            "device": 2307,
+            "inode": 20340346,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "726a945c6dbd4390395699965511fd0bfb4725b6ea6a907d0414ed84841db049",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-26bf24b4977e74ea612314a1a1b85d8880baa7bae6004a9508b2283b576fde45.json",
+            "device": 2307,
+            "inode": 20340538,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "50b5f2344d1892f7f8bd24101fc559ded42fc4813bfbecad7c92e3ee33c7f641",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-45774cee6a5db105f6b3b9dca7d2bcf14588cd7fffd05f1fd4d9a33220e24ba8.json",
+            "device": 2307,
+            "inode": 20341136,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "050c0a31eb72e5c77be4281d0a470313f3d3bc81a5b790373d65b80d841f9b2b",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-fc826cd8f5cf5fe047109fa549398074f5c7701fcba94ee3c992cffd90579050.json",
+            "device": 2307,
+            "inode": 20340919,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "30284f56aa0a111acc4be6577fc03e598f73f58553a1a00ac4257e82ff031b55",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/publication-intent.json",
+            "device": 2307,
+            "inode": 20344372,
+            "bytes": 726,
+            "allocated_bytes": 4096,
+            "sha256": "34883e9820eff37263313c0f6c578f7d9b73c332c3338369ca5d3780e6c10259",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/publication-receipt.json",
+            "device": 2307,
+            "inode": 20344397,
+            "bytes": 539,
+            "allocated_bytes": 4096,
+            "sha256": "af0a06109139fd4775f51851bd290ef48d56bb9a5f229129c28be4ffa47c9912",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000000.json",
+            "device": 2307,
+            "inode": 20339919,
+            "bytes": 1572,
+            "allocated_bytes": 4096,
+            "sha256": "3eb2df3411d95f4daa800fff4a00745a5b9bc27a08d6720f309c6eb2155df2c3",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000001.json",
+            "device": 2307,
+            "inode": 20340301,
+            "bytes": 1634,
+            "allocated_bytes": 4096,
+            "sha256": "988f86c3d101afc3b860ccf2d52d866f2d1ab2d0cca90d2b1ec5fab3faa94402",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000002.json",
+            "device": 2307,
+            "inode": 20340511,
+            "bytes": 1634,
+            "allocated_bytes": 4096,
+            "sha256": "504b2157174c046dd19d580aa4d4620ffdd09127969702b720435072aa2f9a18",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000003.json",
+            "device": 2307,
+            "inode": 20340702,
+            "bytes": 1634,
+            "allocated_bytes": 4096,
+            "sha256": "80699ebb71980aea380af542eab2f1f8f6aa3369aab90ac9197fc63ba17d848d",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000004.json",
+            "device": 2307,
+            "inode": 20340944,
+            "bytes": 1616,
+            "allocated_bytes": 4096,
+            "sha256": "a8b9f54c578293ee8f30f1ffa85cf23a3671729875a6d0d712d68c550d0ecd36",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/session.lock",
+            "device": 2307,
+            "inode": 20339760,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-intent.json",
+            "device": 2307,
+            "inode": 20341633,
+            "bytes": 25196,
+            "allocated_bytes": 28672,
+            "sha256": "2506537cb796763ed4594023ff9c3f484324bec9b424022a0a382d906e54f0df",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-0582ae549021feeb8170785b8067966e.json",
+            "device": 2307,
+            "inode": 20339930,
+            "bytes": 294,
+            "allocated_bytes": 4096,
+            "sha256": "d23f507a945a3c6122d389015601fec1788014da326314d050c2b8d4af315bde",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-06e56feec7b90e5992caa8b6b18506d3.json",
+            "device": 2307,
+            "inode": 20340129,
+            "bytes": 285,
+            "allocated_bytes": 4096,
+            "sha256": "2784bde87be7b8a86ed74f4937d8f71f9e09044a6c891d8a8a40f24bd497f2d6",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-1a5dea59c4f4dd691bceef27c8ba30d8.json",
+            "device": 2307,
+            "inode": 20341176,
+            "bytes": 283,
+            "allocated_bytes": 4096,
+            "sha256": "e9e6058041627bc6eda9cb9b91e5d20aab9ef28de40bee983fdcfd39af8f8ab6",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-22dee4eb4eac9752376baf0a79182c20.json",
+            "device": 2307,
+            "inode": 20341398,
+            "bytes": 332,
+            "allocated_bytes": 4096,
+            "sha256": "a87358b78b3dadd18ccc2b9c4c041d2dbd6dbcc6e8a7fa898b801029be3766a5",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-34b094c4ae427cff4c8466550ff59014.json",
+            "device": 2307,
+            "inode": 20340295,
+            "bytes": 292,
+            "allocated_bytes": 4096,
+            "sha256": "80e0dfc1bb5e6824fad3b7e449f3aa643b64c41734a3738c3ac7ef24dba439d2",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-3bcf68b6c776b2a1dc80b47c72a4ce8e.json",
+            "device": 2307,
+            "inode": 20341663,
+            "bytes": 283,
+            "allocated_bytes": 4096,
+            "sha256": "3f2c972975b8b2c36b0dfcd0c1dab8c5c253169d65634d66777937e7166b0257",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-4526f160eff9921bf99e81e14cabd541.json",
+            "device": 2307,
+            "inode": 20339886,
+            "bytes": 285,
+            "allocated_bytes": 4096,
+            "sha256": "f1f76db3160f19c575f210140e2ebc710f9f7c5c722cbb009418a3bd032d7182",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-550cef78dbba6332ad7b5c0052c076de.json",
+            "device": 2307,
+            "inode": 20340508,
+            "bytes": 292,
+            "allocated_bytes": 4096,
+            "sha256": "7d3e2ddbffb2807418ba022b70eb280859f185916105cd598a43642086c145b7",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-74d65fc2c533071464fb953a2d669721.json",
+            "device": 2307,
+            "inode": 20340304,
+            "bytes": 294,
+            "allocated_bytes": 4096,
+            "sha256": "aed562782ee6f6020cc869dde407a7d589bf60bb8f22a451d279f2f43707f626",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-75f0fdbfac20b9ce58f9f5a5a1cec0a0.json",
+            "device": 2307,
+            "inode": 20340677,
+            "bytes": 285,
+            "allocated_bytes": 4096,
+            "sha256": "f6e8a9b4ef7b7b2d2fec532b7186befee343d75670a929166f2e77afe6a537f5",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-92fe5c16a55461390133e48003d0cbaf.json",
+            "device": 2307,
+            "inode": 20339910,
+            "bytes": 292,
+            "allocated_bytes": 4096,
+            "sha256": "4a75fea2ab6df04d842e6a14b498c15e67365dba948c9403af4ce67a1a21860f",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-96329c6afa5552ec024a83da0c39c643.json",
+            "device": 2307,
+            "inode": 20340686,
+            "bytes": 292,
+            "allocated_bytes": 4096,
+            "sha256": "587d271e0075ec5e55f796fcd556ebe46c85a936160742f3e1f8344d83ce52c5",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-9edcc2b39498006f6560634541be42cb.json",
+            "device": 2307,
+            "inode": 20341382,
+            "bytes": 269,
+            "allocated_bytes": 4096,
+            "sha256": "ff8009ca2cb945110cb5f907d136e2112fcb73cb950808c6b9db03cab9fc14eb",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-ab0fa1e73f5da8ac9b397765522c57fd.json",
+            "device": 2307,
+            "inode": 20340938,
+            "bytes": 288,
+            "allocated_bytes": 4096,
+            "sha256": "f82877ede39c1b58994c835e984377e1401d32359221dc86362113a06add2be1",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-afec27c2d8c9933fc354adcc70b26191.json",
+            "device": 2307,
+            "inode": 20341173,
+            "bytes": 274,
+            "allocated_bytes": 4096,
+            "sha256": "8c911c5ab70cffcf2ca832d01da066bb26cb9d0ae88d1f24b1151e87f78666b6",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-c8c9e054234dc396e89888bbde3f8aa5.json",
+            "device": 2307,
+            "inode": 20340357,
+            "bytes": 285,
+            "allocated_bytes": 4096,
+            "sha256": "14a404b8f70ff2b8e4fb039353c77fd60d02e617980f17bac06a3a4a16e7aa1e",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-cad7dfad7653a1972f7992db735b28a1.json",
+            "device": 2307,
+            "inode": 20341628,
+            "bytes": 332,
+            "allocated_bytes": 4096,
+            "sha256": "602dbacb7a8a9583df08fc093366986dfd4a472a17f5081ce7076ac41534c4ec",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-cb67bc8823be45c4767d1829aa3db842.json",
+            "device": 2307,
+            "inode": 20340930,
+            "bytes": 283,
+            "allocated_bytes": 4096,
+            "sha256": "cefc3ca8dd9cd0c71cf7827713748a480970f9127447aa15aafd4c55de2633e1",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-ddfd039f33d19ebd78e6373a1a588658.json",
+            "device": 2307,
+            "inode": 20341116,
+            "bytes": 290,
+            "allocated_bytes": 4096,
+            "sha256": "69617d5be99ca2dcb43a8203bade534647ce35a2454aede5246d56fa2eb6f0f0",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-df502535b564a9c3a8651193b6e2b73a.json",
+            "device": 2307,
+            "inode": 20340703,
+            "bytes": 294,
+            "allocated_bytes": 4096,
+            "sha256": "2b543f795def62c9409709c22df81814f3d4f60be36cfa71c3cfd140cbce3722",
+            "counted": true
+          },
+          {
+            "path": ".graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-f66b217afa88fdb0996ca24955647fbc.json",
+            "device": 2307,
+            "inode": 20340528,
+            "bytes": 294,
+            "allocated_bytes": 4096,
+            "sha256": "c222cc7bdea835a1184d87cfdf23ea1f7aaad0edb1dc3de3fd5adc90c72c43d4",
+            "counted": true
+          },
+          {
+            "path": "CURRENT",
+            "device": 2307,
+            "inode": 20352034,
+            "bytes": 204,
+            "allocated_bytes": 4096,
+            "sha256": "3a9a37de2cf7b0b8e88b9e82940e9553dead0337ffe2f11a912d1d584ebe2831",
+            "counted": true
+          },
+          {
+            "path": "FORMAT",
+            "device": 2307,
+            "inode": 20339672,
+            "bytes": 22,
+            "allocated_bytes": 4096,
+            "sha256": "cbe5718cb0137d56d649700141781db9bd9294b0adbde5f0b72f48b7d381f543",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352043,
+            "bytes": 11343,
+            "allocated_bytes": 12288,
+            "sha256": "e3aa6efead5e8bce6f3cdc32d8a67e1f763617c2700db51dafad56e6c8512c51",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000001.parquet",
+            "device": 2307,
+            "inode": 20352044,
+            "bytes": 11548,
+            "allocated_bytes": 12288,
+            "sha256": "c3b419c9a1a713c5de9b75395e779ed7b3addc067380db6d0c2facd887611b42",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000002.parquet",
+            "device": 2307,
+            "inode": 20352045,
+            "bytes": 11629,
+            "allocated_bytes": 12288,
+            "sha256": "ea014b2b2803df6ca7872b767a19b9363d1bc9cf20967debbd9e8768e8c87d0f",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000003.parquet",
+            "device": 2307,
+            "inode": 20352046,
+            "bytes": 11339,
+            "allocated_bytes": 12288,
+            "sha256": "47b38adf23b203e58401e5ad0daa35194d62c4396b5ef8f542a999d5052f48a4",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000004.parquet",
+            "device": 2307,
+            "inode": 20352047,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "fd0b2013a7a356bb012ee3cbe23745073340a24b1ffe217103313820ddb3f856",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000002-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352048,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "74db994604515430ab99a6ba696ffe2be7dd9c51e8c7afb3d225655349eecf6e",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000003-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352049,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "68d7737d38cd43f2cdc53b17f3cbc7beb5fe3bc3c83174fefcb6714fb22d4875",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000004-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352050,
+            "bytes": 1542,
+            "allocated_bytes": 4096,
+            "sha256": "78d23d557489b233e69099bd2b441b8be78de15db0f8fefa9e817b734cdeefe1",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000005-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352051,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "e970d17d3288a5b0c53d783be4c395152a271d4fcfa6a06c7266bff5585572ce",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000006-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352052,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "20c6c051a17e00581c0e9b4ec58bb10d44cf14d881c933011d4371f4eb94bb67",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000007-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352053,
+            "bytes": 1542,
+            "allocated_bytes": 4096,
+            "sha256": "9f21ab523c0a6fc246e1e2f468d5416a01fc058e1520073dd547a12ab3229bbe",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000008-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352054,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "2a8f50d19945fee6bda6e83739f75ed1134f2de020da9c4cae76cabea86c8095",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000009-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352055,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "c3097540f7fa95331c76b750768865ec2904dda6f9d50ff6ddddb6b229168428",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000010-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352056,
+            "bytes": 1542,
+            "allocated_bytes": 4096,
+            "sha256": "633a3eaa1a4f28d3a0e7b785aeaa04dddfe7139ab86818e374f11aa0589561c9",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000011-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352057,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "c6ea4dfd8d54f49ba33d1fbef2b474bb090b131693d8b3fb12984d3fa7256077",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000012-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352058,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "a999c141c1a405a288d2fadf0db0dcacd039f44eb3316ae01e52ab591ede7d2d",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000013-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352059,
+            "bytes": 1542,
+            "allocated_bytes": 4096,
+            "sha256": "1de9ab6b213bd2df5b1bce8496c7db80e94454d8298cd327e87ef707656b219c",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000014-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352060,
+            "bytes": 1595,
+            "allocated_bytes": 4096,
+            "sha256": "2c640c4cdd7050f7ce7369014f40bedb9d58bfef56a33f2c756c0a7187e88bf2",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/semantic-routes.json",
+            "device": 2307,
+            "inode": 20352061,
+            "bytes": 173,
+            "allocated_bytes": 4096,
+            "sha256": "cb76eac12be5c052279f30e18f4d9e01e31dc6386c2d2678af9716b2b3186089",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/generation.json",
+            "device": 2307,
+            "inode": 20465444,
+            "bytes": 74,
+            "allocated_bytes": 4096,
+            "sha256": "34384edd3ca020bce4eeb8d6295c3895ce3e8b5852743f9e76572a801b5cc534",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000000001-00000000000000001024.parquet",
+            "device": 2307,
+            "inode": 20465447,
+            "bytes": 21659,
+            "allocated_bytes": 24576,
+            "sha256": "94c0da4b221cc0735d685d6549cad01001e4e4aa795355391a135f6f07ac8b2d",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000001025-00000000000000002048.parquet",
+            "device": 2307,
+            "inode": 20465448,
+            "bytes": 21297,
+            "allocated_bytes": 24576,
+            "sha256": "ba6ff4ed453a2b3b0053a108944235f965ad7980694dacc3a1fc455a827e553c",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000002049-00000000000000003072.parquet",
+            "device": 2307,
+            "inode": 20465449,
+            "bytes": 21305,
+            "allocated_bytes": 24576,
+            "sha256": "681bea5f3af29b4cce5e82cb1782833b839fcab4d9f5fdc957a635f99a2f2def",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000003073-00000000000000004096.parquet",
+            "device": 2307,
+            "inode": 20465450,
+            "bytes": 21297,
+            "allocated_bytes": 24576,
+            "sha256": "c12bc155a3bda71953d16ffb936f77882be64d41614be3cc1b781ad408824f7a",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004097-00000000000000004097.parquet",
+            "device": 2307,
+            "inode": 20465451,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "bf4761364f49453df22885b6552de5603d723300e5c0c6a4e8cb2e56b0eb272d",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004098-00000000000000004098.parquet",
+            "device": 2307,
+            "inode": 20465452,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "964418238ebdfa2db4bab340e51ca2e29786133b15fcec0522cd6121e31b2792",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004099-00000000000000004099.parquet",
+            "device": 2307,
+            "inode": 20465453,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004100-00000000000000004100.parquet",
+            "device": 2307,
+            "inode": 20465454,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "948a21b66530783fa00ccd04ae165e76418db268d73fcfb0d8116f0a8a28bd8f",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004101-00000000000000004101.parquet",
+            "device": 2307,
+            "inode": 20465455,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004102-00000000000000004102.parquet",
+            "device": 2307,
+            "inode": 20465456,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "acbb80055184c49155c7df727248ad680bb0ecaeb53c79f24151e45e50217f5e",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004103-00000000000000004103.parquet",
+            "device": 2307,
+            "inode": 20465457,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004104-00000000000000004104.parquet",
+            "device": 2307,
+            "inode": 20465458,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "ed6b69985da7529dbf13438edc91e56a11266b71a35506e0d0e3c0ec60718a70",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004105-00000000000000004105.parquet",
+            "device": 2307,
+            "inode": 20465459,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes.parquet",
+            "device": 2307,
+            "inode": 20465445,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/runtime_catalog.parquet",
+            "device": 2307,
+            "inode": 20465460,
+            "bytes": 2503,
+            "allocated_bytes": 4096,
+            "sha256": "d99f3dc07d8968cb8dbf60c2312eed8b407ad68e09a0d5f48a01f1da93a8b0dd",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/runtime_entity_label_encoding.json",
+            "device": 2307,
+            "inode": 20465461,
+            "bytes": 74,
+            "allocated_bytes": 4096,
+            "sha256": "a688960f0b7533d9b63091e0f3508bb309a31e01e5d849c2db2cd276e52c98bd",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/surrogate_tails.parquet",
+            "device": 2307,
+            "inode": 20465462,
+            "bytes": 812,
+            "allocated_bytes": 4096,
+            "sha256": "81661b950f96dd86c8da7f5dd431d3a1dead6af44de7a02be8a4b6d06c768176",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-1-397fe6668042ca86.uuidx",
+            "device": 2307,
+            "inode": 20465464,
+            "bytes": 98328,
+            "allocated_bytes": 102400,
+            "sha256": "397fe6668042ca86f2bdea1ee6d56ec5275a440a8e61acb336869fed67e18a10",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-10-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465465,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-11-28a70f15e2fb350f.uuidx",
+            "device": 2307,
+            "inode": 20465466,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "28a70f15e2fb350f2459b683c3b7c6a81bb00574ff56efe669152c31f3fc8889",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-12-c3fcc2a4dbf2633c.uuidx",
+            "device": 2307,
+            "inode": 20465467,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "c3fcc2a4dbf2633c3a895dd6b509c6aa35ae2c54ed84d76f7b29360d77001c3e",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-13-c08b42c022ee5618.uuidx",
+            "device": 2307,
+            "inode": 20465468,
+            "bytes": 48,
+            "allocated_bytes": 4096,
+            "sha256": "c08b42c022ee561806132e091fe30cebdbf03ef1ae86177df337505eb05d1d4c",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-2-c81d1767e9ac1bc1.uuidx",
+            "device": 2307,
+            "inode": 20465469,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "c81d1767e9ac1bc1c84d754bb1cc7a5001c7cfed842f436c8da014c43eafd9a0",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-3-e2b019f7f3c05aba.uuidx",
+            "device": 2307,
+            "inode": 20465470,
+            "bytes": 48,
+            "allocated_bytes": 4096,
+            "sha256": "e2b019f7f3c05aba57d6a9d25c715a4e68b1028d628d1ab9768270770a5b6c18",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-4-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465471,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-5-63503baa305bd954.uuidx",
+            "device": 2307,
+            "inode": 20465472,
+            "bytes": 72,
+            "allocated_bytes": 4096,
+            "sha256": "63503baa305bd954a69872b85d23d0e370d7e60d9bbbd536821e1a3e5afd20ca",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-6-8ec1cee05d6eee90.uuidx",
+            "device": 2307,
+            "inode": 20465473,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "8ec1cee05d6eee9079d94baae683edf8a862372d18fa501182316f68eb9eb865",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-7-8ec1cee05d6eee90.uuidx",
+            "device": 2307,
+            "inode": 20465474,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "8ec1cee05d6eee9079d94baae683edf8a862372d18fa501182316f68eb9eb865",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-8-8fd2ae3b246bd8a7.uuidx",
+            "device": 2307,
+            "inode": 20465475,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "8fd2ae3b246bd8a7d8d9f1c1d7e274463123141478bcef6e55f42303f47c8cba",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-9-2c152ac6e460a08b.uuidx",
+            "device": 2307,
+            "inode": 20465476,
+            "bytes": 144,
+            "allocated_bytes": 4096,
+            "sha256": "2c152ac6e460a08bdb3e53695b9c7d9a27f4386ec77da3d32485d87b8a55fa07",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-1-5f10c0faae23ecb0.uuidx",
+            "device": 2307,
+            "inode": 20465477,
+            "bytes": 102425,
+            "allocated_bytes": 106496,
+            "sha256": "5f10c0faae23ecb058e1008193beda76bdff849914a3d012a141107b654388d1",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-11-21a195b39020a2e3.uuidx",
+            "device": 2307,
+            "inode": 20465478,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "21a195b39020a2e3f2061074d6cfbe1939b25fbcc16e5ce77a0931e181d47fd6",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-13-a94e2bea96c9dc6f.uuidx",
+            "device": 2307,
+            "inode": 20465479,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "a94e2bea96c9dc6f05341f76bb8dd125aa0e986ee07e2746d0d981c52603326f",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-3-3de7593c7bf75f5a.uuidx",
+            "device": 2307,
+            "inode": 20465480,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "3de7593c7bf75f5a64db5ffe5c7d89c0c2eb0af572bd1a6e977856af75b15c33",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-5-1863a7425d22fabc.uuidx",
+            "device": 2307,
+            "inode": 20465481,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "1863a7425d22fabca6426dcdcd7944cdf00406ecb7dbe71f5e81481d71fe02f5",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-7-8b611501c971ec86.uuidx",
+            "device": 2307,
+            "inode": 20465482,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "8b611501c971ec863962a52718641233a06cf07e5f0823b62e25afca8f00efc6",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-9-e3c11e78a2789c0d.uuidx",
+            "device": 2307,
+            "inode": 20465483,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "e3c11e78a2789c0dc45dde890b4370213ace2a4d5ebca753cece4cfeb45877a9",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-base-0-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465484,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l1-10-db6cd59d172e4681.uuidx",
+            "device": 2307,
+            "inode": 20465485,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "db6cd59d172e46811827a7dc721bee4916f42fccc592998a877d99638d06b41e",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l1-2-7ff59ad781fb62e7.uuidx",
+            "device": 2307,
+            "inode": 20465486,
+            "bytes": 102450,
+            "allocated_bytes": 106496,
+            "sha256": "7ff59ad781fb62e733e0541b8081135cfc565571c91b3cbb60dea5f4d6e65c6e",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l1-6-e7aea08b7954b524.uuidx",
+            "device": 2307,
+            "inode": 20465487,
+            "bytes": 50,
+            "allocated_bytes": 4096,
+            "sha256": "e7aea08b7954b52461538e6654c221da92b8b46c36c028b7cba38c196cc93cc8",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l2-12-a34c9afabfbf5b93.uuidx",
+            "device": 2307,
+            "inode": 20465488,
+            "bytes": 75,
+            "allocated_bytes": 4096,
+            "sha256": "a34c9afabfbf5b9318a5a69b4ee7e9d3d7ae4fb200844f0af6accb1b8deb00ff",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l2-4-5603bf3fa0e5432b.uuidx",
+            "device": 2307,
+            "inode": 20465489,
+            "bytes": 102475,
+            "allocated_bytes": 106496,
+            "sha256": "5603bf3fa0e5432bbfc3a736e581e64d70f0dcb5599f3c695f3a7a063b644df4",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l3-8-4ffd4b38c408f5c6.uuidx",
+            "device": 2307,
+            "inode": 20465490,
+            "bytes": 102550,
+            "allocated_bytes": 106496,
+            "sha256": "4ffd4b38c408f5c6b4a5a6e750e0aee18ae0d92522d51be0b80ac2f5fbda3a1d",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/manifest.json",
+            "device": 2307,
+            "inode": 20465491,
+            "bytes": 3100,
+            "allocated_bytes": 4096,
+            "sha256": "35fc6a0e4faf24cef0139b6383b37a2018e56049379df3fc48aca42c39946f06",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-1-8246fb253b7adf63.uuidx",
+            "device": 2307,
+            "inode": 20465492,
+            "bytes": 98328,
+            "allocated_bytes": 102400,
+            "sha256": "8246fb253b7adf6313c7ff893b76908a09aaa3c9564b3f7e65ac25d06928af3d",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-11-d80da74f86524853.uuidx",
+            "device": 2307,
+            "inode": 20465493,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "d80da74f865248532650203e5a43fbb50c3de452f0e8d013e3c5a213a39c2352",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-13-a03568028b1a7bf9.uuidx",
+            "device": 2307,
+            "inode": 20465494,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "a03568028b1a7bf91272d8d38d8a663b41d95bc504aaeddc0a101a36e56e6736",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-3-a1529c8482428e56.uuidx",
+            "device": 2307,
+            "inode": 20465495,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "a1529c8482428e56422886d55fbbac90a43c503097e915c0274cd66a4d8b79fb",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-5-6a711f04f0393aae.uuidx",
+            "device": 2307,
+            "inode": 20465496,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "6a711f04f0393aaefb7d464ee00956ab1f618f956eb88377c5a3e6fbb882abdf",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-7-9c1205ac96be25f3.uuidx",
+            "device": 2307,
+            "inode": 20465497,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "9c1205ac96be25f3439e4df7f5c5800a4bc44653bea2fa043a06014632da2dd8",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-9-c5b0ac201d6103f1.uuidx",
+            "device": 2307,
+            "inode": 20465498,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "c5b0ac201d6103f1084e58ff8626080f6bcee72b433e0404cb1864179df8dd74",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-base-0-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465499,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l1-10-c5b0ac201d6103f1.uuidx",
+            "device": 2307,
+            "inode": 20465500,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "c5b0ac201d6103f1084e58ff8626080f6bcee72b433e0404cb1864179df8dd74",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l1-2-657b2eac6e328463.uuidx",
+            "device": 2307,
+            "inode": 20465501,
+            "bytes": 98352,
+            "allocated_bytes": 102400,
+            "sha256": "657b2eac6e328463fe41874d57a43a48005cfdba47f03d1bb15f94141042f327",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l1-6-4f2873619a456595.uuidx",
+            "device": 2307,
+            "inode": 20465502,
+            "bytes": 48,
+            "allocated_bytes": 4096,
+            "sha256": "4f2873619a4565957f31d01231b7c4e855141ced145dc783c675ac055a3cc560",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l2-12-fa38ae8e5d02b612.uuidx",
+            "device": 2307,
+            "inode": 20465503,
+            "bytes": 72,
+            "allocated_bytes": 4096,
+            "sha256": "fa38ae8e5d02b6127898d1aa0821fac9261d1f1fbb8c428b0617f81f02db393e",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l2-4-6da7b45f02766f4d.uuidx",
+            "device": 2307,
+            "inode": 20465504,
+            "bytes": 98376,
+            "allocated_bytes": 102400,
+            "sha256": "6da7b45f02766f4d87e6739547bd7d69dce23be8a25df142d5845e047851b4b9",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l3-8-4a66bd3bc4523caa.uuidx",
+            "device": 2307,
+            "inode": 20465505,
+            "bytes": 98448,
+            "allocated_bytes": 102400,
+            "sha256": "4a66bd3bc4523caaada802e17dfaa08a9d4f906c011337ae3dc6d0f8deeda25a",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-1-22814aa50d977547.uuidx",
+            "device": 2307,
+            "inode": 20465506,
+            "bytes": 65552,
+            "allocated_bytes": 69632,
+            "sha256": "22814aa50d977547982c0eaec854f8f739b0bd73f505d7e591a45d5925102f76",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-11-3db8a63d75c37fe1.uuidx",
+            "device": 2307,
+            "inode": 20465507,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "3db8a63d75c37fe1da88fdb1e4f83282fc6b427b0bc8161312438b7a6c981619",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-12-73f1c3516c383e54.uuidx",
+            "device": 2307,
+            "inode": 20465508,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "73f1c3516c383e54d081ce830a1a37f70e02fd7347324908cd82a4d334acea1c",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-13-7efa11f3991babcf.uuidx",
+            "device": 2307,
+            "inode": 20465509,
+            "bytes": 32,
+            "allocated_bytes": 4096,
+            "sha256": "7efa11f3991babcf1651fcf04ef4e23d4318f7847aba86fa557b7a800d953d34",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-2-6806674c9d93cd96.uuidx",
+            "device": 2307,
+            "inode": 20465510,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "6806674c9d93cd965eb1f6af50b5c44baaf91265ebcb7dbfffd55ae01a6527d7",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-3-3b692e9d1527917b.uuidx",
+            "device": 2307,
+            "inode": 20465511,
+            "bytes": 32,
+            "allocated_bytes": 4096,
+            "sha256": "3b692e9d1527917b8ed078f103abb6319043272327626249ac433d6a88e26121",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-5-28c91ec4fa116a41.uuidx",
+            "device": 2307,
+            "inode": 20465512,
+            "bytes": 48,
+            "allocated_bytes": 4096,
+            "sha256": "28c91ec4fa116a41ca899971ad23a682cc290e16580bf794677543f365c0833e",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-6-544527a876801bd1.uuidx",
+            "device": 2307,
+            "inode": 20465513,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "544527a876801bd15c89de20568729465c1c84a4e4c565351bb0516a91997212",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-8-44e3e301a9ca8da9.uuidx",
+            "device": 2307,
+            "inode": 20465514,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "44e3e301a9ca8da9105ba1bac1e831577953079c17fc2ac29ae46bf6128bce20",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-9-70045d3d9ecdb570.uuidx",
+            "device": 2307,
+            "inode": 20465515,
+            "bytes": 96,
+            "allocated_bytes": 4096,
+            "sha256": "70045d3d9ecdb57046c5ee2df09c61d617bb6ecc2018f4db469832ed3612eb24",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-manifest.json",
+            "device": 2307,
+            "inode": 20465516,
+            "bytes": 2627,
+            "allocated_bytes": 4096,
+            "sha256": "e4e06a8897f7d4ac567ebf6deecaac3970a17e6c4a1ee0a62862872b6699458b",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-receipt.json",
+            "device": 2307,
+            "inode": 20465517,
+            "bytes": 245,
+            "allocated_bytes": 4096,
+            "sha256": "e326c69a4346cbfbed604c1e631c3a9db43c2ccaa1b06423107039aa7c1a9425",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4.lock",
+            "device": 2307,
+            "inode": 20465518,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-1-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465519,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-10-ef8ea8462befe7a2.uuidx",
+            "device": 2307,
+            "inode": 20465520,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "ef8ea8462befe7a2524ea5968b2e21bba7f7f1842f03a9e96ab77d7ad3686463",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-11-ef8ea8462befe7a2.uuidx",
+            "device": 2307,
+            "inode": 20465521,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "ef8ea8462befe7a2524ea5968b2e21bba7f7f1842f03a9e96ab77d7ad3686463",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-12-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465522,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-13-c310d91ad246a5e5.uuidx",
+            "device": 2307,
+            "inode": 20465523,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "c310d91ad246a5e5f6dda9269da2301121a04a08df1fbe3a37949265d0de6f20",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-2-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465524,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-3-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465525,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-4-51a3e3668b39ce77.uuidx",
+            "device": 2307,
+            "inode": 20465526,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "51a3e3668b39ce77997c0c5758b57651a1744fb7a15af4da271b9274e5ef8bc9",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-5-51a3e3668b39ce77.uuidx",
+            "device": 2307,
+            "inode": 20465527,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "51a3e3668b39ce77997c0c5758b57651a1744fb7a15af4da271b9274e5ef8bc9",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-6-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465528,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-7-506a3574a2dd275f.uuidx",
+            "device": 2307,
+            "inode": 20465529,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "506a3574a2dd275f6d4eda0520080ed990d79840c604ae74708fd7d988db04de",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-8-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465530,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-9-73dafc8bc573abde.uuidx",
+            "device": 2307,
+            "inode": 20465531,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "73dafc8bc573abde8d95f1e37a229713530fc3483e16ebe86e6b4f16b7f6d7d7",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/topology-receipt.json",
+            "device": 2307,
+            "inode": 20465532,
+            "bytes": 245,
+            "allocated_bytes": 4096,
+            "sha256": "813528a16f1835176d1d43bce4ab3af8094779f36d6167f04f7b5b4a136d34c3",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/lease.lock",
+            "device": 2307,
+            "inode": 20352062,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/manifest.json",
+            "device": 2307,
+            "inode": 20352063,
+            "bytes": 1467,
+            "allocated_bytes": 4096,
+            "sha256": "68d188b1b720447ccf4acd68ed21000ba4c89f4241e2302e57b5162879c466b5",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/participants/graph/files.json",
+            "device": 2307,
+            "inode": 20352036,
+            "bytes": 22696,
+            "allocated_bytes": 24576,
+            "sha256": "dae8aaadb3522d68fa1e8175ab26ab5ec2e480369308b788db25535b517e5d80",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/participants/workspace/configuration.json",
+            "device": 2307,
+            "inode": 20352038,
+            "bytes": 105,
+            "allocated_bytes": 4096,
+            "sha256": "5bf75875f9e3215c3f9036f0492c9c9a7209d3a62abf22d42136614f35137b34",
+            "counted": true
+          },
+          {
+            "path": "generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/participants/workspace/ontology.json",
+            "device": 2307,
+            "inode": 20352039,
+            "bytes": 117,
+            "allocated_bytes": 4096,
+            "sha256": "a21dd016f4ba02eca7cc43737d341d99fec00bcb5fb082e2a9877aaa4f27b824",
+            "counted": true
+          },
+          {
+            "path": "graph-objects/lifecycle.lock",
+            "device": 2307,
+            "inode": 20341386,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "locks/checkpoints.lock",
+            "device": 2307,
+            "inode": 20334156,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "locks/writer.lock",
+            "device": 2307,
+            "inode": 20344378,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6268-78c2-b7e0-a2fdd006577e.json",
+            "device": 2307,
+            "inode": 20344384,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "0bfa2fffa934d40376d208fd3f10a6c230d26f430d44b81394e842ac2fcd6303",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-62b7-70a0-84bb-ff9d8af02c64.json",
+            "device": 2307,
+            "inode": 20344428,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "91fead9cd092df3a9175a0c61ca86072dacb7b3a6623f7127e27a56a2f817527",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6323-7561-b306-da263c3d8ad3.json",
+            "device": 2307,
+            "inode": 20344427,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "2c6f897accbc70a2b2f7b49b25c1b09941454d0ace090704b750dd317440535e",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6374-7bf2-9e96-171159ba3d6e.json",
+            "device": 2307,
+            "inode": 20344535,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "fae59484f039e0e97f1573a1dc236bf4c74707066a012efb114a6c866f582a7d",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-63c7-7963-bc64-306e3364a5d2.json",
+            "device": 2307,
+            "inode": 20344620,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "967bd625ff691a5dd890d1bdd64fc443536f48c1a76f7fd498fc0f48982d46f4",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-643d-7971-b1e3-00628e9fce3d.json",
+            "device": 2307,
+            "inode": 20344754,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "3179128a0407a389c6ec25b0d9ff8274b348eb06fbddc9bc9638276279405bb3",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-649c-71c0-90da-45410ba3cb6e.json",
+            "device": 2307,
+            "inode": 20344879,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "2aacd3c83bbeeb007ec92ddd4cdbbee589400bcc8986cdc951b8940b75a9015c",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6503-7211-b753-f90248ceead8.json",
+            "device": 2307,
+            "inode": 20345013,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "ae0f17c44ce97d4e15e2c47782d5033272058d34c17f89dbc2ef7bb25a415e74",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-658c-7e52-b24d-00f6e3d26664.json",
+            "device": 2307,
+            "inode": 20345137,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "434183d198c6903bd36ce97b955a3464dc4b6f9f7c962e1455a66169d50d9527",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-65fa-7b82-8713-1c7cb85c4078.json",
+            "device": 2307,
+            "inode": 20345270,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "ec90b687a2b8721b9032a9edb1b4e34843689e18dcd75cce1b6238f63e0ba082",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-666e-73f2-ab95-ffdd2bf54309.json",
+            "device": 2307,
+            "inode": 20345435,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "1529dddd7d992cc538883cc51e9b4aeceec66ec4963ef25d348d9129b6ea14ee",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-670f-7592-a8c2-0561505bed8d.json",
+            "device": 2307,
+            "inode": 20345583,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "58dc26e69a2d123e313a45fc1d695e8e2db38c1321e38fe9469d864e80cdb851",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6770-7703-a7cf-26dec4261448.json",
+            "device": 2307,
+            "inode": 20345763,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "f5f9f0f9698841173bee05b801618335668129dec6524e15b4199b5340e4de93",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-68a5-7052-939c-aa7aa605ead6.json",
+            "device": 2307,
+            "inode": 20346154,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "8d63abfa94dc3d1516a07d90cebbd9e690e8a302b940cb5200ec373e54a395b4",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-69ce-7813-a151-39e9d9b09ab9.json",
+            "device": 2307,
+            "inode": 20346161,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "99c75aba70fedece49249e3814130acde8362b3f89c43c34f222fa202f9c0448",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6afe-77e3-8fad-e4d678938990.json",
+            "device": 2307,
+            "inode": 20346166,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "1a7356ebefd48dc8a21b05d576c3c345adb997dcb8126207abc7e2e7a0751593",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6c34-7e63-8355-5c64dd316e67.json",
+            "device": 2307,
+            "inode": 20346172,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "2019202890d687cb551aa08a1563803d67f0528f8586c80dc826100f6b660be4",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6d69-7992-8421-041ba4eaec65.json",
+            "device": 2307,
+            "inode": 20346178,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "7f8c180bb18966ca5080e89c585a5dfb3e1a1333440de2c03565a0418078d68d",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6e9c-7aa1-854a-127f0d70dda2.json",
+            "device": 2307,
+            "inode": 20346185,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "a43a9547b1c90b21a3ec1053994ef145784a74c534bad62f069d94dd122d5d4b",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-6fd7-7ee3-bd9a-2a3833968c38.json",
+            "device": 2307,
+            "inode": 20346193,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "ee2ea0782144482a047a809bd7bcb040f126ffd7404bebb8e6c92135e85abcc1",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-7119-7093-9833-8be389828e9f.json",
+            "device": 2307,
+            "inode": 20346198,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "0fa90af5d390e07dfc9fac9c8bfdc8a37466e19ace8226edf34678c91ec49363",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-7279-7c33-aaad-7ef15c8381b4.json",
+            "device": 2307,
+            "inode": 20346203,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "041e0f181952e406397be9e908b7413b5a70f09d6279f242862c7bd051368e77",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-73cc-7332-b577-cf149ec448d9.json",
+            "device": 2307,
+            "inode": 20346208,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "9de1eef61278a35a15fc4cd48de53420823818c36907f127ae323ceafb052fe6",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-7525-7d93-a7a0-5549c0276409.json",
+            "device": 2307,
+            "inode": 20346213,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "812c043c830c93bd5f365c9aaab8cc9420fe8c660953e74e579192356dae3941",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-7679-7d00-afff-796ab66c11f0.json",
+            "device": 2307,
+            "inode": 20346219,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "b00cc44a2cf86e8cd658ed86b80faa11ab3fecb90086ed26dba66c86e732bbff",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-77d8-76a1-ae57-d071f47e685f.json",
+            "device": 2307,
+            "inode": 20346224,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "7f3f07f73f187d330a76040b50012b5de7acf053a045ad421c59e25f07db7a44",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-792e-7a90-8ebc-dc29996d710e.json",
+            "device": 2307,
+            "inode": 20346230,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "fd0fc0051de64ac0d548db52c282d6e1ba595ad83d5edb0484ff485bc0b0dc3c",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-7a92-7773-a261-3c78569e0a40.json",
+            "device": 2307,
+            "inode": 20346235,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "9a332ff5961ec95078fa529b596f09aeaed56c151b900a5ab26215234eda215a",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-7bf6-71a1-a553-019dc468d38f.json",
+            "device": 2307,
+            "inode": 20346242,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "e6bccc2f7203637f826dd7e648ad774f41f71f1b42fefcd6028cc2cf451e896e",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-7d65-72b1-9a9a-f62cadeba000.json",
+            "device": 2307,
+            "inode": 20346396,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "b748f9ce4a27f21543ed9405a2d2d28f2e14b5827053bdbbd8b9c20ff4f7a326",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-7ec5-7a30-ac38-eb6c2791987c.json",
+            "device": 2307,
+            "inode": 20346571,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "7ac82b77b5ba1fe3e242bfdb6ab7c1768d374da1dadd7839c04f59e5490e56da",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-801f-7fd0-b2ae-903bc5423ece.json",
+            "device": 2307,
+            "inode": 20346741,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "04aafd78a6a925ee17534446df1cad62c1dd60e9c0bd2eefe3007d65f55e46bb",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-8171-79a2-8e1f-e1a41f81c3ed.json",
+            "device": 2307,
+            "inode": 20346900,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "18e8f261c36936c16c8522eb8310a4b25c196bc9c3a407f7e94b9b9bff1b8dec",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-82d5-7a90-8826-32037ed348d2.json",
+            "device": 2307,
+            "inode": 20347065,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "4b3e59113da6effd002a7c2581d015a3bfe747b602e40a3056119356a78a2278",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-8430-7dd1-a2b7-5c497ad8aea3.json",
+            "device": 2307,
+            "inode": 20347209,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "b684d4ec53962b12f1358a5959beea0e25b15910c0e2ec5a2212f7a77ac37b1e",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-8597-7142-979b-4096e7dcf58c.json",
+            "device": 2307,
+            "inode": 20347356,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "fa98cf20927e94e0be450fffd45cdf09f8f4c291662b97b225225a48456afe22",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-86f9-7932-a7bb-7de10c1f7125.json",
+            "device": 2307,
+            "inode": 20347530,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "359979cb002afa15183792bba77fb5a7f9fcd1db73f2675f94f51400d346170e",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-8866-70e3-b5d4-8709745887db.json",
+            "device": 2307,
+            "inode": 20347724,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "f409f1929939e59056e9a42c6f029e3dedfded76b012c5bd761133e7196b27d0",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-89d7-76e2-8590-a729c35abddb.json",
+            "device": 2307,
+            "inode": 20347908,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "e7476b2794d66d29208117f4f5b9b67de7f58c5585f5ed816f7805914b3a7cd0",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-8b74-79d2-b8d6-37a464e5a9a0.json",
+            "device": 2307,
+            "inode": 20348075,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "0940bfe533b9a6f51eea05f790a4235e2604603c06c222fabec3e819154f945d",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-8cf5-7a01-8cdb-5b0a2d2713dc.json",
+            "device": 2307,
+            "inode": 20348234,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "378342c145b14ca2269e90d7b44c76288a3b66a9efe67aa2e5bbb436aabdac5b",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-8e86-7003-bf35-57094793d777.json",
+            "device": 2307,
+            "inode": 20348383,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "bb9a97bd6272aac9e2f65edab34ff88c4bf2c334ba19392179ced1a8991326df",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-9004-7e90-9103-ab3a35baf452.json",
+            "device": 2307,
+            "inode": 20348535,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "4127eb27b2af3e569dbd64d07ac2cbd0772573a8775beb52208fb3f75550ab06",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08ecd-917d-7c43-8088-0162bb90ddb7.json",
+            "device": 2307,
+            "inode": 20348688,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "7d4a03445da2ea39466f7a6aa04ff9560ec9141aeafc19e14be5f1a4e9e269f7",
+            "counted": true
+          },
+          {
+            "path": "transactions/01a08eda-3c3a-77e0-98d1-1a828c9a840a.json",
+            "device": 2307,
+            "inode": 20348838,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "2d12799f6b259c0d0eb4b5bca2c81c969bfef64c4eb63336ab14214722647b8d",
+            "counted": true
+          },
+          {
+            "path": "transactions/0c72f52a-fc65-8b7c-862f-06387e1b0884.json",
+            "device": 2307,
+            "inode": 20339693,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "80a683503f0e5dcb6ec09df80f72d652599ed07c6caa5cb4d13802838deededb",
+            "counted": true
+          }
+        ],
+        "allocated_bytes": 2457600,
+        "scope": "Regular files only; globally device/inode deduplicated. Separate source and fixture totals overlap and must not be added."
+      },
+      "whole_fixture": {
+        "files": [
+          {
+            "path": ".graphforge-admission-967b06c2cf96269818ae77a0b19b06ad3f8605b4e7f75627a64a736544f56091.lock",
+            "device": 2307,
+            "inode": 20335218,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": ".tmpCrdwNi/property-overlay-DfhFpv/run-0.jsonl",
+            "device": 2307,
+            "inode": 20447276,
+            "bytes": 320029,
+            "allocated_bytes": 323584,
+            "sha256": "555f9475ffb071dc7c479b6e739e67fa05fa60fe242802e0588611a28ed7f180",
+            "counted": true
+          },
+          {
+            "path": ".tmpmIP2Ss/property-overlay-76T1rD/run-0.jsonl",
+            "device": 2307,
+            "inode": 20447387,
+            "bytes": 320029,
+            "allocated_bytes": 323584,
+            "sha256": "555f9475ffb071dc7c479b6e739e67fa05fa60fe242802e0588611a28ed7f180",
+            "counted": true
+          },
+          {
+            "path": ".tmpywb4Tx/property-overlay-5eJXay/run-0.jsonl",
+            "device": 2307,
+            "inode": 20447369,
+            "bytes": 320029,
+            "allocated_bytes": 323584,
+            "sha256": "555f9475ffb071dc7c479b6e739e67fa05fa60fe242802e0588611a28ed7f180",
+            "counted": true
+          },
+          {
+            "path": "oracle.json",
+            "device": 2307,
+            "inode": 20346144,
+            "bytes": 221392,
+            "allocated_bytes": 225280,
+            "sha256": "b4dab4ab968a0f9777595a11519316f652e780dfb61d76b732f9fc049e4d94fc",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/checkpoint.json",
+            "device": 2307,
+            "inode": 20344374,
+            "bytes": 10178,
+            "allocated_bytes": 12288,
+            "sha256": "a605c0cd50ab2c86f2cc2501b053b93c84181ece5d293498bd80873e77b04903",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20341881,
+            "bytes": 11343,
+            "allocated_bytes": 12288,
+            "sha256": "e3aa6efead5e8bce6f3cdc32d8a67e1f763617c2700db51dafad56e6c8512c51",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000001.parquet",
+            "device": 2307,
+            "inode": 20341885,
+            "bytes": 11548,
+            "allocated_bytes": 12288,
+            "sha256": "c3b419c9a1a713c5de9b75395e779ed7b3addc067380db6d0c2facd887611b42",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000002.parquet",
+            "device": 2307,
+            "inode": 20341886,
+            "bytes": 11629,
+            "allocated_bytes": 12288,
+            "sha256": "ea014b2b2803df6ca7872b767a19b9363d1bc9cf20967debbd9e8768e8c87d0f",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000003.parquet",
+            "device": 2307,
+            "inode": 20341888,
+            "bytes": 11339,
+            "allocated_bytes": 12288,
+            "sha256": "47b38adf23b203e58401e5ad0daa35194d62c4396b5ef8f542a999d5052f48a4",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000004.parquet",
+            "device": 2307,
+            "inode": 20341890,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "fd0b2013a7a356bb012ee3cbe23745073340a24b1ffe217103313820ddb3f856",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/semantic-routes.json",
+            "device": 2307,
+            "inode": 20342071,
+            "bytes": 173,
+            "allocated_bytes": 4096,
+            "sha256": "cb76eac12be5c052279f30e18f4d9e01e31dc6386c2d2678af9716b2b3186089",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/generation.json",
+            "device": 2307,
+            "inode": 20342070,
+            "bytes": 72,
+            "allocated_bytes": 4096,
+            "sha256": "83628bb4c0ac01773986d43b0bda4eaba2769c8330ca13757e5cde14a2289fae",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000000001-00000000000000001024.parquet",
+            "device": 2307,
+            "inode": 20341132,
+            "bytes": 21659,
+            "allocated_bytes": 24576,
+            "sha256": "94c0da4b221cc0735d685d6549cad01001e4e4aa795355391a135f6f07ac8b2d",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000001025-00000000000000002048.parquet",
+            "device": 2307,
+            "inode": 20341640,
+            "bytes": 21297,
+            "allocated_bytes": 24576,
+            "sha256": "ba6ff4ed453a2b3b0053a108944235f965ad7980694dacc3a1fc455a827e553c",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000002049-00000000000000003072.parquet",
+            "device": 2307,
+            "inode": 20341664,
+            "bytes": 21305,
+            "allocated_bytes": 24576,
+            "sha256": "681bea5f3af29b4cce5e82cb1782833b839fcab4d9f5fdc957a635f99a2f2def",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000003073-00000000000000004096.parquet",
+            "device": 2307,
+            "inode": 20341667,
+            "bytes": 21297,
+            "allocated_bytes": 24576,
+            "sha256": "c12bc155a3bda71953d16ffb936f77882be64d41614be3cc1b781ad408824f7a",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/nodes/00000000000000004097-00000000000000004097.parquet",
+            "device": 2307,
+            "inode": 20341671,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "bf4761364f49453df22885b6552de5603d723300e5c0c6a4e8cb2e56b0eb272d",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/runtime_catalog.parquet",
+            "device": 2307,
+            "inode": 20340130,
+            "bytes": 2427,
+            "allocated_bytes": 4096,
+            "sha256": "b54ff73b637ba263fdf90d9372bba1b418f00667af00a0e5d347d5b9fb2a7efc",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/runtime_entity_label_encoding.json",
+            "device": 2307,
+            "inode": 20339908,
+            "bytes": 74,
+            "allocated_bytes": 4096,
+            "sha256": "a688960f0b7533d9b63091e0f3508bb309a31e01e5d849c2db2cd276e52c98bd",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/surrogate_tails.parquet",
+            "device": 2307,
+            "inode": 20342069,
+            "bytes": 812,
+            "allocated_bytes": 4096,
+            "sha256": "c903125bd7bc00c7ed372414b61ab339284f971a7b256de958b1b7a82f77198d",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/forward-v4-1-397fe6668042ca86.uuidx",
+            "device": 2307,
+            "inode": 20340350,
+            "bytes": 98328,
+            "allocated_bytes": 102400,
+            "sha256": "397fe6668042ca86f2bdea1ee6d56ec5275a440a8e61acb336869fed67e18a10",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/identities-v5-1-5f10c0faae23ecb0.uuidx",
+            "device": 2307,
+            "inode": 20340496,
+            "bytes": 102425,
+            "allocated_bytes": 106496,
+            "sha256": "5f10c0faae23ecb058e1008193beda76bdff849914a3d012a141107b654388d1",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/identities-v5-base-0-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20340544,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/manifest.json",
+            "device": 2307,
+            "inode": 20340887,
+            "bytes": 1436,
+            "allocated_bytes": 4096,
+            "sha256": "6a716bf40392cc96863eff972c0937b82b1e9ac2aee19ec48f8fa3335710d379",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/node-surrogates-v5-1-8246fb253b7adf63.uuidx",
+            "device": 2307,
+            "inode": 20340537,
+            "bytes": 98328,
+            "allocated_bytes": 102400,
+            "sha256": "8246fb253b7adf6313c7ff893b76908a09aaa3c9564b3f7e65ac25d06928af3d",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/node-surrogates-v5-base-0-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20340684,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/ordinal-v4-1-22814aa50d977547.uuidx",
+            "device": 2307,
+            "inode": 20340924,
+            "bytes": 65552,
+            "allocated_bytes": 69632,
+            "sha256": "22814aa50d977547982c0eaec854f8f739b0bd73f505d7e591a45d5925102f76",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/ordinal-v4-manifest.json",
+            "device": 2307,
+            "inode": 20342059,
+            "bytes": 932,
+            "allocated_bytes": 4096,
+            "sha256": "2058f8b86a238085b4a57be10d7c47454b364a2b29fc92252bdd31de6e939e64",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/ordinal-v4-receipt.json",
+            "device": 2307,
+            "inode": 20342057,
+            "bytes": 244,
+            "allocated_bytes": 4096,
+            "sha256": "152a1e0dbb705a75ad5ae580b076a8c68e3d6184e789d8cdfd2fb639561f31b2",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/ordinal-v4.lock",
+            "device": 2307,
+            "inode": 20342061,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/graph/topology/uuid-membership/tombstones-v4-1-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20341856,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/encoded-v1/inventory.json",
+            "device": 2307,
+            "inode": 20342075,
+            "bytes": 6057,
+            "allocated_bytes": 8192,
+            "sha256": "b1aea5af3f28471b5d850f10221503b9fe121bfdea52347f88beac796cf4911e",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-1f520e03912dcc0852eb390d584e1265b387db1270646fed89b0071e1c43d43c.json",
+            "device": 2307,
+            "inode": 20340113,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "9fb4bd4742f261ed8f23ef034c2e5d2087f86fbf61cdf05d331d543cbe290085",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-23973f7603084e0f04952225034ddf4badf604772a4112475e73d7df2013129f.json",
+            "device": 2307,
+            "inode": 20340346,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "726a945c6dbd4390395699965511fd0bfb4725b6ea6a907d0414ed84841db049",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-26bf24b4977e74ea612314a1a1b85d8880baa7bae6004a9508b2283b576fde45.json",
+            "device": 2307,
+            "inode": 20340538,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "50b5f2344d1892f7f8bd24101fc559ded42fc4813bfbecad7c92e3ee33c7f641",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-45774cee6a5db105f6b3b9dca7d2bcf14588cd7fffd05f1fd4d9a33220e24ba8.json",
+            "device": 2307,
+            "inode": 20341136,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "050c0a31eb72e5c77be4281d0a470313f3d3bc81a5b790373d65b80d841f9b2b",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/key-fc826cd8f5cf5fe047109fa549398074f5c7701fcba94ee3c992cffd90579050.json",
+            "device": 2307,
+            "inode": 20340919,
+            "bytes": 328,
+            "allocated_bytes": 4096,
+            "sha256": "30284f56aa0a111acc4be6577fc03e598f73f58553a1a00ac4257e82ff031b55",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/publication-intent.json",
+            "device": 2307,
+            "inode": 20344372,
+            "bytes": 726,
+            "allocated_bytes": 4096,
+            "sha256": "34883e9820eff37263313c0f6c578f7d9b73c332c3338369ca5d3780e6c10259",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/publication-receipt.json",
+            "device": 2307,
+            "inode": 20344397,
+            "bytes": 539,
+            "allocated_bytes": 4096,
+            "sha256": "af0a06109139fd4775f51851bd290ef48d56bb9a5f229129c28be4ffa47c9912",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000000.json",
+            "device": 2307,
+            "inode": 20339919,
+            "bytes": 1572,
+            "allocated_bytes": 4096,
+            "sha256": "3eb2df3411d95f4daa800fff4a00745a5b9bc27a08d6720f309c6eb2155df2c3",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000001.json",
+            "device": 2307,
+            "inode": 20340301,
+            "bytes": 1634,
+            "allocated_bytes": 4096,
+            "sha256": "988f86c3d101afc3b860ccf2d52d866f2d1ab2d0cca90d2b1ec5fab3faa94402",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000002.json",
+            "device": 2307,
+            "inode": 20340511,
+            "bytes": 1634,
+            "allocated_bytes": 4096,
+            "sha256": "504b2157174c046dd19d580aa4d4620ffdd09127969702b720435072aa2f9a18",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000003.json",
+            "device": 2307,
+            "inode": 20340702,
+            "bytes": 1634,
+            "allocated_bytes": 4096,
+            "sha256": "80699ebb71980aea380af542eab2f1f8f6aa3369aab90ac9197fc63ba17d848d",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/receipt-00000000000000000004.json",
+            "device": 2307,
+            "inode": 20340944,
+            "bytes": 1616,
+            "allocated_bytes": 4096,
+            "sha256": "a8b9f54c578293ee8f30f1ffa85cf23a3671729875a6d0d712d68c550d0ecd36",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/session.lock",
+            "device": 2307,
+            "inode": 20339760,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-intent.json",
+            "device": 2307,
+            "inode": 20341633,
+            "bytes": 25196,
+            "allocated_bytes": 28672,
+            "sha256": "2506537cb796763ed4594023ff9c3f484324bec9b424022a0a382d906e54f0df",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-0582ae549021feeb8170785b8067966e.json",
+            "device": 2307,
+            "inode": 20339930,
+            "bytes": 294,
+            "allocated_bytes": 4096,
+            "sha256": "d23f507a945a3c6122d389015601fec1788014da326314d050c2b8d4af315bde",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-06e56feec7b90e5992caa8b6b18506d3.json",
+            "device": 2307,
+            "inode": 20340129,
+            "bytes": 285,
+            "allocated_bytes": 4096,
+            "sha256": "2784bde87be7b8a86ed74f4937d8f71f9e09044a6c891d8a8a40f24bd497f2d6",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-1a5dea59c4f4dd691bceef27c8ba30d8.json",
+            "device": 2307,
+            "inode": 20341176,
+            "bytes": 283,
+            "allocated_bytes": 4096,
+            "sha256": "e9e6058041627bc6eda9cb9b91e5d20aab9ef28de40bee983fdcfd39af8f8ab6",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-22dee4eb4eac9752376baf0a79182c20.json",
+            "device": 2307,
+            "inode": 20341398,
+            "bytes": 332,
+            "allocated_bytes": 4096,
+            "sha256": "a87358b78b3dadd18ccc2b9c4c041d2dbd6dbcc6e8a7fa898b801029be3766a5",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-34b094c4ae427cff4c8466550ff59014.json",
+            "device": 2307,
+            "inode": 20340295,
+            "bytes": 292,
+            "allocated_bytes": 4096,
+            "sha256": "80e0dfc1bb5e6824fad3b7e449f3aa643b64c41734a3738c3ac7ef24dba439d2",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-3bcf68b6c776b2a1dc80b47c72a4ce8e.json",
+            "device": 2307,
+            "inode": 20341663,
+            "bytes": 283,
+            "allocated_bytes": 4096,
+            "sha256": "3f2c972975b8b2c36b0dfcd0c1dab8c5c253169d65634d66777937e7166b0257",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-4526f160eff9921bf99e81e14cabd541.json",
+            "device": 2307,
+            "inode": 20339886,
+            "bytes": 285,
+            "allocated_bytes": 4096,
+            "sha256": "f1f76db3160f19c575f210140e2ebc710f9f7c5c722cbb009418a3bd032d7182",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-550cef78dbba6332ad7b5c0052c076de.json",
+            "device": 2307,
+            "inode": 20340508,
+            "bytes": 292,
+            "allocated_bytes": 4096,
+            "sha256": "7d3e2ddbffb2807418ba022b70eb280859f185916105cd598a43642086c145b7",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-74d65fc2c533071464fb953a2d669721.json",
+            "device": 2307,
+            "inode": 20340304,
+            "bytes": 294,
+            "allocated_bytes": 4096,
+            "sha256": "aed562782ee6f6020cc869dde407a7d589bf60bb8f22a451d279f2f43707f626",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-75f0fdbfac20b9ce58f9f5a5a1cec0a0.json",
+            "device": 2307,
+            "inode": 20340677,
+            "bytes": 285,
+            "allocated_bytes": 4096,
+            "sha256": "f6e8a9b4ef7b7b2d2fec532b7186befee343d75670a929166f2e77afe6a537f5",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-92fe5c16a55461390133e48003d0cbaf.json",
+            "device": 2307,
+            "inode": 20339910,
+            "bytes": 292,
+            "allocated_bytes": 4096,
+            "sha256": "4a75fea2ab6df04d842e6a14b498c15e67365dba948c9403af4ce67a1a21860f",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-96329c6afa5552ec024a83da0c39c643.json",
+            "device": 2307,
+            "inode": 20340686,
+            "bytes": 292,
+            "allocated_bytes": 4096,
+            "sha256": "587d271e0075ec5e55f796fcd556ebe46c85a936160742f3e1f8344d83ce52c5",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-9edcc2b39498006f6560634541be42cb.json",
+            "device": 2307,
+            "inode": 20341382,
+            "bytes": 269,
+            "allocated_bytes": 4096,
+            "sha256": "ff8009ca2cb945110cb5f907d136e2112fcb73cb950808c6b9db03cab9fc14eb",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-ab0fa1e73f5da8ac9b397765522c57fd.json",
+            "device": 2307,
+            "inode": 20340938,
+            "bytes": 288,
+            "allocated_bytes": 4096,
+            "sha256": "f82877ede39c1b58994c835e984377e1401d32359221dc86362113a06add2be1",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-afec27c2d8c9933fc354adcc70b26191.json",
+            "device": 2307,
+            "inode": 20341173,
+            "bytes": 274,
+            "allocated_bytes": 4096,
+            "sha256": "8c911c5ab70cffcf2ca832d01da066bb26cb9d0ae88d1f24b1151e87f78666b6",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-c8c9e054234dc396e89888bbde3f8aa5.json",
+            "device": 2307,
+            "inode": 20340357,
+            "bytes": 285,
+            "allocated_bytes": 4096,
+            "sha256": "14a404b8f70ff2b8e4fb039353c77fd60d02e617980f17bac06a3a4a16e7aa1e",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-cad7dfad7653a1972f7992db735b28a1.json",
+            "device": 2307,
+            "inode": 20341628,
+            "bytes": 332,
+            "allocated_bytes": 4096,
+            "sha256": "602dbacb7a8a9583df08fc093366986dfd4a472a17f5081ce7076ac41534c4ec",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-cb67bc8823be45c4767d1829aa3db842.json",
+            "device": 2307,
+            "inode": 20340930,
+            "bytes": 283,
+            "allocated_bytes": 4096,
+            "sha256": "cefc3ca8dd9cd0c71cf7827713748a480970f9127447aa15aafd4c55de2633e1",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-ddfd039f33d19ebd78e6373a1a588658.json",
+            "device": 2307,
+            "inode": 20341116,
+            "bytes": 290,
+            "allocated_bytes": 4096,
+            "sha256": "69617d5be99ca2dcb43a8203bade534647ce35a2454aede5246d56fa2eb6f0f0",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-df502535b564a9c3a8651193b6e2b73a.json",
+            "device": 2307,
+            "inode": 20340703,
+            "bytes": 294,
+            "allocated_bytes": 4096,
+            "sha256": "2b543f795def62c9409709c22df81814f3d4f60be36cfa71c3cfd140cbce3722",
+            "counted": true
+          },
+          {
+            "path": "source/.graphforge-construction/01a08ecd61147410897be91b9ba0ed85/shape-receipt-f66b217afa88fdb0996ca24955647fbc.json",
+            "device": 2307,
+            "inode": 20340528,
+            "bytes": 294,
+            "allocated_bytes": 4096,
+            "sha256": "c222cc7bdea835a1184d87cfdf23ea1f7aaad0edb1dc3de3fd5adc90c72c43d4",
+            "counted": true
+          },
+          {
+            "path": "source/CURRENT",
+            "device": 2307,
+            "inode": 20352034,
+            "bytes": 204,
+            "allocated_bytes": 4096,
+            "sha256": "3a9a37de2cf7b0b8e88b9e82940e9553dead0337ffe2f11a912d1d584ebe2831",
+            "counted": true
+          },
+          {
+            "path": "source/FORMAT",
+            "device": 2307,
+            "inode": 20339672,
+            "bytes": 22,
+            "allocated_bytes": 4096,
+            "sha256": "cbe5718cb0137d56d649700141781db9bd9294b0adbde5f0b72f48b7d381f543",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352043,
+            "bytes": 11343,
+            "allocated_bytes": 12288,
+            "sha256": "e3aa6efead5e8bce6f3cdc32d8a67e1f763617c2700db51dafad56e6c8512c51",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000001.parquet",
+            "device": 2307,
+            "inode": 20352044,
+            "bytes": 11548,
+            "allocated_bytes": 12288,
+            "sha256": "c3b419c9a1a713c5de9b75395e779ed7b3addc067380db6d0c2facd887611b42",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000002.parquet",
+            "device": 2307,
+            "inode": 20352045,
+            "bytes": 11629,
+            "allocated_bytes": 12288,
+            "sha256": "ea014b2b2803df6ca7872b767a19b9363d1bc9cf20967debbd9e8768e8c87d0f",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000003.parquet",
+            "device": 2307,
+            "inode": 20352046,
+            "bytes": 11339,
+            "allocated_bytes": 12288,
+            "sha256": "47b38adf23b203e58401e5ad0daa35194d62c4396b5ef8f542a999d5052f48a4",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000001-00000000000000000004.parquet",
+            "device": 2307,
+            "inode": 20352047,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "fd0b2013a7a356bb012ee3cbe23745073340a24b1ffe217103313820ddb3f856",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000002-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352048,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "74db994604515430ab99a6ba696ffe2be7dd9c51e8c7afb3d225655349eecf6e",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000003-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352049,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "68d7737d38cd43f2cdc53b17f3cbc7beb5fe3bc3c83174fefcb6714fb22d4875",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000004-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352050,
+            "bytes": 1542,
+            "allocated_bytes": 4096,
+            "sha256": "78d23d557489b233e69099bd2b441b8be78de15db0f8fefa9e817b734cdeefe1",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000005-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352051,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "e970d17d3288a5b0c53d783be4c395152a271d4fcfa6a06c7266bff5585572ce",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000006-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352052,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "20c6c051a17e00581c0e9b4ec58bb10d44cf14d881c933011d4371f4eb94bb67",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000007-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352053,
+            "bytes": 1542,
+            "allocated_bytes": 4096,
+            "sha256": "9f21ab523c0a6fc246e1e2f468d5416a01fc058e1520073dd547a12ab3229bbe",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000008-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352054,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "2a8f50d19945fee6bda6e83739f75ed1134f2de020da9c4cae76cabea86c8095",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000009-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352055,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "c3097540f7fa95331c76b750768865ec2904dda6f9d50ff6ddddb6b229168428",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000010-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352056,
+            "bytes": 1542,
+            "allocated_bytes": 4096,
+            "sha256": "633a3eaa1a4f28d3a0e7b785aeaa04dddfe7139ab86818e374f11aa0589561c9",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000011-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352057,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "c6ea4dfd8d54f49ba33d1fbef2b474bb090b131693d8b3fb12984d3fa7256077",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000012-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352058,
+            "bytes": 1608,
+            "allocated_bytes": 4096,
+            "sha256": "a999c141c1a405a288d2fadf0db0dcacd039f44eb3316ae01e52ab591ede7d2d",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000013-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352059,
+            "bytes": 1542,
+            "allocated_bytes": 4096,
+            "sha256": "1de9ab6b213bd2df5b1bce8496c7db80e94454d8298cd327e87ef707656b219c",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/properties/r-caf7594a72aef78670c886a56687e31c55908c136dc05830aca6ace2614f9395/00000000000000000014-00000000000000000000.parquet",
+            "device": 2307,
+            "inode": 20352060,
+            "bytes": 1595,
+            "allocated_bytes": 4096,
+            "sha256": "2c640c4cdd7050f7ce7369014f40bedb9d58bfef56a33f2c756c0a7187e88bf2",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/semantic-routes.json",
+            "device": 2307,
+            "inode": 20352061,
+            "bytes": 173,
+            "allocated_bytes": 4096,
+            "sha256": "cb76eac12be5c052279f30e18f4d9e01e31dc6386c2d2678af9716b2b3186089",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/generation.json",
+            "device": 2307,
+            "inode": 20465444,
+            "bytes": 74,
+            "allocated_bytes": 4096,
+            "sha256": "34384edd3ca020bce4eeb8d6295c3895ce3e8b5852743f9e76572a801b5cc534",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000000001-00000000000000001024.parquet",
+            "device": 2307,
+            "inode": 20465447,
+            "bytes": 21659,
+            "allocated_bytes": 24576,
+            "sha256": "94c0da4b221cc0735d685d6549cad01001e4e4aa795355391a135f6f07ac8b2d",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000001025-00000000000000002048.parquet",
+            "device": 2307,
+            "inode": 20465448,
+            "bytes": 21297,
+            "allocated_bytes": 24576,
+            "sha256": "ba6ff4ed453a2b3b0053a108944235f965ad7980694dacc3a1fc455a827e553c",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000002049-00000000000000003072.parquet",
+            "device": 2307,
+            "inode": 20465449,
+            "bytes": 21305,
+            "allocated_bytes": 24576,
+            "sha256": "681bea5f3af29b4cce5e82cb1782833b839fcab4d9f5fdc957a635f99a2f2def",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000003073-00000000000000004096.parquet",
+            "device": 2307,
+            "inode": 20465450,
+            "bytes": 21297,
+            "allocated_bytes": 24576,
+            "sha256": "c12bc155a3bda71953d16ffb936f77882be64d41614be3cc1b781ad408824f7a",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004097-00000000000000004097.parquet",
+            "device": 2307,
+            "inode": 20465451,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "bf4761364f49453df22885b6552de5603d723300e5c0c6a4e8cb2e56b0eb272d",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004098-00000000000000004098.parquet",
+            "device": 2307,
+            "inode": 20465452,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "964418238ebdfa2db4bab340e51ca2e29786133b15fcec0522cd6121e31b2792",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004099-00000000000000004099.parquet",
+            "device": 2307,
+            "inode": 20465453,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004100-00000000000000004100.parquet",
+            "device": 2307,
+            "inode": 20465454,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "948a21b66530783fa00ccd04ae165e76418db268d73fcfb0d8116f0a8a28bd8f",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004101-00000000000000004101.parquet",
+            "device": 2307,
+            "inode": 20465455,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004102-00000000000000004102.parquet",
+            "device": 2307,
+            "inode": 20465456,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "acbb80055184c49155c7df727248ad680bb0ecaeb53c79f24151e45e50217f5e",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004103-00000000000000004103.parquet",
+            "device": 2307,
+            "inode": 20465457,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004104-00000000000000004104.parquet",
+            "device": 2307,
+            "inode": 20465458,
+            "bytes": 2229,
+            "allocated_bytes": 4096,
+            "sha256": "ed6b69985da7529dbf13438edc91e56a11266b71a35506e0d0e3c0ec60718a70",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes/00000000000000004105-00000000000000004105.parquet",
+            "device": 2307,
+            "inode": 20465459,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/nodes.parquet",
+            "device": 2307,
+            "inode": 20465445,
+            "bytes": 1029,
+            "allocated_bytes": 4096,
+            "sha256": "4946d3f301537616c0b9c7a1491f04f08ef6ef4de6f38d91621e3efa0d47c310",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/runtime_catalog.parquet",
+            "device": 2307,
+            "inode": 20465460,
+            "bytes": 2503,
+            "allocated_bytes": 4096,
+            "sha256": "d99f3dc07d8968cb8dbf60c2312eed8b407ad68e09a0d5f48a01f1da93a8b0dd",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/runtime_entity_label_encoding.json",
+            "device": 2307,
+            "inode": 20465461,
+            "bytes": 74,
+            "allocated_bytes": 4096,
+            "sha256": "a688960f0b7533d9b63091e0f3508bb309a31e01e5d849c2db2cd276e52c98bd",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/surrogate_tails.parquet",
+            "device": 2307,
+            "inode": 20465462,
+            "bytes": 812,
+            "allocated_bytes": 4096,
+            "sha256": "81661b950f96dd86c8da7f5dd431d3a1dead6af44de7a02be8a4b6d06c768176",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-1-397fe6668042ca86.uuidx",
+            "device": 2307,
+            "inode": 20465464,
+            "bytes": 98328,
+            "allocated_bytes": 102400,
+            "sha256": "397fe6668042ca86f2bdea1ee6d56ec5275a440a8e61acb336869fed67e18a10",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-10-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465465,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-11-28a70f15e2fb350f.uuidx",
+            "device": 2307,
+            "inode": 20465466,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "28a70f15e2fb350f2459b683c3b7c6a81bb00574ff56efe669152c31f3fc8889",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-12-c3fcc2a4dbf2633c.uuidx",
+            "device": 2307,
+            "inode": 20465467,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "c3fcc2a4dbf2633c3a895dd6b509c6aa35ae2c54ed84d76f7b29360d77001c3e",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-13-c08b42c022ee5618.uuidx",
+            "device": 2307,
+            "inode": 20465468,
+            "bytes": 48,
+            "allocated_bytes": 4096,
+            "sha256": "c08b42c022ee561806132e091fe30cebdbf03ef1ae86177df337505eb05d1d4c",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-2-c81d1767e9ac1bc1.uuidx",
+            "device": 2307,
+            "inode": 20465469,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "c81d1767e9ac1bc1c84d754bb1cc7a5001c7cfed842f436c8da014c43eafd9a0",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-3-e2b019f7f3c05aba.uuidx",
+            "device": 2307,
+            "inode": 20465470,
+            "bytes": 48,
+            "allocated_bytes": 4096,
+            "sha256": "e2b019f7f3c05aba57d6a9d25c715a4e68b1028d628d1ab9768270770a5b6c18",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-4-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465471,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-5-63503baa305bd954.uuidx",
+            "device": 2307,
+            "inode": 20465472,
+            "bytes": 72,
+            "allocated_bytes": 4096,
+            "sha256": "63503baa305bd954a69872b85d23d0e370d7e60d9bbbd536821e1a3e5afd20ca",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-6-8ec1cee05d6eee90.uuidx",
+            "device": 2307,
+            "inode": 20465473,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "8ec1cee05d6eee9079d94baae683edf8a862372d18fa501182316f68eb9eb865",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-7-8ec1cee05d6eee90.uuidx",
+            "device": 2307,
+            "inode": 20465474,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "8ec1cee05d6eee9079d94baae683edf8a862372d18fa501182316f68eb9eb865",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-8-8fd2ae3b246bd8a7.uuidx",
+            "device": 2307,
+            "inode": 20465475,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "8fd2ae3b246bd8a7d8d9f1c1d7e274463123141478bcef6e55f42303f47c8cba",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/forward-v4-9-2c152ac6e460a08b.uuidx",
+            "device": 2307,
+            "inode": 20465476,
+            "bytes": 144,
+            "allocated_bytes": 4096,
+            "sha256": "2c152ac6e460a08bdb3e53695b9c7d9a27f4386ec77da3d32485d87b8a55fa07",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-1-5f10c0faae23ecb0.uuidx",
+            "device": 2307,
+            "inode": 20465477,
+            "bytes": 102425,
+            "allocated_bytes": 106496,
+            "sha256": "5f10c0faae23ecb058e1008193beda76bdff849914a3d012a141107b654388d1",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-11-21a195b39020a2e3.uuidx",
+            "device": 2307,
+            "inode": 20465478,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "21a195b39020a2e3f2061074d6cfbe1939b25fbcc16e5ce77a0931e181d47fd6",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-13-a94e2bea96c9dc6f.uuidx",
+            "device": 2307,
+            "inode": 20465479,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "a94e2bea96c9dc6f05341f76bb8dd125aa0e986ee07e2746d0d981c52603326f",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-3-3de7593c7bf75f5a.uuidx",
+            "device": 2307,
+            "inode": 20465480,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "3de7593c7bf75f5a64db5ffe5c7d89c0c2eb0af572bd1a6e977856af75b15c33",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-5-1863a7425d22fabc.uuidx",
+            "device": 2307,
+            "inode": 20465481,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "1863a7425d22fabca6426dcdcd7944cdf00406ecb7dbe71f5e81481d71fe02f5",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-7-8b611501c971ec86.uuidx",
+            "device": 2307,
+            "inode": 20465482,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "8b611501c971ec863962a52718641233a06cf07e5f0823b62e25afca8f00efc6",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-9-e3c11e78a2789c0d.uuidx",
+            "device": 2307,
+            "inode": 20465483,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "e3c11e78a2789c0dc45dde890b4370213ace2a4d5ebca753cece4cfeb45877a9",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-base-0-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465484,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l1-10-db6cd59d172e4681.uuidx",
+            "device": 2307,
+            "inode": 20465485,
+            "bytes": 25,
+            "allocated_bytes": 4096,
+            "sha256": "db6cd59d172e46811827a7dc721bee4916f42fccc592998a877d99638d06b41e",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l1-2-7ff59ad781fb62e7.uuidx",
+            "device": 2307,
+            "inode": 20465486,
+            "bytes": 102450,
+            "allocated_bytes": 106496,
+            "sha256": "7ff59ad781fb62e733e0541b8081135cfc565571c91b3cbb60dea5f4d6e65c6e",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l1-6-e7aea08b7954b524.uuidx",
+            "device": 2307,
+            "inode": 20465487,
+            "bytes": 50,
+            "allocated_bytes": 4096,
+            "sha256": "e7aea08b7954b52461538e6654c221da92b8b46c36c028b7cba38c196cc93cc8",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l2-12-a34c9afabfbf5b93.uuidx",
+            "device": 2307,
+            "inode": 20465488,
+            "bytes": 75,
+            "allocated_bytes": 4096,
+            "sha256": "a34c9afabfbf5b9318a5a69b4ee7e9d3d7ae4fb200844f0af6accb1b8deb00ff",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l2-4-5603bf3fa0e5432b.uuidx",
+            "device": 2307,
+            "inode": 20465489,
+            "bytes": 102475,
+            "allocated_bytes": 106496,
+            "sha256": "5603bf3fa0e5432bbfc3a736e581e64d70f0dcb5599f3c695f3a7a063b644df4",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/identities-v5-l3-8-4ffd4b38c408f5c6.uuidx",
+            "device": 2307,
+            "inode": 20465490,
+            "bytes": 102550,
+            "allocated_bytes": 106496,
+            "sha256": "4ffd4b38c408f5c6b4a5a6e750e0aee18ae0d92522d51be0b80ac2f5fbda3a1d",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/manifest.json",
+            "device": 2307,
+            "inode": 20465491,
+            "bytes": 3100,
+            "allocated_bytes": 4096,
+            "sha256": "35fc6a0e4faf24cef0139b6383b37a2018e56049379df3fc48aca42c39946f06",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-1-8246fb253b7adf63.uuidx",
+            "device": 2307,
+            "inode": 20465492,
+            "bytes": 98328,
+            "allocated_bytes": 102400,
+            "sha256": "8246fb253b7adf6313c7ff893b76908a09aaa3c9564b3f7e65ac25d06928af3d",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-11-d80da74f86524853.uuidx",
+            "device": 2307,
+            "inode": 20465493,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "d80da74f865248532650203e5a43fbb50c3de452f0e8d013e3c5a213a39c2352",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-13-a03568028b1a7bf9.uuidx",
+            "device": 2307,
+            "inode": 20465494,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "a03568028b1a7bf91272d8d38d8a663b41d95bc504aaeddc0a101a36e56e6736",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-3-a1529c8482428e56.uuidx",
+            "device": 2307,
+            "inode": 20465495,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "a1529c8482428e56422886d55fbbac90a43c503097e915c0274cd66a4d8b79fb",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-5-6a711f04f0393aae.uuidx",
+            "device": 2307,
+            "inode": 20465496,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "6a711f04f0393aaefb7d464ee00956ab1f618f956eb88377c5a3e6fbb882abdf",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-7-9c1205ac96be25f3.uuidx",
+            "device": 2307,
+            "inode": 20465497,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "9c1205ac96be25f3439e4df7f5c5800a4bc44653bea2fa043a06014632da2dd8",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-9-c5b0ac201d6103f1.uuidx",
+            "device": 2307,
+            "inode": 20465498,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "c5b0ac201d6103f1084e58ff8626080f6bcee72b433e0404cb1864179df8dd74",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-base-0-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465499,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l1-10-c5b0ac201d6103f1.uuidx",
+            "device": 2307,
+            "inode": 20465500,
+            "bytes": 24,
+            "allocated_bytes": 4096,
+            "sha256": "c5b0ac201d6103f1084e58ff8626080f6bcee72b433e0404cb1864179df8dd74",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l1-2-657b2eac6e328463.uuidx",
+            "device": 2307,
+            "inode": 20465501,
+            "bytes": 98352,
+            "allocated_bytes": 102400,
+            "sha256": "657b2eac6e328463fe41874d57a43a48005cfdba47f03d1bb15f94141042f327",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l1-6-4f2873619a456595.uuidx",
+            "device": 2307,
+            "inode": 20465502,
+            "bytes": 48,
+            "allocated_bytes": 4096,
+            "sha256": "4f2873619a4565957f31d01231b7c4e855141ced145dc783c675ac055a3cc560",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l2-12-fa38ae8e5d02b612.uuidx",
+            "device": 2307,
+            "inode": 20465503,
+            "bytes": 72,
+            "allocated_bytes": 4096,
+            "sha256": "fa38ae8e5d02b6127898d1aa0821fac9261d1f1fbb8c428b0617f81f02db393e",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l2-4-6da7b45f02766f4d.uuidx",
+            "device": 2307,
+            "inode": 20465504,
+            "bytes": 98376,
+            "allocated_bytes": 102400,
+            "sha256": "6da7b45f02766f4d87e6739547bd7d69dce23be8a25df142d5845e047851b4b9",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/node-surrogates-v5-l3-8-4a66bd3bc4523caa.uuidx",
+            "device": 2307,
+            "inode": 20465505,
+            "bytes": 98448,
+            "allocated_bytes": 102400,
+            "sha256": "4a66bd3bc4523caaada802e17dfaa08a9d4f906c011337ae3dc6d0f8deeda25a",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-1-22814aa50d977547.uuidx",
+            "device": 2307,
+            "inode": 20465506,
+            "bytes": 65552,
+            "allocated_bytes": 69632,
+            "sha256": "22814aa50d977547982c0eaec854f8f739b0bd73f505d7e591a45d5925102f76",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-11-3db8a63d75c37fe1.uuidx",
+            "device": 2307,
+            "inode": 20465507,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "3db8a63d75c37fe1da88fdb1e4f83282fc6b427b0bc8161312438b7a6c981619",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-12-73f1c3516c383e54.uuidx",
+            "device": 2307,
+            "inode": 20465508,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "73f1c3516c383e54d081ce830a1a37f70e02fd7347324908cd82a4d334acea1c",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-13-7efa11f3991babcf.uuidx",
+            "device": 2307,
+            "inode": 20465509,
+            "bytes": 32,
+            "allocated_bytes": 4096,
+            "sha256": "7efa11f3991babcf1651fcf04ef4e23d4318f7847aba86fa557b7a800d953d34",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-2-6806674c9d93cd96.uuidx",
+            "device": 2307,
+            "inode": 20465510,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "6806674c9d93cd965eb1f6af50b5c44baaf91265ebcb7dbfffd55ae01a6527d7",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-3-3b692e9d1527917b.uuidx",
+            "device": 2307,
+            "inode": 20465511,
+            "bytes": 32,
+            "allocated_bytes": 4096,
+            "sha256": "3b692e9d1527917b8ed078f103abb6319043272327626249ac433d6a88e26121",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-5-28c91ec4fa116a41.uuidx",
+            "device": 2307,
+            "inode": 20465512,
+            "bytes": 48,
+            "allocated_bytes": 4096,
+            "sha256": "28c91ec4fa116a41ca899971ad23a682cc290e16580bf794677543f365c0833e",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-6-544527a876801bd1.uuidx",
+            "device": 2307,
+            "inode": 20465513,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "544527a876801bd15c89de20568729465c1c84a4e4c565351bb0516a91997212",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-8-44e3e301a9ca8da9.uuidx",
+            "device": 2307,
+            "inode": 20465514,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "44e3e301a9ca8da9105ba1bac1e831577953079c17fc2ac29ae46bf6128bce20",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-9-70045d3d9ecdb570.uuidx",
+            "device": 2307,
+            "inode": 20465515,
+            "bytes": 96,
+            "allocated_bytes": 4096,
+            "sha256": "70045d3d9ecdb57046c5ee2df09c61d617bb6ecc2018f4db469832ed3612eb24",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-manifest.json",
+            "device": 2307,
+            "inode": 20465516,
+            "bytes": 2627,
+            "allocated_bytes": 4096,
+            "sha256": "e4e06a8897f7d4ac567ebf6deecaac3970a17e6c4a1ee0a62862872b6699458b",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4-receipt.json",
+            "device": 2307,
+            "inode": 20465517,
+            "bytes": 245,
+            "allocated_bytes": 4096,
+            "sha256": "e326c69a4346cbfbed604c1e631c3a9db43c2ccaa1b06423107039aa7c1a9425",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/ordinal-v4.lock",
+            "device": 2307,
+            "inode": 20465518,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-1-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465519,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-10-ef8ea8462befe7a2.uuidx",
+            "device": 2307,
+            "inode": 20465520,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "ef8ea8462befe7a2524ea5968b2e21bba7f7f1842f03a9e96ab77d7ad3686463",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-11-ef8ea8462befe7a2.uuidx",
+            "device": 2307,
+            "inode": 20465521,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "ef8ea8462befe7a2524ea5968b2e21bba7f7f1842f03a9e96ab77d7ad3686463",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-12-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465522,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-13-c310d91ad246a5e5.uuidx",
+            "device": 2307,
+            "inode": 20465523,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "c310d91ad246a5e5f6dda9269da2301121a04a08df1fbe3a37949265d0de6f20",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-2-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465524,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-3-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465525,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-4-51a3e3668b39ce77.uuidx",
+            "device": 2307,
+            "inode": 20465526,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "51a3e3668b39ce77997c0c5758b57651a1744fb7a15af4da271b9274e5ef8bc9",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-5-51a3e3668b39ce77.uuidx",
+            "device": 2307,
+            "inode": 20465527,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "51a3e3668b39ce77997c0c5758b57651a1744fb7a15af4da271b9274e5ef8bc9",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-6-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465528,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-7-506a3574a2dd275f.uuidx",
+            "device": 2307,
+            "inode": 20465529,
+            "bytes": 8,
+            "allocated_bytes": 4096,
+            "sha256": "506a3574a2dd275f6d4eda0520080ed990d79840c604ae74708fd7d988db04de",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-8-e3b0c44298fc1c14.uuidx",
+            "device": 2307,
+            "inode": 20465530,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/tombstones-v4-9-73dafc8bc573abde.uuidx",
+            "device": 2307,
+            "inode": 20465531,
+            "bytes": 16,
+            "allocated_bytes": 4096,
+            "sha256": "73dafc8bc573abde8d95f1e37a229713530fc3483e16ebe86e6b4f16b7f6d7d7",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/graph/topology/uuid-membership/topology-receipt.json",
+            "device": 2307,
+            "inode": 20465532,
+            "bytes": 245,
+            "allocated_bytes": 4096,
+            "sha256": "813528a16f1835176d1d43bce4ab3af8094779f36d6167f04f7b5b4a136d34c3",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/lease.lock",
+            "device": 2307,
+            "inode": 20352062,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/manifest.json",
+            "device": 2307,
+            "inode": 20352063,
+            "bytes": 1467,
+            "allocated_bytes": 4096,
+            "sha256": "68d188b1b720447ccf4acd68ed21000ba4c89f4241e2302e57b5162879c466b5",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/participants/graph/files.json",
+            "device": 2307,
+            "inode": 20352036,
+            "bytes": 22696,
+            "allocated_bytes": 24576,
+            "sha256": "dae8aaadb3522d68fa1e8175ab26ab5ec2e480369308b788db25535b517e5d80",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/participants/workspace/configuration.json",
+            "device": 2307,
+            "inode": 20352038,
+            "bytes": 105,
+            "allocated_bytes": 4096,
+            "sha256": "5bf75875f9e3215c3f9036f0492c9c9a7209d3a62abf22d42136614f35137b34",
+            "counted": true
+          },
+          {
+            "path": "source/generations/01a08eda-3c3a-77e0-98d1-1a9c9d8dc33f/participants/workspace/ontology.json",
+            "device": 2307,
+            "inode": 20352039,
+            "bytes": 117,
+            "allocated_bytes": 4096,
+            "sha256": "a21dd016f4ba02eca7cc43737d341d99fec00bcb5fb082e2a9877aaa4f27b824",
+            "counted": true
+          },
+          {
+            "path": "source/graph-objects/lifecycle.lock",
+            "device": 2307,
+            "inode": 20341386,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/locks/checkpoints.lock",
+            "device": 2307,
+            "inode": 20334156,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/locks/writer.lock",
+            "device": 2307,
+            "inode": 20344378,
+            "bytes": 0,
+            "allocated_bytes": 0,
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6268-78c2-b7e0-a2fdd006577e.json",
+            "device": 2307,
+            "inode": 20344384,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "0bfa2fffa934d40376d208fd3f10a6c230d26f430d44b81394e842ac2fcd6303",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-62b7-70a0-84bb-ff9d8af02c64.json",
+            "device": 2307,
+            "inode": 20344428,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "91fead9cd092df3a9175a0c61ca86072dacb7b3a6623f7127e27a56a2f817527",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6323-7561-b306-da263c3d8ad3.json",
+            "device": 2307,
+            "inode": 20344427,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "2c6f897accbc70a2b2f7b49b25c1b09941454d0ace090704b750dd317440535e",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6374-7bf2-9e96-171159ba3d6e.json",
+            "device": 2307,
+            "inode": 20344535,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "fae59484f039e0e97f1573a1dc236bf4c74707066a012efb114a6c866f582a7d",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-63c7-7963-bc64-306e3364a5d2.json",
+            "device": 2307,
+            "inode": 20344620,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "967bd625ff691a5dd890d1bdd64fc443536f48c1a76f7fd498fc0f48982d46f4",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-643d-7971-b1e3-00628e9fce3d.json",
+            "device": 2307,
+            "inode": 20344754,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "3179128a0407a389c6ec25b0d9ff8274b348eb06fbddc9bc9638276279405bb3",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-649c-71c0-90da-45410ba3cb6e.json",
+            "device": 2307,
+            "inode": 20344879,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "2aacd3c83bbeeb007ec92ddd4cdbbee589400bcc8986cdc951b8940b75a9015c",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6503-7211-b753-f90248ceead8.json",
+            "device": 2307,
+            "inode": 20345013,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "ae0f17c44ce97d4e15e2c47782d5033272058d34c17f89dbc2ef7bb25a415e74",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-658c-7e52-b24d-00f6e3d26664.json",
+            "device": 2307,
+            "inode": 20345137,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "434183d198c6903bd36ce97b955a3464dc4b6f9f7c962e1455a66169d50d9527",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-65fa-7b82-8713-1c7cb85c4078.json",
+            "device": 2307,
+            "inode": 20345270,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "ec90b687a2b8721b9032a9edb1b4e34843689e18dcd75cce1b6238f63e0ba082",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-666e-73f2-ab95-ffdd2bf54309.json",
+            "device": 2307,
+            "inode": 20345435,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "1529dddd7d992cc538883cc51e9b4aeceec66ec4963ef25d348d9129b6ea14ee",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-670f-7592-a8c2-0561505bed8d.json",
+            "device": 2307,
+            "inode": 20345583,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "58dc26e69a2d123e313a45fc1d695e8e2db38c1321e38fe9469d864e80cdb851",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6770-7703-a7cf-26dec4261448.json",
+            "device": 2307,
+            "inode": 20345763,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "f5f9f0f9698841173bee05b801618335668129dec6524e15b4199b5340e4de93",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-68a5-7052-939c-aa7aa605ead6.json",
+            "device": 2307,
+            "inode": 20346154,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "8d63abfa94dc3d1516a07d90cebbd9e690e8a302b940cb5200ec373e54a395b4",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-69ce-7813-a151-39e9d9b09ab9.json",
+            "device": 2307,
+            "inode": 20346161,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "99c75aba70fedece49249e3814130acde8362b3f89c43c34f222fa202f9c0448",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6afe-77e3-8fad-e4d678938990.json",
+            "device": 2307,
+            "inode": 20346166,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "1a7356ebefd48dc8a21b05d576c3c345adb997dcb8126207abc7e2e7a0751593",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6c34-7e63-8355-5c64dd316e67.json",
+            "device": 2307,
+            "inode": 20346172,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "2019202890d687cb551aa08a1563803d67f0528f8586c80dc826100f6b660be4",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6d69-7992-8421-041ba4eaec65.json",
+            "device": 2307,
+            "inode": 20346178,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "7f8c180bb18966ca5080e89c585a5dfb3e1a1333440de2c03565a0418078d68d",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6e9c-7aa1-854a-127f0d70dda2.json",
+            "device": 2307,
+            "inode": 20346185,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "a43a9547b1c90b21a3ec1053994ef145784a74c534bad62f069d94dd122d5d4b",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-6fd7-7ee3-bd9a-2a3833968c38.json",
+            "device": 2307,
+            "inode": 20346193,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "ee2ea0782144482a047a809bd7bcb040f126ffd7404bebb8e6c92135e85abcc1",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-7119-7093-9833-8be389828e9f.json",
+            "device": 2307,
+            "inode": 20346198,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "0fa90af5d390e07dfc9fac9c8bfdc8a37466e19ace8226edf34678c91ec49363",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-7279-7c33-aaad-7ef15c8381b4.json",
+            "device": 2307,
+            "inode": 20346203,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "041e0f181952e406397be9e908b7413b5a70f09d6279f242862c7bd051368e77",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-73cc-7332-b577-cf149ec448d9.json",
+            "device": 2307,
+            "inode": 20346208,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "9de1eef61278a35a15fc4cd48de53420823818c36907f127ae323ceafb052fe6",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-7525-7d93-a7a0-5549c0276409.json",
+            "device": 2307,
+            "inode": 20346213,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "812c043c830c93bd5f365c9aaab8cc9420fe8c660953e74e579192356dae3941",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-7679-7d00-afff-796ab66c11f0.json",
+            "device": 2307,
+            "inode": 20346219,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "b00cc44a2cf86e8cd658ed86b80faa11ab3fecb90086ed26dba66c86e732bbff",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-77d8-76a1-ae57-d071f47e685f.json",
+            "device": 2307,
+            "inode": 20346224,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "7f3f07f73f187d330a76040b50012b5de7acf053a045ad421c59e25f07db7a44",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-792e-7a90-8ebc-dc29996d710e.json",
+            "device": 2307,
+            "inode": 20346230,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "fd0fc0051de64ac0d548db52c282d6e1ba595ad83d5edb0484ff485bc0b0dc3c",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-7a92-7773-a261-3c78569e0a40.json",
+            "device": 2307,
+            "inode": 20346235,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "9a332ff5961ec95078fa529b596f09aeaed56c151b900a5ab26215234eda215a",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-7bf6-71a1-a553-019dc468d38f.json",
+            "device": 2307,
+            "inode": 20346242,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "e6bccc2f7203637f826dd7e648ad774f41f71f1b42fefcd6028cc2cf451e896e",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-7d65-72b1-9a9a-f62cadeba000.json",
+            "device": 2307,
+            "inode": 20346396,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "b748f9ce4a27f21543ed9405a2d2d28f2e14b5827053bdbbd8b9c20ff4f7a326",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-7ec5-7a30-ac38-eb6c2791987c.json",
+            "device": 2307,
+            "inode": 20346571,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "7ac82b77b5ba1fe3e242bfdb6ab7c1768d374da1dadd7839c04f59e5490e56da",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-801f-7fd0-b2ae-903bc5423ece.json",
+            "device": 2307,
+            "inode": 20346741,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "04aafd78a6a925ee17534446df1cad62c1dd60e9c0bd2eefe3007d65f55e46bb",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-8171-79a2-8e1f-e1a41f81c3ed.json",
+            "device": 2307,
+            "inode": 20346900,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "18e8f261c36936c16c8522eb8310a4b25c196bc9c3a407f7e94b9b9bff1b8dec",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-82d5-7a90-8826-32037ed348d2.json",
+            "device": 2307,
+            "inode": 20347065,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "4b3e59113da6effd002a7c2581d015a3bfe747b602e40a3056119356a78a2278",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-8430-7dd1-a2b7-5c497ad8aea3.json",
+            "device": 2307,
+            "inode": 20347209,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "b684d4ec53962b12f1358a5959beea0e25b15910c0e2ec5a2212f7a77ac37b1e",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-8597-7142-979b-4096e7dcf58c.json",
+            "device": 2307,
+            "inode": 20347356,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "fa98cf20927e94e0be450fffd45cdf09f8f4c291662b97b225225a48456afe22",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-86f9-7932-a7bb-7de10c1f7125.json",
+            "device": 2307,
+            "inode": 20347530,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "359979cb002afa15183792bba77fb5a7f9fcd1db73f2675f94f51400d346170e",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-8866-70e3-b5d4-8709745887db.json",
+            "device": 2307,
+            "inode": 20347724,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "f409f1929939e59056e9a42c6f029e3dedfded76b012c5bd761133e7196b27d0",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-89d7-76e2-8590-a729c35abddb.json",
+            "device": 2307,
+            "inode": 20347908,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "e7476b2794d66d29208117f4f5b9b67de7f58c5585f5ed816f7805914b3a7cd0",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-8b74-79d2-b8d6-37a464e5a9a0.json",
+            "device": 2307,
+            "inode": 20348075,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "0940bfe533b9a6f51eea05f790a4235e2604603c06c222fabec3e819154f945d",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-8cf5-7a01-8cdb-5b0a2d2713dc.json",
+            "device": 2307,
+            "inode": 20348234,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "378342c145b14ca2269e90d7b44c76288a3b66a9efe67aa2e5bbb436aabdac5b",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-8e86-7003-bf35-57094793d777.json",
+            "device": 2307,
+            "inode": 20348383,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "bb9a97bd6272aac9e2f65edab34ff88c4bf2c334ba19392179ced1a8991326df",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-9004-7e90-9103-ab3a35baf452.json",
+            "device": 2307,
+            "inode": 20348535,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "4127eb27b2af3e569dbd64d07ac2cbd0772573a8775beb52208fb3f75550ab06",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08ecd-917d-7c43-8088-0162bb90ddb7.json",
+            "device": 2307,
+            "inode": 20348688,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "7d4a03445da2ea39466f7a6aa04ff9560ec9141aeafc19e14be5f1a4e9e269f7",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/01a08eda-3c3a-77e0-98d1-1a828c9a840a.json",
+            "device": 2307,
+            "inode": 20348838,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "2d12799f6b259c0d0eb4b5bca2c81c969bfef64c4eb63336ab14214722647b8d",
+            "counted": true
+          },
+          {
+            "path": "source/transactions/0c72f52a-fc65-8b7c-862f-06387e1b0884.json",
+            "device": 2307,
+            "inode": 20339693,
+            "bytes": 628,
+            "allocated_bytes": 4096,
+            "sha256": "80a683503f0e5dcb6ec09df80f72d652599ed07c6caa5cb4d13802838deededb",
+            "counted": true
+          }
+        ],
+        "allocated_bytes": 3653632,
+        "scope": "Regular files only; globally device/inode deduplicated. Separate source and fixture totals overlap and must not be added."
+      }
+    },
+    "allocation_after_equal": true
+  },
+  "selection_protocol_before_candidate": {
+    "baseline_source": {
+      "source": "60f02cee3af598fe206aae9ea47a8e4b251f9ded",
+      "executable": "/tmp/gf1207-statistics-baseline-bin",
+      "sha256": "43f59ca29e75504126d16cf26f3cb20ea8e3b93c85eb5a44863f5baa41378cf8",
+      "build_command": "cargo test --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json",
+      "profile": "release optimized"
+    },
+    "selection_rationale": "A saved 10ms of process CPU is one GNU-time reporting quantum; require improvement exceeding observed three-process range plus one quantum. No durable change is allowed for metadata forwarding. Memory overhead must stay within observed baseline span plus one 4096-byte page. Query wall time is observation only, never a CI gate.",
+    "cases": {
+      "count_all": {
+        "baseline_cpu_s": [
+          0.16,
+          0.16,
+          0.16999999999999998
+        ],
+        "minimum_cpu_saving_s": 0.02,
+        "maximum_rss_kib": 74508.0,
+        "maximum_added_permanent_bytes": 0,
+        "maximum_added_io_bytes": 4096,
+        "baseline_warm_median_ns": 14318835.0
+      },
+      "count_identity": {
+        "baseline_cpu_s": [
+          0.14,
+          0.15000000000000002,
+          0.14
+        ],
+        "minimum_cpu_saving_s": 0.02,
+        "maximum_rss_kib": 69952.0,
+        "maximum_added_permanent_bytes": 0,
+        "maximum_added_io_bytes": 4096,
+        "baseline_warm_median_ns": 10623780.0
+      },
+      "count_label": {
+        "baseline_cpu_s": [
+          0.16,
+          0.16,
+          0.16999999999999998
+        ],
+        "minimum_cpu_saving_s": 0.02,
+        "maximum_rss_kib": 75084.0,
+        "maximum_added_permanent_bytes": 0,
+        "maximum_added_io_bytes": 4096,
+        "baseline_warm_median_ns": 14608655.5
+      },
+      "count_property": {
+        "baseline_cpu_s": [
+          0.16,
+          0.17,
+          0.16
+        ],
+        "minimum_cpu_saving_s": 0.02,
+        "maximum_rss_kib": 74308.0,
+        "maximum_added_permanent_bytes": 0,
+        "maximum_added_io_bytes": 4096,
+        "baseline_warm_median_ns": 14199672.5
+      },
+      "sum_property": {
+        "baseline_cpu_s": [
+          0.17,
+          0.16,
+          0.16999999999999998
+        ],
+        "minimum_cpu_saving_s": 0.02,
+        "maximum_rss_kib": 74380.0,
+        "maximum_added_permanent_bytes": 0,
+        "maximum_added_io_bytes": 4096,
+        "baseline_warm_median_ns": 14425702.0
+      },
+      "selective": {
+        "baseline_cpu_s": [
+          0.18,
+          0.16999999999999998,
+          0.16999999999999998
+        ],
+        "minimum_cpu_saving_s": 0.02,
+        "maximum_rss_kib": 75848.0,
+        "maximum_added_permanent_bytes": 0,
+        "maximum_added_io_bytes": 4096,
+        "baseline_warm_median_ns": 15103120.0
+      },
+      "empty": {
+        "baseline_cpu_s": [
+          0.16999999999999998,
+          0.16999999999999998,
+          0.16
+        ],
+        "minimum_cpu_saving_s": 0.02,
+        "maximum_rss_kib": 74400.0,
+        "maximum_added_permanent_bytes": 0,
+        "maximum_added_io_bytes": 4096,
+        "baseline_warm_median_ns": 14588430.0
+      }
+    }
+  },
+  "cases": {
+    "baseline": {
+      "count_all": {
+        "cpu_s": [
+          0.16,
+          0.16999999999999998,
+          0.16999999999999998
+        ],
+        "rss_kib": [
+          73724.0,
+          74268.0,
+          72904.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 14452541.5,
+        "first_execution_ns": [
+          21616296,
+          21021884,
+          21019925
+        ],
+        "oracle": [
+          4101,
+          4101,
+          4101
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-baseline-count_all.strace",
+            "/tmp/gf1249-statistics-baseline-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-baseline-bin",
+          "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+          "trace": "/tmp/gf1249-statistics-baseline-count_all.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259294,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 347,
+              "bytes": 1941930,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453021,
+          "write_bytes": 3090413,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        }
+      },
+      "count_identity": {
+        "cpu_s": [
+          0.14,
+          0.14,
+          0.15
+        ],
+        "rss_kib": [
+          69328.0,
+          68656.0,
+          69176.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          6496.0,
+          6496.0,
+          6496.0
+        ],
+        "warm_median_ns": 10793267.5,
+        "first_execution_ns": [
+          15147595,
+          15108383,
+          15110023
+        ],
+        "oracle": [
+          4101,
+          4101,
+          4101
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-baseline-count_identity.strace",
+            "/tmp/gf1249-statistics-baseline-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-baseline-bin",
+          "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+          "trace": "/tmp/gf1249-statistics-baseline-count_identity.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3296,
+              "bytes": 11950489,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 6778,
+              "bytes": 1430134,
+              "errors": 0
+            },
+            "write": {
+              "calls": 306,
+              "bytes": 1633096,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 14529106,
+          "write_bytes": 2781579,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        }
+      },
+      "count_label": {
+        "cpu_s": [
+          0.16999999999999998,
+          0.16,
+          0.16
+        ],
+        "rss_kib": [
+          74880.0,
+          74640.0,
+          74320.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 14482057.0,
+        "first_execution_ns": [
+          21338900,
+          21195238,
+          22360650
+        ],
+        "oracle": [
+          2053,
+          2053,
+          2053
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-baseline-count_label.strace",
+            "/tmp/gf1249-statistics-baseline-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-baseline-bin",
+          "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+          "trace": "/tmp/gf1249-statistics-baseline-count_label.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259294,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 345,
+              "bytes": 1942003,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453021,
+          "write_bytes": 3090486,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        }
+      },
+      "count_property": {
+        "cpu_s": [
+          0.16999999999999998,
+          0.17,
+          0.17
+        ],
+        "rss_kib": [
+          73108.0,
+          72724.0,
+          73480.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 14402855.0,
+        "first_execution_ns": [
+          22095634,
+          22220238,
+          21114536
+        ],
+        "oracle": [
+          1760,
+          1760,
+          1760
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-baseline-count_property.strace",
+            "/tmp/gf1249-statistics-baseline-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-baseline-bin",
+          "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+          "trace": "/tmp/gf1249-statistics-baseline-count_property.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259294,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 346,
+              "bytes": 1941889,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453021,
+          "write_bytes": 3090372,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        }
+      },
+      "sum_property": {
+        "cpu_s": [
+          0.16,
+          0.16,
+          0.16999999999999998
+        ],
+        "rss_kib": [
+          73656.0,
+          72664.0,
+          72348.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 14267642.5,
+        "first_execution_ns": [
+          22354159,
+          21010284,
+          21131707
+        ],
+        "oracle": [
+          -1262065,
+          -1262065,
+          -1262065
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-baseline-sum_property.strace",
+            "/tmp/gf1249-statistics-baseline-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-baseline-bin",
+          "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+          "trace": "/tmp/gf1249-statistics-baseline-sum_property.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259294,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 345,
+              "bytes": 1941879,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453021,
+          "write_bytes": 3090362,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        }
+      },
+      "selective": {
+        "cpu_s": [
+          0.16999999999999998,
+          0.16999999999999998,
+          0.17
+        ],
+        "rss_kib": [
+          75016.0,
+          74992.0,
+          74704.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 15033632.0,
+        "first_execution_ns": [
+          22901659,
+          23562363,
+          21799639
+        ],
+        "oracle": [
+          2,
+          2,
+          2
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-baseline-selective.strace",
+            "/tmp/gf1249-statistics-baseline-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-baseline-bin",
+          "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+          "trace": "/tmp/gf1249-statistics-baseline-selective.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259294,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 347,
+              "bytes": 1941991,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453021,
+          "write_bytes": 3090474,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        }
+      },
+      "empty": {
+        "cpu_s": [
+          0.17,
+          0.16999999999999998,
+          0.17
+        ],
+        "rss_kib": [
+          73836.0,
+          73932.0,
+          73556.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 14701151.0,
+        "first_execution_ns": [
+          22436151,
+          21281780,
+          21448782
+        ],
+        "oracle": [
+          0,
+          0,
+          0
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-baseline-empty.strace",
+            "/tmp/gf1249-statistics-baseline-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-baseline-bin",
+          "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+          "trace": "/tmp/gf1249-statistics-baseline-empty.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259294,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 347,
+              "bytes": 1942010,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453021,
+          "write_bytes": 3090493,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        }
+      }
+    },
+    "candidate": {
+      "count_all": {
+        "cpu_s": [
+          0.14,
+          0.15,
+          0.14
+        ],
+        "rss_kib": [
+          69916.0,
+          68888.0,
+          69196.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          6496.0,
+          6496.0,
+          6496.0
+        ],
+        "warm_median_ns": 10926379.5,
+        "first_execution_ns": [
+          15422029,
+          15593353,
+          15820357
+        ],
+        "oracle": [
+          4101,
+          4101,
+          4101
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-candidate-count_all.strace",
+            "/tmp/gf1249-statistics-candidate-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-candidate-bin",
+          "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+          "trace": "/tmp/gf1249-statistics-candidate-count_all.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3296,
+              "bytes": 11950493,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 6778,
+              "bytes": 1430134,
+              "errors": 0
+            },
+            "write": {
+              "calls": 304,
+              "bytes": 1633107,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 14529110,
+          "write_bytes": 2781590,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        },
+        "selection": {
+          "cpu_saving_s": 0.03,
+          "minimum_cpu_saving_s": 0.02,
+          "rss_cap_kib": 74508.0,
+          "rss_pass": true,
+          "read_saving_bytes": 923911,
+          "write_saving_bytes": 308823,
+          "cpu_threshold_pass": true
+        }
+      },
+      "count_identity": {
+        "cpu_s": [
+          0.14,
+          0.14,
+          0.15
+        ],
+        "rss_kib": [
+          70184.0,
+          68752.0,
+          69300.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          6496.0,
+          6496.0,
+          6496.0
+        ],
+        "warm_median_ns": 10757851.5,
+        "first_execution_ns": [
+          15215656,
+          15082063,
+          15238336
+        ],
+        "oracle": [
+          4101,
+          4101,
+          4101
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-candidate-count_identity.strace",
+            "/tmp/gf1249-statistics-candidate-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-candidate-bin",
+          "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+          "trace": "/tmp/gf1249-statistics-candidate-count_identity.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3296,
+              "bytes": 11950493,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 6778,
+              "bytes": 1430134,
+              "errors": 0
+            },
+            "write": {
+              "calls": 305,
+              "bytes": 1633088,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 14529110,
+          "write_bytes": 2781571,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        },
+        "selection": {
+          "cpu_saving_s": 0.0,
+          "minimum_cpu_saving_s": 0.02,
+          "rss_cap_kib": 69952.0,
+          "rss_pass": false,
+          "read_saving_bytes": -4,
+          "write_saving_bytes": 8,
+          "cpu_threshold_pass": false
+        }
+      },
+      "count_label": {
+        "cpu_s": [
+          0.14,
+          0.14,
+          0.14
+        ],
+        "rss_kib": [
+          71152.0,
+          70568.0,
+          71468.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          6496.0,
+          6496.0,
+          6496.0
+        ],
+        "warm_median_ns": 11314272.0,
+        "first_execution_ns": [
+          15588562,
+          15600133,
+          15974310
+        ],
+        "oracle": [
+          2053,
+          2053,
+          2053
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-candidate-count_label.strace",
+            "/tmp/gf1249-statistics-candidate-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-candidate-bin",
+          "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+          "trace": "/tmp/gf1249-statistics-candidate-count_label.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3296,
+              "bytes": 11950493,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 6778,
+              "bytes": 1430134,
+              "errors": 0
+            },
+            "write": {
+              "calls": 306,
+              "bytes": 1633223,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 14529110,
+          "write_bytes": 2781706,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        },
+        "selection": {
+          "cpu_saving_s": 0.02,
+          "minimum_cpu_saving_s": 0.02,
+          "rss_cap_kib": 75084.0,
+          "rss_pass": true,
+          "read_saving_bytes": 923911,
+          "write_saving_bytes": 308780,
+          "cpu_threshold_pass": true
+        }
+      },
+      "count_property": {
+        "cpu_s": [
+          0.16,
+          0.16,
+          0.16999999999999998
+        ],
+        "rss_kib": [
+          73324.0,
+          72520.0,
+          73224.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 14306263.5,
+        "first_execution_ns": [
+          20963704,
+          20990224,
+          21151607
+        ],
+        "oracle": [
+          1760,
+          1760,
+          1760
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-candidate-count_property.strace",
+            "/tmp/gf1249-statistics-candidate-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-candidate-bin",
+          "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+          "trace": "/tmp/gf1249-statistics-candidate-count_property.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259298,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 348,
+              "bytes": 1941905,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453025,
+          "write_bytes": 3090388,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        },
+        "selection": {
+          "cpu_saving_s": 0.01,
+          "minimum_cpu_saving_s": 0.02,
+          "rss_cap_kib": 74308.0,
+          "rss_pass": true,
+          "read_saving_bytes": -4,
+          "write_saving_bytes": -16,
+          "cpu_threshold_pass": false
+        }
+      },
+      "sum_property": {
+        "cpu_s": [
+          0.16,
+          0.16999999999999998,
+          0.16
+        ],
+        "rss_kib": [
+          73156.0,
+          71820.0,
+          73508.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 14560608.5,
+        "first_execution_ns": [
+          20957253,
+          22111525,
+          21274959
+        ],
+        "oracle": [
+          -1262065,
+          -1262065,
+          -1262065
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-candidate-sum_property.strace",
+            "/tmp/gf1249-statistics-candidate-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-candidate-bin",
+          "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+          "trace": "/tmp/gf1249-statistics-candidate-sum_property.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259298,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 345,
+              "bytes": 1941879,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453025,
+          "write_bytes": 3090362,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        },
+        "selection": {
+          "cpu_saving_s": 0.0,
+          "minimum_cpu_saving_s": 0.02,
+          "rss_cap_kib": 74380.0,
+          "rss_pass": true,
+          "read_saving_bytes": -4,
+          "write_saving_bytes": 0,
+          "cpu_threshold_pass": false
+        }
+      },
+      "selective": {
+        "cpu_s": [
+          0.17,
+          0.17,
+          0.17
+        ],
+        "rss_kib": [
+          75100.0,
+          74200.0,
+          74268.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          7096.0,
+          7096.0,
+          7096.0
+        ],
+        "warm_median_ns": 15450105.0,
+        "first_execution_ns": [
+          22033564,
+          22882430,
+          21966712
+        ],
+        "oracle": [
+          2,
+          2,
+          2
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-candidate-selective.strace",
+            "/tmp/gf1249-statistics-candidate-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-candidate-bin",
+          "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+          "trace": "/tmp/gf1249-statistics-candidate-selective.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3336,
+              "bytes": 12259298,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 7128,
+              "bytes": 2045244,
+              "errors": 0
+            },
+            "write": {
+              "calls": 346,
+              "bytes": 1942022,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 15453025,
+          "write_bytes": 3090505,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        },
+        "selection": {
+          "cpu_saving_s": -0.0,
+          "minimum_cpu_saving_s": 0.02,
+          "rss_cap_kib": 75848.0,
+          "rss_pass": true,
+          "read_saving_bytes": -4,
+          "write_saving_bytes": -31,
+          "cpu_threshold_pass": false
+        }
+      },
+      "empty": {
+        "cpu_s": [
+          0.14,
+          0.14,
+          0.15
+        ],
+        "rss_kib": [
+          70260.0,
+          70052.0,
+          71064.0
+        ],
+        "filesystem_inputs": [
+          3328.0,
+          3328.0,
+          3328.0
+        ],
+        "filesystem_outputs": [
+          6496.0,
+          6496.0,
+          6496.0
+        ],
+        "warm_median_ns": 11063697.5,
+        "first_execution_ns": [
+          15599323,
+          15724385,
+          15526891
+        ],
+        "oracle": [
+          0,
+          0,
+          0
+        ],
+        "trace": {
+          "case": "statistics_public_query_probe",
+          "command": [
+            "strace",
+            "-f",
+            "-qq",
+            "-yy",
+            "-s",
+            "0",
+            "-e",
+            "trace=read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync",
+            "-o",
+            "/tmp/gf1249-statistics-candidate-empty.strace",
+            "/tmp/gf1249-statistics-candidate-bin",
+            "--exact",
+            "statistics_public_query_probe",
+            "--nocapture",
+            "--test-threads=1"
+          ],
+          "exit": 0,
+          "executable": "/tmp/gf1249-statistics-candidate-bin",
+          "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+          "trace": "/tmp/gf1249-statistics-candidate-empty.strace",
+          "syscalls": {
+            "read": {
+              "calls": 3296,
+              "bytes": 11950493,
+              "errors": 0
+            },
+            "pread64": {
+              "calls": 6778,
+              "bytes": 1430134,
+              "errors": 0
+            },
+            "write": {
+              "calls": 306,
+              "bytes": 1633214,
+              "errors": 0
+            },
+            "fsync": {
+              "calls": 221,
+              "bytes": 0,
+              "errors": 0
+            },
+            "copy_file_range": {
+              "calls": 190,
+              "bytes": 1148483,
+              "errors": 0
+            }
+          },
+          "unfinished_calls": 0,
+          "resumed_calls": 0,
+          "unparsed_results": 0,
+          "read_bytes": 14529110,
+          "write_bytes": 2781697,
+          "scope": "Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence."
+        },
+        "selection": {
+          "cpu_saving_s": 0.03,
+          "minimum_cpu_saving_s": 0.02,
+          "rss_cap_kib": 74400.0,
+          "rss_pass": true,
+          "read_saving_bytes": 923911,
+          "write_saving_bytes": 308796,
+          "cpu_threshold_pass": true
+        }
+      }
+    }
+  },
+  "raw_process_observations": {
+    "baseline": [
+      {
+        "case": "count_all",
+        "repeat": 0,
+        "observation": {
+          "case": "count_all",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21616296,
+            14783127,
+            14696376,
+            14208707,
+            14166536
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73724\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3810\n\tVoluntary context switches: 558\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_all-0.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_identity",
+        "repeat": 0,
+        "observation": {
+          "case": "count_identity",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.node_uuid) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.node_uuid) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15147595,
+            10940425,
+            10669640,
+            10927125,
+            10688871
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69328\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3254\n\tVoluntary context switches: 558\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_identity-0.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_label",
+        "repeat": 0,
+        "observation": {
+          "case": "count_label",
+          "expected": 2053,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@1, 1073741825), projection=[node_uuid@0]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21338900,
+            15243006,
+            14450512,
+            14421860,
+            14510253
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 74880\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3670\n\tVoluntary context switches: 559\n\tInvoluntary context switches: 5\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_label-0.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_property",
+        "repeat": 0,
+        "observation": {
+          "case": "count_property",
+          "expected": 1760,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22095634,
+            15305518,
+            14578983,
+            14194007,
+            14226727
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73108\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3807\n\tVoluntary context switches: 555\n\tInvoluntary context switches: 5\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_property-0.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "sum_property",
+        "repeat": 0,
+        "observation": {
+          "case": "sum_property",
+          "expected": -1262065,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[sum(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[sum(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22354159,
+            15588362,
+            14058874,
+            13805349,
+            14240967
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73656\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3801\n\tVoluntary context switches: 555\n\tInvoluntary context switches: 9\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-sum_property-0.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "selective",
+        "repeat": 0,
+        "observation": {
+          "case": "selective",
+          "expected": 2,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      FilterExec: cypher_cmp_pred(score@0, 10000, 3)\n        HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n          PropertyOverlayExec: route=_untyped\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22901659,
+            16026560,
+            15216126,
+            15002692,
+            15093183
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 75016\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3841\n\tVoluntary context switches: 554\n\tInvoluntary context switches: 12\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-selective-0.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "empty",
+        "repeat": 0,
+        "observation": {
+          "case": "empty",
+          "expected": 0,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@1, 1073741826), projection=[node_uuid@0]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22436151,
+            15823027,
+            14788748,
+            14613554,
+            14304439
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73836\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3907\n\tVoluntary context switches: 555\n\tInvoluntary context switches: 11\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-empty-0.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_identity",
+        "repeat": 1,
+        "observation": {
+          "case": "count_identity",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.node_uuid) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.node_uuid) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15108383,
+            10872274,
+            10834764,
+            10564738,
+            10645800
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 68656\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3113\n\tVoluntary context switches: 547\n\tInvoluntary context switches: 9\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_identity-1.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_label",
+        "repeat": 1,
+        "observation": {
+          "case": "count_label",
+          "expected": 2053,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@1, 1073741825), projection=[node_uuid@0]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21195238,
+            15098733,
+            14462912,
+            14501202,
+            14233537
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 74640\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3775\n\tVoluntary context switches: 551\n\tInvoluntary context switches: 4\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_label-1.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_property",
+        "repeat": 1,
+        "observation": {
+          "case": "count_property",
+          "expected": 1760,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22220238,
+            15028142,
+            14532122,
+            14407381,
+            14247857
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 72724\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3816\n\tVoluntary context switches: 559\n\tInvoluntary context switches: 8\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_property-1.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "sum_property",
+        "repeat": 1,
+        "observation": {
+          "case": "sum_property",
+          "expected": -1262065,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[sum(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[sum(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21010284,
+            14699175,
+            14347670,
+            14221416,
+            14190177
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 72664\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3639\n\tVoluntary context switches: 560\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-sum_property-1.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "selective",
+        "repeat": 1,
+        "observation": {
+          "case": "selective",
+          "expected": 2,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      FilterExec: cypher_cmp_pred(score@0, 10000, 3)\n        HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n          PropertyOverlayExec: route=_untyped\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            23562363,
+            15758276,
+            14680775,
+            14649715,
+            14370100
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 74992\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 4576\n\tVoluntary context switches: 552\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-selective-1.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "empty",
+        "repeat": 1,
+        "observation": {
+          "case": "empty",
+          "expected": 0,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@1, 1073741826), projection=[node_uuid@0]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21281780,
+            15005901,
+            14488982,
+            15000302,
+            14624334
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73932\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3752\n\tVoluntary context switches: 556\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-empty-1.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_all",
+        "repeat": 1,
+        "observation": {
+          "case": "count_all",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21021884,
+            14603264,
+            14038534,
+            14627064,
+            14223957
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.09\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 74268\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3803\n\tVoluntary context switches: 553\n\tInvoluntary context switches: 4\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_all-1.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_label",
+        "repeat": 2,
+        "observation": {
+          "case": "count_label",
+          "expected": 2053,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@1, 1073741825), projection=[node_uuid@0]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22360650,
+            15130144,
+            14582914,
+            14750707,
+            14842588
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 74320\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3745\n\tVoluntary context switches: 554\n\tInvoluntary context switches: 5\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_label-2.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_property",
+        "repeat": 2,
+        "observation": {
+          "case": "count_property",
+          "expected": 1760,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21114536,
+            14775247,
+            14620015,
+            14089844,
+            14083984
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73480\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3774\n\tVoluntary context switches: 552\n\tInvoluntary context switches: 6\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_property-2.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "sum_property",
+        "repeat": 2,
+        "observation": {
+          "case": "sum_property",
+          "expected": -1262065,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[sum(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[sum(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21131707,
+            15113014,
+            14403100,
+            14132185,
+            14114255
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 72348\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3670\n\tVoluntary context switches: 560\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-sum_property-2.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "selective",
+        "repeat": 2,
+        "observation": {
+          "case": "selective",
+          "expected": 2,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      FilterExec: cypher_cmp_pred(score@0, 10000, 3)\n        HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n          PropertyOverlayExec: route=_untyped\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21799639,
+            15430230,
+            15172604,
+            14894660,
+            14799748
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 74704\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3835\n\tVoluntary context switches: 554\n\tInvoluntary context switches: 8\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-selective-2.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "empty",
+        "repeat": 2,
+        "observation": {
+          "case": "empty",
+          "expected": 0,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@1, 1073741826), projection=[node_uuid@0]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21448782,
+            15030732,
+            14273708,
+            14390060,
+            14321979
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73556\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3606\n\tVoluntary context switches: 551\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-empty-2.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_all",
+        "repeat": 2,
+        "observation": {
+          "case": "count_all",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.score)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21019925,
+            15387268,
+            14360860,
+            14647925,
+            14201446
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 72904\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3789\n\tVoluntary context switches: 556\n\tInvoluntary context switches: 10\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_all-2.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_identity",
+        "repeat": 2,
+        "observation": {
+          "case": "count_identity",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.node_uuid) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.node_uuid) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15110023,
+            11087749,
+            10686520,
+            10900015,
+            10552188
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69176\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3207\n\tVoluntary context switches: 548\n\tInvoluntary context switches: 8\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-baseline-count_identity-2.time",
+          "/tmp/gf1249-statistics-baseline-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      }
+    ],
+    "candidate": [
+      {
+        "case": "count_all",
+        "repeat": 0,
+        "observation": {
+          "case": "count_all",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15422029,
+            11002167,
+            10876034,
+            11227621,
+            10852183
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69916\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3270\n\tVoluntary context switches: 556\n\tInvoluntary context switches: 8\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_all-0.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_identity",
+        "repeat": 0,
+        "observation": {
+          "case": "count_identity",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.node_uuid) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.node_uuid) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15215656,
+            10807113,
+            10440936,
+            10396335,
+            10856474
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 70184\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3263\n\tVoluntary context switches: 546\n\tInvoluntary context switches: 3\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_identity-0.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_label",
+        "repeat": 0,
+        "observation": {
+          "case": "count_label",
+          "expected": 2053,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@2, 1073741825), projection=[node_uuid@0, node_id@1]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15588562,
+            11770090,
+            11524597,
+            11280922,
+            10885624
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 71152\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3293\n\tVoluntary context switches: 556\n\tInvoluntary context switches: 13\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_label-0.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_property",
+        "repeat": 0,
+        "observation": {
+          "case": "count_property",
+          "expected": 1760,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            20963704,
+            15087963,
+            14387070,
+            14225457,
+            14092194
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73324\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3793\n\tVoluntary context switches: 557\n\tInvoluntary context switches: 12\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_property-0.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "sum_property",
+        "repeat": 0,
+        "observation": {
+          "case": "sum_property",
+          "expected": -1262065,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[sum(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[sum(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            20957253,
+            14958940,
+            14534973,
+            14586244,
+            14208467
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73156\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3810\n\tVoluntary context switches: 548\n\tInvoluntary context switches: 8\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-sum_property-0.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "selective",
+        "repeat": 0,
+        "observation": {
+          "case": "selective",
+          "expected": 2,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      FilterExec: cypher_cmp_pred(score@1, 10000, 3), projection=[node_id@0]\n        HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@3, score@1]\n          PropertyOverlayExec: route=_untyped\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22033564,
+            15828747,
+            14976251,
+            15071463,
+            16181664
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 75100\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3846\n\tVoluntary context switches: 551\n\tInvoluntary context switches: 9\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-selective-0.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "empty",
+        "repeat": 0,
+        "observation": {
+          "case": "empty",
+          "expected": 0,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@2, 1073741826), projection=[node_uuid@0, node_id@1]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15599323,
+            11174220,
+            10953175,
+            10901765,
+            11209900
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 70260\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3237\n\tVoluntary context switches: 554\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-empty-0.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_identity",
+        "repeat": 1,
+        "observation": {
+          "case": "count_identity",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.node_uuid) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.node_uuid) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15082063,
+            10905985,
+            11315513,
+            10693380,
+            10600389
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 68752\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3221\n\tVoluntary context switches: 547\n\tInvoluntary context switches: 13\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_identity-1.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_label",
+        "repeat": 1,
+        "observation": {
+          "case": "count_label",
+          "expected": 2053,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@2, 1073741825), projection=[node_uuid@0, node_id@1]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15600133,
+            11475786,
+            11266741,
+            11361803,
+            10876344
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 70568\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3301\n\tVoluntary context switches: 553\n\tInvoluntary context switches: 14\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_label-1.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_property",
+        "repeat": 1,
+        "observation": {
+          "case": "count_property",
+          "expected": 1760,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            20990224,
+            15170425,
+            15203275,
+            14963891,
+            15190255
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 72520\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3783\n\tVoluntary context switches: 550\n\tInvoluntary context switches: 17\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_property-1.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "sum_property",
+        "repeat": 1,
+        "observation": {
+          "case": "sum_property",
+          "expected": -1262065,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[sum(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[sum(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22111525,
+            15900699,
+            15629563,
+            15340208,
+            15098713
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 71820\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3691\n\tVoluntary context switches: 558\n\tInvoluntary context switches: 14\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-sum_property-1.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "selective",
+        "repeat": 1,
+        "observation": {
+          "case": "selective",
+          "expected": 2,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      FilterExec: cypher_cmp_pred(score@1, 10000, 3), projection=[node_id@0]\n        HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@3, score@1]\n          PropertyOverlayExec: route=_untyped\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            22882430,
+            16630822,
+            15287577,
+            14936220,
+            15176365
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.21\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 74200\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3869\n\tVoluntary context switches: 552\n\tInvoluntary context switches: 16\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-selective-1.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "empty",
+        "repeat": 1,
+        "observation": {
+          "case": "empty",
+          "expected": 0,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@2, 1073741826), projection=[node_uuid@0, node_id@1]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15724385,
+            11660819,
+            10924555,
+            11041028,
+            10961045
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 84%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 70052\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3128\n\tVoluntary context switches: 553\n\tInvoluntary context switches: 13\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-empty-1.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_all",
+        "repeat": 1,
+        "observation": {
+          "case": "count_all",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15593353,
+            10841613,
+            10744812,
+            10983616,
+            10737371
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 68888\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3128\n\tVoluntary context switches: 554\n\tInvoluntary context switches: 9\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_all-1.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_label",
+        "repeat": 2,
+        "observation": {
+          "case": "count_label",
+          "expected": 2053,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@2, 1073741825), projection=[node_uuid@0, node_id@1]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15974310,
+            11266252,
+            11274441,
+            11030027,
+            10936805
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 71468\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3286\n\tVoluntary context switches: 565\n\tInvoluntary context switches: 5\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_label-2.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_property",
+        "repeat": 2,
+        "observation": {
+          "case": "count_property",
+          "expected": 1760,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21151607,
+            15099133,
+            14323759,
+            14121265,
+            14165736
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.08\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.19\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73224\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3679\n\tVoluntary context switches: 551\n\tInvoluntary context switches: 5\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_property-2.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "sum_property",
+        "repeat": 2,
+        "observation": {
+          "case": "sum_property",
+          "expected": -1262065,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[sum(var_0.score) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[sum(var_0.score) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[score@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21274959,
+            15155315,
+            14397020,
+            14313359,
+            14544783
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 73508\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3823\n\tVoluntary context switches: 553\n\tInvoluntary context switches: 10\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-sum_property-2.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "selective",
+        "repeat": 2,
+        "observation": {
+          "case": "selective",
+          "expected": 2,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      FilterExec: cypher_cmp_pred(score@1, 10000, 3), projection=[node_id@0]\n        HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@3, score@1]\n          PropertyOverlayExec: route=_untyped\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            21966712,
+            16059671,
+            15378488,
+            15730855,
+            14817349
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.10\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.20\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 74268\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3866\n\tVoluntary context switches: 553\n\tInvoluntary context switches: 14\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 7096\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-selective-2.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "empty",
+        "repeat": 2,
+        "observation": {
+          "case": "empty",
+          "expected": 0,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        FilterExec: array_has(type_ids@2, 1073741826), projection=[node_uuid@0, node_id@1]\n          RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n            OrderedPartitionStreamExec: input_partitions=14\n              GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15526891,
+            10980736,
+            11132400,
+            11264231,
+            11000806
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 71064\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3281\n\tVoluntary context switches: 548\n\tInvoluntary context switches: 10\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-empty-2.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_all",
+        "repeat": 2,
+        "observation": {
+          "case": "count_all",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(cypher_row_marker(var_0.node_id)) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_id@2]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15820357,
+            11251192,
+            10915174,
+            10892005,
+            10937585
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.18\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69196\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3290\n\tVoluntary context switches: 548\n\tInvoluntary context switches: 6\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_all-2.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      },
+      {
+        "case": "count_identity",
+        "repeat": 2,
+        "observation": {
+          "case": "count_identity",
+          "expected": 4101,
+          "physical_plan": "AggregateExec: mode=Final, gby=[], aggr=[count(var_0.node_uuid) as value]\n  CoalescePartitionsExec\n    AggregateExec: mode=Partial, gby=[], aggr=[count(var_0.node_uuid) as value]\n      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(node_uuid@0, node_uuid@0)], projection=[node_uuid@1]\n        PropertyOverlayExec: route=_untyped\n        RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1\n          OrderedPartitionStreamExec: input_partitions=14\n            GraphForgeParquetExec: fragments=14, batch_size=8192, limit=none\n",
+          "query_elapsed_ns": [
+            15238336,
+            11597518,
+            10728201,
+            10787502,
+            10681691
+          ]
+        },
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69300\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3223\n\tVoluntary context switches: 555\n\tInvoluntary context switches: 14\n\tSwaps: 0\n\tFile system inputs: 3328\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "command": [
+          "/usr/bin/time",
+          "-v",
+          "-o",
+          "/tmp/gf1249-statistics-candidate-count_identity-2.time",
+          "/tmp/gf1249-statistics-candidate-bin",
+          "--exact",
+          "statistics_public_query_probe",
+          "--nocapture",
+          "--test-threads=1"
+        ]
+      }
+    ]
+  },
+  "descriptor_samples": {
+    "records": [
+      {
+        "variant": "baseline",
+        "case": "count_all",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "scalar_oracle": 4101,
+        "samples": 19,
+        "sampled_allocated_peak": 5447680,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.01072685094550252,
+        "vanished_entries": 3,
+        "permission_denials": 0
+      },
+      {
+        "variant": "baseline",
+        "case": "count_identity",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "scalar_oracle": 4101,
+        "samples": 20,
+        "sampled_allocated_peak": 5386240,
+        "sampled_unlinked_peak": 0,
+        "maximum_sample_gap_seconds": 0.009471148019656539,
+        "vanished_entries": 7,
+        "permission_denials": 0
+      },
+      {
+        "variant": "baseline",
+        "case": "count_label",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "scalar_oracle": 2053,
+        "samples": 22,
+        "sampled_allocated_peak": 5386240,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.010342943947762251,
+        "vanished_entries": 3,
+        "permission_denials": 0
+      },
+      {
+        "variant": "baseline",
+        "case": "count_property",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "scalar_oracle": 1760,
+        "samples": 21,
+        "sampled_allocated_peak": 5447680,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.01015326997730881,
+        "vanished_entries": 7,
+        "permission_denials": 0
+      },
+      {
+        "variant": "baseline",
+        "case": "sum_property",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "scalar_oracle": -1262065,
+        "samples": 21,
+        "sampled_allocated_peak": 5447680,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.009937235969118774,
+        "vanished_entries": 11,
+        "permission_denials": 0
+      },
+      {
+        "variant": "baseline",
+        "case": "selective",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "scalar_oracle": 2,
+        "samples": 21,
+        "sampled_allocated_peak": 5447680,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.009966596961021423,
+        "vanished_entries": 11,
+        "permission_denials": 0
+      },
+      {
+        "variant": "baseline",
+        "case": "empty",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "scalar_oracle": 0,
+        "samples": 21,
+        "sampled_allocated_peak": 5447680,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.01113479898776859,
+        "vanished_entries": 6,
+        "permission_denials": 0
+      },
+      {
+        "variant": "candidate",
+        "case": "count_all",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "scalar_oracle": 4101,
+        "samples": 21,
+        "sampled_allocated_peak": 5238784,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.010696431039832532,
+        "vanished_entries": 7,
+        "permission_denials": 0
+      },
+      {
+        "variant": "candidate",
+        "case": "count_identity",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "scalar_oracle": 4101,
+        "samples": 21,
+        "sampled_allocated_peak": 5386240,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.009519109036773443,
+        "vanished_entries": 6,
+        "permission_denials": 0
+      },
+      {
+        "variant": "candidate",
+        "case": "count_label",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "scalar_oracle": 2053,
+        "samples": 19,
+        "sampled_allocated_peak": 5246976,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.010616648942232132,
+        "vanished_entries": 3,
+        "permission_denials": 0
+      },
+      {
+        "variant": "candidate",
+        "case": "count_property",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "scalar_oracle": 1760,
+        "samples": 19,
+        "sampled_allocated_peak": 5447680,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.010613048914819956,
+        "vanished_entries": 3,
+        "permission_denials": 0
+      },
+      {
+        "variant": "candidate",
+        "case": "sum_property",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "scalar_oracle": -1262065,
+        "samples": 21,
+        "sampled_allocated_peak": 5447680,
+        "sampled_unlinked_peak": 12288,
+        "maximum_sample_gap_seconds": 0.01028467295691371,
+        "vanished_entries": 8,
+        "permission_denials": 0
+      },
+      {
+        "variant": "candidate",
+        "case": "selective",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "scalar_oracle": 2,
+        "samples": 21,
+        "sampled_allocated_peak": 5447680,
+        "sampled_unlinked_peak": 4096,
+        "maximum_sample_gap_seconds": 0.00984836497809738,
+        "vanished_entries": 3,
+        "permission_denials": 0
+      },
+      {
+        "variant": "candidate",
+        "case": "empty",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "scalar_oracle": 0,
+        "samples": 19,
+        "sampled_allocated_peak": 5386240,
+        "sampled_unlinked_peak": 4096,
+        "maximum_sample_gap_seconds": 0.009982806979678571,
+        "vanished_entries": 7,
+        "permission_denials": 0
+      }
+    ],
+    "scope": "Root collector reads only the private fixture/scratch regular files and tracee-descendant FDs; tested executable runs with original ubuntu UID/GID/groups. Global device/inode dedup includes unlinked open descriptors. Non-atomic 5ms requested samples, not a hard bound; excludes directory blocks and unlinked mappings without an open descriptor. These instrumented timings are not performance observations."
+  },
+  "rss_cap_diagnostic": {
+    "protocol": "# Bounded diagnostic for the retained count_identity RSS cap failure\n\nOriginal candidate max70,184 KiB exceeds unchanged69,952 KiB cap by232 KiB; original result remains failed. No thresholds are changed and no rerun replaces it. The explicit identity query has identical executed plan and effectively identical syscall work; code review is checking reachability of changes.\n\nRun exactly eight baseline/candidate pairs, alternating order, on the same frozen executables and fixture. Sample descendant /proc status and smaps to distinguish executable/file-backed residence from anonymous/private memory; retain all samples and GNU-time peaks. Sampling perturbs execution, so timing is not performance evidence. Record sampled component maxima as samples, not bounds. Count every cap crossing for both variants; never stop on green. This diagnoses whether the observed margin is a reproducible candidate allocation change or a process-residence budget that also fails on the unchanged baseline. The original preselected cap remains authoritative and all results are reported.\n",
+    "records": [
+      {
+        "pair": 0,
+        "variant": "baseline",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69364\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3261\n\tVoluntary context switches: 498\n\tInvoluntary context switches: 13\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 69364,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0032112000044435263,
+            "hwm_kib": 5600,
+            "executable_rss_kib": 4584,
+            "other_file_rss_kib": 1304,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.006452950998209417,
+            "hwm_kib": 14900,
+            "executable_rss_kib": 11908,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 540
+          },
+          {
+            "seconds": 0.009747031959705055,
+            "hwm_kib": 16736,
+            "executable_rss_kib": 14788,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 564
+          },
+          {
+            "seconds": 0.01328332896810025,
+            "hwm_kib": 20132,
+            "executable_rss_kib": 16900,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 696
+          },
+          {
+            "seconds": 0.01693225698545575,
+            "hwm_kib": 20140,
+            "executable_rss_kib": 16900,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.0204430929152295,
+            "hwm_kib": 20144,
+            "executable_rss_kib": 16900,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.02382814697921276,
+            "hwm_kib": 20212,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.027325081988237798,
+            "hwm_kib": 20212,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.030725965974852443,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03403359791263938,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03733475995250046,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04064164194278419,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04395031393505633,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04725093592423946,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.050551747903227806,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05386014992836863,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.057165462989360094,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06047505489550531,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06377421598881483,
+            "hwm_kib": 20276,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06708403897937387,
+            "hwm_kib": 20340,
+            "executable_rss_kib": 17220,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 728
+          },
+          {
+            "seconds": 0.07052564295008779,
+            "hwm_kib": 20676,
+            "executable_rss_kib": 17348,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 792
+          },
+          {
+            "seconds": 0.07408821990247816,
+            "hwm_kib": 20676,
+            "executable_rss_kib": 17348,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 792
+          },
+          {
+            "seconds": 0.07753796491306275,
+            "hwm_kib": 20740,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 792
+          },
+          {
+            "seconds": 0.08110672200564295,
+            "hwm_kib": 20796,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.08455090690404177,
+            "hwm_kib": 20796,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.088122273911722,
+            "hwm_kib": 20796,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.0915671979309991,
+            "hwm_kib": 20924,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09513610496651381,
+            "hwm_kib": 20924,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09863790089730173,
+            "hwm_kib": 23684,
+            "executable_rss_kib": 20292,
+            "other_file_rss_kib": 2600,
+            "anonymous_rss_kib": 868
+          },
+          {
+            "seconds": 0.1024661329574883,
+            "hwm_kib": 28408,
+            "executable_rss_kib": 26372,
+            "other_file_rss_kib": 2600,
+            "anonymous_rss_kib": 996
+          },
+          {
+            "seconds": 0.1068833259632811,
+            "hwm_kib": 56288,
+            "executable_rss_kib": 57156,
+            "other_file_rss_kib": 2600,
+            "anonymous_rss_kib": 1160
+          },
+          {
+            "seconds": 0.11162455496378243,
+            "hwm_kib": 64992,
+            "executable_rss_kib": 60612,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 1536
+          },
+          {
+            "seconds": 0.11637782398611307,
+            "hwm_kib": 65200,
+            "executable_rss_kib": 60740,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 1632
+          },
+          {
+            "seconds": 0.12101970089133829,
+            "hwm_kib": 68772,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2380
+          },
+          {
+            "seconds": 0.12576200999319553,
+            "hwm_kib": 69040,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2636
+          },
+          {
+            "seconds": 0.13037316699046642,
+            "hwm_kib": 68824,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2436
+          },
+          {
+            "seconds": 0.1351975869620219,
+            "hwm_kib": 69364,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3112
+          },
+          {
+            "seconds": 0.13977716292720288,
+            "hwm_kib": 69644,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3240
+          },
+          {
+            "seconds": 0.14434977900236845,
+            "hwm_kib": 69396,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2996
+          },
+          {
+            "seconds": 0.149117038003169,
+            "hwm_kib": 69644,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3280
+          },
+          {
+            "seconds": 0.15372580499388278,
+            "hwm_kib": 69684,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3040
+          },
+          {
+            "seconds": 0.15860496694222093,
+            "hwm_kib": 69580,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3384
+          },
+          {
+            "seconds": 0.16339651599992067,
+            "hwm_kib": 69860,
+            "executable_rss_kib": 63556,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3456
+          },
+          {
+            "seconds": 0.16805391397792846,
+            "hwm_kib": 69964,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3252
+          },
+          {
+            "seconds": 0.17022955499123782,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          },
+          {
+            "seconds": 0.17238081491086632,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 0,
+        "variant": "candidate",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69484\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3255\n\tVoluntary context switches: 541\n\tInvoluntary context switches: 9\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 69484,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0029795559821650386,
+            "hwm_kib": 4760,
+            "executable_rss_kib": 3780,
+            "other_file_rss_kib": 1240,
+            "anonymous_rss_kib": 48
+          },
+          {
+            "seconds": 0.006202456075698137,
+            "hwm_kib": 13656,
+            "executable_rss_kib": 11260,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 124
+          },
+          {
+            "seconds": 0.009446587064303458,
+            "hwm_kib": 16024,
+            "executable_rss_kib": 12988,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 568
+          },
+          {
+            "seconds": 0.01275243901181966,
+            "hwm_kib": 19836,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 696
+          },
+          {
+            "seconds": 0.01609601208474487,
+            "hwm_kib": 19876,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.01955381699372083,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.022931560059078038,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.02643406600691378,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.029833730077371,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03314096201211214,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.03642656304873526,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.039728795061819255,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.043031128006987274,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.0463130590505898,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.04958918096963316,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.052873702021315694,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.05615743400994688,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.05943616502918303,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.0627293570432812,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.06603573902975768,
+            "hwm_kib": 20068,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.06951805506832898,
+            "hwm_kib": 20408,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 788
+          },
+          {
+            "seconds": 0.07291335798799992,
+            "hwm_kib": 20408,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 788
+          },
+          {
+            "seconds": 0.07642450404819101,
+            "hwm_kib": 20408,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 788
+          },
+          {
+            "seconds": 0.07983041799161583,
+            "hwm_kib": 20504,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 856
+          },
+          {
+            "seconds": 0.08333924401085824,
+            "hwm_kib": 20540,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 856
+          },
+          {
+            "seconds": 0.086762058082968,
+            "hwm_kib": 20540,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 856
+          },
+          {
+            "seconds": 0.09030409506522119,
+            "hwm_kib": 20668,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 856
+          },
+          {
+            "seconds": 0.09374157898128033,
+            "hwm_kib": 20668,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 856
+          },
+          {
+            "seconds": 0.09713123308029026,
+            "hwm_kib": 23228,
+            "executable_rss_kib": 19836,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 856
+          },
+          {
+            "seconds": 0.10065049899276346,
+            "hwm_kib": 23640,
+            "executable_rss_kib": 20220,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 884
+          },
+          {
+            "seconds": 0.1046160829719156,
+            "hwm_kib": 34328,
+            "executable_rss_kib": 34876,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1052
+          },
+          {
+            "seconds": 0.10914790804963559,
+            "hwm_kib": 63680,
+            "executable_rss_kib": 60092,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 1228
+          },
+          {
+            "seconds": 0.11374211497604847,
+            "hwm_kib": 64712,
+            "executable_rss_kib": 60348,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 1548
+          },
+          {
+            "seconds": 0.11828128003980964,
+            "hwm_kib": 64908,
+            "executable_rss_kib": 60476,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 1644
+          },
+          {
+            "seconds": 0.12303712905850261,
+            "hwm_kib": 68344,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2316
+          },
+          {
+            "seconds": 0.12776591803412884,
+            "hwm_kib": 68604,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2560
+          },
+          {
+            "seconds": 0.1323390540201217,
+            "hwm_kib": 68364,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2328
+          },
+          {
+            "seconds": 0.13697885104920715,
+            "hwm_kib": 69000,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3068
+          },
+          {
+            "seconds": 0.14171359001193196,
+            "hwm_kib": 69252,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3208
+          },
+          {
+            "seconds": 0.14631838607601821,
+            "hwm_kib": 69056,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3020
+          },
+          {
+            "seconds": 0.15107782499399036,
+            "hwm_kib": 69208,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3252
+          },
+          {
+            "seconds": 0.15561755106318742,
+            "hwm_kib": 69412,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3368
+          },
+          {
+            "seconds": 0.16023713699541986,
+            "hwm_kib": 69260,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3224
+          },
+          {
+            "seconds": 0.16502235701773316,
+            "hwm_kib": 69516,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3512
+          },
+          {
+            "seconds": 0.1697490360820666,
+            "hwm_kib": 69556,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3260
+          },
+          {
+            "seconds": 0.174693119013682,
+            "hwm_kib": 69964,
+            "executable_rss_kib": 63868,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3280
+          },
+          {
+            "seconds": 0.17685157898813486,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 1,
+        "variant": "candidate",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 68908\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3232\n\tVoluntary context switches: 522\n\tInvoluntary context switches: 5\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 68908,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0031353679951280355,
+            "hwm_kib": 4828,
+            "executable_rss_kib": 3768,
+            "other_file_rss_kib": 1240,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.0063138880068436265,
+            "hwm_kib": 13788,
+            "executable_rss_kib": 11260,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 384
+          },
+          {
+            "seconds": 0.009577588993124664,
+            "hwm_kib": 15956,
+            "executable_rss_kib": 12924,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 564
+          },
+          {
+            "seconds": 0.012967273010872304,
+            "hwm_kib": 19444,
+            "executable_rss_kib": 16572,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 696
+          },
+          {
+            "seconds": 0.016409108066000044,
+            "hwm_kib": 19744,
+            "executable_rss_kib": 16572,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.01976987102534622,
+            "hwm_kib": 19748,
+            "executable_rss_kib": 16572,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.023119433084502816,
+            "hwm_kib": 19820,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.02660292899236083,
+            "hwm_kib": 19820,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.029979802086018026,
+            "hwm_kib": 19820,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.033269894076511264,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03656106605194509,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.039854687987826765,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04314593900926411,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04643014108296484,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.049709313083440065,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05298925400711596,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05627923598513007,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05956522806081921,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06288350000977516,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06617773207835853,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06947691401001066,
+            "hwm_kib": 20380,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07290043809916824,
+            "hwm_kib": 20412,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.07643219409510493,
+            "hwm_kib": 20412,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.07987427909392864,
+            "hwm_kib": 20476,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.08342268504202366,
+            "hwm_kib": 20532,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08684872009325773,
+            "hwm_kib": 20532,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09039809601381421,
+            "hwm_kib": 20724,
+            "executable_rss_kib": 17404,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09383136103861034,
+            "hwm_kib": 20724,
+            "executable_rss_kib": 17404,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.0973837070632726,
+            "hwm_kib": 20724,
+            "executable_rss_kib": 17404,
+            "other_file_rss_kib": 2468,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10087888303678483,
+            "hwm_kib": 23624,
+            "executable_rss_kib": 20220,
+            "other_file_rss_kib": 2532,
+            "anonymous_rss_kib": 872
+          },
+          {
+            "seconds": 0.10470688506029546,
+            "hwm_kib": 29816,
+            "executable_rss_kib": 27068,
+            "other_file_rss_kib": 2532,
+            "anonymous_rss_kib": 992
+          },
+          {
+            "seconds": 0.10910674708429724,
+            "hwm_kib": 56608,
+            "executable_rss_kib": 58428,
+            "other_file_rss_kib": 2532,
+            "anonymous_rss_kib": 1192
+          },
+          {
+            "seconds": 0.11373813403770328,
+            "hwm_kib": 64484,
+            "executable_rss_kib": 60092,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 1548
+          },
+          {
+            "seconds": 0.11828188004437834,
+            "hwm_kib": 64688,
+            "executable_rss_kib": 60220,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 1644
+          },
+          {
+            "seconds": 0.12286237603984773,
+            "hwm_kib": 68008,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 2332
+          },
+          {
+            "seconds": 0.12762533500790596,
+            "hwm_kib": 68268,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 2580
+          },
+          {
+            "seconds": 0.132244682055898,
+            "hwm_kib": 68268,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 2328
+          },
+          {
+            "seconds": 0.13682838808745146,
+            "hwm_kib": 68184,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 2652
+          },
+          {
+            "seconds": 0.14159768703393638,
+            "hwm_kib": 68436,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 2748
+          },
+          {
+            "seconds": 0.1461233920417726,
+            "hwm_kib": 68280,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 2612
+          },
+          {
+            "seconds": 0.1508957319892943,
+            "hwm_kib": 68576,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 2888
+          },
+          {
+            "seconds": 0.15566283103544265,
+            "hwm_kib": 68300,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 2620
+          },
+          {
+            "seconds": 0.16026170807890594,
+            "hwm_kib": 68728,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 3216
+          },
+          {
+            "seconds": 0.16478069208096713,
+            "hwm_kib": 69008,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 3320
+          },
+          {
+            "seconds": 0.16932421806268394,
+            "hwm_kib": 68812,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2844,
+            "anonymous_rss_kib": 3188
+          },
+          {
+            "seconds": 0.17392264399677515,
+            "hwm_kib": 69364,
+            "executable_rss_kib": 63420,
+            "other_file_rss_kib": 2972,
+            "anonymous_rss_kib": 1424
+          },
+          {
+            "seconds": 0.17607675504405051,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 1,
+        "variant": "baseline",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 68612\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3091\n\tVoluntary context switches: 498\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 68612,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0029312949627637863,
+            "hwm_kib": 4744,
+            "executable_rss_kib": 3684,
+            "other_file_rss_kib": 1236,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.00617414596490562,
+            "hwm_kib": 13720,
+            "executable_rss_kib": 11332,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 120
+          },
+          {
+            "seconds": 0.009557718993164599,
+            "hwm_kib": 16028,
+            "executable_rss_kib": 13060,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 560
+          },
+          {
+            "seconds": 0.012986793997697532,
+            "hwm_kib": 19392,
+            "executable_rss_kib": 16452,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 692
+          },
+          {
+            "seconds": 0.01640657801181078,
+            "hwm_kib": 19624,
+            "executable_rss_kib": 16452,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 700
+          },
+          {
+            "seconds": 0.01977303100284189,
+            "hwm_kib": 19628,
+            "executable_rss_kib": 16452,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.02310946397483349,
+            "hwm_kib": 19764,
+            "executable_rss_kib": 16580,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.026523938053287566,
+            "hwm_kib": 19764,
+            "executable_rss_kib": 16580,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.02988327096682042,
+            "hwm_kib": 19764,
+            "executable_rss_kib": 16580,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.033353675971738994,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.03680866095237434,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.0402635260252282,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.043715851032175124,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.047185646020807326,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.0506501910276711,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.054103275993838906,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.057550049968995154,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.060991095029748976,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.06448880000971258,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.0679703060304746,
+            "hwm_kib": 19880,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07141755998600274,
+            "hwm_kib": 20136,
+            "executable_rss_kib": 16900,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07479104399681091,
+            "hwm_kib": 20136,
+            "executable_rss_kib": 16900,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07816154696047306,
+            "hwm_kib": 20136,
+            "executable_rss_kib": 16900,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.081584800966084,
+            "hwm_kib": 20228,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 800
+          },
+          {
+            "seconds": 0.08494446403346956,
+            "hwm_kib": 20284,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.08838455902878195,
+            "hwm_kib": 20284,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09177255304530263,
+            "hwm_kib": 20284,
+            "executable_rss_kib": 17092,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09512596495915204,
+            "hwm_kib": 20412,
+            "executable_rss_kib": 17092,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09879204398021102,
+            "hwm_kib": 20412,
+            "executable_rss_kib": 17092,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.10217907803598791,
+            "hwm_kib": 23036,
+            "executable_rss_kib": 19652,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.10574602498672903,
+            "hwm_kib": 23800,
+            "executable_rss_kib": 20932,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 908
+          },
+          {
+            "seconds": 0.10984916205052286,
+            "hwm_kib": 42436,
+            "executable_rss_kib": 42628,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1068
+          },
+          {
+            "seconds": 0.11447912896983325,
+            "hwm_kib": 64360,
+            "executable_rss_kib": 60164,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 1512
+          },
+          {
+            "seconds": 0.11911801598034799,
+            "hwm_kib": 64524,
+            "executable_rss_kib": 60292,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 1584
+          },
+          {
+            "seconds": 0.12366241100244224,
+            "hwm_kib": 67260,
+            "executable_rss_kib": 62404,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2328
+          },
+          {
+            "seconds": 0.12839266005903482,
+            "hwm_kib": 68576,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2608
+          },
+          {
+            "seconds": 0.13307511794846505,
+            "hwm_kib": 68672,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2620
+          },
+          {
+            "seconds": 0.13780368701554835,
+            "hwm_kib": 68628,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2688
+          },
+          {
+            "seconds": 0.1423688919749111,
+            "hwm_kib": 68880,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2828
+          },
+          {
+            "seconds": 0.1470555099658668,
+            "hwm_kib": 68644,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2592
+          },
+          {
+            "seconds": 0.15183524996973574,
+            "hwm_kib": 68840,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2872
+          },
+          {
+            "seconds": 0.15639365499373525,
+            "hwm_kib": 68924,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2872
+          },
+          {
+            "seconds": 0.16126012697350234,
+            "hwm_kib": 68648,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2756
+          },
+          {
+            "seconds": 0.16581558203324676,
+            "hwm_kib": 68928,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2876
+          },
+          {
+            "seconds": 0.17115883203223348,
+            "hwm_kib": 68680,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2636
+          },
+          {
+            "seconds": 0.17568945803213865,
+            "hwm_kib": 69120,
+            "executable_rss_kib": 63748,
+            "other_file_rss_kib": 2944,
+            "anonymous_rss_kib": 1540
+          },
+          {
+            "seconds": 0.17785360803827643,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 2,
+        "variant": "baseline",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 88%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.16\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 70068\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3246\n\tVoluntary context switches: 444\n\tInvoluntary context switches: 12\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 70068,
+        "cap_kib": 69952,
+        "cap_pass": false,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0029406449757516384,
+            "hwm_kib": 4688,
+            "executable_rss_kib": 3620,
+            "other_file_rss_kib": 1236,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.006022613029927015,
+            "hwm_kib": 13672,
+            "executable_rss_kib": 11140,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 112
+          },
+          {
+            "seconds": 0.009236903046257794,
+            "hwm_kib": 15984,
+            "executable_rss_kib": 12996,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 560
+          },
+          {
+            "seconds": 0.012658667052164674,
+            "hwm_kib": 19536,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 692
+          },
+          {
+            "seconds": 0.016205414081923664,
+            "hwm_kib": 19900,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 700
+          },
+          {
+            "seconds": 0.01962789800018072,
+            "hwm_kib": 19904,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.023176833987236023,
+            "hwm_kib": 20100,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.02661182906012982,
+            "hwm_kib": 20100,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.030161065980792046,
+            "hwm_kib": 20100,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.03345681703649461,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.036748068989254534,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.040043171029537916,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.04333558306097984,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.04662734502926469,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.04992794699501246,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.053221788024529815,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.05651309003587812,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.05980957206338644,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.06310254405252635,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.06639241601806134,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.06979414005763829,
+            "hwm_kib": 20600,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.07329270499758422,
+            "hwm_kib": 20600,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.0767069790745154,
+            "hwm_kib": 20600,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.08025381597690284,
+            "hwm_kib": 20688,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.08368606003932655,
+            "hwm_kib": 20688,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.0872301070485264,
+            "hwm_kib": 20688,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09065983106847852,
+            "hwm_kib": 20816,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09421478805597872,
+            "hwm_kib": 20816,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2428,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09770762303378433,
+            "hwm_kib": 23376,
+            "executable_rss_kib": 20036,
+            "other_file_rss_kib": 2492,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.10133085097186267,
+            "hwm_kib": 24268,
+            "executable_rss_kib": 20868,
+            "other_file_rss_kib": 2492,
+            "anonymous_rss_kib": 908
+          },
+          {
+            "seconds": 0.10546475904993713,
+            "hwm_kib": 43536,
+            "executable_rss_kib": 43972,
+            "other_file_rss_kib": 2492,
+            "anonymous_rss_kib": 1068
+          },
+          {
+            "seconds": 0.11006561503745615,
+            "hwm_kib": 65044,
+            "executable_rss_kib": 60868,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 1512
+          },
+          {
+            "seconds": 0.1147200430277735,
+            "hwm_kib": 65312,
+            "executable_rss_kib": 60996,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 1604
+          },
+          {
+            "seconds": 0.11928501806687564,
+            "hwm_kib": 68628,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2368
+          },
+          {
+            "seconds": 0.1239395160228014,
+            "hwm_kib": 69396,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2628
+          },
+          {
+            "seconds": 0.1286633440759033,
+            "hwm_kib": 69404,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2448
+          },
+          {
+            "seconds": 0.13323889998719096,
+            "hwm_kib": 69432,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2728
+          },
+          {
+            "seconds": 0.1379060479812324,
+            "hwm_kib": 69520,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2744
+          },
+          {
+            "seconds": 0.14260986598674208,
+            "hwm_kib": 69368,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2728
+          },
+          {
+            "seconds": 0.14721676299814135,
+            "hwm_kib": 69648,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2872
+          },
+          {
+            "seconds": 0.15176057803910226,
+            "hwm_kib": 69388,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2668
+          },
+          {
+            "seconds": 0.15665035007987171,
+            "hwm_kib": 69700,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2964
+          },
+          {
+            "seconds": 0.16145344998221844,
+            "hwm_kib": 69740,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 2692
+          },
+          {
+            "seconds": 0.16623963008169085,
+            "hwm_kib": 70212,
+            "executable_rss_kib": 64516,
+            "other_file_rss_kib": 2772,
+            "anonymous_rss_kib": 3188
+          },
+          {
+            "seconds": 0.16841768100857735,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 2,
+        "variant": "candidate",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 68696\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3211\n\tVoluntary context switches: 474\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 68696,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0029811860295012593,
+            "hwm_kib": 4892,
+            "executable_rss_kib": 3948,
+            "other_file_rss_kib": 1228,
+            "anonymous_rss_kib": 40
+          },
+          {
+            "seconds": 0.007568362052552402,
+            "hwm_kib": 15248,
+            "executable_rss_kib": 12220,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 556
+          },
+          {
+            "seconds": 0.010844164062291384,
+            "hwm_kib": 17560,
+            "executable_rss_kib": 14524,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 564
+          },
+          {
+            "seconds": 0.014329459052532911,
+            "hwm_kib": 19736,
+            "executable_rss_kib": 16572,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 692
+          },
+          {
+            "seconds": 0.017710792017169297,
+            "hwm_kib": 19744,
+            "executable_rss_kib": 16572,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 700
+          },
+          {
+            "seconds": 0.021203608019277453,
+            "hwm_kib": 19748,
+            "executable_rss_kib": 16572,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.024611672037281096,
+            "hwm_kib": 19820,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.028140868060290813,
+            "hwm_kib": 19820,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03157085308339447,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03487040498293936,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03817142709158361,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04146868805401027,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.044762480072677135,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04805304203182459,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05134231399279088,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.054633456049486995,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05792414699681103,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.0612121190642938,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06453549105208367,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06785037403460592,
+            "hwm_kib": 20224,
+            "executable_rss_kib": 17020,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 736
+          },
+          {
+            "seconds": 0.07133956905454397,
+            "hwm_kib": 20380,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.07473177299834788,
+            "hwm_kib": 20380,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.07823958899825811,
+            "hwm_kib": 20444,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.08165239298250526,
+            "hwm_kib": 20532,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.08518572908360511,
+            "hwm_kib": 20532,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.08861110301222652,
+            "hwm_kib": 20532,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09215829998720437,
+            "hwm_kib": 20724,
+            "executable_rss_kib": 17404,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.0955904540605843,
+            "hwm_kib": 20724,
+            "executable_rss_kib": 17404,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09920527203939855,
+            "hwm_kib": 23540,
+            "executable_rss_kib": 20156,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.10273381799925119,
+            "hwm_kib": 24296,
+            "executable_rss_kib": 21756,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 900
+          },
+          {
+            "seconds": 0.1071023300755769,
+            "hwm_kib": 43440,
+            "executable_rss_kib": 45820,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1072
+          },
+          {
+            "seconds": 0.11160948500037193,
+            "hwm_kib": 64336,
+            "executable_rss_kib": 60092,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 1540
+          },
+          {
+            "seconds": 0.11614994006231427,
+            "hwm_kib": 64548,
+            "executable_rss_kib": 60220,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 1600
+          },
+          {
+            "seconds": 0.12081175798084587,
+            "hwm_kib": 67960,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2344
+          },
+          {
+            "seconds": 0.12539381405804306,
+            "hwm_kib": 68228,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2596
+          },
+          {
+            "seconds": 0.1299931900575757,
+            "hwm_kib": 68228,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2344
+          },
+          {
+            "seconds": 0.13475634902715683,
+            "hwm_kib": 68144,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2672
+          },
+          {
+            "seconds": 0.13928222400136292,
+            "hwm_kib": 68420,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2788
+          },
+          {
+            "seconds": 0.14382599003147334,
+            "hwm_kib": 68144,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2528
+          },
+          {
+            "seconds": 0.14843039598781615,
+            "hwm_kib": 68428,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2804
+          },
+          {
+            "seconds": 0.15302624204196036,
+            "hwm_kib": 68436,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2568
+          },
+          {
+            "seconds": 0.15783747204113752,
+            "hwm_kib": 68416,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2864
+          },
+          {
+            "seconds": 0.16235711704939604,
+            "hwm_kib": 68504,
+            "executable_rss_kib": 62844,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2872
+          },
+          {
+            "seconds": 0.16713268705643713,
+            "hwm_kib": 69092,
+            "executable_rss_kib": 63292,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 3084
+          },
+          {
+            "seconds": 0.16928211704362184,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          },
+          {
+            "seconds": 0.17141725705005229,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 3,
+        "variant": "candidate",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 85%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69196\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3246\n\tVoluntary context switches: 494\n\tInvoluntary context switches: 14\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 69196,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0029337949818000197,
+            "hwm_kib": 4600,
+            "executable_rss_kib": 3540,
+            "other_file_rss_kib": 1240,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.006020292988978326,
+            "hwm_kib": 13580,
+            "executable_rss_kib": 11068,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 112
+          },
+          {
+            "seconds": 0.009266284061595798,
+            "hwm_kib": 15956,
+            "executable_rss_kib": 12924,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 560
+          },
+          {
+            "seconds": 0.012606707052327693,
+            "hwm_kib": 19552,
+            "executable_rss_kib": 16444,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 636
+          },
+          {
+            "seconds": 0.016131473006680608,
+            "hwm_kib": 20064,
+            "executable_rss_kib": 16892,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 700
+          },
+          {
+            "seconds": 0.01954133703839034,
+            "hwm_kib": 20064,
+            "executable_rss_kib": 16892,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.023093673982657492,
+            "hwm_kib": 20264,
+            "executable_rss_kib": 17084,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.026510967989452183,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17084,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.030044644023291767,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17084,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03333630599081516,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03661457705311477,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03990527905989438,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04319739108905196,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04646875208709389,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04975825408473611,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05304552603047341,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.056322147022001445,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05960061901714653,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06289535108953714,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06618627300485969,
+            "hwm_kib": 20332,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06947488407604396,
+            "hwm_kib": 20576,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07282915699761361,
+            "hwm_kib": 20576,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.0762960520805791,
+            "hwm_kib": 20576,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.0796920460416004,
+            "hwm_kib": 20688,
+            "executable_rss_kib": 17404,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 816
+          },
+          {
+            "seconds": 0.08319832198321819,
+            "hwm_kib": 20728,
+            "executable_rss_kib": 17404,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08659118507057428,
+            "hwm_kib": 20728,
+            "executable_rss_kib": 17404,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09011833206750453,
+            "hwm_kib": 20856,
+            "executable_rss_kib": 17532,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09354397607967257,
+            "hwm_kib": 20856,
+            "executable_rss_kib": 17532,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09710446302779019,
+            "hwm_kib": 20856,
+            "executable_rss_kib": 18428,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10058396798558533,
+            "hwm_kib": 23500,
+            "executable_rss_kib": 20220,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 872
+          },
+          {
+            "seconds": 0.10456947307102382,
+            "hwm_kib": 32324,
+            "executable_rss_kib": 33212,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1016
+          },
+          {
+            "seconds": 0.1092626410536468,
+            "hwm_kib": 63216,
+            "executable_rss_kib": 60028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1188
+          },
+          {
+            "seconds": 0.11386426701210439,
+            "hwm_kib": 65040,
+            "executable_rss_kib": 60732,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 1544
+          },
+          {
+            "seconds": 0.11845390300732106,
+            "hwm_kib": 65192,
+            "executable_rss_kib": 60796,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 1640
+          },
+          {
+            "seconds": 0.12305131007451564,
+            "hwm_kib": 68524,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 2300
+          },
+          {
+            "seconds": 0.1277396980440244,
+            "hwm_kib": 68796,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 2548
+          },
+          {
+            "seconds": 0.13245940604247153,
+            "hwm_kib": 68796,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 2296
+          },
+          {
+            "seconds": 0.13718005502596498,
+            "hwm_kib": 69132,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3036
+          },
+          {
+            "seconds": 0.14184108201880008,
+            "hwm_kib": 69380,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3132
+          },
+          {
+            "seconds": 0.14639944804366678,
+            "hwm_kib": 69388,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3144
+          },
+          {
+            "seconds": 0.1511202270630747,
+            "hwm_kib": 69652,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3436
+          },
+          {
+            "seconds": 0.15579005400650203,
+            "hwm_kib": 69684,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3168
+          },
+          {
+            "seconds": 0.16055597399827093,
+            "hwm_kib": 69576,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3416
+          },
+          {
+            "seconds": 0.16519103106111288,
+            "hwm_kib": 69704,
+            "executable_rss_kib": 63484,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3456
+          },
+          {
+            "seconds": 0.17005798208992928,
+            "hwm_kib": 69816,
+            "executable_rss_kib": 63868,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3204
+          },
+          {
+            "seconds": 0.17222050298005342,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          },
+          {
+            "seconds": 0.17436694307252765,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 3,
+        "variant": "baseline",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69668\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3244\n\tVoluntary context switches: 497\n\tInvoluntary context switches: 10\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 69668,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.002933804993517697,
+            "hwm_kib": 4668,
+            "executable_rss_kib": 3680,
+            "other_file_rss_kib": 1240,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.006014763028360903,
+            "hwm_kib": 13720,
+            "executable_rss_kib": 11140,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 116
+          },
+          {
+            "seconds": 0.009243144071660936,
+            "hwm_kib": 16032,
+            "executable_rss_kib": 12996,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 564
+          },
+          {
+            "seconds": 0.012582186027429998,
+            "hwm_kib": 19436,
+            "executable_rss_kib": 16388,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 640
+          },
+          {
+            "seconds": 0.015903179068118334,
+            "hwm_kib": 19752,
+            "executable_rss_kib": 16580,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.019379424047656357,
+            "hwm_kib": 19756,
+            "executable_rss_kib": 16580,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.0227249669842422,
+            "hwm_kib": 19888,
+            "executable_rss_kib": 16708,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.026253752992488444,
+            "hwm_kib": 19892,
+            "executable_rss_kib": 16708,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.029656257014721632,
+            "hwm_kib": 19892,
+            "executable_rss_kib": 16708,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03299726906698197,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.03627207106910646,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.03955487301573157,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.04283346398733556,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.046118036028929055,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.049395057023502886,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.052682479028590024,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.055962191079743207,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.05925208202097565,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.06259150500409305,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.06591953709721565,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.06921501900069416,
+            "hwm_kib": 20008,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07264419307466596,
+            "hwm_kib": 20360,
+            "executable_rss_kib": 17092,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.07614102901425213,
+            "hwm_kib": 20360,
+            "executable_rss_kib": 17092,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.0795853640884161,
+            "hwm_kib": 20360,
+            "executable_rss_kib": 17156,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.08293480705469847,
+            "hwm_kib": 20480,
+            "executable_rss_kib": 17156,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08642010204494,
+            "hwm_kib": 20480,
+            "executable_rss_kib": 17156,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08980506600346416,
+            "hwm_kib": 20480,
+            "executable_rss_kib": 17156,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09330214106012136,
+            "hwm_kib": 20608,
+            "executable_rss_kib": 17284,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09660313301719725,
+            "hwm_kib": 20608,
+            "executable_rss_kib": 17284,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09995071601588279,
+            "hwm_kib": 22912,
+            "executable_rss_kib": 19524,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10349142306949943,
+            "hwm_kib": 23804,
+            "executable_rss_kib": 20420,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 912
+          },
+          {
+            "seconds": 0.10772519209422171,
+            "hwm_kib": 43524,
+            "executable_rss_kib": 44996,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1076
+          },
+          {
+            "seconds": 0.11228397802915424,
+            "hwm_kib": 64892,
+            "executable_rss_kib": 60676,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 1528
+          },
+          {
+            "seconds": 0.11679369199555367,
+            "hwm_kib": 65112,
+            "executable_rss_kib": 60868,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 1592
+          },
+          {
+            "seconds": 0.12133807805366814,
+            "hwm_kib": 67812,
+            "executable_rss_kib": 62788,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 2348
+          },
+          {
+            "seconds": 0.12608552700839937,
+            "hwm_kib": 69160,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 2608
+          },
+          {
+            "seconds": 0.13081903499551117,
+            "hwm_kib": 69264,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 2624
+          },
+          {
+            "seconds": 0.13560170505661517,
+            "hwm_kib": 69556,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3084
+          },
+          {
+            "seconds": 0.14021016203332692,
+            "hwm_kib": 69824,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3184
+          },
+          {
+            "seconds": 0.1447513970779255,
+            "hwm_kib": 69620,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 2980
+          },
+          {
+            "seconds": 0.14962955901864916,
+            "hwm_kib": 69860,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3232
+          },
+          {
+            "seconds": 0.15450253000017256,
+            "hwm_kib": 69872,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3028
+          },
+          {
+            "seconds": 0.15928224904928356,
+            "hwm_kib": 69748,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3224
+          },
+          {
+            "seconds": 0.16400793800130486,
+            "hwm_kib": 70048,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3408
+          },
+          {
+            "seconds": 0.16873632709030062,
+            "hwm_kib": 69808,
+            "executable_rss_kib": 63876,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3172
+          },
+          {
+            "seconds": 0.1736888299928978,
+            "hwm_kib": 70420,
+            "executable_rss_kib": 64452,
+            "other_file_rss_kib": 2764,
+            "anonymous_rss_kib": 3204
+          },
+          {
+            "seconds": 0.1758647810202092,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 4,
+        "variant": "baseline",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.08\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69700\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3128\n\tVoluntary context switches: 483\n\tInvoluntary context switches: 5\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 69700,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0029419059865176678,
+            "hwm_kib": 4732,
+            "executable_rss_kib": 3616,
+            "other_file_rss_kib": 1228,
+            "anonymous_rss_kib": 40
+          },
+          {
+            "seconds": 0.0060367240803316236,
+            "hwm_kib": 13580,
+            "executable_rss_kib": 11012,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 112
+          },
+          {
+            "seconds": 0.009290955029428005,
+            "hwm_kib": 16016,
+            "executable_rss_kib": 12996,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 560
+          },
+          {
+            "seconds": 0.012695739045739174,
+            "hwm_kib": 19484,
+            "executable_rss_kib": 16452,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 636
+          },
+          {
+            "seconds": 0.016189033980481327,
+            "hwm_kib": 19932,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 700
+          },
+          {
+            "seconds": 0.019601547974161804,
+            "hwm_kib": 19936,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.02313160407356918,
+            "hwm_kib": 20132,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.026588608976453543,
+            "hwm_kib": 20136,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.030124486074782908,
+            "hwm_kib": 20136,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03343358798883855,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.0367396300425753,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.04004612204153091,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.043341264012269676,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.04665154602844268,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.049940478056669235,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.05324309004936367,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.056535942014306784,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.05984520399942994,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.06313480506651103,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.06643501704093069,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.06972959905397147,
+            "hwm_kib": 20252,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07324085501022637,
+            "hwm_kib": 20572,
+            "executable_rss_kib": 17348,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07665126898791641,
+            "hwm_kib": 20572,
+            "executable_rss_kib": 17348,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.08015496504958719,
+            "hwm_kib": 20572,
+            "executable_rss_kib": 17348,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.08357749902643263,
+            "hwm_kib": 20720,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.08712730603292584,
+            "hwm_kib": 20720,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09054859005846083,
+            "hwm_kib": 20720,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09410069708246738,
+            "hwm_kib": 20848,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09752800106070936,
+            "hwm_kib": 20848,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2460,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.10113792901393026,
+            "hwm_kib": 23088,
+            "executable_rss_kib": 19716,
+            "other_file_rss_kib": 2524,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.10463125398382545,
+            "hwm_kib": 23980,
+            "executable_rss_kib": 20612,
+            "other_file_rss_kib": 2524,
+            "anonymous_rss_kib": 908
+          },
+          {
+            "seconds": 0.10902413702569902,
+            "hwm_kib": 43508,
+            "executable_rss_kib": 45700,
+            "other_file_rss_kib": 2524,
+            "anonymous_rss_kib": 1072
+          },
+          {
+            "seconds": 0.11356828198768198,
+            "hwm_kib": 65288,
+            "executable_rss_kib": 60996,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 1540
+          },
+          {
+            "seconds": 0.11807857698295265,
+            "hwm_kib": 65568,
+            "executable_rss_kib": 61188,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 1608
+          },
+          {
+            "seconds": 0.12264649197459221,
+            "hwm_kib": 68732,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2356
+          },
+          {
+            "seconds": 0.12715791701339185,
+            "hwm_kib": 69580,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2612
+          },
+          {
+            "seconds": 0.1317558930022642,
+            "hwm_kib": 69580,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2360
+          },
+          {
+            "seconds": 0.1365083430428058,
+            "hwm_kib": 69484,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2704
+          },
+          {
+            "seconds": 0.14123816101346165,
+            "hwm_kib": 69736,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2768
+          },
+          {
+            "seconds": 0.14574325608555228,
+            "hwm_kib": 69528,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2584
+          },
+          {
+            "seconds": 0.1504696150077507,
+            "hwm_kib": 69788,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2904
+          },
+          {
+            "seconds": 0.1551843429915607,
+            "hwm_kib": 69880,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2912
+          },
+          {
+            "seconds": 0.1599382320418954,
+            "hwm_kib": 69656,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2848
+          },
+          {
+            "seconds": 0.16459500999189913,
+            "hwm_kib": 69936,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2968
+          },
+          {
+            "seconds": 0.16933911899104714,
+            "hwm_kib": 69656,
+            "executable_rss_kib": 64132,
+            "other_file_rss_kib": 2836,
+            "anonymous_rss_kib": 2692
+          },
+          {
+            "seconds": 0.17392113502137363,
+            "hwm_kib": 69700,
+            "executable_rss_kib": 64900,
+            "other_file_rss_kib": 2964,
+            "anonymous_rss_kib": 1636
+          },
+          {
+            "seconds": 0.17611531598959118,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 4,
+        "variant": "candidate",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 70416\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3235\n\tVoluntary context switches: 469\n\tInvoluntary context switches: 9\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 70416,
+        "cap_kib": 69952,
+        "cap_pass": false,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.002938895020633936,
+            "hwm_kib": 4668,
+            "executable_rss_kib": 3608,
+            "other_file_rss_kib": 1228,
+            "anonymous_rss_kib": 48
+          },
+          {
+            "seconds": 0.006034253048710525,
+            "hwm_kib": 13712,
+            "executable_rss_kib": 11132,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 116
+          },
+          {
+            "seconds": 0.009416106971912086,
+            "hwm_kib": 15896,
+            "executable_rss_kib": 12860,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 564
+          },
+          {
+            "seconds": 0.012786980019882321,
+            "hwm_kib": 19308,
+            "executable_rss_kib": 16444,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 692
+          },
+          {
+            "seconds": 0.01622358406893909,
+            "hwm_kib": 19684,
+            "executable_rss_kib": 16508,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.01967398903798312,
+            "hwm_kib": 19688,
+            "executable_rss_kib": 16508,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.023029571981169283,
+            "hwm_kib": 19888,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.02643426600843668,
+            "hwm_kib": 19888,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.02979207900352776,
+            "hwm_kib": 19888,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03326775401365012,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03675166005268693,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.040234124986454844,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04358228808268905,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04691752104554325,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05025153304450214,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05357795499730855,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.056909068021923304,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.060232600080780685,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06358107307460159,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06691484607290477,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.07023681805003434,
+            "hwm_kib": 20296,
+            "executable_rss_kib": 17084,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 740
+          },
+          {
+            "seconds": 0.0736953130690381,
+            "hwm_kib": 20448,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07726758008357137,
+            "hwm_kib": 20448,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.0807180650299415,
+            "hwm_kib": 20448,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.08410537801682949,
+            "hwm_kib": 20536,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08758169400971383,
+            "hwm_kib": 20536,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09097919799387455,
+            "hwm_kib": 20536,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09431974007748067,
+            "hwm_kib": 20664,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09775766497477889,
+            "hwm_kib": 20664,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10137319297064096,
+            "hwm_kib": 23096,
+            "executable_rss_kib": 19772,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10490081901662052,
+            "hwm_kib": 24048,
+            "executable_rss_kib": 20924,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 908
+          },
+          {
+            "seconds": 0.10930453101173043,
+            "hwm_kib": 43004,
+            "executable_rss_kib": 45244,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1072
+          },
+          {
+            "seconds": 0.1138198560802266,
+            "hwm_kib": 65356,
+            "executable_rss_kib": 61116,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 1524
+          },
+          {
+            "seconds": 0.11851996404584497,
+            "hwm_kib": 65452,
+            "executable_rss_kib": 61308,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 1592
+          },
+          {
+            "seconds": 0.12311283103190362,
+            "hwm_kib": 68640,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2252
+          },
+          {
+            "seconds": 0.12773437704890966,
+            "hwm_kib": 69544,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2504
+          },
+          {
+            "seconds": 0.13246716605499387,
+            "hwm_kib": 69544,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2252
+          },
+          {
+            "seconds": 0.13713997404556721,
+            "hwm_kib": 69460,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2584
+          },
+          {
+            "seconds": 0.14170014904811978,
+            "hwm_kib": 69708,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2668
+          },
+          {
+            "seconds": 0.14627239503897727,
+            "hwm_kib": 69988,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 2964
+          },
+          {
+            "seconds": 0.15094739303458482,
+            "hwm_kib": 70280,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 3264
+          },
+          {
+            "seconds": 0.15570833208039403,
+            "hwm_kib": 70304,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 3040
+          },
+          {
+            "seconds": 0.16041707107797265,
+            "hwm_kib": 70308,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 3360
+          },
+          {
+            "seconds": 0.1651044290047139,
+            "hwm_kib": 70444,
+            "executable_rss_kib": 64252,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 3404
+          },
+          {
+            "seconds": 0.16970236506313086,
+            "hwm_kib": 70560,
+            "executable_rss_kib": 64636,
+            "other_file_rss_kib": 2788,
+            "anonymous_rss_kib": 3144
+          },
+          {
+            "seconds": 0.17185959499329329,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          },
+          {
+            "seconds": 0.17400903603993356,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 5,
+        "variant": "candidate",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 88%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69884\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3189\n\tVoluntary context switches: 461\n\tInvoluntary context switches: 10\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 69884,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0032813410507515073,
+            "hwm_kib": 5328,
+            "executable_rss_kib": 4220,
+            "other_file_rss_kib": 1240,
+            "anonymous_rss_kib": 40
+          },
+          {
+            "seconds": 0.006982541061006486,
+            "hwm_kib": 14044,
+            "executable_rss_kib": 11708,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 428
+          },
+          {
+            "seconds": 0.010237851995043457,
+            "hwm_kib": 15892,
+            "executable_rss_kib": 13116,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 564
+          },
+          {
+            "seconds": 0.013698067050427198,
+            "hwm_kib": 19800,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 696
+          },
+          {
+            "seconds": 0.017256194027140737,
+            "hwm_kib": 19808,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 700
+          },
+          {
+            "seconds": 0.020566535997204483,
+            "hwm_kib": 19812,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.023966719047166407,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.027461325051262975,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.030881229089573026,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.034227012074552476,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.037567095016129315,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.041138002066873014,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04476109007373452,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.048398307990282774,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05204666603822261,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05566155398264527,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05928471207153052,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06290068000089377,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06654168898239732,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.07034064002800733,
+            "hwm_kib": 20224,
+            "executable_rss_kib": 17020,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 736
+          },
+          {
+            "seconds": 0.0741862520808354,
+            "hwm_kib": 20380,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.0780213640537113,
+            "hwm_kib": 20380,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.08150388905778527,
+            "hwm_kib": 20444,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.08492435398511589,
+            "hwm_kib": 20536,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08845629007555544,
+            "hwm_kib": 20536,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09187274402938783,
+            "hwm_kib": 20536,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09539170004427433,
+            "hwm_kib": 20664,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09885340498294681,
+            "hwm_kib": 20664,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10278120904695243,
+            "hwm_kib": 22968,
+            "executable_rss_kib": 19580,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10636553599033505,
+            "hwm_kib": 23852,
+            "executable_rss_kib": 20476,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 904
+          },
+          {
+            "seconds": 0.11058806499931961,
+            "hwm_kib": 43640,
+            "executable_rss_kib": 44156,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1068
+          },
+          {
+            "seconds": 0.115180331049487,
+            "hwm_kib": 65092,
+            "executable_rss_kib": 60860,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 1532
+          },
+          {
+            "seconds": 0.11988442006986588,
+            "hwm_kib": 65316,
+            "executable_rss_kib": 61052,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 1588
+          },
+          {
+            "seconds": 0.12450964702293277,
+            "hwm_kib": 68980,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 2344
+          },
+          {
+            "seconds": 0.1291603740537539,
+            "hwm_kib": 69368,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 2588
+          },
+          {
+            "seconds": 0.13380951108410954,
+            "hwm_kib": 69164,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 2416
+          },
+          {
+            "seconds": 0.1384628190426156,
+            "hwm_kib": 69672,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 3000
+          },
+          {
+            "seconds": 0.1430371340829879,
+            "hwm_kib": 69948,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 3168
+          },
+          {
+            "seconds": 0.14768278098199517,
+            "hwm_kib": 69696,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 2920
+          },
+          {
+            "seconds": 0.15249784209299833,
+            "hwm_kib": 69944,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 3204
+          },
+          {
+            "seconds": 0.15710904798470438,
+            "hwm_kib": 69984,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 2928
+          },
+          {
+            "seconds": 0.16172472503967583,
+            "hwm_kib": 69884,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 3184
+          },
+          {
+            "seconds": 0.16649716498795897,
+            "hwm_kib": 70004,
+            "executable_rss_kib": 63996,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 3224
+          },
+          {
+            "seconds": 0.17113280203193426,
+            "hwm_kib": 70108,
+            "executable_rss_kib": 64636,
+            "other_file_rss_kib": 2784,
+            "anonymous_rss_kib": 2952
+          },
+          {
+            "seconds": 0.17330883198883384,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 5,
+        "variant": "baseline",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.06\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69000\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3213\n\tVoluntary context switches: 478\n\tInvoluntary context switches: 12\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 69000,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.003183629014529288,
+            "hwm_kib": 5512,
+            "executable_rss_kib": 4480,
+            "other_file_rss_kib": 1240,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.0064203799702227116,
+            "hwm_kib": 14008,
+            "executable_rss_kib": 11780,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 444
+          },
+          {
+            "seconds": 0.009661481017246842,
+            "hwm_kib": 16228,
+            "executable_rss_kib": 13316,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 568
+          },
+          {
+            "seconds": 0.013583015068434179,
+            "hwm_kib": 19936,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 696
+          },
+          {
+            "seconds": 0.01695800805464387,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.02048135397490114,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.023769865976646543,
+            "hwm_kib": 20152,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.027139549027197063,
+            "hwm_kib": 20152,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.030610513989813626,
+            "hwm_kib": 20152,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03390514606144279,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03719501802697778,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04048692004289478,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04377291107084602,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.047071363078430295,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.050360205001197755,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05365833698306233,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05708121100906283,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06068607897032052,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06430282699875534,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06787572300527245,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.07169381505809724,
+            "hwm_kib": 20584,
+            "executable_rss_kib": 17348,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07541476504411548,
+            "hwm_kib": 20584,
+            "executable_rss_kib": 17348,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07889843103475869,
+            "hwm_kib": 20584,
+            "executable_rss_kib": 17348,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.08243463700637221,
+            "hwm_kib": 20704,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08585780102293938,
+            "hwm_kib": 20736,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08941462798975408,
+            "hwm_kib": 20736,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09284564200788736,
+            "hwm_kib": 20864,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09640516899526119,
+            "hwm_kib": 20864,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09988506406079978,
+            "hwm_kib": 23360,
+            "executable_rss_kib": 19972,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10350252198986709,
+            "hwm_kib": 23764,
+            "executable_rss_kib": 20740,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 872
+          },
+          {
+            "seconds": 0.10749543702695519,
+            "hwm_kib": 35156,
+            "executable_rss_kib": 35588,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1044
+          },
+          {
+            "seconds": 0.112145013990812,
+            "hwm_kib": 64072,
+            "executable_rss_kib": 60036,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 1248
+          },
+          {
+            "seconds": 0.11661006801296026,
+            "hwm_kib": 64768,
+            "executable_rss_kib": 60420,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 1548
+          },
+          {
+            "seconds": 0.12128418602515012,
+            "hwm_kib": 64912,
+            "executable_rss_kib": 60484,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 1644
+          },
+          {
+            "seconds": 0.12603192497044802,
+            "hwm_kib": 68408,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2388
+          },
+          {
+            "seconds": 0.13060340099036694,
+            "hwm_kib": 68668,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2632
+          },
+          {
+            "seconds": 0.13522936799563468,
+            "hwm_kib": 68424,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2540
+          },
+          {
+            "seconds": 0.1400701890233904,
+            "hwm_kib": 68792,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2848
+          },
+          {
+            "seconds": 0.1449579200707376,
+            "hwm_kib": 68888,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2852
+          },
+          {
+            "seconds": 0.14985347201582044,
+            "hwm_kib": 68672,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2796
+          },
+          {
+            "seconds": 0.15443344798404723,
+            "hwm_kib": 68948,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2912
+          },
+          {
+            "seconds": 0.15910692606121302,
+            "hwm_kib": 68684,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2648
+          },
+          {
+            "seconds": 0.16401874797884375,
+            "hwm_kib": 68940,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2944
+          },
+          {
+            "seconds": 0.16880429803859442,
+            "hwm_kib": 68980,
+            "executable_rss_kib": 63236,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 2672
+          },
+          {
+            "seconds": 0.1735214659711346,
+            "hwm_kib": 69548,
+            "executable_rss_kib": 63620,
+            "other_file_rss_kib": 2800,
+            "anonymous_rss_kib": 3136
+          },
+          {
+            "seconds": 0.17567846702877432,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 6,
+        "variant": "baseline",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 70204\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3218\n\tVoluntary context switches: 479\n\tInvoluntary context switches: 13\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 70204,
+        "cap_kib": 69952,
+        "cap_pass": false,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.003250192035920918,
+            "hwm_kib": 4840,
+            "executable_rss_kib": 3632,
+            "other_file_rss_kib": 1304,
+            "anonymous_rss_kib": 48
+          },
+          {
+            "seconds": 0.006484562065452337,
+            "hwm_kib": 13928,
+            "executable_rss_kib": 11332,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 124
+          },
+          {
+            "seconds": 0.009745173039846122,
+            "hwm_kib": 16096,
+            "executable_rss_kib": 12996,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 564
+          },
+          {
+            "seconds": 0.013195088016800582,
+            "hwm_kib": 19720,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 696
+          },
+          {
+            "seconds": 0.016549080959521234,
+            "hwm_kib": 20016,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.01997708505950868,
+            "hwm_kib": 20016,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.023355419049039483,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.02670020202640444,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03010762599296868,
+            "hwm_kib": 20216,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03340563806705177,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03670600906480104,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.040003531030379236,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04328955302480608,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04659086500760168,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.04987921705469489,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05316990800201893,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.05670937499962747,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06002492702100426,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06330779904965311,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06660501100122929,
+            "hwm_kib": 20280,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.06990980298724025,
+            "hwm_kib": 20712,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.0733746379846707,
+            "hwm_kib": 20712,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.07674593105912209,
+            "hwm_kib": 20712,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 764
+          },
+          {
+            "seconds": 0.08024667704012245,
+            "hwm_kib": 20736,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 792
+          },
+          {
+            "seconds": 0.08364400104619563,
+            "hwm_kib": 20800,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08715381601359695,
+            "hwm_kib": 20800,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09056991001125425,
+            "hwm_kib": 20928,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09410246706102043,
+            "hwm_kib": 20928,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09752277098596096,
+            "hwm_kib": 20928,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10113605903461576,
+            "hwm_kib": 23616,
+            "executable_rss_kib": 20164,
+            "other_file_rss_kib": 2600,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10466426506172866,
+            "hwm_kib": 24380,
+            "executable_rss_kib": 22084,
+            "other_file_rss_kib": 2600,
+            "anonymous_rss_kib": 912
+          },
+          {
+            "seconds": 0.10908200801350176,
+            "hwm_kib": 43720,
+            "executable_rss_kib": 45956,
+            "other_file_rss_kib": 2600,
+            "anonymous_rss_kib": 1080
+          },
+          {
+            "seconds": 0.11364405404310673,
+            "hwm_kib": 65176,
+            "executable_rss_kib": 60868,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 1548
+          },
+          {
+            "seconds": 0.11816326796542853,
+            "hwm_kib": 65396,
+            "executable_rss_kib": 60996,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 1612
+          },
+          {
+            "seconds": 0.12308115104679018,
+            "hwm_kib": 68564,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2364
+          },
+          {
+            "seconds": 0.12785494001582265,
+            "hwm_kib": 69464,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2612
+          },
+          {
+            "seconds": 0.13260239898227155,
+            "hwm_kib": 69464,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2412
+          },
+          {
+            "seconds": 0.13754877203609794,
+            "hwm_kib": 69400,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2660
+          },
+          {
+            "seconds": 0.1421151680406183,
+            "hwm_kib": 69652,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2800
+          },
+          {
+            "seconds": 0.14678446506150067,
+            "hwm_kib": 69444,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2592
+          },
+          {
+            "seconds": 0.15157160500530154,
+            "hwm_kib": 69668,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2884
+          },
+          {
+            "seconds": 0.15633783501107246,
+            "hwm_kib": 69736,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2608
+          },
+          {
+            "seconds": 0.16121773596387357,
+            "hwm_kib": 69524,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2880
+          },
+          {
+            "seconds": 0.16576515196356922,
+            "hwm_kib": 69804,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2952
+          },
+          {
+            "seconds": 0.17108831205405295,
+            "hwm_kib": 69896,
+            "executable_rss_kib": 64196,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3060
+          },
+          {
+            "seconds": 0.1732683030422777,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          },
+          {
+            "seconds": 0.17541465302929282,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 6,
+        "variant": "candidate",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 87%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 69336\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3276\n\tVoluntary context switches: 499\n\tInvoluntary context switches: 7\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 69336,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.002950865076854825,
+            "hwm_kib": 4556,
+            "executable_rss_kib": 3500,
+            "other_file_rss_kib": 1240,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.006082494044676423,
+            "hwm_kib": 13580,
+            "executable_rss_kib": 11068,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 112
+          },
+          {
+            "seconds": 0.009338955045677722,
+            "hwm_kib": 15956,
+            "executable_rss_kib": 12924,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 560
+          },
+          {
+            "seconds": 0.012762499041855335,
+            "hwm_kib": 19484,
+            "executable_rss_kib": 16444,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 636
+          },
+          {
+            "seconds": 0.016177133074961603,
+            "hwm_kib": 19872,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 700
+          },
+          {
+            "seconds": 0.01997086510527879,
+            "hwm_kib": 19872,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.023403099039569497,
+            "hwm_kib": 19944,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.026986036100424826,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03041993104852736,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03379864408634603,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03711095603648573,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04041538806632161,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.043755911057814956,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04706478305160999,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05036029510665685,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05372165807057172,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.057056511053815484,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.0603753631003201,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06368401506915689,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06700690707657486,
+            "hwm_kib": 20012,
+            "executable_rss_kib": 16828,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.07031503901816905,
+            "hwm_kib": 20220,
+            "executable_rss_kib": 17020,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 736
+          },
+          {
+            "seconds": 0.07370882306713611,
+            "hwm_kib": 20412,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 792
+          },
+          {
+            "seconds": 0.07721056905575097,
+            "hwm_kib": 20412,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 792
+          },
+          {
+            "seconds": 0.08061573305167258,
+            "hwm_kib": 20476,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 792
+          },
+          {
+            "seconds": 0.08413300907704979,
+            "hwm_kib": 20532,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.08756223309319466,
+            "hwm_kib": 20532,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.0910856690024957,
+            "hwm_kib": 20532,
+            "executable_rss_kib": 17212,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09452638402581215,
+            "hwm_kib": 20660,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.09807961108162999,
+            "hwm_kib": 20660,
+            "executable_rss_kib": 17340,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.10157793608959764,
+            "hwm_kib": 23412,
+            "executable_rss_kib": 20028,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 848
+          },
+          {
+            "seconds": 0.1049758200533688,
+            "hwm_kib": 24104,
+            "executable_rss_kib": 20924,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 900
+          },
+          {
+            "seconds": 0.10914950806181878,
+            "hwm_kib": 43764,
+            "executable_rss_kib": 43836,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1064
+          },
+          {
+            "seconds": 0.11375628504902124,
+            "hwm_kib": 64548,
+            "executable_rss_kib": 60348,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 1516
+          },
+          {
+            "seconds": 0.11845616309437901,
+            "hwm_kib": 64836,
+            "executable_rss_kib": 60476,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 1604
+          },
+          {
+            "seconds": 0.12309417000506073,
+            "hwm_kib": 68080,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2372
+          },
+          {
+            "seconds": 0.12777086801361293,
+            "hwm_kib": 68668,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2624
+          },
+          {
+            "seconds": 0.13250802701804787,
+            "hwm_kib": 68452,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2512
+          },
+          {
+            "seconds": 0.13717369409278035,
+            "hwm_kib": 68816,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2788
+          },
+          {
+            "seconds": 0.1418193420395255,
+            "hwm_kib": 68916,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 2872
+          },
+          {
+            "seconds": 0.14635636704042554,
+            "hwm_kib": 69160,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3176
+          },
+          {
+            "seconds": 0.15105068509001285,
+            "hwm_kib": 69496,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3452
+          },
+          {
+            "seconds": 0.15571581199765205,
+            "hwm_kib": 69496,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3260
+          },
+          {
+            "seconds": 0.16037971002515405,
+            "hwm_kib": 69532,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3552
+          },
+          {
+            "seconds": 0.16493761504534632,
+            "hwm_kib": 69604,
+            "executable_rss_kib": 63228,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3560
+          },
+          {
+            "seconds": 0.16960492299403995,
+            "hwm_kib": 69808,
+            "executable_rss_kib": 63804,
+            "other_file_rss_kib": 2816,
+            "anonymous_rss_kib": 3324
+          },
+          {
+            "seconds": 0.1717914540786296,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 7,
+        "variant": "candidate",
+        "sha256": "32504e1c427668c2c582a6fd234e6b914484269d8d2936eeee84d8ee02c526ed",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-candidate-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.05\n\tSystem time (seconds): 0.09\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 68964\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3246\n\tVoluntary context switches: 495\n\tInvoluntary context switches: 12\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 68964,
+        "cap_kib": 69952,
+        "cap_pass": true,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.0032241600565612316,
+            "hwm_kib": 5008,
+            "executable_rss_kib": 3976,
+            "other_file_rss_kib": 1232,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.006905209040269256,
+            "hwm_kib": 13788,
+            "executable_rss_kib": 11516,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 400
+          },
+          {
+            "seconds": 0.010425075073726475,
+            "hwm_kib": 16020,
+            "executable_rss_kib": 12988,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 560
+          },
+          {
+            "seconds": 0.014248667052015662,
+            "hwm_kib": 19512,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 692
+          },
+          {
+            "seconds": 0.01773916301317513,
+            "hwm_kib": 19808,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 700
+          },
+          {
+            "seconds": 0.02153879404067993,
+            "hwm_kib": 19812,
+            "executable_rss_kib": 16636,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.02528107399120927,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.028798170038498938,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03218921402003616,
+            "hwm_kib": 19884,
+            "executable_rss_kib": 16700,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.035593818058259785,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.03908228303771466,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04253982799127698,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.046002762974239886,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.04943137802183628,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05274503002874553,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.05603693099692464,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.059332182980142534,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.06262053502723575,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.0659174770116806,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.069220629055053,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16764,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 712
+          },
+          {
+            "seconds": 0.07272382499650121,
+            "hwm_kib": 20316,
+            "executable_rss_kib": 17084,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.07613083906471729,
+            "hwm_kib": 20316,
+            "executable_rss_kib": 17084,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.07965406496077776,
+            "hwm_kib": 20316,
+            "executable_rss_kib": 17084,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 760
+          },
+          {
+            "seconds": 0.08308028907049447,
+            "hwm_kib": 20432,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 816
+          },
+          {
+            "seconds": 0.0866284960648045,
+            "hwm_kib": 20436,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 816
+          },
+          {
+            "seconds": 0.09006034000776708,
+            "hwm_kib": 20436,
+            "executable_rss_kib": 17148,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 816
+          },
+          {
+            "seconds": 0.09359585598576814,
+            "hwm_kib": 20564,
+            "executable_rss_kib": 17276,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 816
+          },
+          {
+            "seconds": 0.0970319010084495,
+            "hwm_kib": 20564,
+            "executable_rss_kib": 17276,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 816
+          },
+          {
+            "seconds": 0.1004290550481528,
+            "hwm_kib": 23124,
+            "executable_rss_kib": 19772,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 816
+          },
+          {
+            "seconds": 0.10395766096189618,
+            "hwm_kib": 23560,
+            "executable_rss_kib": 20156,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 868
+          },
+          {
+            "seconds": 0.1079025249928236,
+            "hwm_kib": 31824,
+            "executable_rss_kib": 32572,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1012
+          },
+          {
+            "seconds": 0.11233760800678283,
+            "hwm_kib": 62636,
+            "executable_rss_kib": 59708,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1188
+          },
+          {
+            "seconds": 0.11687096301466227,
+            "hwm_kib": 64516,
+            "executable_rss_kib": 60220,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 1544
+          },
+          {
+            "seconds": 0.12141305906698108,
+            "hwm_kib": 64720,
+            "executable_rss_kib": 60348,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 1640
+          },
+          {
+            "seconds": 0.1260560160735622,
+            "hwm_kib": 67964,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 2320
+          },
+          {
+            "seconds": 0.13065360207110643,
+            "hwm_kib": 68224,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 2564
+          },
+          {
+            "seconds": 0.13529823906719685,
+            "hwm_kib": 67980,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 2404
+          },
+          {
+            "seconds": 0.13995699700899422,
+            "hwm_kib": 68264,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 2676
+          },
+          {
+            "seconds": 0.14457323297392577,
+            "hwm_kib": 68376,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 2716
+          },
+          {
+            "seconds": 0.14925710100214928,
+            "hwm_kib": 68712,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 3132
+          },
+          {
+            "seconds": 0.1538471169769764,
+            "hwm_kib": 68996,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 3336
+          },
+          {
+            "seconds": 0.15846545400563627,
+            "hwm_kib": 68840,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 3224
+          },
+          {
+            "seconds": 0.1632560039870441,
+            "hwm_kib": 69124,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 3504
+          },
+          {
+            "seconds": 0.16802660305984318,
+            "hwm_kib": 69164,
+            "executable_rss_kib": 62908,
+            "other_file_rss_kib": 2752,
+            "anonymous_rss_kib": 3232
+          },
+          {
+            "seconds": 0.17275138199329376,
+            "hwm_kib": 69648,
+            "executable_rss_kib": 63612,
+            "other_file_rss_kib": 2880,
+            "anonymous_rss_kib": 3276
+          },
+          {
+            "seconds": 0.17489110201131552,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      },
+      {
+        "pair": 7,
+        "variant": "baseline",
+        "sha256": "91e6fd04982cd44d801ee73795602f0c5222a4144ca3342c2d43f467dfd60403",
+        "gnu_time": "\tCommand being timed: \"/tmp/gf1249-statistics-baseline-bin --exact statistics_public_query_probe --nocapture --test-threads=1\"\n\tUser time (seconds): 0.07\n\tSystem time (seconds): 0.07\n\tPercent of CPU this job got: 86%\n\tElapsed (wall clock) time (h:mm:ss or m:ss): 0:00.17\n\tAverage shared text size (kbytes): 0\n\tAverage unshared data size (kbytes): 0\n\tAverage stack size (kbytes): 0\n\tAverage total size (kbytes): 0\n\tMaximum resident set size (kbytes): 70164\n\tAverage resident set size (kbytes): 0\n\tMajor (requiring I/O) page faults: 0\n\tMinor (reclaiming a frame) page faults: 3247\n\tVoluntary context switches: 488\n\tInvoluntary context switches: 11\n\tSwaps: 0\n\tFile system inputs: 0\n\tFile system outputs: 6496\n\tSocket messages sent: 0\n\tSocket messages received: 0\n\tSignals delivered: 0\n\tPage size (bytes): 4096\n\tExit status: 0\n",
+        "rss_kib": 70164,
+        "cap_kib": 69952,
+        "cap_pass": false,
+        "permission_denials": 0,
+        "samples": [
+          {
+            "seconds": 0.003238881006836891,
+            "hwm_kib": 4604,
+            "executable_rss_kib": 3536,
+            "other_file_rss_kib": 1240,
+            "anonymous_rss_kib": 44
+          },
+          {
+            "seconds": 0.006504752091132104,
+            "hwm_kib": 13732,
+            "executable_rss_kib": 11332,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 124
+          },
+          {
+            "seconds": 0.009795863996259868,
+            "hwm_kib": 16032,
+            "executable_rss_kib": 12996,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 564
+          },
+          {
+            "seconds": 0.01341310201678425,
+            "hwm_kib": 19380,
+            "executable_rss_kib": 16644,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 696
+          },
+          {
+            "seconds": 0.01691244705580175,
+            "hwm_kib": 19948,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 704
+          },
+          {
+            "seconds": 0.020487335044890642,
+            "hwm_kib": 19952,
+            "executable_rss_kib": 16772,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 708
+          },
+          {
+            "seconds": 0.02391196903772652,
+            "hwm_kib": 20152,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.02746913500595838,
+            "hwm_kib": 20152,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03088296006899327,
+            "hwm_kib": 20152,
+            "executable_rss_kib": 16964,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 716
+          },
+          {
+            "seconds": 0.03422898205462843,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.037546725012362,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.04090457805432379,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.04422883002553135,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.047567893052473664,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.050893314997665584,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.0542484080651775,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.05756613006815314,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.06091731309425086,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.0642278150189668,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.06757394806481898,
+            "hwm_kib": 20268,
+            "executable_rss_kib": 17028,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.07091372099239379,
+            "hwm_kib": 20652,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 768
+          },
+          {
+            "seconds": 0.07445952703710645,
+            "hwm_kib": 20680,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.0778811820782721,
+            "hwm_kib": 20680,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.08124961506109685,
+            "hwm_kib": 20680,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 796
+          },
+          {
+            "seconds": 0.0847284400369972,
+            "hwm_kib": 20736,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.08812895405571908,
+            "hwm_kib": 20736,
+            "executable_rss_kib": 17412,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09161630901508033,
+            "hwm_kib": 20864,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09503068309277296,
+            "hwm_kib": 20864,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.09854487900156528,
+            "hwm_kib": 20864,
+            "executable_rss_kib": 17540,
+            "other_file_rss_kib": 2472,
+            "anonymous_rss_kib": 852
+          },
+          {
+            "seconds": 0.10204459505621344,
+            "hwm_kib": 23636,
+            "executable_rss_kib": 20228,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 872
+          },
+          {
+            "seconds": 0.10584469605237246,
+            "hwm_kib": 28928,
+            "executable_rss_kib": 26500,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 992
+          },
+          {
+            "seconds": 0.11050881398841739,
+            "hwm_kib": 55920,
+            "executable_rss_kib": 59204,
+            "other_file_rss_kib": 2536,
+            "anonymous_rss_kib": 1192
+          },
+          {
+            "seconds": 0.11517424101475626,
+            "hwm_kib": 65264,
+            "executable_rss_kib": 60868,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 1548
+          },
+          {
+            "seconds": 0.11985914909746498,
+            "hwm_kib": 65480,
+            "executable_rss_kib": 60996,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 1644
+          },
+          {
+            "seconds": 0.12453190702944994,
+            "hwm_kib": 69188,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2356
+          },
+          {
+            "seconds": 0.12922350503504276,
+            "hwm_kib": 69456,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2604
+          },
+          {
+            "seconds": 0.13393864408135414,
+            "hwm_kib": 69456,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 2380
+          },
+          {
+            "seconds": 0.13861415104474872,
+            "hwm_kib": 69756,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3056
+          },
+          {
+            "seconds": 0.14324737805873156,
+            "hwm_kib": 70004,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3152
+          },
+          {
+            "seconds": 0.14783565502148122,
+            "hwm_kib": 69832,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3000
+          },
+          {
+            "seconds": 0.15271707600913942,
+            "hwm_kib": 70132,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3288
+          },
+          {
+            "seconds": 0.15749912604223937,
+            "hwm_kib": 70140,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3152
+          },
+          {
+            "seconds": 0.16222861502319574,
+            "hwm_kib": 70208,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3428
+          },
+          {
+            "seconds": 0.16695669305045158,
+            "hwm_kib": 70288,
+            "executable_rss_kib": 64004,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3436
+          },
+          {
+            "seconds": 0.1717387930257246,
+            "hwm_kib": 70284,
+            "executable_rss_kib": 64516,
+            "other_file_rss_kib": 2848,
+            "anonymous_rss_kib": 3184
+          },
+          {
+            "seconds": 0.17389804404228926,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          },
+          {
+            "seconds": 0.17602950404398143,
+            "hwm_kib": null,
+            "executable_rss_kib": 0,
+            "other_file_rss_kib": 0,
+            "anonymous_rss_kib": 0
+          }
+        ]
+      }
+    ]
+  },
+  "deterministic_regression": {
+    "test": "count_row_marker_avoids_property_values_through_public_lifecycle",
+    "rows": 129,
+    "unrequested_value_bytes": 29952,
+    "count_spill_bytes": 16184,
+    "property_count_spill_bytes": 50465,
+    "authentication_bytes_each": 8850,
+    "physical_rows_each": 129,
+    "count_logical_decoder_peak_bytes": 38,
+    "property_count_logical_decoder_peak_bytes": 624,
+    "bounds": "Avoided logical spill >= raw unrequested payload bytes; count spill and decoder peak <= rows*256; count decoder peak below property-count control; equal nonzero authentication and physical rows. Completed per-plan-occurrence counters, not additive shared-plan totals or process/native RSS.",
+    "public_sequence": "Public construction; exact UUID/nullable-score/payload hash and count/SUM oracles; retained stream across SET; immediate new query; reopen; export; full verification; clean import; subsequent REMOVE and reopen.",
+    "corruption_test": "count_row_marker_rejects_property_corruption_after_facade_open: tamper actual retained property file after opening facade; normal count and a demanded-route empty predicate return structured GF_PROJECT_CORRUPT; unknown-label count returns exact non-null zero without opening unrelated payload."
+  },
+  "verification": {
+    "focused": "2 count-marker tests passed; 4 with_aggregation tests passed; 13 demand tests passed.",
+    "inherited_semantics": "Merged #1251 covers optional nullable entities, aliases, scalar null/empty inputs, grouping, fixed/variable edge counts and actual shortcut admission. Merged #1253 preserves typed corruption through projected adapters.",
+    "quality": "cargo clippy --workspace -- -D warnings passed; cargo fmt --all -- --check passed; make pre-push-fast passed; make gate-registry-check passed (14 tests).",
+    "full_local": "make pre-push exited 2: storage 1097 passed, one known #1192 hardcoded-/tmp UnsupportedFilesystem failure, two pre-existing ignored. Earlier 59 permanent-storage tests, 118 BDD scenarios and real lifecycle 1x/2x/4x/resume tests passed. Full local command is not green; exact-head CI required before merge.",
+    "failed_superseded": [
+      "Original row-marker prototype compile used unsupported reverse iteration on an opaque schema iterator; corrected before final source.",
+      "Earlier shared-target worktree build reused stale relative-depinfo artifacts and failed on missing diagnostics field; bounded package cache invalidation restored correct builds. Both final release executables were built after explicit five-package release invalidation.",
+      "Nullable COUNT baseline bug and typed corruption adapter bug were independently repaired and merged as #1251 and #1253 before this paired baseline.",
+      "New unknown-label corruption-refusal expectation was incorrect: existing demand contract deliberately avoids unrelated payload. Failed log retained; final test checks exact non-null zero there and typed refusal on demanded routes.",
+      "Original explicit-identity RSS control missed historical cap by 232 KiB. Bounded diagnostic does not replace or turn that failed observation green."
+    ]
+  },
+  "interpretation": [
+    "Affected count-all/label/empty queries meet their unchanged 0.02-second process-CPU threshold in this final comparison; historical #1207 count-all observation did not. Warm estimator is median of three per-process medians over executions 2-5, never pooled.",
+    "Explicit identity/count-property/SUM/selective queries are controls, not claimed improvements. Identity control maximum 70184 KiB exceeds original 69952 KiB cap. The cap is unchanged and remains failed. Eight fixed alternating diagnostic pairs also exceed it on baseline 3/8 and candidate 1/8; median GNU RSS baseline69684/candidate69266 KiB. Identical plans and work plus variable executable mapping residence do not establish a candidate query-allocation regression, but cannot retrospectively identify the cause of the original maximum.",
+    "Diagnostic smaps samples are instrumented observations without phase markers, not hard bounds or performance timings. Mapped executable residence dominates the sampled RSS. Kernel status/GNU-time RSS and smaps are non-atomic accounting boundaries and need not coincide. No additional run replaces the original failure.",
+    "Successful syscall return bytes include cached/non-file I/O; copy/sendfile count one read and one write. GNU-time filesystem inputs remain3328 blocks for every original process, so no block-device read saving is claimed. Outputs fall7096 to6496 blocks for affected cases.",
+    "Permanent and whole-fixture physical censuses overlap and must not be added. FD sampler deduplicates regular files by device/inode across all owners, including unlinked descriptors; excludes directory blocks and unlinked mappings without open descriptors. Sampling gaps and peaks are observations, not hard bounds.",
+    "Marker selection preserves qualifiers, scalar fallback and true-for-null row cardinality. It changes no permanent format or publishing policy. Authenticated selected-route validation is unchanged; no global unrelated-route verification is added.",
+    "No final capacity claim: existing admitted S20/S22 integration follows the merge; no S24/S26 or new certification workflow."
+  ],
+  "reproduction": {
+    "build": "At each source, use isolated CARGO_TARGET_DIR and cargo test --locked --release -p graphforge-api --test permanent_storage_budgets --no-run --message-format=json; copy the compiler executable outside Cargo and hash before subprocess work.",
+    "fixture": "Reuse identical compacted/cleaned #1207 4101-node fragmentation fixture. To regenerate, use its fragmentation_statistics_public_probe prepare/compact workflow and explicit private-fixture cleanup as documented in query-maintenance-assessment-1207.json.",
+    "query": "TMPDIR=<native scratch> GF_STATS_ROOT=<fixture> GF_STATS_CASE=<case> /usr/bin/time -v FROZEN --exact statistics_public_query_probe --nocapture --test-threads=1. Three processes/case, five queries each; fsync/POSIX_FADV_DONTNEED is cache advice, not guaranteed eviction.",
+    "collectors": {
+      "gf1249-statistics-measure.py": {
+        "sha256": "1ca4d5f106631adeccffcbf85897fdb56d36700733d4dec1fe3c42a81d60a1fb",
+        "source": "import hashlib,json,os,re,subprocess,sys\nfrom pathlib import Path\nphase=sys.argv[1];p=json.loads(Path(f'/tmp/gf1249-statistics-{phase}-provenance.json').read_text());binary=Path(p['executable']);assert hashlib.sha256(binary.read_bytes()).hexdigest()==p['sha256']\nroot=Path('/home/ubuntu/graphforge-native-tmp-1195/gf1207-fragment-integrated-32');cases=['count_all','count_identity','count_label','count_property','sum_property','selective','empty'];records=[]\nfor repeat in range(3):\n for case in cases[repeat:]+cases[:repeat]:\n  for path in (root/'source').rglob('*'):\n   if not path.is_file():continue\n   fd=os.open(path,os.O_RDONLY)\n   try:os.fsync(fd);os.posix_fadvise(fd,0,0,os.POSIX_FADV_DONTNEED)\n   finally:os.close(fd)\n  log=Path(f'/tmp/gf1249-statistics-{phase}-{case}-{repeat}.log');tm=log.with_suffix('.time');env=dict(os.environ,TMPDIR=str(root),GF_STATS_ROOT=str(root),GF_STATS_CASE=case)\n  cmd=['/usr/bin/time','-v','-o',str(tm),str(binary),'--exact','statistics_public_query_probe','--nocapture','--test-threads=1']\n  with log.open('x') as f:subprocess.run(cmd,env=env,stdout=f,stderr=subprocess.STDOUT,check=True)\n  matches=re.findall(r'STATISTICS_QUERY (\\{.*\\})',log.read_text());assert len(matches)==1\n  record={'case':case,'repeat':repeat,'observation':json.loads(matches[0]),'gnu_time':tm.read_text(),'command':cmd};records.append(record);print(json.dumps(record),flush=True)\nassert hashlib.sha256(binary.read_bytes()).hexdigest()==p['sha256']\nPath(f'/tmp/gf1249-statistics-{phase}-results.json').write_text(json.dumps({'provenance':p,'fixture':str(root),'scope':'Three fresh processes per scalar query; five execute-only latency samples per process. Process CPU/RSS/I/O include facade open, exact scalar oracle, physical explanation. File-cache advice is not guaranteed eviction. Fixture previously compacted and cleaned; exact same fixture for comparisons.','records':records},indent=2)+'\\n')\n"
+      },
+      "gf1249-statistics-trace.py": {
+        "sha256": "90e97eb2bab1b632d5b24e9e81ce7293307f3765814e7bceea69263ff54d9906",
+        "source": "import collections,hashlib,json,os,pathlib,re,subprocess,sys\nexe=pathlib.Path(sys.argv[1]).resolve();case=sys.argv[2];tag=sys.argv[3];rounds=int(sys.argv[4])\nroot=pathlib.Path('/home/ubuntu/graphforge-native-tmp-1195')/('gf1249-statistics-trace-'+tag);root.mkdir(exist_ok=False)\ntrace=pathlib.Path('/tmp')/('gf1249-statistics-'+tag+'.strace');log=pathlib.Path('/tmp')/('gf1249-statistics-'+tag+'-trace.log')\nnames='read,pread64,readv,preadv,write,pwrite64,writev,pwritev,copy_file_range,sendfile,fsync,fdatasync'\ncommand=['strace','-f','-qq','-yy','-s','0','-e','trace='+names,'-o',str(trace),str(exe),'--exact',case,'--nocapture','--test-threads=1']\nsha=hashlib.sha256(exe.read_bytes()).hexdigest()\nwith log.open('w') as out: completed=subprocess.run(command,env=dict(os.environ,TMPDIR=str(root),LC_ALL='C',GF_FRAGMENT_ROOT=os.environ.get('GF_FRAGMENT_TRACE_ROOT',f'/home/ubuntu/graphforge-native-tmp-1195/gf1207-fragment-integrated-{rounds}'),GF_FRAGMENT_MODE=os.environ.get('GF_FRAGMENT_TRACE_MODE','read'),GF_FRAGMENT_ROUNDS=str(rounds)),stdout=out,stderr=subprocess.STDOUT)\nassert sha==hashlib.sha256(exe.read_bytes()).hexdigest()\ncounts=collections.defaultdict(lambda:dict(calls=0,bytes=0,errors=0));unfinished=resumed=unparsed=0\nfor line in trace.open():\n if '<unfinished ...>' in line:unfinished+=1\n if 'resumed>' in line:resumed+=1\n call=re.search(r'\\b('+names.replace(',','|')+r')\\(',line) or re.search(r'<\\.\\.\\. (\\w+) resumed>',line)\n result=re.search(r'\\s= (-?\\d+)(?:\\s|$)',line)\n if not call:continue\n if not result:\n  if '<unfinished ...>' not in line:unparsed+=1\n  continue\n d=counts[call[1]];d['calls']+=1;n=int(result[1]);d['errors']+=int(n<0);d['bytes']+=max(n,0)\nrecord={'case':case,'command':command,'exit':completed.returncode,'executable':str(exe),'sha256':sha,'trace':str(trace),'syscalls':dict(counts),'unfinished_calls':unfinished,'resumed_calls':resumed,'unparsed_results':unparsed,'read_bytes':sum(counts[n]['bytes'] for n in ['read','pread64','readv','preadv','copy_file_range','sendfile']),'write_bytes':sum(counts[n]['bytes'] for n in ['write','pwrite64','writev','pwritev','copy_file_range','sendfile']),'scope':'Successful syscall return bytes across tracee process tree, including non-file descriptors; not physical disk I/O. Copy/sendfile count one read and one write. Traced timings are not latency evidence.'}\npathlib.Path('/tmp/gf1249-statistics-'+tag+'-trace.json').write_text(json.dumps(record,indent=2)+'\\n');print(json.dumps(record));raise SystemExit(completed.returncode)\n"
+      },
+      "gf1249-statistics-sample.py": {
+        "sha256": "43383cbc9cc9022ef3beedcc3557a2c246fbce2b854da573e93021367b48758d",
+        "source": "import hashlib,json,os,pathlib,pwd,stat,subprocess,time\nP=pathlib.Path; account=pwd.getpwnam('ubuntu'); fixture=P('/home/ubuntu/graphforge-native-tmp-1195/gf1207-wide-integrated');records=[]\nfor variant,provenance in [(v,f'/tmp/gf1249-statistics-{v}-provenance.json') for v in ['baseline','candidate']]:\n p=json.loads(P(provenance).read_text());exe=P(p['executable']);assert hashlib.sha256(exe.read_bytes()).hexdigest()==p['sha256']\n for case in ['count_all','count_identity','count_label','count_property','sum_property','selective','empty']:\n  fixture=P('/home/ubuntu/graphforge-native-tmp-1195')/'gf1207-fragment-integrated-32'\n  scratch=P('/home/ubuntu/graphforge-native-tmp-1195')/f'gf1249-statistics-fd-{variant}-{case}';scratch.mkdir(mode=0o700);os.chown(scratch,account.pw_uid,account.pw_gid)\n  env=dict(os.environ,TMPDIR=str(scratch),GF_STATS_ROOT=str(fixture),GF_STATS_CASE=case)\n  log=P(f'/tmp/gf1249-statistics-fd-{variant}-{case}.log');samples=[];vanished=0;permissions=0\n  with log.open('x') as out:\n   proc=subprocess.Popen([str(exe),'--exact','statistics_public_query_probe','--nocapture','--test-threads=1'],env=env,stdout=out,stderr=subprocess.STDOUT,user=account.pw_uid,group=account.pw_gid,extra_groups=os.getgrouplist(account.pw_name,account.pw_gid))\n   start=time.monotonic()\n   while proc.poll() is None:\n    seen=set();allocated=unlinked=0\n    for root in [fixture,scratch]:\n     for directory,_,names in os.walk(root):\n      for name in names:\n       try:s=os.stat(P(directory)/name,follow_symlinks=False)\n       except FileNotFoundError:vanished+=1;continue\n       key=(s.st_dev,s.st_ino)\n       if not stat.S_ISREG(s.st_mode) or key in seen:continue\n       seen.add(key);allocated+=s.st_blocks*512\n    pending=[proc.pid];pids=set()\n    while pending:\n     pid=pending.pop()\n     if pid in pids:continue\n     pids.add(pid)\n     try:pending.extend(map(int,P(f'/proc/{pid}/task/{pid}/children').read_text().split()));fds=list(P(f'/proc/{pid}/fd').iterdir())\n     except (FileNotFoundError,ProcessLookupError):vanished+=1;continue\n     except PermissionError:permissions+=1;continue\n     for fd in fds:\n      try:\n       target=os.readlink(fd)\n       if not any(target.startswith(str(root)+'/') for root in [fixture,scratch]):continue\n       s=fd.stat()\n      except (FileNotFoundError,ProcessLookupError):vanished+=1;continue\n      except PermissionError:permissions+=1;continue\n      key=(s.st_dev,s.st_ino)\n      if not stat.S_ISREG(s.st_mode) or key in seen:continue\n      seen.add(key);allocated+=s.st_blocks*512\n      if s.st_nlink==0:unlinked+=s.st_blocks*512\n    samples.append({'seconds':time.monotonic()-start,'allocated_bytes':allocated,'unlinked_allocated_bytes':unlinked});time.sleep(.005)\n   assert proc.wait()==0, log.read_text()\n  assert permissions==0,permissions\n  assert hashlib.sha256(exe.read_bytes()).hexdigest()==p['sha256']\n  import re\n  q=[json.loads(m.group(1)) for line in log.read_text().splitlines() if (m:=re.search(r'STATISTICS_QUERY (\\{.*\\})$',line))]\n  assert len(q)==1 and q[0]['case']==case\n  record={'variant':variant,'case':case,'sha256':p['sha256'],'scalar_oracle':q[0]['expected'],'samples':len(samples),'sampled_allocated_peak':max(s['allocated_bytes'] for s in samples),'sampled_unlinked_peak':max(s['unlinked_allocated_bytes'] for s in samples),'maximum_sample_gap_seconds':max(b['seconds']-a['seconds'] for a,b in zip(samples,samples[1:])),'vanished_entries':vanished,'permission_denials':permissions};records.append(record);P(f'/tmp/gf1249-statistics-fd-{variant}-{case}.samples.json').write_text(json.dumps(samples));print(json.dumps(record),flush=True)\nP('/tmp/gf1249-statistics-open-file-samples.json').write_text(json.dumps({'records':records,'scope':'Root collector reads only the private fixture/scratch regular files and tracee-descendant FDs; tested executable runs with original ubuntu UID/GID/groups. Global device/inode dedup includes unlinked open descriptors. Non-atomic 5ms requested samples, not a hard bound; excludes directory blocks and unlinked mappings without an open descriptor. These instrumented timings are not performance observations.'},indent=2)+'\\n')\n"
+      },
+      "gf1249-rss-diagnostic.py": {
+        "sha256": "b37408bdc07033730e5e7800bf540f9ecced0ca1c3b206986b8a3a1729105aae",
+        "source": "import hashlib,json,os,re,subprocess,time\nfrom pathlib import Path\nP=Path;root=P('/home/ubuntu/graphforge-native-tmp-1195/gf1207-fragment-integrated-32');records=[]\nfor pair in range(8):\n for variant in (['baseline','candidate'] if pair%2==0 else ['candidate','baseline']):\n  p=json.loads(P(f'/tmp/gf1249-statistics-{variant}-provenance.json').read_text());exe=P(p['executable']);assert hashlib.sha256(exe.read_bytes()).hexdigest()==p['sha256']\n  prefix=f'/tmp/gf1249-rss-diagnostic-{pair}-{variant}';samples=[];denials=0\n  with open(prefix+'.log','x') as log:\n   proc=subprocess.Popen(['/usr/bin/time','-v','-o',prefix+'.time',str(exe),'--exact','statistics_public_query_probe','--nocapture','--test-threads=1'],env=dict(os.environ,TMPDIR=str(root),GF_STATS_ROOT=str(root),GF_STATS_CASE='count_identity'),stdout=log,stderr=subprocess.STDOUT)\n   start=time.monotonic()\n   while proc.poll() is None:\n    try:\n     children=P(f'/proc/{proc.pid}/task/{proc.pid}/children').read_text().split()\n     for pid in children:\n      status=P(f'/proc/{pid}/status').read_text();smaps=P(f'/proc/{pid}/smaps').read_text();totals={'executable_rss_kib':0,'other_file_rss_kib':0,'anonymous_rss_kib':0}\n      category='anonymous_rss_kib'\n      for line in smaps.splitlines():\n       if re.match(r'^[0-9a-f]+-[0-9a-f]+ ',line):\n        fields=line.split(maxsplit=5);name=fields[5] if len(fields)>5 else ''\n        category='executable_rss_kib' if name==str(exe) else ('other_file_rss_kib' if name.startswith('/') else 'anonymous_rss_kib')\n       elif line.startswith('Rss:'):totals[category]+=int(line.split()[1])\n      hwm=re.search(r'^VmHWM:\\s+(\\d+)',status,re.M)\n      samples.append({'seconds':time.monotonic()-start,'hwm_kib':int(hwm[1]) if hwm else None,**totals})\n    except (FileNotFoundError,ProcessLookupError):pass\n    except PermissionError:denials+=1\n    time.sleep(.002)\n   assert proc.wait()==0\n  assert denials==0\n  tm=P(prefix+'.time').read_text();rss=int(re.search(r'Maximum resident set size \\(kbytes\\): (\\d+)',tm)[1]);record={'pair':pair,'variant':variant,'sha256':p['sha256'],'gnu_time':tm,'rss_kib':rss,'cap_kib':69952,'cap_pass':rss<=69952,'permission_denials':denials,'samples':samples};records.append(record);print(pair,variant,rss,flush=True)\n  assert hashlib.sha256(exe.read_bytes()).hexdigest()==p['sha256']\nP('/tmp/gf1249-rss-diagnostic.json').write_text(json.dumps({'protocol':P('/tmp/gf1249-rss-diagnostic-plan.md').read_text(),'records':records},indent=2)+'\\n')\n"
+      }
+    }
+  },
+  "raw_artifact_hashes": {
+    "/tmp/gf1249-statistics-fd-candidate-empty.log": "c78e151f1d8667d5d3fa83dd995cd806c0347028f18e708ff0e527eb0d5a11e1",
+    "/tmp/gf1249-statistics-fd-candidate-selective.log": "9ed80c023366fe19cff6c1b81e09677e86dd761819297613b6e906b2a9c0fd33",
+    "/tmp/gf1249-statistics-fd-candidate-sum_property.log": "e6830acc9fa82459cb7c58e24903dd88040ef3d0185b04ca2ecd56b3c8e28547",
+    "/tmp/gf1249-statistics-fd-candidate-count_property.log": "e2aafe87f90f59d7b675d3bc82ad0834bb0fab666807e470f42f83db1a3e6f68",
+    "/tmp/gf1249-statistics-fd-candidate-count_label.log": "01eb3ecbcdd0f0dc815e586422e481f2bbf1afd11b0a34c4619f7eb603dfd17a",
+    "/tmp/gf1249-statistics-fd-candidate-count_identity.log": "b195b9d0c1ca498ebcfb213e4a1d3984979fe6d77a63c2e8c6d77e23227bd9c6",
+    "/tmp/gf1249-statistics-fd-candidate-count_all.log": "1ed9695992093ccbbe9f947a2bb45150306fd953f527d1291edc216ff524eee3",
+    "/tmp/gf1249-statistics-fd-baseline-empty.log": "337c98bf9c3c3afe1c2a14e19e8fc9c13425cd83f96e4ab6f567fd59cf38557b",
+    "/tmp/gf1249-statistics-fd-baseline-selective.log": "5aaad6c6a7328431df658a12929c7b73c4f0572f4aac49470b78681b7cd078fd",
+    "/tmp/gf1249-statistics-fd-baseline-sum_property.log": "71ba94d824d58e8985b54bc72e2cd3d5296a8dd96ca4557dd7baa8cf4b862782",
+    "/tmp/gf1249-statistics-fd-baseline-count_property.log": "b148aafb485d7b68a52351fd48493f88cbcf0df31c78d3ebf719b95a57ee494a",
+    "/tmp/gf1249-statistics-fd-baseline-count_label.log": "50a211fccb62c1c2ea4b4c04d56264f0bc770f896c02cf31e6da3c19fc3d3fd7",
+    "/tmp/gf1249-statistics-fd-baseline-count_identity.log": "5b74a3e50171275e0de14d296f4dfd1bff23978b8ca61c37e1786ca91761ab20",
+    "/tmp/gf1249-statistics-fd-baseline-count_all.log": "5f9c2250fc9b16e229203a7792175b2430076f90a6df9f18dc34a14b1c755b81",
+    "/tmp/gf1249-statistics-fd-campaign.log": "339e352323c56be37cb041856f92aae17869265f5accf2529ced6dd3356c2457",
+    "/tmp/gf1249-statistics-candidate-empty-trace.log": "57a94346192bcc3cad01365b436bf2272c6c4b1d70f66fe5ae548fb334ae9ebb",
+    "/tmp/gf1249-statistics-candidate-selective-trace.log": "13e7501cc6f6263c399cdf9d64e9d703d462423b99bf5e41c781224c602f1731",
+    "/tmp/gf1249-statistics-candidate-sum_property-trace.log": "9670621e6ecd123da202596a862edfc196b5636febd3055196394d58b02678a1",
+    "/tmp/gf1249-statistics-candidate-count_property-trace.log": "199616abd5fd63da1bb603026d4fc9d62eda071566760a4cde39f23375725923",
+    "/tmp/gf1249-statistics-candidate-count_label-trace.log": "e02fb595a61a67e33c4a3d684f878bcaa41c55d3242711910a44ad62c8623372",
+    "/tmp/gf1249-statistics-candidate-count_identity-trace.log": "01453185f0722084918bb9fc6a4cfc11200f3ad16381f9579055ba8f0487ed76",
+    "/tmp/gf1249-statistics-candidate-count_all-trace.log": "380be878f86f66dc9eb3b1c6d70459e2ed9ebd56bc9a6955c646204166e1262f",
+    "/tmp/gf1249-statistics-baseline-empty-trace.log": "af502155a3099921e5bceca477788fed527cc94745d8b4d39ac9a9c87e29f8e9",
+    "/tmp/gf1249-statistics-baseline-selective-trace.log": "ba6c9023ef8af4f189c94f23a9e896debef982b964c1aa1bdcfb8209ededc076",
+    "/tmp/gf1249-statistics-baseline-sum_property-trace.log": "6f100fb11d1b9e290db9ac054da269c2e336beca7d208830238e6d8d0941c061",
+    "/tmp/gf1249-statistics-baseline-count_property-trace.log": "8dda5c9d61c66f7c6f6850f578734ee2636f84ff877174f3b5fd76ce96643fd7",
+    "/tmp/gf1249-statistics-baseline-count_label-trace.log": "137c9c369d259a234b3ef8db1fe0dd77f140343ebf2f00fce73544927b1661c6",
+    "/tmp/gf1249-statistics-baseline-count_identity-trace.log": "2efa9a9c7ac12b66c869967769677ebd7921a61eea39411f4fd0df44ac0bfdcf",
+    "/tmp/gf1249-statistics-baseline-count_all-trace.log": "22461ed0d69609ae9be343efa455c1fa867f1acce6d659be71079f0c80fe3484",
+    "/tmp/gf1249-statistics-candidate-count_identity-2.log": "b2c8f54ec1967b9ebf0a9dd05de0b8ead37b023d68f0a16640dc7c1db4f4b365",
+    "/tmp/gf1249-statistics-candidate-count_all-2.log": "56cf9d62f827379e8c65331b6c502c1ccfac6dde722f1dcb0a8c26fa8c5b5ffd",
+    "/tmp/gf1249-statistics-candidate-empty-2.log": "ed95569d2d7a771d9e12841315d10c66ce6208e76a8e490c8ed9c3b82b64eea9",
+    "/tmp/gf1249-statistics-candidate-selective-2.log": "6cb8c078496e885c046d35612e7412a45b32422194f650ceaeae5d581e3c91fd",
+    "/tmp/gf1249-statistics-candidate-sum_property-2.log": "94bace7a0c8a2cd385311e591902b176608413bfbe890641c25fb13c646d6f6b",
+    "/tmp/gf1249-statistics-candidate-count_property-2.log": "843e2bab13bec374fc8209ace54f2079b0a97a53d118332c0c4ef52b498e4409",
+    "/tmp/gf1249-statistics-candidate-count_label-2.log": "88c714746c9df1a9cdcfa79f90bf6591bea86fc90443df73fba8dd867e80258f",
+    "/tmp/gf1249-statistics-candidate-count_all-1.log": "3c072d29383cf8b1a9cca3147eb64b80688505ec146a47b91efcdb40b8151f02",
+    "/tmp/gf1249-statistics-candidate-empty-1.log": "5776e44d0c5f60407dad26f5a66913d0c5f110258f57149e8eb9b436668754ec",
+    "/tmp/gf1249-statistics-candidate-selective-1.log": "e26ebc2442564a439cbee699a18a2e083ba49ca21a771f72d17f02eb583fe2ff",
+    "/tmp/gf1249-statistics-candidate-sum_property-1.log": "242623753b642af694163c56f9fac934160ae4503d66ea65d5b5f25edcb725ea",
+    "/tmp/gf1249-statistics-candidate-count_property-1.log": "4d6dd687411b4ae3f8686cb71372232e9ef09cad377939a42c62eadeefe351a9",
+    "/tmp/gf1249-statistics-candidate-count_label-1.log": "79108302be73f4647a2edc1251ea2296d935ff29704b38e097d9957848d7aba1",
+    "/tmp/gf1249-statistics-candidate-count_identity-1.log": "fb6e78497a9208f11c849b5684fdfa11cf482db5f32c50700cfbe32262c5314c",
+    "/tmp/gf1249-statistics-candidate-empty-0.log": "c0efa599b02c9ef8d9f7fa9eccba4b7ca119e385c1460ee8cb549d789be627d4",
+    "/tmp/gf1249-statistics-candidate-selective-0.log": "63d6b61d9dd7e4c215c2f1b5c0b98e07798c301f58f1f5a1ba11dfcffa33d18d",
+    "/tmp/gf1249-statistics-candidate-sum_property-0.log": "13aeaae296d565169e387b9003298a59a9a8c28008f5c585c3ca4b1a28cafd38",
+    "/tmp/gf1249-statistics-candidate-count_property-0.log": "21ffa6721a84a0c3a62a88260080e4c3c99fac2c630c74114ef69e2276d5fb61",
+    "/tmp/gf1249-statistics-candidate-count_label-0.log": "f6f9279e0cc10dcdaaec987352214a52aa54251ded461f1389f7ff578db277d9",
+    "/tmp/gf1249-statistics-candidate-count_identity-0.log": "dd8174afa1fcb5e5e768698f7daf20773606a3a9926282023a0bff7cfc3cee05",
+    "/tmp/gf1249-statistics-candidate-count_all-0.log": "4107ef04d12db44803f4d65c8affb64348faba6cafe6eb49987d338d741eb087",
+    "/tmp/gf1249-statistics-candidate-campaign.log": "fba29bda5072e10f3a6f0eba86a19ecab16754296d1062215df9056517c6d8d9",
+    "/tmp/gf1249-statistics-baseline-count_identity-2.log": "1a8934d72cd141a3ea8e262c2b5bb14a41dd495fafccdf383ff5a45c7f69c6d4",
+    "/tmp/gf1249-statistics-baseline-count_all-2.log": "e4448a05199216b5f44a7c2d7454859657abc7c91813a41db99d938b3e2032da",
+    "/tmp/gf1249-statistics-baseline-empty-2.log": "12929b70f69587442edbc8212724dde224a9d9bafc5381dad18cc9ebfd8c9a0d",
+    "/tmp/gf1249-statistics-baseline-selective-2.log": "60df0f7c9cb88d6a0fd179d4b849b509e9f8f9a743b74ba18668a715969f0f68",
+    "/tmp/gf1249-statistics-baseline-sum_property-2.log": "adc029b1c0b00e4e6121dec2f3bc3fb45b36291297d7862425c02c07512e46bc",
+    "/tmp/gf1249-statistics-baseline-count_property-2.log": "a9d38786a89b932a3645235a92e891c22921e06ebba6d24ac31b4a2abe70835f",
+    "/tmp/gf1249-statistics-baseline-count_label-2.log": "9774f0d0404b6cb0d1e261af88c77c054c10f660bdf6d91bf81ffefa1aba8a58",
+    "/tmp/gf1249-statistics-baseline-count_all-1.log": "7d3d236a559e3750b9f988bbe76c931c8a366edab8fad7222b33dc2da757c8ba",
+    "/tmp/gf1249-statistics-baseline-empty-1.log": "c8afcc7118f5b5d74df6d2d91ea7e1a7f3992773e0032832a8c6d9ed85898e2a",
+    "/tmp/gf1249-statistics-baseline-selective-1.log": "165e0af6f95c140c31aa467fab652640d4624f9b5ab12e048e074858e56a88b5",
+    "/tmp/gf1249-statistics-baseline-sum_property-1.log": "5ea5ea417d0de6632e2a0d21b6a90234605528282560d871a6e8e2f8e914fc67",
+    "/tmp/gf1249-statistics-baseline-count_property-1.log": "6aae46dc0fb34d6783f5ad940aec082f94bf9c7582e1a8aaef25e12192f9120c",
+    "/tmp/gf1249-statistics-baseline-count_label-1.log": "abd82365b5ece99fd7fe32ee721722d3d22891b9276c0feccfc5b2e33b898116",
+    "/tmp/gf1249-statistics-baseline-count_identity-1.log": "79f45895c6989671729f3029a351cb0e3778b85d556dac29d83f67340277c693",
+    "/tmp/gf1249-statistics-baseline-empty-0.log": "1db5a4a07542d1aa28c8dca0d22f0e57c032bc3afeeb6238f1df5a1bcb3bbc3f",
+    "/tmp/gf1249-statistics-baseline-selective-0.log": "7e7502bb91fbc6577d846cdcf9796bf70d54be95f070cfb276dd303c781dd288",
+    "/tmp/gf1249-statistics-baseline-sum_property-0.log": "60be8bd10ddcd274fabe566127360d596e4339f03384858951e982911b733377",
+    "/tmp/gf1249-statistics-baseline-count_property-0.log": "dab96d9fe4fffdadb9cb85cce05b68110522268fc73f3dc76e1ecfe9e8c791c1",
+    "/tmp/gf1249-statistics-baseline-count_label-0.log": "5d138bb1af68675d6069de7677f2b7facc090fb15ef9d90aff1285be761ca2fc",
+    "/tmp/gf1249-statistics-baseline-count_identity-0.log": "a166b0aa2c522122cbc502af139d31c4f6bd59d6907db942e6a4855f152ae987",
+    "/tmp/gf1249-statistics-baseline-count_all-0.log": "75a02881b57c3083100a3d15e8e2c3f81c088f675895ce2e978e668c8d691475",
+    "/tmp/gf1249-statistics-baseline-campaign.log": "fa744ead2e2016f2431c3ede63c20f602369844ec388ebcf67dbeda4d875b8ba",
+    "/tmp/gf1249-statistics-candidate-build.log": "fb91390fd89919dee64ec5f52d2ea14a8bdfc0aa03f8313e11e4364faae6400a",
+    "/tmp/gf1249-statistics-baseline-build.log": "5f09429cb7d9c143ae690c53fabb6b9e3df237c770de856d10375699abb86ac0",
+    "/tmp/gf1249-statistics-candidate-count_identity-2.time": "8ef886596988e1dddfa22c156653cf049f57b477fac56e72f274ca4ff2d5fcaf",
+    "/tmp/gf1249-statistics-candidate-count_all-2.time": "3b2c210dee479c5c14c09ef47d5e4c825c1e145cdea4b608f6f3e23ca08525e5",
+    "/tmp/gf1249-statistics-candidate-empty-2.time": "f15c53ef799181bc26a9499740c39ce9e1301ce95fdc8fe796c42adffafc368d",
+    "/tmp/gf1249-statistics-candidate-selective-2.time": "13fc5c47cd764f7246ab54dda2e202024ec873241846c215de07ea52151a678b",
+    "/tmp/gf1249-statistics-candidate-sum_property-2.time": "9d22c03ff96d7cf9f43ffdc6bae9eb91682df336ab9db570c065f8c0c910eb58",
+    "/tmp/gf1249-statistics-candidate-count_property-2.time": "7ce865a67e235ddb39439c2c79dd5e06d4618b0d4f2efa08f064068ffa5d0573",
+    "/tmp/gf1249-statistics-candidate-count_label-2.time": "4e57fd1a198a33dd5b6f9314f0a0907a38ff5e0e8efe72478cd14653075f214d",
+    "/tmp/gf1249-statistics-candidate-count_all-1.time": "3cf037b140e52d9badfc562ba0a383993e2fc038ebd8b942260ec60b85085975",
+    "/tmp/gf1249-statistics-candidate-empty-1.time": "8aaf5761f8db8f73ad0c7f021b6a60099211dd825008d247be7d336734304096",
+    "/tmp/gf1249-statistics-candidate-selective-1.time": "596c6ac36ea7f7fc24d9cc002028a3df6974712da9571efdd4f8f3bd5ceab23c",
+    "/tmp/gf1249-statistics-candidate-sum_property-1.time": "f39dd39c3717a263b76ac981a29cd6123f38deab7ceaee4a684d58a8016731f2",
+    "/tmp/gf1249-statistics-candidate-count_property-1.time": "3d88b8d37ddca8c3a9baf59af1c19632c4de8163d0549fbe51092e2bafef70f2",
+    "/tmp/gf1249-statistics-candidate-count_label-1.time": "fbd1feccf07895055fcde34d9aa7c5c892f53357656b00101061f5e456c39550",
+    "/tmp/gf1249-statistics-candidate-count_identity-1.time": "e0655ed442f0848374b0b4d7f94d0366a342f12827570cfa07474cd49343d4e4",
+    "/tmp/gf1249-statistics-candidate-empty-0.time": "349c8f4cabffbe8c634bf16c52b321c1dfd4417dd4ae0fa82c01fa340ae9031a",
+    "/tmp/gf1249-statistics-candidate-selective-0.time": "34e009f61084c988fc570fcfe783b89c6ff937b65909d592dd534b46345ac4ad",
+    "/tmp/gf1249-statistics-candidate-sum_property-0.time": "f788557f5636aa2941bbecb0530715c2110d9cfe3c4bc945ab09ac219fdd041b",
+    "/tmp/gf1249-statistics-candidate-count_property-0.time": "7ae244fb9333c8b14a32881d83f47f7d46124e88bd75a62d4bbc2445ef3353c2",
+    "/tmp/gf1249-statistics-candidate-count_label-0.time": "88d2bd7c0b08fc760366705197733002a2d2a33259e0b80e8419e463f939e869",
+    "/tmp/gf1249-statistics-candidate-count_identity-0.time": "c07aea4b9e8d021fe73e27051d28b2cb036b2297829e847f088ec729d920e2e3",
+    "/tmp/gf1249-statistics-candidate-count_all-0.time": "084d9149e8633d224ad79d8810d9a3f68e50a2f899eacb7093cc067e37d7c8d5",
+    "/tmp/gf1249-statistics-baseline-count_identity-2.time": "8e94b31d0d2dd58658b6ea9bd97ddf0f3ca9f0a52bb0755501d71477313ac518",
+    "/tmp/gf1249-statistics-baseline-count_all-2.time": "30f5a867b4520a0fde3236a034e534c0278a664fd297b7b6bdd7060f337032ea",
+    "/tmp/gf1249-statistics-baseline-empty-2.time": "74c44385a5668f54b88bff77883c1862e5998b300e1bd6b9677ddb7968acd054",
+    "/tmp/gf1249-statistics-baseline-selective-2.time": "cad39dc1748590eba68f4076d357a1bf6b5cfe14a14757f441f909e37b1af87f",
+    "/tmp/gf1249-statistics-baseline-sum_property-2.time": "ddd70c59783d62de03e701781e5f4261f8854cb331acc282674eb4212f80c623",
+    "/tmp/gf1249-statistics-baseline-count_property-2.time": "0e807527836ce6571473eba3beef24f748f3bf50a634e6818130946823b5496b",
+    "/tmp/gf1249-statistics-baseline-count_label-2.time": "5fd699eec2cbbdb5a7cdf69e63b761224d4cb427294868cfc12b415ad9a44605",
+    "/tmp/gf1249-statistics-baseline-count_all-1.time": "0a7d2a7cea91a1401770a1cfce5887d5c0c57796e8ccb12b39c878be934fc194",
+    "/tmp/gf1249-statistics-baseline-empty-1.time": "7dac869873f7a7d7f704e440ba7e2ec98ef54c75572f5e1b527c5388fd62a9a5",
+    "/tmp/gf1249-statistics-baseline-selective-1.time": "f5fb131bbb6eabfbe7fd9c95b4427c6d89af785e137a072373ae530704b96d88",
+    "/tmp/gf1249-statistics-baseline-sum_property-1.time": "43e92451cf87312def555f8de5c8564c395f0d20cc2f1f8ac3f6b3675b58f317",
+    "/tmp/gf1249-statistics-baseline-count_property-1.time": "e234c95bef5cfea427b3cff9b7d6b4961b56f3b632f1eeba136f18e90039f40b",
+    "/tmp/gf1249-statistics-baseline-count_label-1.time": "2f61e8902dabda5da02e7a3acae095a3c9166dfa5f49767e09b1fd2adbac4b4b",
+    "/tmp/gf1249-statistics-baseline-count_identity-1.time": "579a533575f92e51991554562da0ef6cbab36c616533475610393b7cbaef501f",
+    "/tmp/gf1249-statistics-baseline-empty-0.time": "e5ce4cc94992418f5435f942ee90918f41e1f2536d09bbaf2a9a3902e5aa88d8",
+    "/tmp/gf1249-statistics-baseline-selective-0.time": "b2529e0265e0ec9458c07524ac418d01cff30c43b859c559ca3d5494e94c270e",
+    "/tmp/gf1249-statistics-baseline-sum_property-0.time": "928f45d7c973a57fc9924d932b8d6fc7fd7fccde886eb8232bef9ad01cd71e3c",
+    "/tmp/gf1249-statistics-baseline-count_property-0.time": "927e5d7598bbebc9acc9ead0d48da1b35227559f7079d7438ec45e512be8c92f",
+    "/tmp/gf1249-statistics-baseline-count_label-0.time": "505e8de0546a40009b85a95395b96d7e3bae6c458d3adc48c17741ec847418bd",
+    "/tmp/gf1249-statistics-baseline-count_identity-0.time": "24a87cc460b9d8a20c4a20814a74e8fd5d797e6394e68511680e58c52ef78340",
+    "/tmp/gf1249-statistics-baseline-count_all-0.time": "6aa021353431240af101b01028768a0e9ef97e65e15b276215736f05477af98e",
+    "/tmp/gf1249-statistics-candidate-empty.strace": "39235733234732bb4e249ee94935ac2a8e3a9ff6dfc5312dd15b48e9716d0102",
+    "/tmp/gf1249-statistics-candidate-selective.strace": "d76c6daaef0f97d6736037b4bef3ae9b50b2285344a156cc04788da77ffd1d39",
+    "/tmp/gf1249-statistics-candidate-sum_property.strace": "eb1ac28331ec8bdc298506bdd1db199fae1299d066edcf612bf8c2f77de189cb",
+    "/tmp/gf1249-statistics-candidate-count_property.strace": "a8d89c082c081d56c8c34140d8de1dad23aa42aec1d415f596005fa128426abc",
+    "/tmp/gf1249-statistics-candidate-count_label.strace": "0a7539211dfc0fd45b00b77a2f7aa240c9942ecd2d23fca05f8721a1f11f6bf0",
+    "/tmp/gf1249-statistics-candidate-count_identity.strace": "5c11e0b493d8030648237cced43b155d729d10919a7a0747b2ecf811eb55efd6",
+    "/tmp/gf1249-statistics-candidate-count_all.strace": "2b4433c1eaee55618f64aaa71c2cabf936557b7a47fe895ab31314c10492df51",
+    "/tmp/gf1249-statistics-baseline-empty.strace": "ea24b5e25ac1c518bba5beb98ebf1c8790397fd3998b3d75ebf20383e1918344",
+    "/tmp/gf1249-statistics-baseline-selective.strace": "2105a7cd658821eedc91605e2e6b2119db69527a80fcd82cbe37cb7c531a7f9a",
+    "/tmp/gf1249-statistics-baseline-sum_property.strace": "b5b045d2ff10e680edf71f2bb0406ddc81a4e3a4220aa046d0b9ec0446a3b559",
+    "/tmp/gf1249-statistics-baseline-count_property.strace": "1d2c8785cb9a1cf762539e35a15fbfc6aae7a8cd4ba0c68e3417effa2b26f10b",
+    "/tmp/gf1249-statistics-baseline-count_label.strace": "20056cfa8f93e2409a1cd3d48eb091e1356472f7914664242359ba9132a210a7",
+    "/tmp/gf1249-statistics-baseline-count_identity.strace": "ffa2744fd14bc214b7a2c32eddab559cecf4693d9f19329fc5650cb590447ea6",
+    "/tmp/gf1249-statistics-baseline-count_all.strace": "24f24e996a185567dfb90157282b564e65f677cd8a45562de1673feb9569882e",
+    "/tmp/gf1249-statistics-fd-candidate-empty.samples.json": "fdc0017acefc8f5da79117ed55b92c306e3d756733b155d693612ed3dcfd1482",
+    "/tmp/gf1249-statistics-fd-candidate-selective.samples.json": "37b5a6414887e3ee1d72019177e581d996d6594332bad7993cef5069b0571a71",
+    "/tmp/gf1249-statistics-fd-candidate-sum_property.samples.json": "9cd92571e961b245cf665b6e8f2644d7a95ae9ea1a6a9af45837669f01e9e66a",
+    "/tmp/gf1249-statistics-fd-candidate-count_property.samples.json": "36caffba0c0125838564d4e580ee45534ef17ff8ca4af6c81b49787db01521d9",
+    "/tmp/gf1249-statistics-fd-candidate-count_label.samples.json": "017f667eef872ba9eb7494ccd5d1896b2fd97cbefc532c30f609463080b22851",
+    "/tmp/gf1249-statistics-fd-candidate-count_identity.samples.json": "b695fe17ea5b2beed2225b99f52f8fdabbdcc9a952804f1260440f45f0c58844",
+    "/tmp/gf1249-statistics-fd-candidate-count_all.samples.json": "33380d5c5cca385700736c977ac2d836fd11974332380ecdb356c01edeb0e41e",
+    "/tmp/gf1249-statistics-fd-baseline-empty.samples.json": "784a914aa01341bdc970393a6d9638dbe188c0b67d55add32d68d6953dd7769a",
+    "/tmp/gf1249-statistics-fd-baseline-selective.samples.json": "d9de4d151a6eca7a468e20ea0317bd8c0df78c3b482327524de86e3b3d093fb5",
+    "/tmp/gf1249-statistics-fd-baseline-sum_property.samples.json": "77f6452f55c2d22f9dc1c9f0788130c62b3504edbbd021c9e212dab0950fd3e8",
+    "/tmp/gf1249-statistics-fd-baseline-count_property.samples.json": "5bce3c6540fc61b19d3ec164ae895fdd7da5a22831ea6f719ec14ac070f49c96",
+    "/tmp/gf1249-statistics-fd-baseline-count_label.samples.json": "b1ad4f5bd6926aa2eb1479e3425a7ff367f490d780f38e158e99c65e212619a1",
+    "/tmp/gf1249-statistics-fd-baseline-count_identity.samples.json": "1d8b548e8e11fa7bf9bfc08c719713a3ef95fab7194d505da6a5a666dbb8d60e",
+    "/tmp/gf1249-statistics-fd-baseline-count_all.samples.json": "e80dcfd022fce135278266c0a73c9db1463ad63504fe8c5a2d2918ebe43bd0c0",
+    "/tmp/gf1249-rss-diagnostic-7-baseline.log": "e01f7d6537d1f7654bc49926e0955c1acb4f6988324906d65f022cb0ed05ea67",
+    "/tmp/gf1249-rss-diagnostic-7-candidate.log": "b844b6bfe357dd145981f3acb1d3baeaef5e94b956db5e93d1cd836a78175df9",
+    "/tmp/gf1249-rss-diagnostic-6-candidate.log": "5499f7cd6ef88163cbc29d5dd1176edceb09f8d97196ef5d286071a623579274",
+    "/tmp/gf1249-rss-diagnostic-6-baseline.log": "04f06ba185e7256530a8c9b12833e39829f8ebd43aa22e9a98ed7c1779fcd055",
+    "/tmp/gf1249-rss-diagnostic-5-baseline.log": "6c62a3ca39eb6a0aed1d123ee159ddf4e438a5a94f765c0497bd0d847efce223",
+    "/tmp/gf1249-rss-diagnostic-5-candidate.log": "80b5bee9bd1caa34bfe6b99bc2bfd6dfc601451dbf87d3719f89ad75e04b0a61",
+    "/tmp/gf1249-rss-diagnostic-4-candidate.log": "8110288a15278507a34610628b22e64c91927adf15437361f75112b8f2f0d617",
+    "/tmp/gf1249-rss-diagnostic-4-baseline.log": "4e712ebc0588cd64666590af69f0b0a6cf512dfcd4919e2f16e5700c3f0646e9",
+    "/tmp/gf1249-rss-diagnostic-3-baseline.log": "d08d035337a98529d0fc3bdfe6a7f60598b23079af5572c6306371ea118b583b",
+    "/tmp/gf1249-rss-diagnostic-3-candidate.log": "efe1889ea690f9c93b1e41e62bf806e079102648562418e11aea84083ff06a41",
+    "/tmp/gf1249-rss-diagnostic-2-candidate.log": "50ddd72c6de3263fd632bfe2604dd35cc519487dfd7b985bdf335cff9eb7f257",
+    "/tmp/gf1249-rss-diagnostic-2-baseline.log": "bdd571675e64f3c4d715ed6546dad5c13ff602f301ee1a9036021c44e41a3b01",
+    "/tmp/gf1249-rss-diagnostic-1-baseline.log": "d7aea89be0dcd5c753ce3aef70d229640ba70c5e9bdd1ec9f812f23f9ad39cdd",
+    "/tmp/gf1249-rss-diagnostic-1-candidate.log": "c030e59202eaa9d71508ad45fce87f5f75f6173fcf2b895906d0fe3031d400ea",
+    "/tmp/gf1249-rss-diagnostic-0-candidate.log": "df13006b93ae6afdac55d27d8d7f40c8b31559021e0b587316be783e5596f36e",
+    "/tmp/gf1249-rss-diagnostic-0-baseline.log": "8e050401762928ff61ace4156af2d3fcce2aba44c89e53845af6d122b28894ee",
+    "/tmp/gf1249-rss-diagnostic-campaign.log": "d5db3cb797fab621887a007de1afb00042feed78be8b2d2e5218bd484e16b588",
+    "/tmp/gf1249-rss-diagnostic-7-baseline.time": "7ea5f8d8354e7edca281a73e24047634713ec196d8d258ad095a3892914c1ebf",
+    "/tmp/gf1249-rss-diagnostic-7-candidate.time": "6bb9708b5cd4e06d1a0802c17850d5266b77af15a39a6aa8b46a0fabea45ebb9",
+    "/tmp/gf1249-rss-diagnostic-6-candidate.time": "0bea2edc9ec21e112b75a17a5d8169ae71ec6f3d8f38155eb8a58249f1296412",
+    "/tmp/gf1249-rss-diagnostic-6-baseline.time": "f5973154b725763291a1f6dd3d15b6ddefc8386f0f2c1c2e84a4a58afb44b4ae",
+    "/tmp/gf1249-rss-diagnostic-5-baseline.time": "af3da227492117d85e67cba98d3af1f5310bab80fcd102365a2b920cedaa1a0a",
+    "/tmp/gf1249-rss-diagnostic-5-candidate.time": "e3e0ebc6057bb5e535429025345a9122ee08650fe8ea21aef35c8fe1500f7d51",
+    "/tmp/gf1249-rss-diagnostic-4-candidate.time": "0eac7d529b9559d4daea887da7b467f6ae7ce91030e67ebddb6c32ddba050399",
+    "/tmp/gf1249-rss-diagnostic-4-baseline.time": "242561e9977e521cd635ccf339d3f06ce8e2f358ca79eccac908bb1811f40330",
+    "/tmp/gf1249-rss-diagnostic-3-baseline.time": "dbb3ad26367a2ee443b1ca7cdd8763532e76d449ae55b68a6b8797d3571d4083",
+    "/tmp/gf1249-rss-diagnostic-3-candidate.time": "f3ba78e3ea2d7541f2f8f39d31befc9ef953aa87da20a4a9533177ec0fba4927",
+    "/tmp/gf1249-rss-diagnostic-2-candidate.time": "5407368db4d9e439646d44c8c51af40a6781cecefe5c19a20161417fea9f1196",
+    "/tmp/gf1249-rss-diagnostic-2-baseline.time": "ce8cb4ccd8c7a4d46f063556687d7cac6cb6b0b02e8bc1738e760d2e0dac419c",
+    "/tmp/gf1249-rss-diagnostic-1-baseline.time": "2346a3c3f3449d1f557cb1c0da174b0f84c695caaa5174071de0db7d5dae3b47",
+    "/tmp/gf1249-rss-diagnostic-1-candidate.time": "ce22b1d0f926b2e90573be48df65f5561b5f36700bc27c8cb0eae334259d440f",
+    "/tmp/gf1249-rss-diagnostic-0-candidate.time": "285dfb86c9bb5d59f2f076307233475b901ba2dca1bb424dc0dd14421251fc5f",
+    "/tmp/gf1249-rss-diagnostic-0-baseline.time": "9e56ddaef50ef5b4300727c757dd22d0e1bd0e5cbed592d4b4b3581e88f8b929",
+    "/tmp/gf1249-integrated-demand.log": "c7f081090d34270c28f07509b618955a6bb20c43a80078768c4572a918510b6d",
+    "/tmp/gf1249-integrated-prepush.log": "4a856569e292fda861c9804d539d5c4898f6f1b5caed9e49da4fac254b051514",
+    "/tmp/gf1249-integrated-clippy.log": "0480ae00150bc47f4b3612f07030a21f0dbacdf15d8faf59ddae00ba54ca5647",
+    "/tmp/gf1249-integrated-registry.log": "48050d5bb60544c041fc9097ae026c0d092c34d2f3eb30c9ab1edcf6c44c9987",
+    "/tmp/gf1249-integrated-semantics.log": "fdbccb3c7bdc536ea28ad6ec73a7ce4facf654542233576e83415ecab3a83eb9",
+    "/tmp/gf1249-integrated-fast.log": "0c41930afb384907a2857261f2d46b0695d8f4a4a123bfef43931a0d465c411e",
+    "/tmp/gf1249-integrated-public.log": "bf88536cb29c213a8f1d3c02af41631eee3cd2617526bd12cd8e1c8ffa0d4bd8"
+  }
+}


### PR DESCRIPTION
COUNT(*) could hydrate the last property column solely to count rows. Select an existing qualified identity for its true-for-null row marker, retaining scalar fallback and explicit nullable COUNT semantics. Add completed-reader diagnostics and a public construction/mutation/snapshot/reopen/export/full-verification/clean-import regression with deterministic avoided-materialization budgets.

On the frozen 4,101-node comparison, count-all/label/empty queries save 0.03/0.02/0.03 s median process CPU and about 924 KB syscall reads plus 309 KB writes per five queries. All exact oracles pass. The explicit identity-control RSS ceiling remains failed (70,184 vs 69,952 KiB); a fixed eight-pair diagnostic also crosses that cap on unchanged baseline 3/8 and candidate 1/8. The evidence preserves this limitation and does not claim every resource ceiling passes or prove RSS equivalence. Permanent allocation is unchanged.

Validation: focused count-marker tests 2 passed; aggregation 4 passed; demand 13 passed; workspace clippy, formatting, pre-push-fast and gate-registry checks passed. Full local pre-push reached the known #1192 hardcoded-/tmp admission failure (storage 1,097 passed, 1 failed, 2 pre-existing ignored); earlier 59 permanent-storage tests, 118 BDD scenarios and lifecycle growth/resume checks passed. Required exact-head CI remains the merge gate. Independent implementation and evidence reviews verified semantics, diagnostics and the disclosed resource disposition.

Closes #1249.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791708547&installation_model_id=20486&pr_number=1255&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1255&signature=fb7e05eb65c26fc5f36cfd30eac4aa0978674e6ec28ce8900b5eb30e8159e504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->