### PR TITLE
fix(api): refresh construction workspace and generation readers

### DIFF
--- a/crates/graphforge-api/src/algorithm_embedding_publication.rs
+++ b/crates/graphforge-api/src/algorithm_embedding_publication.rs
@@ -104,7 +104,7 @@ impl GraphForge {
         let eligible_count = u64::try_from(prepared.rows.len()).map_err(|_| {
             GfError::Execution("algorithm embedding row count cannot be represented".to_owned())
         })?;
-        let project_dir = self.dir.clone();
+        let project_dir = self.dir();
         let projection_bytes = prepared.projection_bytes.clone();
         self.publish_prepared_algorithm_embeddings(
             &prepared,
@@ -218,10 +218,13 @@ impl GraphForge {
         if replace_alias {
             return Ok(());
         }
-        if self.embedding_spaces()?.iter().any(|space| {
-            space.aliases.iter().any(|alias| alias == display_name)
-                && space.compatibility_id != compatibility_id.to_hex()
-        }) {
+        if Self::embedding_spaces_at(self.workspace_for_session().path())?
+            .iter()
+            .any(|space| {
+                space.aliases.iter().any(|alias| alias == display_name)
+                    && space.compatibility_id != compatibility_id.to_hex()
+            })
+        {
             return Err(validation(
                 "embedding alias already targets another compatibility identity; explicit replacement is required",
             ));
@@ -241,7 +244,7 @@ impl GraphForge {
     {
         let now = transaction_time_micros();
         refresh_embedding_generation(
-            &self.dir,
+            &self.dir(),
             EmbeddingRefreshRequest {
                 descriptor: &prepared.descriptor,
                 generated_at_micros: now,
@@ -632,7 +635,7 @@ mod tests {
         let reopened = GraphForge::new(Some(path)).unwrap();
         assert_eq!(reopened.embedding_space(Some("structural")).unwrap(), first);
         let discovered = discover_embedding_spaces(
-            &reopened.dir,
+            &reopened.dir(),
             EmbeddingSpaceDiscoveryLimits::default(),
             || Ok(()),
         )

--- a/crates/graphforge-api/src/algorithm_writeback.rs
+++ b/crates/graphforge-api/src/algorithm_writeback.rs
@@ -50,15 +50,17 @@ impl GraphForge {
                 "algorithm result {value_name:?} must be non-null {expected:?}"
             )));
         }
+        let workspace = self.workspace_for_session();
+        let dir = workspace.path().to_path_buf();
         reject_property_collision(
-            &self.dir,
+            &dir,
             &self.property_inventory_for_session(),
             stem,
             property,
             &expected,
         )?;
 
-        let known = persisted_node_uuids(&self.dir)?;
+        let known = persisted_node_uuids(&dir)?;
         let updates = algorithm_property_updates(
             algorithm,
             property,
@@ -77,7 +79,7 @@ impl GraphForge {
         transaction.intern_property(property, Some(label))?;
         let working = transaction.catalog();
         let catalog = graphforge_storage::GraphCatalog::open_authenticated_with_semantic_bindings(
-            &self.dir,
+            &dir,
             self.ontology.as_ref(),
             &working.lock().expect("mutation catalog poisoned"),
             self.semantic_storage_bindings
@@ -91,7 +93,7 @@ impl GraphForge {
             graphforge_exec::ExecutionSession::new_with_target_provider_resources_and_identity(
                 catalog,
                 self.ontology.clone(),
-                self.dir.clone(),
+                dir,
                 self.ontology_mode,
                 self.adjacency_provider_for_session(),
                 Some(std::sync::Arc::clone(&self.ordinal_identities)),
@@ -270,7 +272,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let graph = GraphForge::new(Some(dir.path().to_str().unwrap())).unwrap();
         graph.execute("CREATE (:Person)").unwrap();
-        let nodes = graphforge_storage::read_nodes(&graph.dir).unwrap();
+        let nodes = graphforge_storage::read_nodes(&graph.dir()).unwrap();
         let uuids = fixed_uuid_column(&nodes[0], "node_uuid").unwrap();
         let uuid = uuid_at(uuids, 0).unwrap();
         (dir, graph, uuid)
@@ -294,7 +296,7 @@ mod tests {
         uuid: [u8; 16],
     ) -> graphforge_storage::PropertySnapshotRow {
         let (mut rows, _) = graphforge_storage::read_authenticated_property_snapshots_for(
-            &graph.dir,
+            &graph.dir(),
             graphforge_storage::PropertyRouteKind::Node,
             "_untyped",
             &BTreeSet::from([uuid]),
@@ -333,7 +335,7 @@ mod tests {
     #[test]
     fn rank_and_cluster_writes_persist_without_topology_changes() {
         let (dir, graph, uuid) = graph();
-        let generation = graphforge_storage::read_topology_generation(&graph.dir).unwrap();
+        let generation = graphforge_storage::read_topology_generation(&graph.dir()).unwrap();
         let rank = result(&[uuid], "score", Arc::new(Float64Array::from(vec![0.75])));
         let cluster = result(&[uuid], "community_id", Arc::new(Int64Array::from(vec![7])));
         let rank_algorithm = Algorithm::Rank(RankAlgorithm::Degree);
@@ -346,7 +348,7 @@ mod tests {
         );
         assert!(
             graphforge_storage::enumerate_property_fragments(
-                &graph.dir,
+                &graph.dir(),
                 graphforge_storage::PropertyRouteKind::Node,
                 "_untyped",
             )
@@ -356,14 +358,14 @@ mod tests {
         write(&graph, rank_algorithm, Some("ranked"), &rank).unwrap();
         write(&graph, cluster_algorithm, Some("group"), &cluster).unwrap();
         assert_eq!(
-            graphforge_storage::read_topology_generation(&graph.dir).unwrap(),
+            graphforge_storage::read_topology_generation(&graph.dir()).unwrap(),
             generation
         );
         drop(graph);
 
         let reopened = GraphForge::new(Some(dir.path().to_str().unwrap())).unwrap();
         let props =
-            graphforge_storage::read_entity_properties(&reopened.dir, "_untyped", &uuid, false)
+            graphforge_storage::read_entity_properties(&reopened.dir(), "_untyped", &uuid, false)
                 .unwrap();
         assert_eq!(props["ranked"], IrLiteral::Float(0.75));
         assert_eq!(props["group"], IrLiteral::Int(7));
@@ -381,7 +383,7 @@ mod tests {
         let before = authenticated_properties(&graph, uuid);
         assert_eq!(before.values["metric"], IrLiteral::Str("old".into()));
         let fragments_before = graphforge_storage::enumerate_property_fragments(
-            &graph.dir,
+            &graph.dir(),
             graphforge_storage::PropertyRouteKind::Node,
             "_untyped",
         )
@@ -401,7 +403,7 @@ mod tests {
         assert_eq!(authenticated_properties(&graph, uuid), before);
         assert_eq!(
             graphforge_storage::enumerate_property_fragments(
-                &graph.dir,
+                &graph.dir(),
                 graphforge_storage::PropertyRouteKind::Node,
                 "_untyped",
             )

--- a/crates/graphforge-api/src/analyst.rs
+++ b/crates/graphforge-api/src/analyst.rs
@@ -30,10 +30,10 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        let workspace = self.workspace_for_session();
-        let (label_id, _) = self.algorithm_label(label, "rank")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
+        let workspace = self.workspace_for_session();
+        let (label_id, _) = self.algorithm_label(label, "rank")?;
         let projection = graphforge_exec::rank_projection_fingerprint(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -114,10 +114,10 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        let workspace = self.workspace_for_session();
-        let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let projection = graphforge_exec::cluster_projection_fingerprint(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -206,10 +206,10 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        let workspace = self.workspace_for_session();
-        let (label_id, stem) = self.algorithm_label(label, "similar")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "similar")?;
         let projection = graphforge_exec::similar_projection_fingerprint(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -307,13 +307,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let workspace = self.workspace_for_session();
         let label_id = label
             .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
             .transpose()?
             .unwrap_or(graphforge_value::EntityTypeSelection::All);
-        let adjacency_provider = self.adjacency_provider_for_session();
-        adjacency_provider.revalidate();
         let prepared = graphforge_exec::prepare_embedding_invocation_descriptor_with_compute(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -626,13 +626,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let workspace = self.workspace_for_session();
         let label_id = label
             .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
             .transpose()?
             .unwrap_or(graphforge_value::EntityTypeSelection::All);
-        let adjacency_provider = self.adjacency_provider_for_session();
-        adjacency_provider.revalidate();
         let projection = graphforge_exec::analyze_projection_fingerprint(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -749,6 +749,8 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let workspace = self.workspace_for_session();
         let source = source
             .map(|selector| self.resolve_node_selector(selector))
@@ -765,8 +767,6 @@ impl GraphForge {
             normalized.walk_length = Some(normalized.walk_length.unwrap_or(10));
             normalized.seed = Some(normalized.seed.unwrap_or(0));
         }
-        let adjacency_provider = self.adjacency_provider_for_session();
-        adjacency_provider.revalidate();
         let projection = graphforge_exec::paths_projection_fingerprint(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -968,10 +968,10 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        let workspace = self.workspace_for_session();
-        let (label_id, stem) = self.algorithm_label(label, "rank")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "rank")?;
         let batch = graphforge_exec::rank_algorithm_with_compute(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -1031,10 +1031,10 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        let workspace = self.workspace_for_session();
-        let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let batch = graphforge_exec::cluster_algorithm_with_compute(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -1085,19 +1085,19 @@ impl GraphForge {
                 options.by
             )));
         }
+        let _adjacency_visibility = self
+            .adjacency_visibility
+            .read()
+            .expect("adjacency visibility lock poisoned");
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
+        let workspace = self.workspace_for_session();
         let source = source
             .map(|selector| self.resolve_node_selector(selector))
             .transpose()?;
         let target = target
             .map(|selector| self.resolve_node_selector(selector))
             .transpose()?;
-        let _adjacency_visibility = self
-            .adjacency_visibility
-            .read()
-            .expect("adjacency visibility lock poisoned");
-        let workspace = self.workspace_for_session();
-        let adjacency_provider = self.adjacency_provider_for_session();
-        adjacency_provider.revalidate();
         graphforge_exec::paths_algorithm_with_compute(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -1132,13 +1132,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let workspace = self.workspace_for_session();
         let label_id = label
             .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
             .transpose()?
             .unwrap_or(graphforge_value::EntityTypeSelection::All);
-        let adjacency_provider = self.adjacency_provider_for_session();
-        adjacency_provider.revalidate();
         graphforge_exec::analyze_algorithm_with_compute(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -1172,13 +1172,13 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let adjacency_provider = self.adjacency_provider_for_session();
+        adjacency_provider.revalidate();
         let workspace = self.workspace_for_session();
         let label_id = label
             .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
             .transpose()?
             .unwrap_or(graphforge_value::EntityTypeSelection::All);
-        let adjacency_provider = self.adjacency_provider_for_session();
-        adjacency_provider.revalidate();
         graphforge_exec::embedding_algorithm_execution_with_compute(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),
@@ -1213,10 +1213,10 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
-        let workspace = self.workspace_for_session();
-        let (label_id, stem) = self.algorithm_label(label, "similar")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "similar")?;
         graphforge_exec::similar_algorithm_with_compute(
             &graphforge_exec::AdmittedAdjacencyProvider::new(
                 adjacency_provider.as_ref(),

--- a/crates/graphforge-api/src/analyst.rs
+++ b/crates/graphforge-api/src/analyst.rs
@@ -26,11 +26,12 @@ impl GraphForge {
             )
             .into());
         }
-        let (label_id, _) = self.algorithm_label(label, "rank")?;
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let (label_id, _) = self.algorithm_label(label, "rank")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         let projection = graphforge_exec::rank_projection_fingerprint(
@@ -38,7 +39,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             options,
@@ -109,11 +110,12 @@ impl GraphForge {
             )
             .into());
         }
-        let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         let projection = graphforge_exec::cluster_projection_fingerprint(
@@ -121,7 +123,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             std::slice::from_ref(&stem),
@@ -200,11 +202,12 @@ impl GraphForge {
         label: &str,
         options: &SimilarOptions,
     ) -> Result<InvocationDescriptor, InvocationError> {
-        let (label_id, stem) = self.algorithm_label(label, "similar")?;
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "similar")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         let projection = graphforge_exec::similar_projection_fingerprint(
@@ -212,7 +215,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             std::slice::from_ref(&stem),
@@ -300,14 +303,15 @@ impl GraphForge {
         label: Option<&str>,
         options: &EmbeddingAnalyzeOptions,
     ) -> Result<InvocationDescriptor, InvocationError> {
-        let label_id = label
-            .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
-            .transpose()?
-            .unwrap_or(graphforge_value::EntityTypeSelection::All);
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let label_id = label
+            .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
+            .transpose()?
+            .unwrap_or(graphforge_value::EntityTypeSelection::All);
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         let prepared = graphforge_exec::prepare_embedding_invocation_descriptor_with_compute(
@@ -315,7 +319,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             label,
@@ -618,14 +622,15 @@ impl GraphForge {
         label: Option<&str>,
         options: &AnalyzeOptions,
     ) -> Result<InvocationDescriptor, InvocationError> {
-        let label_id = label
-            .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
-            .transpose()?
-            .unwrap_or(graphforge_value::EntityTypeSelection::All);
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let label_id = label
+            .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
+            .transpose()?
+            .unwrap_or(graphforge_value::EntityTypeSelection::All);
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         let projection = graphforge_exec::analyze_projection_fingerprint(
@@ -633,7 +638,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             options,
@@ -740,6 +745,11 @@ impl GraphForge {
             ))
             .into());
         }
+        let _adjacency_visibility = self
+            .adjacency_visibility
+            .read()
+            .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
         let source = source
             .map(|selector| self.resolve_node_selector(selector))
             .transpose()?
@@ -755,10 +765,6 @@ impl GraphForge {
             normalized.walk_length = Some(normalized.walk_length.unwrap_or(10));
             normalized.seed = Some(normalized.seed.unwrap_or(0));
         }
-        let _adjacency_visibility = self
-            .adjacency_visibility
-            .read()
-            .expect("adjacency visibility lock poisoned");
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         let projection = graphforge_exec::paths_projection_fingerprint(
@@ -766,7 +772,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             source,
             target,
@@ -958,11 +964,12 @@ impl GraphForge {
             .as_ref()
             .map(|_| self.graph_visibility.lock())
             .transpose()?;
-        let (label_id, stem) = self.algorithm_label(label, "rank")?;
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "rank")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         let batch = graphforge_exec::rank_algorithm_with_compute(
@@ -970,7 +977,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             std::slice::from_ref(&stem),
@@ -1020,11 +1027,12 @@ impl GraphForge {
             .as_ref()
             .map(|_| self.graph_visibility.lock())
             .transpose()?;
-        let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "cluster")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         let batch = graphforge_exec::cluster_algorithm_with_compute(
@@ -1032,7 +1040,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             std::slice::from_ref(&stem),
@@ -1087,6 +1095,7 @@ impl GraphForge {
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         graphforge_exec::paths_algorithm_with_compute(
@@ -1094,7 +1103,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             source.map(|uuid| *uuid.as_bytes()),
             target.map(|uuid| *uuid.as_bytes()),
@@ -1119,14 +1128,15 @@ impl GraphForge {
         options: AnalyzeOptions,
     ) -> Result<arrow::record_batch::RecordBatch, GfError> {
         let dispatch_options = options;
-        let label_id = label
-            .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
-            .transpose()?
-            .unwrap_or(graphforge_value::EntityTypeSelection::All);
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let label_id = label
+            .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
+            .transpose()?
+            .unwrap_or(graphforge_value::EntityTypeSelection::All);
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         graphforge_exec::analyze_algorithm_with_compute(
@@ -1134,7 +1144,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             &dispatch_options,
@@ -1158,14 +1168,15 @@ impl GraphForge {
         options: &EmbeddingAnalyzeOptions,
     ) -> Result<arrow::record_batch::RecordBatch, GfError> {
         let _admission = self.admit_heavy_query()?;
-        let label_id = label
-            .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
-            .transpose()?
-            .unwrap_or(graphforge_value::EntityTypeSelection::All);
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let label_id = label
+            .map(|value| self.algorithm_label(value, "analyze").map(|(id, _)| id))
+            .transpose()?
+            .unwrap_or(graphforge_value::EntityTypeSelection::All);
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         graphforge_exec::embedding_algorithm_execution_with_compute(
@@ -1173,7 +1184,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             label,
@@ -1198,11 +1209,12 @@ impl GraphForge {
         options: SimilarOptions,
     ) -> Result<arrow::record_batch::RecordBatch, GfError> {
         let _admission = self.admit_heavy_query()?;
-        let (label_id, stem) = self.algorithm_label(label, "similar")?;
         let _adjacency_visibility = self
             .adjacency_visibility
             .read()
             .expect("adjacency visibility lock poisoned");
+        let workspace = self.workspace_for_session();
+        let (label_id, stem) = self.algorithm_label(label, "similar")?;
         let adjacency_provider = self.adjacency_provider_for_session();
         adjacency_provider.revalidate();
         graphforge_exec::similar_algorithm_with_compute(
@@ -1210,7 +1222,7 @@ impl GraphForge {
                 adjacency_provider.as_ref(),
                 self.property_inventory_for_session(),
             ),
-            &self.dir,
+            workspace.path(),
             self.ontology_mode,
             label_id,
             std::slice::from_ref(&stem),

--- a/crates/graphforge-api/src/belief_projection.rs
+++ b/crates/graphforge-api/src/belief_projection.rs
@@ -422,8 +422,8 @@ impl GraphForge {
             ..Default::default()
         };
         let materialized = graphforge_storage::materialize_graph_projection(
-            &self.dir,
-            &projected.dir,
+            &self.dir(),
+            &projected.dir(),
             &storage_selection,
         )?;
         projected.ontology.clone_from(&self.ontology);
@@ -439,7 +439,7 @@ impl GraphForge {
             .write()
             .expect("adjacency provider lock poisoned") =
             Arc::new(crate::adjacency_provider_for_graph(
-                &projected.dir,
+                &projected.dir(),
                 projected.ontology_mode,
                 projected.property_inventory_for_session(),
             )?);
@@ -1709,7 +1709,7 @@ mod tests {
             })
             .unwrap();
         crate::permanent_parquet_test_support::assert_file(
-            &projection.graph.dir.join("topology/nodes.parquet"),
+            &projection.graph.dir().join("topology/nodes.parquet"),
         );
         assert_ne!(projection.source_generation_uuid(), Uuid::nil());
         assert!(!projection.policy_bytes().is_empty());
@@ -1721,7 +1721,7 @@ mod tests {
         assert_ne!(projection.graph_content_fingerprint(), [0; 32]);
         assert_eq!(projection.source_record_uuids(), &[uuid7(5)]);
         assert_eq!(
-            graphforge_storage::read_nodes(&projection.graph.dir)
+            graphforge_storage::read_nodes(&projection.graph.dir())
                 .unwrap()
                 .iter()
                 .map(RecordBatch::num_rows)
@@ -1903,7 +1903,7 @@ mod tests {
         assert!(current_selection.node_uuids.is_empty());
         let empty_target = tempfile::tempdir().unwrap();
         let empty_summary = graphforge_storage::materialize_graph_projection(
-            &graph.dir,
+            &graph.dir(),
             empty_target.path(),
             &graphforge_storage::GraphProjectionSelection::default(),
         )
@@ -1925,7 +1925,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(
-            graphforge_storage::read_nodes(&before_retraction.graph.dir)
+            graphforge_storage::read_nodes(&before_retraction.graph.dir())
                 .unwrap()
                 .iter()
                 .map(RecordBatch::num_rows)
@@ -1940,7 +1940,7 @@ mod tests {
             })
             .unwrap();
         assert!(
-            graphforge_storage::read_nodes(&after_retraction.graph.dir)
+            graphforge_storage::read_nodes(&after_retraction.graph.dir())
                 .unwrap()
                 .iter()
                 .map(RecordBatch::num_rows)
@@ -1971,7 +1971,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(
-            graphforge_storage::read_nodes(&inside_validity.graph.dir)
+            graphforge_storage::read_nodes(&inside_validity.graph.dir())
                 .unwrap()
                 .iter()
                 .map(RecordBatch::num_rows)
@@ -1986,7 +1986,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(
-            graphforge_storage::read_nodes(&exclusive_upper.graph.dir)
+            graphforge_storage::read_nodes(&exclusive_upper.graph.dir())
                 .unwrap()
                 .iter()
                 .map(RecordBatch::num_rows)

--- a/crates/graphforge-api/src/bulk_construction.rs
+++ b/crates/graphforge-api/src/bulk_construction.rs
@@ -599,7 +599,7 @@ impl GraphForge {
         let mut next_catalog = prior_catalog.clone();
         let now = (self.clock.lock().expect("clock lock poisoned"))()?;
         let mut writer =
-            graphforge_storage::GraphWriter::open_at(&self.dir, self.ontology_mode, now)?;
+            graphforge_storage::GraphWriter::open_at(&self.dir(), self.ontology_mode, now)?;
         for row in &normalized.rows {
             let type_id = match self
                 .ontology
@@ -629,7 +629,7 @@ impl GraphForge {
         let publication = (|| -> Result<(), super::GfError> {
             writer.flush()?;
             if self.path.is_some() {
-                super::persist_runtime_catalog(&self.dir, &next_catalog)?;
+                super::persist_runtime_catalog(&self.dir(), &next_catalog)?;
             }
             let receipt = graphforge_exec::MutationReceipt {
                 effects: vec![graphforge_exec::MutationEffect {
@@ -660,7 +660,7 @@ impl GraphForge {
                 .expect("generation UUID lock poisoned")
                 == expected_parent;
             if still_prior {
-                crate::rematerialize_graph_workspace(&prior_generation, &self.dir)?;
+                crate::rematerialize_graph_workspace(&prior_generation, &self.dir())?;
             } else {
                 *self
                     .runtime_catalog
@@ -955,13 +955,13 @@ impl GraphForge {
         let mut next_catalog = prior_catalog.clone();
         let now = (self.clock.lock().expect("clock lock poisoned"))()?;
         let mut writer =
-            graphforge_storage::GraphWriter::open_at(&self.dir, self.ontology_mode, now)?;
+            graphforge_storage::GraphWriter::open_at(&self.dir(), self.ontology_mode, now)?;
         let endpoints = normalized
             .rows
             .iter()
             .flat_map(|row| [row.source_uuid, row.target_uuid])
             .collect::<BTreeSet<_>>();
-        register_existing_endpoints(&mut writer, &self.dir, &endpoints)?;
+        register_existing_endpoints(&mut writer, &self.dir(), &endpoints)?;
         for row in &normalized.rows {
             next_catalog.intern_relation_type(&row.rel_type)?;
             writer.create_edge(
@@ -986,7 +986,7 @@ impl GraphForge {
         let publication = (|| -> Result<(), super::GfError> {
             writer.flush()?;
             if self.path.is_some() {
-                super::persist_runtime_catalog(&self.dir, &next_catalog)?;
+                super::persist_runtime_catalog(&self.dir(), &next_catalog)?;
             }
             let receipt = graphforge_exec::MutationReceipt {
                 effects: vec![graphforge_exec::MutationEffect {
@@ -1025,7 +1025,7 @@ impl GraphForge {
                 .expect("generation UUID lock poisoned")
                 == expected_parent;
             if still_prior {
-                crate::rematerialize_graph_workspace(&prior_generation, &self.dir)?;
+                crate::rematerialize_graph_workspace(&prior_generation, &self.dir())?;
             } else {
                 *self
                     .runtime_catalog
@@ -2007,7 +2007,7 @@ fn open_membership_index(
     BulkValidationError,
 > {
     let current_generation =
-        graphforge_storage::read_topology_generation(&graph.dir).map_err(|error| {
+        graphforge_storage::read_topology_generation(&graph.dir()).map_err(|error| {
             contract_error(
                 input_kind,
                 BulkValidationReason::ProjectState,
@@ -2027,15 +2027,16 @@ fn open_membership_index(
     {
         *cached = None;
     }
-    if !graphforge_storage::uuid_membership_index_present(&graph.dir) {
-        let has_nodes = graphforge_storage::node_topology_present(&graph.dir).map_err(|error| {
-            contract_error(
-                input_kind,
-                BulkValidationReason::ProjectState,
-                &error.to_string(),
-            )
-        })?;
-        let has_edges = std::fs::read_dir(graph.dir.join("topology/edges"))
+    if !graphforge_storage::uuid_membership_index_present(&graph.dir()) {
+        let has_nodes =
+            graphforge_storage::node_topology_present(&graph.dir()).map_err(|error| {
+                contract_error(
+                    input_kind,
+                    BulkValidationReason::ProjectState,
+                    &error.to_string(),
+                )
+            })?;
+        let has_edges = std::fs::read_dir(graph.dir().join("topology/edges"))
             .ok()
             .is_some_and(|mut entries| entries.any(|entry| entry.is_ok()));
         if has_nodes || has_edges {
@@ -2049,7 +2050,7 @@ fn open_membership_index(
     }
     if cached.is_none() {
         *cached = Some(
-            graphforge_storage::UuidMembershipIndex::open(&graph.dir).map_err(|error| {
+            graphforge_storage::UuidMembershipIndex::open(&graph.dir()).map_err(|error| {
                 contract_error(
                     input_kind,
                     BulkValidationReason::ProjectState,
@@ -2152,7 +2153,7 @@ fn candidate_endpoint_uuids(
 
 #[cfg(test)]
 fn indexed_uuid_count(graph: &GraphForge, kind: graphforge_storage::UuidIndexKind) -> u64 {
-    graphforge_storage::UuidMembershipIndex::open(&graph.dir)
+    graphforge_storage::UuidMembershipIndex::open(&graph.dir())
         .expect("published graph has an authenticated UUID membership index")
         .count(kind)
 }
@@ -2675,14 +2676,14 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let graph = GraphForge::new(Some(directory.path().to_str().unwrap())).unwrap();
         let mut writer = graphforge_storage::GraphWriter::open_at(
-            &graph.dir,
+            &graph.dir(),
             graph.ontology_mode,
             (graph.clock.lock().unwrap())().unwrap(),
         )
         .unwrap();
         let missing = uuid(70_001);
         let failure =
-            register_existing_endpoints(&mut writer, &graph.dir, &BTreeSet::from([missing]))
+            register_existing_endpoints(&mut writer, &graph.dir(), &BTreeSet::from([missing]))
                 .unwrap_err();
         assert_eq!(
             failure.to_string(),
@@ -3894,7 +3895,7 @@ mod tests {
     #[test]
     fn validation_is_zero_write_for_catalog_generation_and_graph_bytes() {
         let graph = GraphForge::new(None).unwrap();
-        let before = crate::graph_snapshot::capture(&graph.dir).unwrap();
+        let before = crate::graph_snapshot::capture(&graph.dir()).unwrap();
         let catalog = graph.runtime_catalog.lock().unwrap().to_record_batch();
         let generation = *graph.current_generation_uuid.lock().unwrap();
         let invalid = node_batch(&[uuid(30), uuid(30)], &["Person", "Person"], &[None, None]);
@@ -3904,7 +3905,7 @@ mod tests {
                 .is_err()
         );
         assert_eq!(
-            crate::graph_snapshot::capture(&graph.dir).unwrap().bytes,
+            crate::graph_snapshot::capture(&graph.dir()).unwrap().bytes,
             before.bytes
         );
         assert_eq!(
@@ -3923,7 +3924,7 @@ mod tests {
             1
         );
         assert_eq!(
-            crate::graph_snapshot::capture(&graph.dir).unwrap().bytes,
+            crate::graph_snapshot::capture(&graph.dir()).unwrap().bytes,
             before.bytes
         );
         assert_eq!(
@@ -4024,7 +4025,7 @@ mod tests {
             1
         );
 
-        let before_graph = crate::graph_snapshot::capture(&graph.dir).unwrap();
+        let before_graph = crate::graph_snapshot::capture(&graph.dir()).unwrap();
         let before_catalog = graph.runtime_catalog.lock().unwrap().to_record_batch();
         let before_generation = *graph.current_generation_uuid.lock().unwrap();
         let before_ontology = graph
@@ -4057,7 +4058,7 @@ mod tests {
         assert_eq!(error.reason, BulkValidationReason::PropertyTypeMismatch);
         assert_eq!(error.field.as_deref(), Some("score"));
         assert_eq!(
-            crate::graph_snapshot::capture(&graph.dir).unwrap().bytes,
+            crate::graph_snapshot::capture(&graph.dir()).unwrap().bytes,
             before_graph.bytes
         );
         assert_eq!(

--- a/crates/graphforge-api/src/composite_publish.rs
+++ b/crates/graphforge-api/src/composite_publish.rs
@@ -489,6 +489,8 @@ impl GraphForge {
         optimistic: bool,
         routes: &CompositePropertyRoutes,
     ) -> Result<RecordBatch, GfError> {
+        let workspace = self.workspace_for_session();
+        let dir = workspace.path().to_path_buf();
         let root = self.resolved_generation.container_root();
         let expected_parent = parent.generation_uuid();
         let transaction_uuid = request.context.operation_uuid.0;
@@ -510,7 +512,7 @@ impl GraphForge {
                 eligible_delta_operations(request, routes)?
             };
             let property_inventory =
-                crate::property_inventory_for_hydrated_generation(parent, &self.dir)?;
+                crate::property_inventory_for_hydrated_generation(parent, &dir)?;
             #[cfg(test)]
             after_property_inventory_capture_for_test();
             apply_graph_mutations(
@@ -522,7 +524,7 @@ impl GraphForge {
                 routes,
             )?;
             if self.path.is_some() {
-                crate::persist_runtime_catalog(&self.dir, &next_catalog)?;
+                crate::persist_runtime_catalog(&dir, &next_catalog)?;
             }
             let prepared_delta = if let Some(operations) = delta_operations {
                 let delta_request = graphforge_storage::GraphDeltaPublishRequest {
@@ -546,10 +548,10 @@ impl GraphForge {
             let graph = if let Some(prepared) = prepared_delta.as_ref() {
                 prepared.files_participant.clone()
             } else {
-                let (inventory, participant) = graphforge_storage::capture_graph_files(&self.dir)?;
+                let (inventory, participant) = graphforge_storage::capture_graph_files(&dir)?;
                 if routes.requires_canonical {
                     let (participant, lease) = graphforge_storage::prepare_graph_files_replacement(
-                        parent, &self.dir, &inventory,
+                        parent, &dir, &inventory,
                     )?;
                     canonical_lease = lease;
                     participant
@@ -578,7 +580,7 @@ impl GraphForge {
                     &publication,
                     content_fingerprint,
                     prepared_delta.as_ref().map_or_else(
-                        || canonical_lease.is_none().then_some(self.dir.as_path()),
+                        || canonical_lease.is_none().then_some(dir.as_path()),
                         |prepared| prepared.graph_tree_source(),
                     ),
                     self.lifecycle_mode,
@@ -588,7 +590,7 @@ impl GraphForge {
                     root,
                     &publication,
                     prepared_delta.as_ref().map_or_else(
-                        || canonical_lease.is_none().then_some(self.dir.as_path()),
+                        || canonical_lease.is_none().then_some(dir.as_path()),
                         |prepared| prepared.graph_tree_source(),
                     ),
                     self.lifecycle_mode,
@@ -652,9 +654,7 @@ impl GraphForge {
                 // the validation or conflict that caused publication to abort.
                 if let Ok(durable) = graphforge_storage::resolve_project_generation(root) {
                     if durable.generation_uuid() == expected_parent {
-                        if crate::rematerialize_graph_workspace(&prior_generation, &self.dir)
-                            .is_ok()
-                        {
+                        if crate::rematerialize_graph_workspace(&prior_generation, &dir).is_ok() {
                             *self
                                 .runtime_catalog
                                 .lock()
@@ -941,11 +941,11 @@ fn reconcile_workspace_to(
     graph: &GraphForge,
     generation: &ResolvedProjectGeneration,
 ) -> Result<(), GfError> {
-    crate::rematerialize_graph_workspace(generation, &graph.dir)?;
+    crate::rematerialize_graph_workspace(generation, &graph.dir())?;
     *graph
         .runtime_catalog
         .lock()
-        .expect("runtime catalog poisoned") = crate::load_runtime_catalog(&graph.dir)?;
+        .expect("runtime catalog poisoned") = crate::load_runtime_catalog(&graph.dir())?;
     graph.install_property_generation(generation)?;
     graph.adjacency_provider_for_session().invalidate();
     Ok(())
@@ -1065,7 +1065,7 @@ fn build_validation_snapshot(
             .map(str::to_owned)
             .collect();
     }
-    for batch in graphforge_storage::read_nodes(&graph.dir)
+    for batch in graphforge_storage::read_nodes(&graph.dir())
         .map_err(|error| GfError::Storage(format!("failed to read node topology: {error}")))?
     {
         let Some(column) = batch.column_by_name("node_uuid") else {
@@ -1346,7 +1346,7 @@ fn apply_graph_mutations(
         return Ok(());
     }
     let mut writer =
-        graphforge_storage::GraphWriter::open_at(&graph.dir, graph.ontology_mode, recorded_at)?
+        graphforge_storage::GraphWriter::open_at(&graph.dir(), graph.ontology_mode, recorded_at)?
             .with_semantic_composition_fingerprint(
                 graph
                     .default_composition_snapshot()
@@ -1373,7 +1373,7 @@ fn apply_graph_mutations(
             _ => None,
         })
         .collect::<BTreeSet<_>>();
-    register_existing_endpoints(&mut writer, &graph.dir, &endpoints, &same_request_nodes)?;
+    register_existing_endpoints(&mut writer, &graph.dir(), &endpoints, &same_request_nodes)?;
     let mut node_sets: HashMap<String, HashMap<[u8; 16], HashMap<String, IrLiteral>>> =
         HashMap::new();
     let mut edge_sets: HashMap<String, HashMap<[u8; 16], HashMap<String, IrLiteral>>> =
@@ -1512,7 +1512,7 @@ fn apply_graph_mutations(
     for (stem, updates) in &node_sets {
         graphforge_storage::stage_set_node_properties_authenticated(
             &mut staged,
-            &graph.dir,
+            &graph.dir(),
             inventory,
             stem,
             updates,
@@ -1521,7 +1521,7 @@ fn apply_graph_mutations(
     for (stem, updates) in &edge_sets {
         graphforge_storage::stage_set_edge_properties_authenticated(
             &mut staged,
-            &graph.dir,
+            &graph.dir(),
             inventory,
             stem,
             updates,
@@ -1530,7 +1530,7 @@ fn apply_graph_mutations(
     for (stem, removals) in &node_removes {
         graphforge_storage::stage_remove_node_properties_authenticated(
             &mut staged,
-            &graph.dir,
+            &graph.dir(),
             inventory,
             stem,
             removals,
@@ -1539,7 +1539,7 @@ fn apply_graph_mutations(
     for (stem, removals) in &edge_removes {
         graphforge_storage::stage_remove_edge_properties_authenticated(
             &mut staged,
-            &graph.dir,
+            &graph.dir(),
             inventory,
             stem,
             removals,
@@ -1547,13 +1547,13 @@ fn apply_graph_mutations(
     }
     graphforge_storage::stage_delete_edges_authenticated(
         &mut staged,
-        &graph.dir,
+        &graph.dir(),
         inventory,
         &delete_edges,
     )?;
     graphforge_storage::stage_delete_nodes_authenticated(
         &mut staged,
-        &graph.dir,
+        &graph.dir(),
         inventory,
         &delete_nodes,
     )?;
@@ -2375,7 +2375,7 @@ mod tests {
         columns[3] = Arc::new(arrow::array::UInt64Array::from(vec![u64::MAX]));
         let batch = arrow::array::RecordBatch::try_new(batch.schema(), columns).unwrap();
         let mut catalog = RuntimeCatalog::from_record_batch(&batch).unwrap();
-        let before = graphforge_storage::capture_graph_files(&graph.dir)
+        let before = graphforge_storage::capture_graph_files(&graph.dir())
             .unwrap()
             .1
             .bytes;
@@ -2400,7 +2400,7 @@ mod tests {
         assert!(error.to_string().contains("observation count overflow"));
         assert_eq!(catalog.to_record_batch(), batch);
         assert_eq!(
-            graphforge_storage::capture_graph_files(&graph.dir)
+            graphforge_storage::capture_graph_files(&graph.dir())
                 .unwrap()
                 .1
                 .bytes,

--- a/crates/graphforge-api/src/composition_binding_tests.rs
+++ b/crates/graphforge-api/src/composition_binding_tests.rs
@@ -330,7 +330,7 @@ fn facade_migrates_legacy_routes_with_atomic_participants_and_plain_reopen() {
     let path = dir.path().join("project");
     let forge = GraphForge::new(Some(path.to_str().unwrap())).unwrap();
     let mut writer =
-        graphforge_storage::GraphWriter::open_at(&forge.dir, OntologyMode::Strict, 1).unwrap();
+        graphforge_storage::GraphWriter::open_at(&forge.dir(), OntologyMode::Strict, 1).unwrap();
     let left = graphforge_core::uuid::new_v7();
     let right = graphforge_core::uuid::new_v7();
     writer
@@ -763,7 +763,7 @@ fn facade_reopens_relation_edge_property_through_default_context() {
         .unwrap()
         .value(0);
     let node_batch = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
-        std::fs::File::open(forge.dir.join("topology/nodes.parquet")).unwrap(),
+        std::fs::File::open(forge.dir().join("topology/nodes.parquet")).unwrap(),
     )
     .unwrap()
     .build()
@@ -786,7 +786,7 @@ fn facade_reopens_relation_edge_property_through_default_context() {
         .install_generation_composition_context(&context)
         .unwrap();
     let reopened_edge = reopened
-        .dir
+        .dir()
         .join("topology/edges")
         .join(edge_path.file_name().unwrap());
     assert!(

--- a/crates/graphforge-api/src/construction.rs
+++ b/crates/graphforge-api/src/construction.rs
@@ -129,14 +129,14 @@ impl GraphForge {
         // selection, endpoint registration against live topology, surrogate
         // allocation, flush, and publication (see #704).
         let _visibility = self.graph_visibility.lock()?;
-        let prior = crate::graph_snapshot::capture(&self.dir)?;
+        let prior = crate::graph_snapshot::capture(&self.dir())?;
         let expected_generation = *self
             .current_generation_uuid
             .lock()
             .expect("generation UUID lock poisoned");
         let now = (self.clock.lock().expect("clock lock poisoned"))()?;
         let mut writer =
-            graphforge_storage::GraphWriter::open_at(&self.dir, self.ontology_mode, now)?;
+            graphforge_storage::GraphWriter::open_at(&self.dir(), self.ontology_mode, now)?;
         writer
             .register_existing_endpoints(&[src_uuid, dst_uuid])
             .map_err(|error| match error {
@@ -179,7 +179,7 @@ impl GraphForge {
                 .expect("generation UUID lock poisoned")
                 == expected_generation;
             if still_prior {
-                crate::graph_snapshot::restore(&prior.bytes, &self.dir)?;
+                crate::graph_snapshot::restore(&prior.bytes, &self.dir())?;
                 self.adjacency_provider_for_session().invalidate();
             }
             return Err(error);
@@ -538,7 +538,8 @@ mod tests {
             1
         );
 
-        let rows = graphforge_storage::read_node_property_rows(&reopened.dir, "_untyped").unwrap();
+        let rows =
+            graphforge_storage::read_node_property_rows(&reopened.dir(), "_untyped").unwrap();
         assert_eq!(rows.len(), 1);
         let stored = rows.values().next().unwrap();
         for (name, value) in temporal {
@@ -653,7 +654,7 @@ mod tests {
             .unwrap()
             .to_record_batch()
             .num_rows();
-        let generation = graphforge_storage::read_topology_generation(&graph.dir).unwrap();
+        let generation = graphforge_storage::read_topology_generation(&graph.dir()).unwrap();
 
         for (label, props) in [
             ("", properties()),
@@ -680,11 +681,11 @@ mod tests {
             catalog_rows
         );
         assert_eq!(
-            graphforge_storage::read_topology_generation(&graph.dir).unwrap(),
+            graphforge_storage::read_topology_generation(&graph.dir()).unwrap(),
             generation
         );
         assert_eq!(
-            graphforge_storage::read_nodes(&graph.dir)
+            graphforge_storage::read_nodes(&graph.dir())
                 .unwrap()
                 .iter()
                 .map(arrow::record_batch::RecordBatch::num_rows)
@@ -717,11 +718,11 @@ mod tests {
 
         let graph = GraphForge::new(dir.path().to_str()).unwrap();
         let handle = graph.add_node("Person", &properties()).unwrap();
-        let generation = graphforge_storage::read_topology_generation(&graph.dir).unwrap();
+        let generation = graphforge_storage::read_topology_generation(&graph.dir()).unwrap();
         let error = graph.add_node("Unknown", &HashMap::new()).unwrap_err();
         assert!(matches!(error, GfError::Bind { .. }));
         assert_eq!(
-            graphforge_storage::read_topology_generation(&graph.dir).unwrap(),
+            graphforge_storage::read_topology_generation(&graph.dir()).unwrap(),
             generation
         );
         assert_eq!(
@@ -765,7 +766,8 @@ mod tests {
             .current_generation_uuid
             .lock()
             .expect("generation UUID lock poisoned");
-        let topology_generation = graphforge_storage::read_topology_generation(&graph.dir).unwrap();
+        let topology_generation =
+            graphforge_storage::read_topology_generation(&graph.dir()).unwrap();
 
         let error = graph
             .add_node(
@@ -783,10 +785,10 @@ mod tests {
             generation_uuid
         );
         assert_eq!(
-            graphforge_storage::read_topology_generation(&graph.dir).unwrap(),
+            graphforge_storage::read_topology_generation(&graph.dir()).unwrap(),
             topology_generation
         );
-        let rows = graphforge_storage::read_node_property_rows(&graph.dir, "Host").unwrap();
+        let rows = graphforge_storage::read_node_property_rows(&graph.dir(), "Host").unwrap();
         assert_eq!(rows.len(), 1);
         let properties = rows.get(valid.uuid.as_bytes()).unwrap();
         assert_eq!(

--- a/crates/graphforge-api/src/embedding_freshness.rs
+++ b/crates/graphforge-api/src/embedding_freshness.rs
@@ -73,6 +73,15 @@ impl GraphForge {
         display_name: Option<&str>,
         force_stale: bool,
     ) -> Result<EmbeddingSpaceFreshnessInspection, GfError> {
+        let _visibility = self.graph_visibility.read()?;
+        self.inspect_embedding_space_freshness_guarded(display_name, force_stale)
+    }
+
+    pub(crate) fn inspect_embedding_space_freshness_guarded(
+        &self,
+        display_name: Option<&str>,
+        force_stale: bool,
+    ) -> Result<EmbeddingSpaceFreshnessInspection, GfError> {
         let prepared = self.prepare_embedding_space_read(display_name, force_stale)?;
         let compatibility_id = prepared.publication().manifest.compatibility_id();
         let freshness = prepared.freshness();
@@ -93,20 +102,21 @@ impl GraphForge {
         let _visibility = self.embedding_refresh_visibility.lock().map_err(|_| {
             GfError::Execution("embedding refresh visibility lock is poisoned".into())
         })?;
-        let (_, lineage) = self.resolve_embedding_space_lineage(display_name)?;
+        let workspace = self.workspace_for_session();
+        let dir = workspace.path();
+        let (_, lineage) = Self::resolve_embedding_space_lineage_at(dir, display_name)?;
         let compatibility_id = lineage.compatibility_id();
         let publication = lineage
             .active()
             .ok_or_else(|| SearchArtifactError::Missing {
-                path: self
-                    .dir
+                path: dir
                     .join("embeddings/spaces")
                     .join(compatibility_id.to_hex())
                     .join("active.json"),
             })?;
-        let current_source = current_source(&self.dir, publication)?;
+        let current_source = current_source(dir, publication)?;
         prepare_embedding_read(
-            &self.dir,
+            dir,
             lineage.descriptor(),
             current_source,
             force_stale,
@@ -114,8 +124,7 @@ impl GraphForge {
             || Ok(()),
         )?
         .ok_or_else(|| SearchArtifactError::Missing {
-            path: self
-                .dir
+            path: dir
                 .join("embeddings/spaces")
                 .join(compatibility_id.to_hex())
                 .join("active.json"),
@@ -256,13 +265,13 @@ mod tests {
         )
         .unwrap();
         let source = EmbeddingSourceState::new(
-            read_search_generation(&graph.dir).unwrap(),
+            read_search_generation(&graph.dir()).unwrap(),
             [1; 32],
             [2; 32],
             u64::from(count),
         );
         let publication = publish_embedding_generation(
-            &graph.dir,
+            &graph.dir(),
             EmbeddingPublicationRequest {
                 descriptor: &descriptor,
                 source,
@@ -278,7 +287,7 @@ mod tests {
         .publication()
         .clone();
         reset_embedding_mutation_journal(
-            &graph.dir,
+            &graph.dir(),
             &publication.manifest,
             EmbeddingMutationJournalLimits::default(),
             SearchCoordinationLimits::default(),
@@ -327,7 +336,7 @@ mod tests {
     fn unproven_generation_advance_blocks_unless_explicitly_forced() {
         let graph = GraphForge::new(None).unwrap();
         publish(&graph, 2);
-        bump_search_generation(&graph.dir).unwrap();
+        bump_search_generation(&graph.dir()).unwrap();
 
         let blocked = graph
             .inspect_embedding_space_freshness(Some("semantic"), false)
@@ -358,10 +367,10 @@ mod tests {
     fn proven_small_mutation_is_mildly_stale_and_serveable() {
         let graph = GraphForge::new(None).unwrap();
         let publication = publish(&graph, 100);
-        let generation = bump_search_generation(&graph.dir).unwrap();
+        let generation = bump_search_generation(&graph.dir()).unwrap();
         let current_source = EmbeddingSourceState::new(generation, [3; 32], [2; 32], 100);
         merge_embedding_mutation_batch(
-            &graph.dir,
+            &graph.dir(),
             &publication.manifest,
             EmbeddingMutationBatch {
                 current_source,
@@ -393,7 +402,7 @@ mod tests {
         let graph = GraphForge::new(None).unwrap();
         let descriptor = descriptor();
         let root = graph
-            .dir
+            .dir()
             .join("embeddings/spaces")
             .join(descriptor.compatibility_id().unwrap().to_hex());
         std::fs::create_dir_all(&root).unwrap();

--- a/crates/graphforge-api/src/embedding_publication.rs
+++ b/crates/graphforge-api/src/embedding_publication.rs
@@ -102,11 +102,13 @@ impl GraphForge {
         &self,
         request: CallerEmbeddingBatchRequest,
     ) -> Result<EmbeddingSpaceInfo, GfError> {
+        let _visibility = self.graph_visibility.lock()?;
+        let workspace = self.workspace_for_session();
         let prepared = self.prepare_caller_publication(request)?;
         let eligible_count = u64::try_from(prepared.rows.len()).map_err(|_| {
             GfError::Execution("caller embedding row count cannot be represented".to_owned())
         })?;
-        let project_dir = self.dir.clone();
+        let project_dir = workspace.path().to_path_buf();
         self.publish_prepared_caller_embeddings(
             &prepared,
             move |projection_bytes| {
@@ -245,10 +247,13 @@ impl GraphForge {
         if replace_alias {
             return Ok(());
         }
-        if self.embedding_spaces()?.iter().any(|space| {
-            space.aliases.iter().any(|alias| alias == display_name)
-                && space.compatibility_id != compatibility_id.to_hex()
-        }) {
+        if Self::embedding_spaces_at(self.workspace_for_session().path())?
+            .iter()
+            .any(|space| {
+                space.aliases.iter().any(|alias| alias == display_name)
+                    && space.compatibility_id != compatibility_id.to_hex()
+            })
+        {
             return Err(validation(
                 "embedding alias already targets another compatibility identity; explicit replacement is required",
             ));
@@ -269,7 +274,7 @@ impl GraphForge {
         let now = transaction_time_micros();
         let projection_bytes = RefCell::new(prepared.projection_bytes.clone());
         refresh_embedding_generation(
-            &self.dir,
+            &self.dir(),
             EmbeddingRefreshRequest {
                 descriptor: &prepared.descriptor,
                 generated_at_micros: now,
@@ -291,7 +296,7 @@ impl GraphForge {
             },
             checkpoint,
         )?;
-        self.bind_embedding_space_alias(
+        self.bind_embedding_space_alias_guarded(
             &prepared.display_name,
             &prepared.descriptor.compatibility_id()?.to_hex(),
             prepared.replace_alias,
@@ -468,7 +473,7 @@ mod tests {
             replacement
         );
         let discovered = discover_embedding_spaces(
-            &reopened.dir,
+            &reopened.dir(),
             EmbeddingSpaceDiscoveryLimits::default(),
             || Ok(()),
         )
@@ -556,11 +561,12 @@ mod tests {
             .unwrap();
         assert_eq!(info.dimensions, 7);
         assert_eq!(info.active.unwrap().vector_count, 0);
-        let discovered =
-            discover_embedding_spaces(&graph.dir, EmbeddingSpaceDiscoveryLimits::default(), || {
-                Ok(())
-            })
-            .unwrap();
+        let discovered = discover_embedding_spaces(
+            &graph.dir(),
+            EmbeddingSpaceDiscoveryLimits::default(),
+            || Ok(()),
+        )
+        .unwrap();
         let active = discovered[0].active().unwrap();
         let rows =
             read_vector_snapshot(&active.path, 7, VectorStoreLimits::default(), || Ok(())).unwrap();
@@ -668,11 +674,12 @@ mod tests {
             )
             .unwrap();
 
-        let discovered =
-            discover_embedding_spaces(&graph.dir, EmbeddingSpaceDiscoveryLimits::default(), || {
-                Ok(())
-            })
-            .unwrap();
+        let discovered = discover_embedding_spaces(
+            &graph.dir(),
+            EmbeddingSpaceDiscoveryLimits::default(),
+            || Ok(()),
+        )
+        .unwrap();
         let active = discovered[0].active().unwrap();
         let rows =
             read_vector_snapshot(&active.path, 2, VectorStoreLimits::default(), || Ok(())).unwrap();
@@ -702,11 +709,12 @@ mod tests {
             info.producer,
             EmbeddingSpaceProducer::CallerSupplied { .. }
         ));
-        let discovered =
-            discover_embedding_spaces(&graph.dir, EmbeddingSpaceDiscoveryLimits::default(), || {
-                Ok(())
-            })
-            .unwrap();
+        let discovered = discover_embedding_spaces(
+            &graph.dir(),
+            EmbeddingSpaceDiscoveryLimits::default(),
+            || Ok(()),
+        )
+        .unwrap();
         assert!(matches!(
             discovered[0].descriptor().producer(),
             EmbeddingProducerIdentity::CallerSupplied { .. }

--- a/crates/graphforge-api/src/embedding_refresh.rs
+++ b/crates/graphforge-api/src/embedding_refresh.rs
@@ -116,7 +116,7 @@ impl GraphForge {
                 continue;
             }
             if merge_embedding_mutation_batch(
-                &self.dir,
+                &self.dir(),
                 &active.manifest,
                 EmbeddingMutationBatch {
                     current_source,
@@ -132,7 +132,7 @@ impl GraphForge {
             {
                 continue;
             }
-            let Ok(config) = read_refresh_config(&self.dir) else {
+            let Ok(config) = read_refresh_config(&self.dir()) else {
                 continue;
             };
             let policy = config.resolved_policy(runtime.compatibility_id());
@@ -265,7 +265,6 @@ impl GraphForge {
             clock: std::sync::Mutex::new(Arc::clone(
                 &self.clock.lock().expect("clock lock poisoned"),
             )),
-            dir: self.dir.clone(),
             workspace_guard: Arc::clone(&self.workspace_guard),
             graph_open_evidence: self.graph_open_evidence.clone(),
             project_open_recovery: self.project_open_recovery.clone(),
@@ -302,7 +301,7 @@ impl GraphForge {
     pub fn embedding_refresh_project_policy(
         &self,
     ) -> Result<EmbeddingRefreshProjectPolicy, GfError> {
-        Ok(read_refresh_config(&self.dir)?.project_policy())
+        Ok(read_refresh_config(&self.dir())?.project_policy())
     }
 
     /// Replace durable project-wide refresh defaults and the idle local worker.
@@ -318,6 +317,8 @@ impl GraphForge {
         &self,
         policy: EmbeddingRefreshProjectPolicy,
     ) -> Result<EmbeddingRefreshProjectPolicy, GfError> {
+        let _visibility = self.graph_visibility.lock()?;
+        let workspace = self.workspace_for_session();
         let replacement = scheduler_for_policy(policy)?;
         let mut scheduler = self
             .embedding_refresh_scheduler
@@ -325,7 +326,7 @@ impl GraphForge {
             .map_err(|_| validation("embedding refresh scheduler lock is poisoned"))?;
         ensure_idle(&scheduler.snapshot()?)?;
         let config = update_embedding_refresh_config(
-            &self.dir,
+            workspace.path(),
             EmbeddingRefreshConfigUpdate::SetProjectPolicy(policy),
             EmbeddingRefreshConfigLimits::default(),
             || Ok(()),
@@ -348,9 +349,11 @@ impl GraphForge {
         display_name: Option<&str>,
         policy: Option<EmbeddingRefreshSpacePolicy>,
     ) -> Result<EmbeddingRefreshInspection, GfError> {
+        let _visibility = self.graph_visibility.lock()?;
+        let workspace = self.workspace_for_session();
         let (_, lineage) = self.resolve_embedding_space_lineage(display_name)?;
         update_embedding_refresh_config(
-            &self.dir,
+            workspace.path(),
             EmbeddingRefreshConfigUpdate::SetSpacePolicy {
                 compatibility_id: lineage.compatibility_id(),
                 policy,
@@ -359,7 +362,7 @@ impl GraphForge {
             || Ok(()),
         )?;
         self.publish_workspace_update()?;
-        self.inspect_embedding_refresh(display_name)
+        self.inspect_embedding_refresh_guarded(display_name)
     }
 
     /// Inspect durable policy/outcome and this process's worker state.
@@ -374,9 +377,19 @@ impl GraphForge {
         &self,
         display_name: Option<&str>,
     ) -> Result<EmbeddingRefreshInspection, GfError> {
-        let (space, lineage) = self.resolve_embedding_space_lineage(display_name)?;
+        let _visibility = self.graph_visibility.read()?;
+        self.inspect_embedding_refresh_guarded(display_name)
+    }
+
+    fn inspect_embedding_refresh_guarded(
+        &self,
+        display_name: Option<&str>,
+    ) -> Result<EmbeddingRefreshInspection, GfError> {
+        let workspace = self.workspace_for_session();
+        let (space, lineage) =
+            Self::resolve_embedding_space_lineage_at(workspace.path(), display_name)?;
         let compatibility_id = lineage.compatibility_id();
-        let config = read_refresh_config(&self.dir)?;
+        let config = read_refresh_config(workspace.path())?;
         let state = config
             .spaces()
             .into_iter()
@@ -387,7 +400,7 @@ impl GraphForge {
             .map_err(|_| validation("embedding refresh scheduler lock is poisoned"))?
             .snapshot()?;
         let freshness = if space.active.is_some() {
-            Some(self.inspect_embedding_space_freshness(display_name, false)?)
+            Some(self.inspect_embedding_space_freshness_guarded(display_name, false)?)
         } else {
             None
         };
@@ -561,7 +574,7 @@ mod tests {
             completed_at_micros: 10,
         };
         update_embedding_refresh_config(
-            &graph.dir,
+            &graph.dir(),
             EmbeddingRefreshConfigUpdate::RecordOutcome {
                 compatibility_id: EmbeddingCompatibilityId::from_hex(&compatibility_id).unwrap(),
                 outcome,

--- a/crates/graphforge-api/src/embedding_spaces.rs
+++ b/crates/graphforge-api/src/embedding_spaces.rs
@@ -143,15 +143,18 @@ impl GraphForge {
     /// Returns structured storage, corruption, incompatibility, cancellation,
     /// or resource errors. A dangling durable alias fails closed.
     pub fn embedding_spaces(&self) -> Result<Vec<EmbeddingSpaceInfo>, GfError> {
-        let catalog = read_embedding_space_catalog(
-            &self.dir,
-            EmbeddingSpaceCatalogLimits::default(),
-            || Ok(()),
-        )?;
+        let _visibility = self.graph_visibility.read()?;
+        let workspace = self.workspace_for_session();
+        Self::embedding_spaces_at(workspace.path())
+    }
+
+    pub(crate) fn embedding_spaces_at(
+        dir: &std::path::Path,
+    ) -> Result<Vec<EmbeddingSpaceInfo>, GfError> {
+        let catalog =
+            read_embedding_space_catalog(dir, EmbeddingSpaceCatalogLimits::default(), || Ok(()))?;
         let discovered =
-            discover_embedding_spaces(&self.dir, EmbeddingSpaceDiscoveryLimits::default(), || {
-                Ok(())
-            })?;
+            discover_embedding_spaces(dir, EmbeddingSpaceDiscoveryLimits::default(), || Ok(()))?;
         join_spaces(&catalog, &discovered)
     }
 
@@ -166,11 +169,21 @@ impl GraphForge {
         compatibility_id: &str,
         replace: bool,
     ) -> Result<EmbeddingSpaceInfo, GfError> {
+        let _visibility = self.graph_visibility.lock()?;
+        self.bind_embedding_space_alias_guarded(display_name, compatibility_id, replace)
+    }
+
+    pub(crate) fn bind_embedding_space_alias_guarded(
+        &self,
+        display_name: &str,
+        compatibility_id: &str,
+        replace: bool,
+    ) -> Result<EmbeddingSpaceInfo, GfError> {
+        let workspace = self.workspace_for_session();
+        let dir = workspace.path();
         let compatibility_id = EmbeddingCompatibilityId::from_hex(compatibility_id)?;
         let discovered =
-            discover_embedding_spaces(&self.dir, EmbeddingSpaceDiscoveryLimits::default(), || {
-                Ok(())
-            })?;
+            discover_embedding_spaces(dir, EmbeddingSpaceDiscoveryLimits::default(), || Ok(()))?;
         let exists = discovered
             .iter()
             .any(|space| space.compatibility_id() == compatibility_id);
@@ -180,7 +193,7 @@ impl GraphForge {
             ));
         }
         let catalog = bind_existing_embedding_space_catalog_entry(
-            &self.dir,
+            dir,
             display_name,
             compatibility_id,
             replace,
@@ -197,8 +210,10 @@ impl GraphForge {
     /// # Errors
     /// Rejects malformed names and preserves structured storage failures.
     pub fn remove_embedding_space_alias(&self, display_name: &str) -> Result<bool, GfError> {
+        let _visibility = self.graph_visibility.lock()?;
+        let workspace = self.workspace_for_session();
         let removed = remove_embedding_space_catalog_entry(
-            &self.dir,
+            workspace.path(),
             display_name,
             EmbeddingSpaceCatalogLimits::default(),
             || Ok(()),
@@ -218,8 +233,10 @@ impl GraphForge {
     /// Rejects malformed names and preserves structured storage, cancellation,
     /// and lock failures. No partial vector generation is exposed.
     pub fn delete_embedding_space(&self, display_name: Option<&str>) -> Result<bool, GfError> {
+        let _visibility = self.graph_visibility.lock()?;
+        let workspace = self.workspace_for_session();
         let catalog = read_embedding_space_catalog(
-            &self.dir,
+            workspace.path(),
             EmbeddingSpaceCatalogLimits::default(),
             || Ok(()),
         )?;
@@ -236,7 +253,7 @@ impl GraphForge {
             return Ok(false);
         };
         let deleted = delete_embedding_space_lineage(
-            &self.dir,
+            workspace.path(),
             compatibility_id,
             EmbeddingSpaceCatalogLimits::default(),
             SearchCoordinationLimits::default(),
@@ -256,8 +273,10 @@ impl GraphForge {
         &self,
         display_name: Option<&str>,
     ) -> Result<Option<EmbeddingSpaceInfo>, GfError> {
+        let _visibility = self.graph_visibility.lock()?;
+        let workspace = self.workspace_for_session();
         let catalog = update_embedding_space_catalog(
-            &self.dir,
+            workspace.path(),
             EmbeddingSpaceCatalogUpdate::SetDefault { display_name },
             EmbeddingSpaceCatalogLimits::default(),
             || Ok(()),
@@ -266,10 +285,11 @@ impl GraphForge {
         let Some(display_name) = display_name else {
             return Ok(None);
         };
-        let discovered =
-            discover_embedding_spaces(&self.dir, EmbeddingSpaceDiscoveryLimits::default(), || {
-                Ok(())
-            })?;
+        let discovered = discover_embedding_spaces(
+            workspace.path(),
+            EmbeddingSpaceDiscoveryLimits::default(),
+            || Ok(()),
+        )?;
         resolve_named_space(join_spaces(&catalog, &discovered)?, display_name).map(Some)
     }
 
@@ -282,6 +302,7 @@ impl GraphForge {
         &self,
         display_name: Option<&str>,
     ) -> Result<EmbeddingSpaceInfo, GfError> {
+        let _visibility = self.graph_visibility.read()?;
         self.resolve_embedding_space_lineage(display_name)
             .map(|(info, _)| info)
     }
@@ -296,15 +317,24 @@ impl GraphForge {
         ),
         GfError,
     > {
-        let catalog = read_embedding_space_catalog(
-            &self.dir,
-            EmbeddingSpaceCatalogLimits::default(),
-            || Ok(()),
-        )?;
+        let workspace = self.workspace_for_session();
+        Self::resolve_embedding_space_lineage_at(workspace.path(), display_name)
+    }
+
+    pub(crate) fn resolve_embedding_space_lineage_at(
+        dir: &std::path::Path,
+        display_name: Option<&str>,
+    ) -> Result<
+        (
+            EmbeddingSpaceInfo,
+            graphforge_storage::DiscoveredEmbeddingSpace,
+        ),
+        GfError,
+    > {
+        let catalog =
+            read_embedding_space_catalog(dir, EmbeddingSpaceCatalogLimits::default(), || Ok(()))?;
         let discovered =
-            discover_embedding_spaces(&self.dir, EmbeddingSpaceDiscoveryLimits::default(), || {
-                Ok(())
-            })?;
+            discover_embedding_spaces(dir, EmbeddingSpaceDiscoveryLimits::default(), || Ok(()))?;
         let spaces = join_spaces(&catalog, &discovered)?;
         let selected = match display_name {
             Some(display_name) => resolve_named_space(spaces, display_name)?,
@@ -318,8 +348,7 @@ impl GraphForge {
             .into_iter()
             .find(|space| space.compatibility_id() == compatibility_id)
             .ok_or_else(|| graphforge_storage::SearchArtifactError::Missing {
-                path: self
-                    .dir
+                path: dir
                     .join("embeddings/spaces")
                     .join(compatibility_id.to_hex())
                     .join("space.json"),
@@ -525,7 +554,7 @@ mod tests {
 
     fn publish(graph: &GraphForge, descriptor: &EmbeddingCompatibilityDescriptor, marker: u8) {
         publish_embedding_generation(
-            &graph.dir,
+            &graph.dir(),
             EmbeddingPublicationRequest {
                 descriptor,
                 source: EmbeddingSourceState::new(7, [marker; 32], [marker + 1; 32], 1),
@@ -671,7 +700,7 @@ mod tests {
             .unwrap();
 
         let interrupted_marker = graph
-            .dir
+            .dir()
             .join("embeddings")
             .join(format!(".deleting-{deleted_id}"));
         std::fs::write(&interrupted_marker, deleted_id.as_bytes()).unwrap();
@@ -697,14 +726,14 @@ mod tests {
         assert_eq!(spaces[0].compatibility_id, retained_id);
         assert!(
             !graph
-                .dir
+                .dir()
                 .join("embeddings/spaces")
                 .join(&deleted_id)
                 .exists()
         );
         assert!(
             graph
-                .dir
+                .dir()
                 .join("embeddings/spaces")
                 .join(&retained_id)
                 .exists()
@@ -790,7 +819,7 @@ mod tests {
         });
         let compatibility_id = descriptor.compatibility_id().unwrap().to_hex();
         let root = graph
-            .dir
+            .dir()
             .join("embeddings")
             .join("spaces")
             .join(&compatibility_id);
@@ -817,7 +846,7 @@ mod tests {
     fn dangling_catalog_identity_fails_closed() {
         let graph = GraphForge::new(None).unwrap();
         update_embedding_space_catalog(
-            &graph.dir,
+            &graph.dir(),
             EmbeddingSpaceCatalogUpdate::Bind {
                 display_name: "dangling",
                 compatibility_id: EmbeddingCompatibilityId::from_hex(&"9".repeat(64)).unwrap(),

--- a/crates/graphforge-api/src/explanation.rs
+++ b/crates/graphforge-api/src/explanation.rs
@@ -54,6 +54,7 @@ impl GraphForge {
         // Pin the composition projection and all generation-coupled planning
         // authorities together. Projection does not publish its candidate.
         let _read_visibility = self.graph_visibility.read()?;
+        let workspace = self.workspace_for_session();
         let composition = self
             .default_composition_snapshot()
             .map(|context| self.bind_generation_storage(&context))
@@ -103,13 +104,13 @@ impl GraphForge {
             composition.as_ref().map(|(_, candidate, _)| candidate),
         )?;
         if stage == Some(ExplainStage::LogicalPlan) {
-            return self.explain_logical_stage(&plan, &catalog, execution_mode);
+            return self.explain_logical_stage(&plan, &catalog, execution_mode, workspace.path());
         }
         // Preserve the all-stage presentation: some operators only lower in
         // the directory-backed physical stage, so that section remains useful
         // when the directory-less logical renderer cannot represent them.
         let logical = if stage.is_none() {
-            self.explain_logical_stage(&plan, &catalog, execution_mode)
+            self.explain_logical_stage(&plan, &catalog, execution_mode, workspace.path())
                 .unwrap_or_else(|error| format!("(logical plan unavailable: {error})"))
         } else {
             String::new()
@@ -118,7 +119,7 @@ impl GraphForge {
             self.adjacency_provider_for_session()
         } else {
             Arc::new(crate::adjacency_provider_for_graph(
-                &self.dir,
+                workspace.path(),
                 execution_mode,
                 self.property_inventory_for_session(),
             )?)
@@ -127,7 +128,7 @@ impl GraphForge {
             graphforge_exec::ExecutionSession::new_with_target_provider_resources_and_identity(
                 catalog,
                 self.ontology.clone(),
-                self.dir.clone(),
+                workspace.path().to_path_buf(),
                 execution_mode,
                 adjacency_provider,
                 Some(Arc::clone(&self.ordinal_identities)),
@@ -151,6 +152,7 @@ impl GraphForge {
         plan: &GraphPlan,
         catalog: &GraphCatalog,
         execution_mode: OntologyMode,
+        dir: &std::path::Path,
     ) -> Result<String, GfError> {
         let needs_writes = plan.ops.iter().any(|op| {
             matches!(
@@ -165,7 +167,7 @@ impl GraphForge {
         if needs_writes {
             graphforge_rel::explain_logical_for_writes(
                 plan,
-                &catalog.lowering_snapshot(Some(&self.dir))?,
+                &catalog.lowering_snapshot(Some(dir))?,
                 self.ontology.as_ref(),
                 execution_mode,
             )

--- a/crates/graphforge-api/src/knowledge.rs
+++ b/crates/graphforge-api/src/knowledge.rs
@@ -2864,7 +2864,7 @@ fn match_requested_node_uuids(
     if pending.is_empty() {
         return Ok(());
     }
-    let batches = graphforge_storage::read_nodes(&graph.dir)
+    let batches = graphforge_storage::read_nodes(&graph.dir())
         .map_err(|error| GfError::Storage(error.to_string()))?;
     match_requested_uuids(batches, "node_uuid", pending)
 }

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -30,7 +30,7 @@ pub use graphforge_observability as telemetry;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use arrow::datatypes::SchemaRef;
@@ -416,6 +416,33 @@ pub use search_index::SearchIndexOptions;
 // GraphForge
 // ---------------------------------------------------------------------------
 
+/// A selected graph path and the owner keeping its private resources alive.
+/// Pinned generations can read a path different from the temporary guard root.
+#[derive(Clone, Debug)]
+struct GraphWorkspace {
+    dir: PathBuf,
+    _owner: Arc<tempfile::TempDir>,
+}
+
+impl GraphWorkspace {
+    fn path(&self) -> &Path {
+        &self.dir
+    }
+}
+
+impl std::ops::Deref for GraphWorkspace {
+    type Target = Path;
+    fn deref(&self) -> &Path {
+        self.path()
+    }
+}
+
+impl AsRef<Path> for GraphWorkspace {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
 struct PreparedGenerationReadAuthority {
     properties: Arc<graphforge_storage::AuthenticatedPropertyInventory>,
     ordinal: Option<graphforge_storage::ordinal_identity_v4::V4OrdinalIdentityHandle>,
@@ -461,9 +488,8 @@ pub struct GraphForge {
     /// Project directory backing topology/properties Parquet files. For an
     /// instance this is a private mutable workspace materialized from the pinned
     /// graph generation (file-backed tree or legacy snapshot).
-    dir: PathBuf,
-    /// Keeps the private mutable graph workspace alive for the engine's life.
-    workspace_guard: Arc<tempfile::TempDir>,
+    /// Readers capture one owner under graph visibility before publication may rotate it.
+    workspace_guard: Arc<RwLock<GraphWorkspace>>,
     /// Structural evidence for how the graph workspace was opened.
     graph_open_evidence: graphforge_storage::GraphFilesOpenEvidence,
     /// Safe recovery-on-open summary (cleanup, deferral, or checkpoint skip).
@@ -552,7 +578,7 @@ impl std::fmt::Debug for GraphForge {
                 "generation_uuid",
                 &self.resolved_generation.generation_uuid(),
             )
-            .field("dir", &self.dir)
+            .field("dir", &self.dir())
             .field("ontology_mode", &self.ontology_mode)
             .field("write_options", &self.write_options)
             .field("has_ontology", &self.ontology.is_some())
@@ -710,8 +736,10 @@ impl GraphForge {
             provider_refresh_driver_active: Arc::new(AtomicBool::new(false)),
             provider_refresh_runtimes: Arc::new(Mutex::new(Vec::new())),
             provider_find_runtimes: Arc::new(Mutex::new(Vec::new())),
-            dir,
-            workspace_guard: workspace,
+            workspace_guard: Arc::new(RwLock::new(GraphWorkspace {
+                dir,
+                _owner: workspace,
+            })),
             graph_open_evidence,
             project_open_recovery,
             tempdir: Some(Arc::new(tmp)),
@@ -917,8 +945,10 @@ impl GraphForge {
             provider_refresh_driver_active: Arc::new(AtomicBool::new(false)),
             provider_refresh_runtimes: Arc::new(Mutex::new(Vec::new())),
             provider_find_runtimes: Arc::new(Mutex::new(Vec::new())),
-            dir,
-            workspace_guard: workspace,
+            workspace_guard: Arc::new(RwLock::new(GraphWorkspace {
+                dir,
+                _owner: workspace,
+            })),
             graph_open_evidence,
             project_open_recovery,
             tempdir: None,
@@ -994,6 +1024,27 @@ impl GraphForge {
         }
     }
 
+    fn workspace_for_session(&self) -> GraphWorkspace {
+        self.workspace_guard
+            .read()
+            .expect("workspace lock poisoned")
+            .clone()
+    }
+
+    fn dir(&self) -> GraphWorkspace {
+        self.workspace_for_session()
+    }
+
+    fn replace_workspace_owner(&self, workspace: GraphWorkspace) -> GraphWorkspace {
+        std::mem::replace(
+            &mut *self
+                .workspace_guard
+                .write()
+                .expect("workspace lock poisoned"),
+            workspace,
+        )
+    }
+
     fn adjacency_provider_for_session(&self) -> Arc<graphforge_exec::PersistentAdjacencyProvider> {
         Arc::clone(
             &self
@@ -1063,7 +1114,7 @@ impl GraphForge {
         &self,
         generation: &ResolvedProjectGeneration,
     ) -> Result<(), GfError> {
-        let prepared = self.prepare_generation_read_authority(generation, &self.dir)?;
+        let prepared = self.prepare_generation_read_authority(generation, &self.dir())?;
         self.install_prepared_generation_read_authority(generation.generation_uuid(), prepared);
         Ok(())
     }
@@ -1246,7 +1297,7 @@ impl GraphForge {
             .lock()
             .expect("semantic storage binding lock poisoned");
         GraphCatalog::open_authenticated_with_semantic_bindings(
-            &self.dir,
+            &self.dir(),
             self.ontology.as_ref(),
             &runtime,
             candidate.or(installed.as_ref()),
@@ -1402,12 +1453,12 @@ impl GraphForge {
                 let projection =
                     graphforge_storage::SemanticStorageBindings::project_legacy_unambiguous(
                         context.composition(),
-                        &self.dir,
+                        &self.dir(),
                     )?;
                 (projection.bindings, projection.route_moves)
             } else {
                 if current.is_none() {
-                    graphforge_storage::require_atomic_legacy_migration(&self.dir)?;
+                    graphforge_storage::require_atomic_legacy_migration(&self.dir())?;
                 }
                 (
                     graphforge_storage::SemanticStorageBindings::project(
@@ -1495,6 +1546,8 @@ impl GraphForge {
         let _read_visibility = (!is_write)
             .then(|| self.graph_visibility.read())
             .transpose()?;
+        let workspace = self.workspace_for_session();
+        let dir = workspace.path().to_path_buf();
         let prior_catalog = self
             .runtime_catalog
             .lock()
@@ -1529,7 +1582,7 @@ impl GraphForge {
                 ));
             }
             legacy_migration = Some(graphforge_storage::apply_legacy_route_moves(
-                &self.dir,
+                &dir,
                 legacy_route_moves.expect("checked"),
                 candidate_bindings.expect("legacy migration has candidate bindings"),
             )?);
@@ -1546,7 +1599,7 @@ impl GraphForge {
             self.adjacency_provider_for_session()
         } else {
             Arc::new(adjacency_provider_for_graph(
-                &self.dir,
+                &dir,
                 execution_mode,
                 self.property_inventory_for_session(),
             )?)
@@ -1554,7 +1607,7 @@ impl GraphForge {
         let session = ExecutionSession::new_with_target_provider_resources_and_identity(
             catalog,
             self.ontology.clone(),
-            self.dir.clone(),
+            dir,
             execution_mode,
             adjacency_provider,
             Some(Arc::clone(&self.ordinal_identities)),
@@ -1689,13 +1742,13 @@ impl GraphForge {
             ));
         }
 
-        if !graphforge_storage::uuid_membership_index_is_fresh(&self.dir)? {
+        if !graphforge_storage::uuid_membership_index_is_fresh(&self.dir())? {
             graphforge_storage::rebuild_uuid_membership_indexes(
-                &self.dir,
+                &self.dir(),
                 graphforge_storage::UuidIndexBuildLimits::default(),
             )?;
         }
-        let graph = graphforge_storage::capture_graph_files(&self.dir)?.1;
+        let graph = graphforge_storage::capture_graph_files(&self.dir())?.1;
         let provenance_enabled = parent.capability("provenance")?.is_some();
         let installed_bindings = self
             .semantic_storage_bindings
@@ -1730,7 +1783,7 @@ impl GraphForge {
         let publication = match graphforge_storage::stage_project_generation_with_graph_tree_mode(
             root,
             &request,
-            Some(self.dir.as_path()),
+            Some(self.dir().path()),
             self.lifecycle_mode,
         )? {
             ProjectStageOutcome::AlreadyPublished(receipt) => Ok(receipt),
@@ -1789,13 +1842,13 @@ impl GraphForge {
                 "project generation changed before graph publication".into(),
             ));
         }
-        if !graphforge_storage::uuid_membership_index_is_fresh(&self.dir)? {
+        if !graphforge_storage::uuid_membership_index_is_fresh(&self.dir())? {
             graphforge_storage::rebuild_uuid_membership_indexes(
-                &self.dir,
+                &self.dir(),
                 graphforge_storage::UuidIndexBuildLimits::default(),
             )?;
         }
-        let graph = graphforge_storage::capture_graph_files(&self.dir)?.1;
+        let graph = graphforge_storage::capture_graph_files(&self.dir())?.1;
         let provenance_enabled = parent.capability("provenance")?.is_some();
         let participants = graph_publication_participants(
             &parent,
@@ -1827,7 +1880,7 @@ impl GraphForge {
         let publication = match graphforge_storage::stage_project_generation_with_graph_tree_mode(
             root,
             &request,
-            Some(self.dir.as_path()),
+            Some(self.dir().path()),
             self.lifecycle_mode,
         )? {
             ProjectStageOutcome::AlreadyPublished(receipt) => Ok(receipt),
@@ -1898,10 +1951,20 @@ impl GraphForge {
         cypher: &str,
         params: &HashMap<String, IrLiteral>,
     ) -> Result<graphforge_exec::SendableRecordBatchStream, GfError> {
+        self.execute_stream_with_workspace(cypher, params)
+            .map(|(stream, _)| stream)
+    }
+
+    fn execute_stream_with_workspace(
+        &self,
+        cypher: &str,
+        params: &HashMap<String, IrLiteral>,
+    ) -> Result<(graphforge_exec::SendableRecordBatchStream, GraphWorkspace), GfError> {
         use graphforge_exec::ExecutionSession;
 
         let admission = self.admit_heavy_query_owned()?;
         let _read_visibility = self.graph_visibility.read()?;
+        let workspace = self.workspace_for_session();
         let composition = self
             .default_composition_snapshot()
             .map(|context| self.bind_generation_storage(&context))
@@ -1980,7 +2043,7 @@ impl GraphForge {
             self.adjacency_provider_for_session()
         } else {
             Arc::new(adjacency_provider_for_graph(
-                &self.dir,
+                workspace.path(),
                 execution_mode,
                 self.property_inventory_for_session(),
             )?)
@@ -1988,7 +2051,7 @@ impl GraphForge {
         let session = ExecutionSession::new_with_target_provider_resources_and_identity(
             catalog,
             self.ontology.clone(),
-            self.dir.clone(),
+            workspace.path().to_path_buf(),
             execution_mode,
             adjacency_provider,
             Some(Arc::clone(&self.ordinal_identities)),
@@ -2009,17 +2072,24 @@ impl GraphForge {
         // stream is demand-driven and may outlive this call; holding the slot
         // for the full consumer lifetime would serialize all streaming clients.
         drop(admission);
-        Ok(self.finish_public_stream(stream))
+        Ok((
+            self.finish_public_stream(stream, workspace.clone()),
+            workspace,
+        ))
     }
 
-    fn finish_public_stream(&self, stream: SendableRecordBatchStream) -> SendableRecordBatchStream {
+    fn finish_public_stream(
+        &self,
+        stream: SendableRecordBatchStream,
+        workspace: GraphWorkspace,
+    ) -> SendableRecordBatchStream {
         Box::pin(WorkspacePinnedStream {
             stream: self.graph_visibility.health.guard_stream(shape_stream(
                 stream,
                 self.ontology_mode,
                 self.ontology.as_ref(),
             )),
-            _workspace: Arc::clone(&self.workspace_guard),
+            _workspace: workspace,
         })
     }
 
@@ -2051,14 +2121,14 @@ impl GraphForge {
         ),
         GfError,
     > {
-        let stream = self.execute_stream_with_params(cypher, params)?;
+        let (stream, workspace) = self.execute_stream_with_workspace(cypher, params)?;
         let schema = stream.schema();
         Ok((
             stream,
             schema,
             RuntimeGuard {
                 runtime: Arc::clone(&self.runtime),
-                workspace: Arc::clone(&self.workspace_guard),
+                workspace,
                 tempdir: self.tempdir.clone(),
             },
         ))
@@ -2107,7 +2177,7 @@ impl GraphForge {
         let cleanup_result =
             self.adjacency_provider_for_session()
                 .reset_graph(|| -> Result<(), GfError> {
-                    let entries = std::fs::read_dir(&self.dir).map_err(|e| {
+                    let entries = std::fs::read_dir(self.dir()).map_err(|e| {
                         GfError::Storage(format!("failed to read in-memory project: {e}"))
                     })?;
                     let mut first_error = None;
@@ -2298,7 +2368,7 @@ impl GraphForge {
                 .write()
                 .expect("adjacency provider lock poisoned") =
                 Arc::new(adjacency_provider_for_graph(
-                    &self.dir,
+                    &self.dir(),
                     self.ontology_mode,
                     self.property_inventory_for_session(),
                 )?);
@@ -2742,7 +2812,7 @@ pub struct RuntimeGuard {
     /// Private mutable graph workspace hydrated for this facade (`dir`).
     /// Held solely so `TempDir` cleanup waits until stream consumers finish.
     #[allow(dead_code)]
-    workspace: Arc<tempfile::TempDir>,
+    workspace: GraphWorkspace,
     /// In-memory project root, when the facade is not path-backed.
     #[allow(dead_code)]
     tempdir: Option<Arc<tempfile::TempDir>>,
@@ -3553,7 +3623,7 @@ impl Shaper {
 // workspace owner. Compaction may rotate the facade while this stream lives.
 struct WorkspacePinnedStream {
     stream: SendableRecordBatchStream,
-    _workspace: Arc<tempfile::TempDir>,
+    _workspace: GraphWorkspace,
 }
 
 impl futures::Stream for WorkspacePinnedStream {
@@ -3841,7 +3911,7 @@ mod tests {
         .unwrap();
         let before_catalog = view.runtime_catalog.lock().unwrap().to_record_batch();
         let before_generation = view.generation_for_read().unwrap().generation_uuid();
-        let before_files = files(&view.dir);
+        let before_files = files(&view.dir());
         assert!(
             view.explain("CREATE (:NewLabel {fresh:1})")
                 .unwrap()
@@ -3887,7 +3957,7 @@ mod tests {
             view.generation_for_read().unwrap().generation_uuid(),
             before_generation
         );
-        assert_eq!(files(&view.dir), before_files);
+        assert_eq!(files(&view.dir()), before_files);
         // Execution binding observes runtime names, unlike snapshot-only EXPLAIN.
         // Rejection must nevertheless preserve canonical data and authority.
         for query in [
@@ -3898,7 +3968,7 @@ mod tests {
         ] {
             assert!(view.execute(query).is_err());
         }
-        assert_eq!(files(&view.dir), before_files);
+        assert_eq!(files(&view.dir()), before_files);
         assert_eq!(
             view.generation_for_read().unwrap().generation_uuid(),
             before_generation
@@ -3956,7 +4026,7 @@ mod tests {
         graph
             .execute("CREATE (:Person {name: 'Ada'})")
             .expect("create compact-root fixture");
-        publish_compact_graph_workspace(project.path(), &graph.dir);
+        publish_compact_graph_workspace(project.path(), &graph.dir());
         drop(graph);
 
         let reopened = GraphForge::new(Some(project.path().to_str().unwrap())).unwrap();
@@ -3973,14 +4043,14 @@ mod tests {
         assert_eq!(reopened.graph_open_evidence().files_copied, 3);
         let mut control_bytes = 0;
         for relative in controls {
-            let file = std::fs::File::open(reopened.dir.join(relative)).unwrap();
+            let file = std::fs::File::open(reopened.dir().join(relative)).unwrap();
             assert_eq!(graphforge_filesystem::file_link_count(&file).unwrap(), 1);
             control_bytes += file.metadata().unwrap().len();
         }
         assert_eq!(reopened.graph_open_evidence().bytes_copied, control_bytes);
         assert!(reopened.graph_open_evidence().files_reused > 0);
-        assert!(!reopened.dir.join("files").exists());
-        assert!(reopened.dir.join("topology").is_dir());
+        assert!(!reopened.dir().join("files").exists());
+        assert!(reopened.dir().join("topology").is_dir());
 
         let resolved = graphforge_storage::resolve_project_generation(project.path()).unwrap();
         let (read_only_dir, read_only_guard, read_only_evidence) =
@@ -3993,7 +4063,7 @@ mod tests {
         let rematerialized = rematerialized_owner.path().join("workspace");
         std::fs::create_dir(&rematerialized).unwrap();
         rematerialize_graph_workspace(&resolved, &rematerialized).unwrap();
-        let (expected, _) = graphforge_storage::capture_graph_files(&reopened.dir).unwrap();
+        let (expected, _) = graphforge_storage::capture_graph_files(&reopened.dir()).unwrap();
         let (actual, _) = graphforge_storage::capture_graph_files(&rematerialized).unwrap();
         assert_eq!(actual, expected);
 
@@ -4097,7 +4167,7 @@ mod tests {
                 .value(0),
             7
         );
-        assert!(!reopened.dir.join("deltas").exists());
+        assert!(!reopened.dir().join("deltas").exists());
         assert!(reopened.graph_open_evidence().files_reused > 0);
         assert!(reopened.graph_open_evidence().files_copied > 0);
     }
@@ -4130,8 +4200,8 @@ mod tests {
         let gf = GraphForge::new(None).expect("in-memory instance");
         assert!(gf.path().is_none());
         assert_eq!(gf.ontology_mode(), OntologyMode::Exploratory);
-        assert!(gf.dir.is_dir());
-        assert!(gf.dir.file_name().is_some_and(|name| {
+        assert!(gf.dir().is_dir());
+        assert!(gf.dir().file_name().is_some_and(|name| {
             name.to_string_lossy()
                 .starts_with("graphforge-graph-workspace-")
         }));
@@ -4427,13 +4497,13 @@ mod tests {
             .adjacency("KNOWS", graphforge_ir::Direction::Out)
             .unwrap();
         let generation =
-            graphforge_storage::generation::read_topology_generation(&graph.dir).unwrap();
+            graphforge_storage::generation::read_topology_generation(&graph.dir()).unwrap();
         graph.clear().unwrap();
         graph
             .execute("CREATE (:Person)-[:KNOWS]->(:Person)-[:KNOWS]->(:Person)")
             .unwrap();
         assert_eq!(
-            graphforge_storage::generation::read_topology_generation(&graph.dir).unwrap(),
+            graphforge_storage::generation::read_topology_generation(&graph.dir()).unwrap(),
             generation
         );
         let count = graph
@@ -4497,15 +4567,15 @@ mod tests {
         })
         .expect("register fixture procedure");
 
-        let original = std::fs::metadata(&gf.dir)
+        let original = std::fs::metadata(&gf.dir())
             .expect("fixture directory metadata")
             .permissions();
         let mut restricted = original.clone();
         restricted.set_mode(0o500);
-        std::fs::set_permissions(&gf.dir, restricted)
+        std::fs::set_permissions(&gf.dir(), restricted)
             .expect("restrict fixture directory permissions");
         let mut guard = PermissionGuard {
-            path: gf.dir.clone(),
+            path: gf.dir().to_path_buf(),
             original: Some(original),
         };
 
@@ -5532,7 +5602,7 @@ mod tests {
     fn persistent_open_does_not_cleanup_generation_files() {
         let dir = tempfile::TempDir::new().unwrap();
         let first = GraphForge::new(dir.path().to_str()).unwrap();
-        let topology = first.dir.join("topology");
+        let topology = first.dir().join("topology");
         std::fs::create_dir_all(&topology).unwrap();
         let stale = topology.join("nodes.parquet.Abc123.tmp");
         let unrelated = topology.join("notes.tmp");
@@ -5544,8 +5614,13 @@ mod tests {
         let path = dir.path().to_str().unwrap();
         let graph = GraphForge::new(Some(path)).unwrap();
 
-        assert!(graph.dir.join("topology/nodes.parquet.Abc123.tmp").exists());
-        assert!(graph.dir.join("topology/notes.tmp").exists());
+        assert!(
+            graph
+                .dir()
+                .join("topology/nodes.parquet.Abc123.tmp")
+                .exists()
+        );
+        assert!(graph.dir().join("topology/notes.tmp").exists());
         assert_eq!(graph.path(), Some(dir.path()));
     }
 

--- a/crates/graphforge-api/src/maintenance.rs
+++ b/crates/graphforge-api/src/maintenance.rs
@@ -173,8 +173,10 @@ impl GraphForge {
             let prepared = self.prepare_generation_read_authority(&current, &dir)?;
             let catalog = crate::load_runtime_catalog(&dir)?;
             let bindings = graphforge_storage::semantic_storage_bindings(&current)?;
-            let old_workspace = std::mem::replace(&mut self.workspace_guard, workspace);
-            self.dir = dir;
+            let old_workspace = self.replace_workspace_owner(crate::GraphWorkspace {
+                dir,
+                _owner: workspace,
+            });
             self.graph_open_evidence = evidence;
             self.install_prepared_generation_read_authority(current.generation_uuid(), prepared);
             self.resolved_generation = current;
@@ -459,8 +461,9 @@ mod tests {
             })
             .unwrap();
         *graph.uuid_membership_index.lock().unwrap() =
-            Some(graphforge_storage::UuidMembershipIndex::open(&graph.dir).unwrap());
-        let old_dir = graph.dir.clone();
+            Some(graphforge_storage::UuidMembershipIndex::open(&graph.dir()).unwrap());
+        // Observe reclamation without adding another workspace owner.
+        let old_dir = graph.dir().to_path_buf();
         let snapshot = graph
             .execute_stream("MATCH (n) RETURN n.node_uuid, n.score")
             .unwrap();
@@ -477,7 +480,7 @@ mod tests {
         let report = graph.compact_graph_delta(&request, None).unwrap();
 
         assert!(report.cleanup.is_some());
-        assert_ne!(graph.dir, old_dir);
+        assert_ne!(graph.dir().path(), old_dir.as_path());
         assert!(graph.uuid_membership_index.lock().unwrap().is_none());
         assert!(old_dir.exists(), "active stream retains old workspace");
         drop(snapshot);

--- a/crates/graphforge-api/src/multi_ontology.rs
+++ b/crates/graphforge-api/src/multi_ontology.rs
@@ -495,7 +495,7 @@ impl GraphForge {
             cancellation,
         )
         .map_err(MultiOntologyError::from)?;
-        crate::rematerialize_graph_workspace(&self.resolved_generation, &self.dir)
+        crate::rematerialize_graph_workspace(&self.resolved_generation, &self.dir())
             .map_err(MultiOntologyError::from)?;
         *self
             .semantic_storage_bindings
@@ -524,7 +524,7 @@ impl GraphForge {
             .runtime_catalog
             .lock()
             .expect("runtime catalog poisoned") =
-            crate::load_runtime_catalog(&self.dir).map_err(MultiOntologyError::from)?;
+            crate::load_runtime_catalog(&self.dir()).map_err(MultiOntologyError::from)?;
         self.adjacency_provider_for_session().invalidate();
         Ok(ModuleMigrationReceipt {
             project_generation_uuid: expected_generation,
@@ -2852,7 +2852,7 @@ mod tests {
             serde_json::json!({
                 "first_serialized": deterministic_first,
                 "second_serialized": deterministic_second,
-                "forbidden_path": graph.dir.to_string_lossy()
+                "forbidden_path": graph.dir().to_string_lossy()
             }),
         );
         let packaged = GraphForge::new(None).unwrap();

--- a/crates/graphforge-api/src/mutation_transaction.rs
+++ b/crates/graphforge-api/src/mutation_transaction.rs
@@ -36,7 +36,7 @@ impl<'a> FacadeMutationLifecycle<'a> {
             None
         } else {
             Some(graphforge_storage::GraphWorkspaceCheckpoint::capture(
-                &graph.dir,
+                &graph.dir(),
             )?)
         };
         Ok(Self {
@@ -50,16 +50,16 @@ impl<'a> FacadeMutationLifecycle<'a> {
     }
 
     fn refresh_unpublished(&self) -> Result<(), GfError> {
-        let (inventory, _) = graphforge_storage::capture_graph_files(&self.graph.dir)?;
+        let (inventory, _) = graphforge_storage::capture_graph_files(&self.graph.dir())?;
         let inventory = Arc::new(
             graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
                 &self.parent,
-                &self.graph.dir,
+                &self.graph.dir(),
                 inventory,
             )?,
         );
         let adjacency = Arc::new(crate::adjacency_provider_for_graph(
-            &self.graph.dir,
+            &self.graph.dir(),
             self.graph.ontology_mode,
             Arc::clone(&inventory),
         )?);
@@ -129,10 +129,10 @@ impl FacadeMutationLifecycle<'_> {
         )?;
         if current.generation_uuid() == self.parent.generation_uuid() {
             if let Some(checkpoint) = &mut self.unpublished {
-                checkpoint.restore(&self.graph.dir)?;
+                checkpoint.restore(&self.graph.dir())?;
                 self.refresh_unpublished()?;
             } else {
-                crate::rematerialize_graph_workspace(&self.parent, &self.graph.dir)?;
+                crate::rematerialize_graph_workspace(&self.parent, &self.graph.dir())?;
                 self.graph.install_property_generation(&self.parent)?;
             }
             *self
@@ -143,8 +143,8 @@ impl FacadeMutationLifecycle<'_> {
         } else {
             // Publication may have succeeded before a later operation failed.
             // Reconcile from the selected generation; never reinstall old files.
-            crate::rematerialize_graph_workspace(&current, &self.graph.dir)?;
-            let catalog = crate::load_runtime_catalog(&self.graph.dir)?;
+            crate::rematerialize_graph_workspace(&current, &self.graph.dir())?;
+            let catalog = crate::load_runtime_catalog(&self.graph.dir())?;
             self.graph.install_property_generation(&current)?;
             *self
                 .graph
@@ -231,7 +231,7 @@ mod tests {
             let inventory = graph.property_inventory_for_session();
             let catalog =
                 graphforge_storage::GraphCatalog::open_authenticated_with_semantic_bindings(
-                    &graph.dir,
+                    &graph.dir(),
                     None,
                     &working.lock().unwrap(),
                     None,
@@ -241,7 +241,7 @@ mod tests {
             let session = graphforge_exec::ExecutionSession::new_with_target(
                 catalog,
                 None,
-                graph.dir.clone(),
+                graph.dir().to_path_buf(),
                 graph.ontology_mode,
             )
             .unwrap();
@@ -305,7 +305,7 @@ mod tests {
                 graph.execute("CREATE (:Person {name:'retained'})").unwrap();
             }
             let prior_catalog = graph.runtime_catalog.lock().unwrap().to_record_batch();
-            let prior_files = graphforge_storage::capture_graph_files(&graph.dir)
+            let prior_files = graphforge_storage::capture_graph_files(&graph.dir())
                 .unwrap()
                 .0;
             let prior_generation = *graph.current_generation_uuid.lock().unwrap();
@@ -320,7 +320,7 @@ mod tests {
                 prior_catalog
             );
             assert_eq!(
-                graphforge_storage::capture_graph_files(&graph.dir)
+                graphforge_storage::capture_graph_files(&graph.dir())
                     .unwrap()
                     .0,
                 prior_files
@@ -415,7 +415,7 @@ mod tests {
                     "MATCH (n:Person) SET n.metric = CASE n.name {} END",
                     cases.join(" ")
                 );
-                let topology = graphforge_storage::read_topology_generation(&graph.dir).unwrap();
+                let topology = graphforge_storage::read_topology_generation(&graph.dir()).unwrap();
                 let before = *graph.current_generation_uuid.lock().unwrap();
                 let mut outcomes = Vec::new();
                 for analyst in [analyst_first, !analyst_first] {
@@ -426,7 +426,7 @@ mod tests {
                     }
                     outcomes.push(graph.last_mutation_outcome.lock().unwrap().clone().unwrap());
                     assert_eq!(
-                        graphforge_storage::read_topology_generation(&graph.dir).unwrap(),
+                        graphforge_storage::read_topology_generation(&graph.dir()).unwrap(),
                         topology
                     );
                     assert_ne!(*graph.current_generation_uuid.lock().unwrap(), before);
@@ -625,12 +625,12 @@ mod recovery_tests {
         let read = bind("MATCH (n:Person) RETURN n.name");
         let write = bind("MATCH (n:Person) DELETE n SET n.metric = 1");
         let physical_catalog =
-            graphforge_storage::GraphCatalog::open(&graph.dir, None, &catalog.lock().unwrap())
+            graphforge_storage::GraphCatalog::open(&graph.dir(), None, &catalog.lock().unwrap())
                 .unwrap();
         let session = graphforge_exec::ExecutionSession::new_with_target(
             physical_catalog,
             None,
-            graph.dir.clone(),
+            graph.dir().to_path_buf(),
             graphforge_core::OntologyMode::Exploratory,
         )
         .unwrap();

--- a/crates/graphforge-api/src/mutation_transaction_fault_tests.rs
+++ b/crates/graphforge-api/src/mutation_transaction_fault_tests.rs
@@ -48,7 +48,7 @@ fn mutation_authority_fault_helper() {
     let before = graphforge_storage::resolve_project_generation(std::path::Path::new(&root))
         .unwrap()
         .generation_uuid();
-    let topology = graphforge_storage::read_topology_generation(&graph.dir).unwrap();
+    let topology = graphforge_storage::read_topology_generation(&graph.dir()).unwrap();
     let edges = graph
         .execute("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name ORDER BY a.name")
         .unwrap()
@@ -109,7 +109,7 @@ fn mutation_authority_fault_helper() {
         drop(catalog);
         values(owner, published, score);
         assert_eq!(
-            graphforge_storage::read_topology_generation(&owner.dir).unwrap(),
+            graphforge_storage::read_topology_generation(&owner.dir()).unwrap(),
             topology
         );
         let actual = owner

--- a/crates/graphforge-api/src/node_selector.rs
+++ b/crates/graphforge-api/src/node_selector.rs
@@ -62,7 +62,9 @@ impl GraphForge {
         let inventory = self.property_inventory_for_session();
         for stem in inventory.routes(graphforge_storage::PropertyRouteKind::Node) {
             for (bytes, properties) in graphforge_storage::read_node_property_rows_from_inventory(
-                &self.dir, &inventory, stem,
+                &self.dir(),
+                &inventory,
+                stem,
             )? {
                 scanned += 1;
                 if scanned > MAX_SELECTOR_ROWS {
@@ -112,7 +114,7 @@ impl GraphForge {
     fn node_uuids(&self, label_id: Option<EntityTypeId>) -> Result<HashSet<Uuid>, GfError> {
         let mut uuids = HashSet::new();
         let mut scanned = 0usize;
-        for batch in graphforge_storage::read_nodes(&self.dir)
+        for batch in graphforge_storage::read_nodes(&self.dir())
             .map_err(|error| GfError::Storage(error.to_string()))?
         {
             let uuid_column = batch
@@ -195,7 +197,7 @@ mod tests {
     use graphforge_core::PathsOptions;
 
     fn first_uuid(graph: &GraphForge) -> Uuid {
-        let batches = graphforge_storage::read_nodes(&graph.dir).unwrap();
+        let batches = graphforge_storage::read_nodes(&graph.dir()).unwrap();
         let column = batches[0]
             .column_by_name("node_uuid")
             .unwrap()
@@ -293,7 +295,7 @@ mod tests {
             *uuid.as_bytes(),
             HashMap::from([("name".into(), IrLiteral::Str("unique".into()))]),
         )]);
-        graphforge_storage::set_node_properties(&other.dir, "Person", &updates).unwrap();
+        graphforge_storage::set_node_properties(&other.dir(), "Person", &updates).unwrap();
         let duplicate = NodeSelector::Match {
             label: "Person".into(),
             property: "name".into(),
@@ -303,11 +305,11 @@ mod tests {
         assert_eq!(other.resolve_node_selector(&duplicate).unwrap(), uuid);
         // Explicitly admit the malformed workspace to test cross-route duplicate rejection.
         let generation = other.generation_for_read().unwrap();
-        let (captured, _) = graphforge_storage::capture_graph_files(&other.dir).unwrap();
+        let (captured, _) = graphforge_storage::capture_graph_files(&other.dir()).unwrap();
         let inventory =
             graphforge_storage::AuthenticatedPropertyInventory::from_materialized_inventory(
                 &generation,
-                &other.dir,
+                &other.dir(),
                 captured,
             )
             .unwrap();

--- a/crates/graphforge-api/src/ontology_composition_lifecycle.rs
+++ b/crates/graphforge-api/src/ontology_composition_lifecycle.rs
@@ -212,7 +212,7 @@ impl GraphForge {
             if let Err(error) = graphforge_storage::SemanticStorageBindings::project_with_graph_scan_identity_equivalent(
                 compiled,
                 current_bindings.as_ref(),
-                &self.dir,
+                &self.dir(),
                 &identity_equivalent,
             ) {
                 let retained = compiled
@@ -227,7 +227,7 @@ impl GraphForge {
                     .filter(|binding| !retained.contains(&binding.symbol))
                     .map(|binding| {
                         graphforge_storage::SemanticStorageBindings::binding_has_retained_data(
-                            binding, &self.dir,
+                            binding, &self.dir(),
                         )
                         .map(|has_data| has_data.then_some(binding))
                     })
@@ -450,7 +450,7 @@ impl GraphForge {
             graphforge_storage::SemanticStorageBindings::project_with_graph_scan_identity_equivalent(
                 &compiled_candidate,
                 previous_bindings.as_ref(),
-                &self.dir,
+                &self.dir(),
                 &identity_equivalent,
             )?;
         let published_binding = graphforge_ir::CompositionBindingContext::new(
@@ -490,7 +490,7 @@ impl GraphForge {
             .write()
             .expect("adjacency provider lock poisoned") =
             std::sync::Arc::new(crate::adjacency_provider_for_graph(
-                &self.dir,
+                &self.dir(),
                 self.ontology_mode,
                 self.property_inventory_for_session(),
             )?);

--- a/crates/graphforge-api/src/portable.rs
+++ b/crates/graphforge-api/src/portable.rs
@@ -1031,7 +1031,7 @@ mod tests {
             .to_owned();
         let read_edge_properties = || {
             graphforge_storage::read_authenticated_property_snapshots_for(
-                &graph.dir,
+                &graph.dir(),
                 graphforge_storage::PropertyRouteKind::Edge,
                 &edge_route,
                 &std::collections::BTreeSet::from([edge_uuid.into_bytes()]),
@@ -1048,7 +1048,7 @@ mod tests {
         assert_eq!(
             graphforge_storage::stage_set_edge_properties_authenticated(
                 &mut staged,
-                &graph.dir,
+                &graph.dir(),
                 &inventory,
                 &edge_route,
                 &std::collections::HashMap::from([(
@@ -1062,7 +1062,7 @@ mod tests {
             .unwrap(),
             1
         );
-        graphforge_storage::commit_topology_aware(staged, &graph.dir).unwrap();
+        graphforge_storage::commit_topology_aware(staged, &graph.dir()).unwrap();
         let set_properties = read_edge_properties();
         assert_eq!(
             set_properties.get("weight"),
@@ -1093,7 +1093,7 @@ mod tests {
         assert_eq!(
             graphforge_storage::stage_remove_edge_properties_authenticated(
                 &mut staged,
-                &graph.dir,
+                &graph.dir(),
                 &inventory,
                 &edge_route,
                 &std::collections::HashMap::from([(
@@ -1104,7 +1104,7 @@ mod tests {
             .unwrap(),
             1
         );
-        graphforge_storage::commit_topology_aware(staged, &graph.dir).unwrap();
+        graphforge_storage::commit_topology_aware(staged, &graph.dir()).unwrap();
         let removed_properties = read_edge_properties();
         assert_eq!(
             removed_properties.get("weight"),
@@ -1212,7 +1212,8 @@ mod tests {
         let before_fingerprint = logical_fingerprint(&before.batches);
         let limits = graphforge_core::portable::PortableV2Limits::default();
         let graph_fingerprint =
-            graphforge_storage::portable_v2_graph_data_fingerprint(&reopened.dir, limits).unwrap();
+            graphforge_storage::portable_v2_graph_data_fingerprint(&reopened.dir(), limits)
+                .unwrap();
         let package = root.path().join("lifecycle.gfpb");
         let exported = reopened
             .export_portable_v2(
@@ -1274,7 +1275,8 @@ mod tests {
         );
         assert_eq!(logical_fingerprint(&after.batches), before_fingerprint);
         assert_eq!(
-            graphforge_storage::portable_v2_graph_data_fingerprint(&imported.dir, limits).unwrap(),
+            graphforge_storage::portable_v2_graph_data_fingerprint(&imported.dir(), limits)
+                .unwrap(),
             graph_fingerprint
         );
         let imported_inventory =

--- a/crates/graphforge-api/src/provider_embedding.rs
+++ b/crates/graphforge-api/src/provider_embedding.rs
@@ -307,13 +307,13 @@ impl GraphForge {
         validate_provider_request(request)?;
         let label_id = self.search_label_id(&request.label)?;
         let projection = project_text_source(
-            &self.dir,
+            &self.dir(),
             label_id,
             Some(&request.properties),
             TextSearchLimits::default(),
             &mut *checkpoint,
         )?;
-        let source = capture_projected_source(&self.dir, &projection, checkpoint)?;
+        let source = capture_projected_source(&self.dir(), &projection, checkpoint)?;
         Ok((projection, source))
     }
 
@@ -324,10 +324,12 @@ impl GraphForge {
         replace_alias: bool,
     ) -> Result<(), ProviderEmbeddingPlanError> {
         if !replace_alias
-            && self.embedding_spaces()?.iter().any(|space| {
-                space.aliases.iter().any(|alias| alias == display_name)
-                    && space.compatibility_id != compatibility_id
-            })
+            && Self::embedding_spaces_at(self.workspace_for_session().path())?
+                .iter()
+                .any(|space| {
+                    space.aliases.iter().any(|alias| alias == display_name)
+                        && space.compatibility_id != compatibility_id
+                })
         {
             return Err(validation(
                 "embedding alias already targets another compatibility identity; explicit replacement is required",

--- a/crates/graphforge-api/src/provider_embedding_execution.rs
+++ b/crates/graphforge-api/src/provider_embedding_execution.rs
@@ -241,7 +241,7 @@ impl GraphForge {
         let mut first_attempt = Some(prepared);
 
         let result = publish_provider_embedding_generation(
-            &self.dir,
+            &self.dir(),
             &publication,
             EmbeddingRefreshLimits::default(),
             |artifact_checkpoint| {
@@ -333,7 +333,7 @@ fn record_refresh_outcome(
     status: EmbeddingRefreshOutcomeStatus,
 ) -> Result<(), ProviderEmbeddingExecutionError> {
     record_embedding_refresh_outcome(
-        &graph.dir,
+        &graph.dir(),
         lineage,
         EmbeddingRefreshOutcomeAttempt {
             status,
@@ -1169,7 +1169,7 @@ mod tests {
         assert_eq!(outcome.status, EmbeddingRefreshOutcomeStatus::Succeeded);
         assert_eq!(
             outcome.graph_generation,
-            graphforge_storage::generation::read_search_generation(&graph.dir).unwrap()
+            graphforge_storage::generation::read_search_generation(&graph.dir()).unwrap()
         );
         assert_eq!(
             refreshed.freshness.as_ref().unwrap().compatibility_id,

--- a/crates/graphforge-api/src/provider_rerank.rs
+++ b/crates/graphforge-api/src/provider_rerank.rs
@@ -227,7 +227,7 @@ impl GraphForge {
     where
         F: FnMut(&ProviderModelContract, &str) -> ProviderResult<u64>,
     {
-        let generation = read_search_generation(&self.dir)?;
+        let generation = read_search_generation(&self.dir())?;
         let prepared =
             self.prepare_rerank_plan(canonical, request, &mut count_tokens, &mut || Ok(()))?;
         let runtime = graphforge_search::StandardProviderExecutionRuntime::new();
@@ -267,7 +267,7 @@ impl GraphForge {
             ProviderExecutionController::new(&request.contract, request.execution_limits, runtime)?;
 
         for attempt in 1_u8..=2 {
-            let generation = read_search_generation(&self.dir)?;
+            let generation = read_search_generation(&self.dir())?;
             let prepared =
                 self.prepare_rerank_plan(canonical, request, count_tokens, checkpoint)?;
             let candidates = prepared
@@ -305,14 +305,14 @@ impl GraphForge {
                         provider_checkpoint,
                     )
                 })?;
-            if generation != read_search_generation(&self.dir)? {
+            if generation != read_search_generation(&self.dir())? {
                 if attempt == 2 {
                     return Err(SearchArtifactError::ConcurrentMutation.into());
                 }
                 continue;
             }
             let result = self.shape_rerank_application(request, application)?;
-            if generation == read_search_generation(&self.dir)? {
+            if generation == read_search_generation(&self.dir())? {
                 return Ok(result);
             }
             if attempt == 2 {
@@ -341,7 +341,7 @@ impl GraphForge {
         hits.truncate(request.candidate_depth);
         let label_id = self.search_label_id(&request.label)?;
         let projection = project_text_source(
-            &self.dir,
+            &self.dir(),
             label_id,
             Some(&request.properties),
             TextSearchLimits::default(),
@@ -419,7 +419,7 @@ impl GraphForge {
         hits.truncate(request.limit);
         let label_id = self.search_label_id(&request.label)?;
         let batch = shape_search_output(
-            &self.dir,
+            &self.dir(),
             &self.property_inventory_for_session(),
             label_id,
             &hits,

--- a/crates/graphforge-api/src/resumable_construction.rs
+++ b/crates/graphforge-api/src/resumable_construction.rs
@@ -6,7 +6,6 @@ mod codec_tests;
 use arrow::record_batch::RecordBatch;
 use graphforge_core::uuid::Uuid;
 use sha2::{Digest, Sha256};
-use std::path::Path;
 
 use crate::{
     ConstructionChunkReceipt, GfError, GraphConstructionBudgets, GraphConstructionEvidence,
@@ -44,6 +43,8 @@ pub struct GraphConstructionSession<'a> {
     graph: &'a GraphForge,
     session_uuid: Uuid,
     inner: graphforge_storage::GraphConstructionSession,
+    /// Keep the admitted source workspace stable while storage retains its capabilities.
+    _parent_workspace: super::GraphWorkspace,
 }
 
 impl GraphForge {
@@ -73,7 +74,10 @@ impl GraphForge {
         if self.read_only {
             return Err(validation("historical graph views cannot construct"));
         }
-        let parent_topology_generation = graphforge_storage::read_topology_generation(&self.dir)?;
+        let _visibility = self.graph_visibility.read()?;
+        let workspace = self.workspace_for_session();
+        let dir = workspace.path();
+        let parent_topology_generation = graphforge_storage::read_topology_generation(dir)?;
         let project = self.resolved_generation.container_root();
         let inner = if let Some(allocation) = &self.allocation_operation {
             let authority = if self.ontology_mode == OntologyMode::Exploratory {
@@ -93,7 +97,7 @@ impl GraphForge {
             };
             graphforge_storage::GraphConstructionSession::open_with_allocation(
                 project,
-                &self.dir,
+                dir,
                 session_uuid,
                 parent_topology_generation,
                 self.ontology_mode,
@@ -107,7 +111,7 @@ impl GraphForge {
             if resume {
                 graphforge_storage::GraphConstructionSession::resume_with_mode_and_lifecycle_from_graph(
                     project,
-                    &self.dir,
+                    dir,
                     session_uuid,
                     self.ontology_mode,
                     budgets,
@@ -116,7 +120,7 @@ impl GraphForge {
             } else {
                 graphforge_storage::GraphConstructionSession::open_with_mode_and_lifecycle_from_graph(
                     project,
-                    &self.dir,
+                    dir,
                     session_uuid,
                     parent_topology_generation,
                     self.ontology_mode,
@@ -141,7 +145,7 @@ impl GraphForge {
             if resume {
                 graphforge_storage::GraphConstructionSession::resume_with_semantic_authority_and_lifecycle_from_graph(
                     project,
-                    &self.dir,
+                    dir,
                     session_uuid,
                     self.ontology_mode,
                     budgets,
@@ -151,7 +155,7 @@ impl GraphForge {
             } else {
                 graphforge_storage::GraphConstructionSession::open_with_semantic_authority_and_lifecycle_from_graph(
                     project,
-                    &self.dir,
+                    dir,
                     session_uuid,
                     parent_topology_generation,
                     self.ontology_mode,
@@ -165,6 +169,7 @@ impl GraphForge {
             graph: self,
             session_uuid,
             inner,
+            _parent_workspace: workspace,
         })
     }
 }
@@ -275,6 +280,11 @@ impl GraphConstructionSession<'_> {
             token.checkpoint()?;
         }
         let _visibility = self.graph.graph_visibility.lock()?;
+        let _adjacency_visibility = self
+            .graph
+            .adjacency_visibility
+            .write()
+            .expect("adjacency visibility lock poisoned");
         let target = derived_uuid(self.session_uuid, b"generation");
         let transaction = derived_uuid(self.session_uuid, b"transaction");
         let published = if let Some(replay) =
@@ -306,6 +316,7 @@ impl GraphConstructionSession<'_> {
         };
 
         let refresh = (|| {
+            refresh_boundary(RefreshBoundary::BeforeHydrate)?;
             let root = self.graph.resolved_generation.container_root();
             let resolved = graphforge_storage::resolve_project_generation(root)?;
             if resolved.generation_uuid() != published.generation_uuid {
@@ -316,52 +327,47 @@ impl GraphConstructionSession<'_> {
             let (prepared_dir, prepared_guard, hydration_evidence) =
                 super::hydrate_graph_workspace(&resolved, false)?;
             self.inner.record_hydration_evidence(&hydration_evidence)?;
+            refresh_boundary(RefreshBoundary::AfterHydrate)?;
             let runtime_catalog = super::load_runtime_catalog(&prepared_dir)?;
-            let property_inventory = std::sync::Arc::new(
-                graphforge_storage::AuthenticatedPropertyInventory::from_resolved_generation(
-                    &resolved,
-                )?,
-            );
-            replace_workspace(&prepared_dir, &self.graph.dir)?;
+            let prepared = self
+                .graph
+                .prepare_generation_read_authority(&resolved, &prepared_dir)?;
+            refresh_boundary(RefreshBoundary::BeforeInstall)?;
             Ok((
                 resolved,
-                prepared_guard,
+                super::GraphWorkspace {
+                    dir: prepared_dir,
+                    _owner: prepared_guard,
+                },
                 runtime_catalog,
-                property_inventory,
+                prepared,
             ))
         })();
-        let (resolved, prepared_guard, runtime_catalog, property_inventory) =
+        let (resolved, prepared_guard, runtime_catalog, prepared) =
             refresh.map_err(|error: GfError| {
                 GfError::Storage(format!(
                     "phase=POST_PUBLICATION_REFRESH committed=true generation_uuid={} recovery=reopen_or_resume cause={error}",
                     published.generation_uuid
                 ))
             })?;
-        drop(prepared_guard);
+        // Readers retain stable paths and capabilities. Never rename a workspace
+        // pinned by an ordinal handle or an unconsumed stream (including Windows).
+        // All fallible preparation precedes this transition under write visibility.
+        let old_workspace = self.graph.replace_workspace_owner(prepared_guard);
         *self
             .graph
             .runtime_catalog
             .lock()
             .expect("runtime catalog poisoned") = runtime_catalog;
-        *self
-            .graph
-            .property_authority
-            .lock()
-            .expect("property authority lock poisoned") = super::GenerationPropertyAuthority {
-            generation_uuid: resolved.generation_uuid(),
-            inventory: property_inventory,
-        };
-        *self
-            .graph
-            .current_generation_uuid
-            .lock()
-            .expect("generation UUID lock poisoned") = resolved.generation_uuid();
+        self.graph
+            .install_prepared_generation_read_authority(resolved.generation_uuid(), prepared);
         *self
             .graph
             .uuid_membership_index
             .lock()
             .expect("UUID membership lock poisoned") = None;
-        self.graph.adjacency_provider_for_session().invalidate();
+        // Release old reader handles before their workspace; streams own their pins.
+        drop(old_workspace);
         Ok(GraphConstructionPublicationReceipt {
             generation_uuid: published.generation_uuid,
             idempotent_replay: published.idempotent_replay,
@@ -397,53 +403,11 @@ impl GraphConstructionSession<'_> {
     }
 }
 
-fn replace_workspace(prepared: &Path, target: &Path) -> Result<(), GfError> {
-    refresh_boundary(RefreshBoundary::BeforeMove)?;
-    let parent = target.parent().ok_or_else(|| {
-        GfError::Storage("graph workspace has no parent for atomic replacement".into())
-    })?;
-    let backup = parent.join(format!(".graphforge-workspace-backup-{}", Uuid::now_v7()));
-    std::fs::rename(target, &backup).map_err(|error| {
-        GfError::Storage(format!("failed to preserve graph workspace: {error}"))
-    })?;
-    if let Err(error) = refresh_boundary(RefreshBoundary::AfterOldMoved) {
-        restore_workspace(&backup, target, None)?;
-        return Err(error);
-    }
-    if let Err(error) = std::fs::rename(prepared, target) {
-        restore_workspace(&backup, target, None)?;
-        return Err(GfError::Storage(format!(
-            "failed to install prepared graph workspace: {error}"
-        )));
-    }
-    if let Err(error) = refresh_boundary(RefreshBoundary::AfterNewInstalled) {
-        restore_workspace(&backup, target, Some(prepared))?;
-        return Err(error);
-    }
-    // The backup is no longer authoritative. Failure to reclaim it cannot make
-    // the already-installed workspace or in-memory replacement state invalid.
-    let _ = std::fs::remove_dir_all(backup);
-    Ok(())
-}
-
-fn restore_workspace(backup: &Path, target: &Path, prepared: Option<&Path>) -> Result<(), GfError> {
-    if let Some(prepared) = prepared {
-        std::fs::rename(target, prepared).map_err(|error| {
-            GfError::Storage(format!(
-                "failed to withdraw prepared graph workspace during rollback: {error}"
-            ))
-        })?;
-    }
-    std::fs::rename(backup, target).map_err(|error| {
-        GfError::Storage(format!("failed to restore prior graph workspace: {error}"))
-    })
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RefreshBoundary {
-    BeforeMove,
-    AfterOldMoved,
-    AfterNewInstalled,
+    BeforeHydrate,
+    AfterHydrate,
+    BeforeInstall,
 }
 
 #[cfg(not(test))]
@@ -487,39 +451,10 @@ fn validation(message: impl Into<String>) -> GfError {
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{ArrayRef, FixedSizeBinaryArray, StringArray};
+    use arrow::array::{Array, ArrayRef, FixedSizeBinaryArray, StringArray};
     use arrow::record_batch::RecordBatch;
 
     use super::*;
-
-    #[test]
-    fn refresh_boundaries_preserve_the_prior_workspace_on_failure() {
-        for boundary in [
-            RefreshBoundary::BeforeMove,
-            RefreshBoundary::AfterOldMoved,
-            RefreshBoundary::AfterNewInstalled,
-        ] {
-            let parent = tempfile::tempdir().unwrap();
-            let target = parent.path().join("live");
-            let prepared = parent.path().join("prepared");
-            std::fs::create_dir(&target).unwrap();
-            std::fs::create_dir(&prepared).unwrap();
-            std::fs::write(target.join("generation"), b"old").unwrap();
-            std::fs::write(prepared.join("generation"), b"new").unwrap();
-
-            REFRESH_FAILURE.with(|failure| failure.set(Some(boundary)));
-            let error = replace_workspace(&prepared, &target).unwrap_err();
-            REFRESH_FAILURE.with(|failure| failure.set(None));
-
-            assert!(
-                error
-                    .to_string()
-                    .contains("injected construction refresh failure")
-            );
-            assert_eq!(std::fs::read(target.join("generation")).unwrap(), b"old");
-            assert_eq!(std::fs::read(prepared.join("generation")).unwrap(), b"new");
-        }
-    }
 
     fn nodes(ids: &[Uuid]) -> RecordBatch {
         let uuids =
@@ -599,27 +534,110 @@ mod tests {
 
     #[test]
     fn post_publication_refresh_failure_reports_committed_authority() {
-        let graph = GraphForge::new(None).unwrap();
-        let root = graph.resolved_generation.container_root().to_path_buf();
-        let mut session = graph.begin_graph_construction(Default::default()).unwrap();
-        session
-            .append_nodes("nodes", &nodes(&[Uuid::now_v7()]))
-            .unwrap();
+        for boundary in [
+            RefreshBoundary::BeforeHydrate,
+            RefreshBoundary::AfterHydrate,
+            RefreshBoundary::BeforeInstall,
+        ] {
+            let graph = GraphForge::new(None).unwrap();
+            let root = graph.resolved_generation.container_root().to_path_buf();
+            let old_workspace = graph.workspace_for_session();
+            let old_generation = *graph.current_generation_uuid.lock().unwrap();
+            let mut session = graph.begin_graph_construction(Default::default()).unwrap();
+            session
+                .append_nodes("nodes", &nodes(&[Uuid::now_v7()]))
+                .unwrap();
+            REFRESH_FAILURE.with(|failure| failure.set(Some(boundary)));
+            let error = session.seal_and_publish().unwrap_err();
+            REFRESH_FAILURE.with(|failure| failure.set(None));
+            assert!(session.progress().publication_committed);
+            let committed = graphforge_storage::resolve_project_generation(&root)
+                .unwrap()
+                .generation_uuid();
+            let message = error.to_string();
+            assert!(message.contains("phase=POST_PUBLICATION_REFRESH"));
+            assert!(message.contains("committed=true"));
+            assert!(message.contains(&format!("generation_uuid={committed}")));
+            assert!(message.contains("recovery=reopen_or_resume"));
+            assert_eq!(old_workspace.path(), graph.workspace_for_session().path());
+            assert_eq!(
+                *graph.current_generation_uuid.lock().unwrap(),
+                old_generation
+            );
+            assert_eq!(graph.node_count("Person").unwrap(), 0);
+            let retry = session.seal_and_publish().unwrap();
+            assert!(retry.idempotent_replay);
+            assert_eq!(retry.generation_uuid, committed);
+            assert_eq!(graph.node_count("Person").unwrap(), 1);
+            assert_ne!(old_workspace.path(), graph.workspace_for_session().path());
+        }
+    }
 
-        REFRESH_FAILURE.with(|failure| failure.set(Some(RefreshBoundary::BeforeMove)));
-        let error = session.seal_and_publish().unwrap_err();
-        REFRESH_FAILURE.with(|failure| failure.set(None));
+    fn relationship_identities(batches: &[RecordBatch]) -> std::collections::BTreeSet<[Uuid; 3]> {
+        let identities: std::collections::BTreeSet<_> = batches
+            .iter()
+            .flat_map(|batch| {
+                let columns: Vec<_> = (0..3)
+                    .map(|column| {
+                        batch
+                            .column(column)
+                            .as_any()
+                            .downcast_ref::<FixedSizeBinaryArray>()
+                            .unwrap()
+                    })
+                    .collect();
+                for column in &columns {
+                    assert_eq!(column.null_count(), 0);
+                }
+                (0..batch.num_rows())
+                    .map(|row| {
+                        std::array::from_fn(|column| {
+                            Uuid::from_slice(columns[column].value(row)).unwrap()
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(
+            identities.len(),
+            batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+            "relationship rows must not be duplicated"
+        );
+        identities
+    }
 
-        let progress = session.progress();
-        assert!(progress.publication_committed);
-        let committed = graphforge_storage::resolve_project_generation(&root)
-            .unwrap()
-            .generation_uuid();
-        let message = error.to_string();
-        assert!(message.contains("phase=POST_PUBLICATION_REFRESH"));
-        assert!(message.contains("committed=true"));
-        assert!(message.contains(&format!("generation_uuid={committed}")));
-        assert!(message.contains("recovery=reopen_or_resume"));
+    const RELATIONSHIP_IDENTITIES: &str = "MATCH (a)-[r:KNOWS]->(b) RETURN a.node_uuid AS source, r.edge_uuid AS edge, b.node_uuid AS target";
+
+    fn assert_construction_relationships(graph: &GraphForge, expected: &[[Uuid; 3]]) {
+        let result = graph.execute(RELATIONSHIP_IDENTITIES).unwrap();
+        assert_eq!(
+            relationship_identities(&result.batches),
+            expected.iter().copied().collect()
+        );
+        for query in [
+            "MATCH ()-[r:KNOWS]->() RETURN count(r) AS n",
+            "MATCH ()-[r:KNOWS]->() RETURN count(*) AS n",
+        ] {
+            let result = graph.execute(query).unwrap();
+            assert_eq!(
+                result
+                    .batches
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                1
+            );
+            assert_eq!(result.batches[0].column(0).null_count(), 0);
+            assert_eq!(
+                result.batches[0]
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<arrow::array::Int64Array>()
+                    .unwrap()
+                    .value(0),
+                expected.len() as i64
+            );
+        }
     }
 
     #[test]
@@ -679,6 +697,11 @@ mod tests {
             first.generation_uuid
         );
         drop(session);
+        let original_relationships = [
+            [node_ids[0], edge_ids[0], node_ids[1]],
+            [node_ids[1], edge_ids[1], node_ids[2]],
+        ];
+        assert_construction_relationships(&graph, &original_relationships);
 
         let mut resumed = graph
             .resume_graph_construction(session_uuid, budgets)
@@ -693,8 +716,9 @@ mod tests {
             first.generation_uuid
         );
         drop(resumed);
+        assert_construction_relationships(&graph, &original_relationships);
 
-        let index = graphforge_storage::UuidMembershipIndex::open(&graph.dir).unwrap();
+        let index = graphforge_storage::UuidMembershipIndex::open(&graph.dir()).unwrap();
         assert_eq!(index.count(graphforge_storage::UuidIndexKind::Node), 3);
         assert_eq!(index.count(graphforge_storage::UuidIndexKind::Edge), 2);
         let catalog = graph.runtime_catalog.lock().unwrap();
@@ -725,6 +749,14 @@ mod tests {
         let old_stream = graph
             .execute_stream("MATCH (n:Person) RETURN n.node_uuid")
             .unwrap();
+        let original_workspace = graph.workspace_for_session();
+        let (old_relationship_stream, _, old_runtime_guard) = graph
+            .execute_stream_owned(RELATIONSHIP_IDENTITIES, &std::collections::HashMap::new())
+            .unwrap();
+        assert_eq!(
+            original_workspace.path(),
+            old_runtime_guard.workspace.path()
+        );
         let added_node = Uuid::now_v7();
         let added_edge = Uuid::now_v7();
         let mut child = graph.begin_graph_construction(budgets).unwrap();
@@ -771,6 +803,28 @@ mod tests {
             })
             .collect();
         assert_eq!(old_ids, node_ids.into_iter().collect());
+        assert_ne!(original_workspace.path(), graph.dir().path());
+        assert!(original_workspace.path().is_dir());
+        let old_relationship_batches: Vec<RecordBatch> = old_runtime_guard
+            .block_on(async {
+                old_relationship_stream
+                    .try_collect()
+                    .await
+                    .map_err(|error| GfError::Storage(format!("{error}")))
+            })
+            .unwrap();
+        assert_eq!(
+            relationship_identities(&old_relationship_batches),
+            original_relationships.into_iter().collect()
+        );
+        let current_relationships = [
+            original_relationships[0],
+            original_relationships[1],
+            [node_ids[2], added_edge, added_node],
+        ];
+        assert_construction_relationships(&graph, &current_relationships);
+        let reopened = GraphForge::new(root.to_str()).unwrap();
+        assert_construction_relationships(&reopened, &current_relationships);
 
         let resolved_child = graphforge_storage::resolve_project_generation(&root).unwrap();
         assert_eq!(
@@ -798,7 +852,7 @@ mod tests {
             })
         }));
 
-        let child_index = graphforge_storage::UuidMembershipIndex::open(&graph.dir).unwrap();
+        let child_index = graphforge_storage::UuidMembershipIndex::open(&graph.dir()).unwrap();
         assert_eq!(
             child_index.count(graphforge_storage::UuidIndexKind::Node),
             4
@@ -841,7 +895,8 @@ mod tests {
             child_receipt.generation_uuid
         );
         drop(historical_replay);
-        let current_index = graphforge_storage::UuidMembershipIndex::open(&graph.dir).unwrap();
+        assert_construction_relationships(&graph, &current_relationships);
+        let current_index = graphforge_storage::UuidMembershipIndex::open(&graph.dir()).unwrap();
         assert_eq!(
             current_index.count(graphforge_storage::UuidIndexKind::Node),
             4
@@ -849,6 +904,39 @@ mod tests {
         assert_eq!(
             current_index.count(graphforge_storage::UuidIndexKind::Edge),
             3
+        );
+        drop(current_index);
+        let reopened = GraphForge::new(root.to_str()).unwrap();
+        let final_node = Uuid::now_v7();
+        let final_edge = Uuid::now_v7();
+        let mut next = reopened.begin_graph_construction(budgets).unwrap();
+        next.append_nodes("reopened-node", &nodes(&[final_node]))
+            .unwrap();
+        next.append_edges(
+            "reopened-edge",
+            &edges(&[final_edge], &[(added_node, final_node)]),
+        )
+        .unwrap();
+        let cancelled = crate::CancellationToken::new();
+        cancelled.cancel();
+        assert_eq!(
+            next.seal_and_publish_with_cancellation(&cancelled)
+                .unwrap_err()
+                .code(),
+            "GF_CANCELLED"
+        );
+        assert_construction_relationships(&reopened, &current_relationships);
+        next.seal_and_publish().unwrap();
+        let final_relationships = [
+            current_relationships[0],
+            current_relationships[1],
+            current_relationships[2],
+            [added_node, final_edge, final_node],
+        ];
+        assert_construction_relationships(&reopened, &final_relationships);
+        assert_construction_relationships(
+            &GraphForge::new(root.to_str()).unwrap(),
+            &final_relationships,
         );
     }
 

--- a/crates/graphforge-api/src/resumable_construction/codec_tests.rs
+++ b/crates/graphforge-api/src/resumable_construction/codec_tests.rs
@@ -91,7 +91,7 @@ fn graph_rows(graph: &GraphForge) -> (Vec<NodeRow>, Vec<EdgeRow>) {
 }
 
 fn ordinals(graph: &GraphForge, ids: &[Uuid]) -> Vec<Option<u64>> {
-    UuidMembershipIndex::open(&graph.dir)
+    UuidMembershipIndex::open(&graph.dir())
         .unwrap()
         .lookup_node_surrogates(ids)
         .unwrap()

--- a/crates/graphforge-api/src/same_process_concurrency_tests.rs
+++ b/crates/graphforge-api/src/same_process_concurrency_tests.rs
@@ -117,13 +117,13 @@ fn lazy_rank_keeps_graph_workspace_inventory_unchanged() {
     let project = tempfile::tempdir().unwrap();
     seed(project.path());
     let graph = GraphForge::new(project.path().to_str()).unwrap();
-    let before = graphforge_storage::capture_graph_files(&graph.dir)
+    let before = graphforge_storage::capture_graph_files(&graph.dir())
         .unwrap()
         .0;
-    assert!(!graphforge_storage::adjacency::adjacency_dir(&graph.dir).exists());
+    assert!(!graphforge_storage::adjacency::adjacency_dir(&graph.dir()).exists());
     graph.rank("Person", RankOptions::default()).unwrap();
     assert_eq!(
-        graphforge_storage::capture_graph_files(&graph.dir)
+        graphforge_storage::capture_graph_files(&graph.dir())
             .unwrap()
             .0,
         before,

--- a/crates/graphforge-api/src/search_find.rs
+++ b/crates/graphforge-api/src/search_find.rs
@@ -33,6 +33,9 @@ impl GraphForge {
         if options.semantic_query.is_some() {
             return self.find_with_configured_provider(options);
         }
+        let _visibility = self.graph_visibility.read()?;
+        let workspace = self.workspace_for_session();
+        let dir = workspace.path();
         let FindOptions {
             query,
             label,
@@ -69,8 +72,9 @@ impl GraphForge {
             return Err(validation("find requires text or vector retrieval"));
         }
         for attempt in 1_u8..=2 {
-            let before = read_search_generation(&self.dir)?;
+            let before = read_search_generation(dir)?;
             let hits = self.retrieve_find_hits(
+                dir,
                 &label,
                 label_id,
                 query.as_deref(),
@@ -79,13 +83,9 @@ impl GraphForge {
                 force_stale,
                 limit,
             )?;
-            let batch = shape_search_output(
-                &self.dir,
-                &self.property_inventory_for_session(),
-                label_id,
-                &hits,
-            )?;
-            if before == read_search_generation(&self.dir)? {
+            let batch =
+                shape_search_output(dir, &self.property_inventory_for_session(), label_id, &hits)?;
+            if before == read_search_generation(dir)? {
                 return Ok(batch);
             }
             if attempt == 2 {
@@ -98,6 +98,7 @@ impl GraphForge {
     #[allow(clippy::too_many_arguments)]
     fn retrieve_find_hits(
         &self,
+        dir: &std::path::Path,
         label: &str,
         label_id: graphforge_value::EntityTypeSelection,
         query: Option<&str>,
@@ -109,7 +110,7 @@ impl GraphForge {
         let text = query
             .map(|query| {
                 search_graph_native(
-                    &self.dir,
+                    dir,
                     FindSearchRequest {
                         label,
                         label_id,
@@ -170,13 +171,16 @@ impl GraphForge {
         force_stale: bool,
         limit: usize,
     ) -> Result<Vec<VectorSearchHit>, GfError> {
+        // The caller retains graph read visibility for the entire find attempt.
+        let workspace = self.workspace_for_session();
+        let dir = workspace.path();
         let space = space.expect("vector query form requires space");
         match vector_query {
             VectorQuery::Raw(vector) => {
                 let key = SearchArtifactKey::vector(label, space)?;
-                if current_search_artifact(&self.dir, &key)?.is_some() {
+                if current_search_artifact(dir, &key)?.is_some() {
                     return soft_dimension_miss(search_graph_vectors(
-                        &self.dir,
+                        dir,
                         VectorIndexRequest {
                             label,
                             label_id,
@@ -190,7 +194,7 @@ impl GraphForge {
                 }
                 let prepared = self.prepare_embedding_space_read(Some(space), force_stale)?;
                 soft_dimension_miss(search_embedding_generation(
-                    &self.dir,
+                    dir,
                     EmbeddingGenerationQuery {
                         prepared: &prepared,
                         label_id,
@@ -204,7 +208,7 @@ impl GraphForge {
             VectorQuery::Node(node_uuid) => {
                 let prepared = self.prepare_embedding_space_read(Some(space), force_stale)?;
                 soft_dimension_miss(search_embedding_generation(
-                    &self.dir,
+                    dir,
                     EmbeddingGenerationQuery {
                         prepared: &prepared,
                         label_id,

--- a/crates/graphforge-api/src/search_index.rs
+++ b/crates/graphforge-api/src/search_index.rs
@@ -141,7 +141,7 @@ impl GraphForge {
                 rebuild,
             } => {
                 prepare_search_index(
-                    &self.dir,
+                    &self.dir(),
                     SearchIndexRequest::Text {
                         label,
                         label_id,
@@ -160,7 +160,7 @@ impl GraphForge {
             } => {
                 let node_uuid = self.resolve_node_selector(&node)?;
                 prepare_search_index(
-                    &self.dir,
+                    &self.dir(),
                     SearchIndexRequest::Vector {
                         label,
                         label_id,
@@ -196,7 +196,7 @@ impl GraphForge {
     ) -> Result<TextIndexInspection, GfError> {
         let label_id = self.search_label_id(label)?;
         let inspection = inspect_text_index_freshness(
-            &self.dir,
+            &self.dir(),
             LazyTextRequest { label, label_id },
             properties,
             graphforge_search::TextLifecycleLimits::default(),
@@ -241,8 +241,9 @@ impl GraphForge {
             .expect("adjacency visibility lock poisoned");
         let token = cancellation.unwrap_or_default();
         token.checkpoint()?;
-        let adjacency = graphforge_storage::adjacency::adjacency_dir(&self.dir);
-        let workspace_parent = self.dir.parent().ok_or_else(|| {
+        let adjacency = graphforge_storage::adjacency::adjacency_dir(&self.dir());
+        let workspace = self.workspace_for_session();
+        let workspace_parent = workspace.path().parent().ok_or_else(|| {
             GfError::Storage("graph workspace has no same-filesystem parent".into())
         })?;
         let staged = tempfile::Builder::new()
@@ -255,7 +256,7 @@ impl GraphForge {
         // scoped to the unpublished artifact (#336).
         let build_options = self.adjacency_build_options(staged.path());
         graphforge_storage::adjacency::build_adjacency_index_from_inventory(
-            &self.dir,
+            &self.dir(),
             staged.path(),
             Some(&self.property_inventory_for_session()),
             transaction_time_micros(),
@@ -263,7 +264,7 @@ impl GraphForge {
             &mut || token.checkpoint(),
         )?;
         let issues = graphforge_storage::adjacency::validate_adjacency_index_from_inventory(
-            &self.dir,
+            &self.dir(),
             staged.path(),
             Some(&self.property_inventory_for_session()),
         )?;
@@ -279,7 +280,7 @@ impl GraphForge {
         // Keep rollback bytes beside (not inside) the private workspace. The
         // operation-wide visibility lock makes the two directory renames an
         // atomic observation boundary for every reader of this workspace.
-        let backup = self.dir.with_file_name(format!(
+        let backup = self.dir().with_file_name(format!(
             ".graphforge-adjacency-backup.{}",
             uuid::Uuid::new_v4().simple()
         ));
@@ -401,7 +402,7 @@ impl GraphForge {
             .read()
             .expect("adjacency visibility lock poisoned");
         let inspection = graphforge_storage::adjacency::inspect_adjacency_index_from_inventory(
-            &self.dir,
+            &self.dir(),
             Some(&self.property_inventory_for_session()),
         )?;
         Ok(AdjacencyInspection {
@@ -606,18 +607,24 @@ mod tests {
 
         graph.index_search("Person", text(None, false)).unwrap();
         let key = SearchArtifactKey::text("Person", ["name", "summary"]).unwrap();
-        let first = current_search_artifact(&graph.dir, &key).unwrap().unwrap();
+        let first = current_search_artifact(&graph.dir(), &key)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             first.manifest.properties.as_deref().unwrap(),
             ["name", "summary"]
         );
 
         graph.index_search("Person", text(None, false)).unwrap();
-        let reused = current_search_artifact(&graph.dir, &key).unwrap().unwrap();
+        let reused = current_search_artifact(&graph.dir(), &key)
+            .unwrap()
+            .unwrap();
         assert_eq!(reused.path, first.path);
 
         graph.index_search("Person", text(None, true)).unwrap();
-        let replaced = current_search_artifact(&graph.dir, &key).unwrap().unwrap();
+        let replaced = current_search_artifact(&graph.dir(), &key)
+            .unwrap()
+            .unwrap();
         assert_ne!(replaced.path, first.path);
 
         assert_validation(graph.index_search("Person", text(Some(vec![]), false)));
@@ -629,7 +636,7 @@ mod tests {
 
         graph.index_search("NoText", text(None, false)).unwrap();
         let no_text_probe = SearchArtifactKey::text("NoText", ["_"]).unwrap();
-        let no_text_label_root = no_text_probe.artifact_root(&graph.dir);
+        let no_text_label_root = no_text_probe.artifact_root(&graph.dir());
         let no_text_label_root = no_text_label_root
             .parent()
             .expect("text key has a property component");
@@ -640,7 +647,7 @@ mod tests {
         reopened
             .index_search("Person", text(Some(vec!["summary", "name"]), false))
             .unwrap();
-        let after_reopen = current_search_artifact(&reopened.dir, &key)
+        let after_reopen = current_search_artifact(&reopened.dir(), &key)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -714,7 +721,9 @@ mod tests {
         );
 
         let key = SearchArtifactKey::text("Person", ["name"]).unwrap();
-        let artifact = current_search_artifact(&graph.dir, &key).unwrap().unwrap();
+        let artifact = current_search_artifact(&graph.dir(), &key)
+            .unwrap()
+            .unwrap();
         let manifest_path = artifact.path.join("manifest.json");
         let mut manifest: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
@@ -763,7 +772,9 @@ mod tests {
             )
             .unwrap();
         let key = SearchArtifactKey::vector("Person", "semantic").unwrap();
-        let first = current_search_artifact(&graph.dir, &key).unwrap().unwrap();
+        let first = current_search_artifact(&graph.dir(), &key)
+            .unwrap()
+            .unwrap();
 
         graph
             .index_search(
@@ -771,7 +782,9 @@ mod tests {
                 vector(NodeSelector::Uuid(person.uuid), &[1.0, 0.0]),
             )
             .unwrap();
-        let repeated = current_search_artifact(&graph.dir, &key).unwrap().unwrap();
+        let repeated = current_search_artifact(&graph.dir(), &key)
+            .unwrap()
+            .unwrap();
         assert_eq!(repeated.path, first.path);
 
         graph
@@ -780,7 +793,9 @@ mod tests {
                 vector(NodeSelector::Uuid(person.uuid), &[0.0, 1.0]),
             )
             .unwrap();
-        let replaced = current_search_artifact(&graph.dir, &key).unwrap().unwrap();
+        let replaced = current_search_artifact(&graph.dir(), &key)
+            .unwrap()
+            .unwrap();
         assert_ne!(replaced.path, first.path);
         crate::permanent_parquet_test_support::assert_file(
             &replaced.path.join(graphforge_storage::VECTOR_DATA_FILE),
@@ -816,7 +831,7 @@ mod tests {
                 vector(NodeSelector::Uuid(person.uuid), &[0.0, 1.0]),
             )
             .unwrap();
-        let after_reopen = current_search_artifact(&reopened.dir, &key)
+        let after_reopen = current_search_artifact(&reopened.dir(), &key)
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -843,7 +858,7 @@ mod tests {
             Some(receipt.source_topology_fingerprint.as_str())
         );
         assert!(
-            graphforge_storage::adjacency::validate_adjacency_index(&graph.dir)
+            graphforge_storage::adjacency::validate_adjacency_index(&graph.dir())
                 .unwrap()
                 .is_empty()
         );
@@ -855,7 +870,11 @@ mod tests {
         ));
         graph.index_search("adjacency", text(None, false)).unwrap();
         let key = SearchArtifactKey::text("adjacency", ["name"]).unwrap();
-        assert!(current_search_artifact(&graph.dir, &key).unwrap().is_some());
+        assert!(
+            current_search_artifact(&graph.dir(), &key)
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[test]
@@ -866,14 +885,14 @@ mod tests {
             .unwrap();
         let prior = graph.index_adjacency().unwrap();
         let prior_manifest =
-            std::fs::read(graphforge_storage::adjacency::manifest_path(&graph.dir)).unwrap();
+            std::fs::read(graphforge_storage::adjacency::manifest_path(&graph.dir())).unwrap();
         let token = CancellationToken::new();
         token.cancel();
 
         let error = graph.rebuild_adjacency(Some(token)).unwrap_err();
         assert_eq!(error.code(), "GF_CANCELLED");
         assert_eq!(
-            std::fs::read(graphforge_storage::adjacency::manifest_path(&graph.dir)).unwrap(),
+            std::fs::read(graphforge_storage::adjacency::manifest_path(&graph.dir())).unwrap(),
             prior_manifest
         );
         assert_eq!(graph.inspect_adjacency().unwrap(), prior);
@@ -893,7 +912,7 @@ mod tests {
             .execute("CREATE (a:Person)-[:KNOWS]->(b:Person)")
             .unwrap();
         graph.index_adjacency().unwrap();
-        let manifest = graphforge_storage::adjacency::manifest_path(&graph.dir);
+        let manifest = graphforge_storage::adjacency::manifest_path(&graph.dir());
         let prior_manifest = std::fs::read(&manifest).unwrap();
         graph
             .execute("CREATE (c:Person)-[:KNOWS]->(d:Person)")
@@ -932,7 +951,10 @@ mod tests {
         let reopened = Arc::new(GraphForge::new(Some(path)).unwrap());
         assert_eq!(reopened.inspect_adjacency().unwrap(), before_cancel);
         assert_eq!(
-            std::fs::read(graphforge_storage::adjacency::manifest_path(&reopened.dir)).unwrap(),
+            std::fs::read(graphforge_storage::adjacency::manifest_path(
+                &reopened.dir()
+            ))
+            .unwrap(),
             prior_manifest
         );
         let (rebuilt, rebuilt_stage) = rebuild_through_barrier(Arc::clone(&reopened));
@@ -1099,6 +1121,6 @@ mod tests {
         assert_validation(
             other.index_search("Person", vector(NodeSelector::Handle(foreign), &[1.0])),
         );
-        assert!(!other.dir.join("embeddings").exists());
+        assert!(!other.dir().join("embeddings").exists());
     }
 }

--- a/crates/graphforge-api/src/transaction.rs
+++ b/crates/graphforge-api/src/transaction.rs
@@ -746,7 +746,7 @@ mod tests {
         let graph = GraphForge::new(directory.path().to_str()).unwrap();
         graph.execute("CREATE (:Person {name:'retained'})").unwrap();
         let catalog = graph.runtime_catalog.lock().unwrap().to_record_batch();
-        let files = graphforge_storage::capture_graph_files(&graph.dir)
+        let files = graphforge_storage::capture_graph_files(&graph.dir())
             .unwrap()
             .0;
         let generation = *graph.current_generation_uuid.lock().unwrap();
@@ -764,7 +764,7 @@ mod tests {
             catalog
         );
         assert_eq!(
-            graphforge_storage::capture_graph_files(&graph.dir)
+            graphforge_storage::capture_graph_files(&graph.dir())
                 .unwrap()
                 .0,
             files

--- a/crates/graphforge-api/src/workspace_ontology.rs
+++ b/crates/graphforge-api/src/workspace_ontology.rs
@@ -316,8 +316,10 @@ impl GraphForge {
                     prepared,
                 );
             }
-            self.dir = dir;
-            self.workspace_guard = workspace;
+            self.replace_workspace_owner(crate::GraphWorkspace {
+                dir,
+                _owner: workspace,
+            });
             self.graph_open_evidence = evidence;
             *self
                 .uuid_membership_index
@@ -367,7 +369,7 @@ impl GraphForge {
             .write()
             .expect("adjacency provider lock poisoned") =
             std::sync::Arc::new(crate::adjacency_provider_for_graph(
-                &self.dir,
+                &self.dir(),
                 self.ontology_mode,
                 self.property_inventory_for_session(),
             )?);
@@ -1176,7 +1178,7 @@ mod tests {
             "unknown Ghost must stay queryable as tagged runtime label"
         );
 
-        let batches = graphforge_storage::read_nodes(&graph.dir).unwrap();
+        let batches = graphforge_storage::read_nodes(&graph.dir()).unwrap();
         let type_ids = batches[0]
             .column_by_name("type_ids")
             .unwrap()

--- a/docs/guide/graph-construction.md
+++ b/docs/guide/graph-construction.md
@@ -240,3 +240,20 @@ python3 scripts/ci/bulk-construction-conformance.py validate
 - [Quick Start](quickstart.md) — five-minute walkthrough
 - [Tutorial](tutorial.md) — guided citation-network example
 - [API Reference](../reference/api.md) — complete method signatures
+
+### Publication and existing readers
+
+Successful resumable construction updates the same facade's workspace, property
+inventory, adjacency provider and ordinal identity authority together. Immediate
+queries therefore observe the published relationships and endpoints without
+requiring reopen. Publication prepares one new workspace and adopts its owner;
+it does not rename directories pinned by existing readers. A lazy stream and its
+runtime guard retain the workspace selected when the stream was created, so
+subsequent construction cannot change that stream's identities or remove its
+files. Those overlapping live workspaces remain real resource owners until the
+last reader releases them.
+
+If reader preparation fails after durable publication, the error still reports
+`committed=true` and recovery by reopen or resume. The facade retains its prior
+workspace until all replacement readers are ready; exact retry adopts the
+already committed generation.

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -331,7 +331,7 @@
         },
         {
           "path": "crates/graphforge-api/src/resumable_construction.rs",
-          "symbol": "refresh_boundaries_preserve_the_prior_workspace_on_failure"
+          "symbol": "post_publication_refresh_failure_reports_committed_authority"
         },
         {
           "path": "crates/graphforge-api/tests/resumable_construction_surface.rs",


### PR DESCRIPTION
Public construction could publish a relationship successfully yet return zero relationships on the same facade; reopening returned the correct graph. Construction now installs the selected workspace, adjacency inventory, ordinal resolver and property authority together using the existing generation reader machinery.

The workspace retains its selected graph path and temporary owner separately, so pinned views keep their correct path and existing streams retain their original generation. Preparation completes before installation at a stable path. Internal query, mutation, metadata and worker call sites retain the corresponding workspace through use. Adjacency providers are captured immediately under their visibility guard, with path selectors resolved under that same guard.

Regression coverage checks exact endpoint/edge identities and counts after initial, child and reopened-facade construction, cancellation/retry, current and historical replay, and lazy streams retained across publication. Three preparation failure boundaries check committed-error reporting, preservation of the prior view and successful retry. The regression fails on main before the repair.

Validation:
- Targeted construction regressions: 4 passed. Public algorithm regressions after the final ordering correction: 3 passed, covering 94 contracts. Non-Cypher surface policy: 12 passed with the evidence inventory pointing to the public preparation-failure/retry regression.
- Full final API library: 738 passed, 0 failed (24.46 seconds).
- `cargo fmt --all -- --check`, `git diff --check`, `cargo clippy --workspace -- -D warnings`, `make pre-push-fast`, and `make gate-registry-check`: passed.
- `make pre-push`: failed only at the existing #1192 hardcoded-`/tmp` socket fixture (`GF_UNSUPPORTED_FILESYSTEM`, storage: 1,097 passed, 1 failed, 2 existing ignored). The full API library and preceding integration/CLI suites passed; later stages were not reached. No skips or admission changes were added. Exact-head CI remains required.

Closes #1257
