### PR TITLE
feat(observability): expose scoped construction operation timings

### DIFF
--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -1003,6 +1003,14 @@ fn sanitize_receipt(value: &serde_json::Value) -> Option<serde_json::Value> {
             {
                 return None;
             }
+            if object.get("operation_timings").is_some_and(|timings| {
+                !matches!(
+                    object.get("outcome").and_then(serde_json::Value::as_str),
+                    Some("validated" | "committed")
+                ) || !sanitized_import_operation_timings(timings)
+            }) {
+                return None;
+            }
             let mut receipt = serde_json::Map::new();
             for key in [
                 "contract",
@@ -1011,6 +1019,7 @@ fn sanitize_receipt(value: &serde_json::Value) -> Option<serde_json::Value> {
                 "rows_rejected",
                 "bytes_accepted",
                 "construction",
+                "operation_timings",
             ] {
                 if let Some(item) = object.get(key) {
                     receipt.insert(key.to_owned(), item.clone());
@@ -1162,6 +1171,31 @@ fn sanitized_numeric_tree(value: &serde_json::Value) -> bool {
         }),
         serde_json::Value::String(_) => false,
     }
+}
+
+fn sanitized_import_operation_timings(value: &serde_json::Value) -> bool {
+    let Some(phases) = value.as_object() else {
+        return false;
+    };
+    phases.len() == 5
+        && ["begin", "resume", "append", "seal", "publish"]
+            .iter()
+            .all(|phase| {
+                let Some(timing) = phases.get(*phase).and_then(serde_json::Value::as_object) else {
+                    return false;
+                };
+                if timing.len() != 3 {
+                    return false;
+                }
+                let (Some(calls), Some(errors), Some(elapsed)) = (
+                    timing.get("calls").and_then(serde_json::Value::as_u64),
+                    timing.get("errors").and_then(serde_json::Value::as_u64),
+                    timing.get("elapsed_ns").and_then(serde_json::Value::as_u64),
+                ) else {
+                    return false;
+                };
+                errors <= calls && (calls != 0 || elapsed == 0)
+            })
 }
 
 fn sanitized_construction_tree(value: &serde_json::Value) -> bool {
@@ -2028,6 +2062,44 @@ mod tests {
 
     use super::*;
     use std::collections::VecDeque;
+
+    #[test]
+    fn import_operation_timings_are_closed_numeric_observations() {
+        let mut timings = serde_json::json!({});
+        for phase in ["begin", "resume", "append", "seal", "publish"] {
+            timings[phase] = serde_json::json!({"calls": 0, "errors": 0, "elapsed_ns": 0});
+        }
+        timings["resume"] = serde_json::json!({"calls": 1, "errors": 0, "elapsed_ns": 25});
+        timings["publish"] = serde_json::json!({"calls": 2, "errors": 1, "elapsed_ns": 50});
+        let receipt = serde_json::json!({"contract":"graphforge-import-session/1", "outcome":"committed", "operation_timings":timings});
+        let parsed = parse_receipts(&serde_json::to_vec(&receipt).unwrap(), true).unwrap();
+        assert_eq!(parsed[0]["operation_timings"], timings);
+        for (phase, key, value) in [
+            ("append", "elapsed_ns", serde_json::json!(1)),
+            ("append", "errors", serde_json::json!(1)),
+            ("resume", "elapsed_ns", serde_json::json!(-1)),
+            ("resume", "calls", serde_json::json!(1.5)),
+            ("resume", "errors", serde_json::json!(2)),
+            ("publish", "elapsed_ns", serde_json::json!("/private/path")),
+            ("publish", "path", serde_json::json!(0)),
+        ] {
+            let mut malformed = receipt.clone();
+            malformed["operation_timings"][phase][key] = value;
+            assert!(
+                parse_receipts(&serde_json::to_vec(&malformed).unwrap(), true).is_err(),
+                "{phase}.{key}"
+            );
+        }
+        let mut missing = receipt.clone();
+        missing["operation_timings"]
+            .as_object_mut()
+            .unwrap()
+            .remove("seal");
+        assert!(parse_receipts(&serde_json::to_vec(&missing).unwrap(), true).is_err());
+        let mut extra = receipt;
+        extra["operation_timings"]["private_path"] = serde_json::json!({});
+        assert!(parse_receipts(&serde_json::to_vec(&extra).unwrap(), true).is_err());
+    }
 
     #[test]
     fn child_receipts_are_bounded_allowlisted_and_strip_content_bearing_paths() {

--- a/benchmarks/runners/certify/src/lib.rs
+++ b/benchmarks/runners/certify/src/lib.rs
@@ -3047,7 +3047,8 @@ fi
             .observe(Phase::Reopen, &source_command, &[])
             .unwrap();
         let operation =
-            graphforge_storage::StorageAllocationOperation::from_paths(&[root.clone()]).unwrap();
+            graphforge_storage::StorageAllocationOperation::from_paths(std::slice::from_ref(&root))
+                .unwrap();
         let baseline_current = operation.totals().unwrap().0;
         let temporary = root.join("transient");
         let file = fs::File::create(&temporary).unwrap();

--- a/benchmarks/schemas/certification-evidence.json
+++ b/benchmarks/schemas/certification-evidence.json
@@ -22,6 +22,30 @@
   "required": ["schema", "profile_id", "status", "phases", "failed_phase"],
   "additionalProperties": false,
   "$defs": {
+    "importCallTiming": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["calls", "errors", "elapsed_ns"],
+      "properties": {
+        "calls": { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 },
+        "errors": { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 },
+        "elapsed_ns": { "type": "integer", "minimum": 0, "maximum": 18446744073709551615 }
+      },
+      "if": { "properties": { "calls": { "const": 0 } } },
+      "then": { "properties": { "errors": { "const": 0 }, "elapsed_ns": { "const": 0 } } }
+    },
+    "importOperationTimings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["begin", "resume", "append", "seal", "publish"],
+      "properties": {
+        "begin": { "$ref": "#/$defs/importCallTiming" },
+        "resume": { "$ref": "#/$defs/importCallTiming" },
+        "append": { "$ref": "#/$defs/importCallTiming" },
+        "seal": { "$ref": "#/$defs/importCallTiming" },
+        "publish": { "$ref": "#/$defs/importCallTiming" }
+      }
+    },
     "phaseName": {
       "enum": [
         "admission",
@@ -66,9 +90,22 @@
           "items": {
             "type": "object",
             "propertyNames": {
-              "enum": ["retained_owners", "contract", "outcome", "rows_accepted", "rows_rejected", "bytes_accepted", "construction", "format", "rows", "batches", "bytes", "complete", "result_sha256", "scalar_u64", "query_evidence", "storage", "reopen_agrees", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "transient_peak_allocated_bytes", "logical_read_bytes", "logical_write_bytes", "reader_calls", "publication_work_units", "live_nodes", "live_edges", "one_hop_rows", "two_hop_rows", "source_fingerprint", "imported_fingerprint", "equivalent", "kind", "selected_generation_class", "work_detected", "repaired_journals", "aborted_journals", "removed_generations", "preserved_unknown_entries", "deferred", "elapsed_ms", "package_digest", "transport_digest", "entry_count", "payload_bytes", "representation", "selection_fingerprint", "allocation_logical_bytes", "allocation_allocated_bytes", "allocation_physical_objects", "integrity", "compatibility", "idempotent_replay"]
+              "enum": ["retained_owners", "contract", "outcome", "rows_accepted", "rows_rejected", "bytes_accepted", "construction", "operation_timings", "format", "rows", "batches", "bytes", "complete", "result_sha256", "scalar_u64", "query_evidence", "storage", "reopen_agrees", "source_project_current_allocated_bytes", "retained_storage_bytes", "transient_peak_storage_bytes", "transient_peak_allocated_bytes", "logical_read_bytes", "logical_write_bytes", "reader_calls", "publication_work_units", "live_nodes", "live_edges", "one_hop_rows", "two_hop_rows", "source_fingerprint", "imported_fingerprint", "equivalent", "kind", "selected_generation_class", "work_detected", "repaired_journals", "aborted_journals", "removed_generations", "preserved_unknown_entries", "deferred", "elapsed_ms", "package_digest", "transport_digest", "entry_count", "payload_bytes", "representation", "selection_fingerprint", "allocation_logical_bytes", "allocation_allocated_bytes", "allocation_physical_objects", "integrity", "compatibility", "idempotent_replay"]
+            },
+            "properties": {
+              "operation_timings": { "$ref": "#/$defs/importOperationTimings" }
             },
             "allOf": [
+              {
+                "if": { "required": ["operation_timings"] },
+                "then": {
+                  "required": ["contract", "outcome"],
+                  "properties": {
+                    "contract": { "const": "graphforge-import-session/1" },
+                    "outcome": { "enum": ["validated", "committed"] }
+                  }
+                }
+              },
               {
                 "if": {
                   "properties": {

--- a/benchmarks/scripts/test-tiny-lifecycle-certification.py
+++ b/benchmarks/scripts/test-tiny-lifecycle-certification.py
@@ -278,6 +278,31 @@ def validate_growth(observations: list[dict[str, object]]) -> None:
         positive_slopes(field, values, work)
 
 
+def validate_operation_timings(evidence: dict[str, object]) -> None:
+    """Prove ordinary child receipts retain disjoint per-command observations."""
+    receipts = [
+        receipt
+        for phase in evidence["phases"]
+        for receipt in phase.get("receipts", [])
+        if receipt.get("contract") == "graphforge-import-session/1"
+        and receipt.get("outcome") in {"validated", "committed"}
+    ]
+    if [receipt["outcome"] for receipt in receipts] != ["validated", "committed"]:
+        raise SystemExit("tiny lifecycle omitted validation/publication timing receipts")
+    expected_calls = (
+        {"begin": 1, "resume": 0, "append": None, "seal": 1, "publish": 0},
+        {"begin": 0, "resume": 1, "append": 0, "seal": 0, "publish": 1},
+    )
+    for receipt, expected in zip(receipts, expected_calls, strict=True):
+        timings = receipt.get("operation_timings")
+        if not isinstance(timings, dict) or set(timings) != set(expected):
+            raise SystemExit("tiny lifecycle omitted closed operation timings")
+        for name, calls in expected.items():
+            row = timings[name]
+            if row["errors"] != 0 or (row["calls"] < 2 if calls is None else row["calls"] != calls):
+                raise SystemExit("tiny lifecycle operation timing calls differ from executed path")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--gf", required=True, type=executable)
@@ -410,6 +435,7 @@ def run(args: argparse.Namespace, scale: int) -> dict[str, object]:
         jsonschema.Draft202012Validator(schema).validate(evidence)
         if evidence["status"] != "passed" or len(evidence["phases"]) != 10:
             raise SystemExit("tiny lifecycle did not assemble complete passed evidence")
+        validate_operation_timings(evidence)
         queries = {
             phase["phase"]: [
                 receipt

--- a/benchmarks/tests/test_smoke.py
+++ b/benchmarks/tests/test_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 from pathlib import Path
 import tempfile
@@ -11,6 +12,63 @@ from tests.lifecycle_storage_fixture import retained_owners
 
 
 class WorkspaceSmokeTests(unittest.TestCase):
+    def test_import_operation_timings_schema_preserves_closed_unsigned_fields(self) -> None:
+        schema = json.loads(
+            (workspace_root() / "schemas" / "certification-evidence.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        validator = Draft202012Validator(schema)
+        timings = {
+            phase: {"calls": 0, "errors": 0, "elapsed_ns": 0}
+            for phase in ("begin", "resume", "append", "seal", "publish")
+        }
+        timings["append"] = {"calls": 2, "errors": 0, "elapsed_ns": 17}
+        document = {
+            "schema": "graphforge-public-certification/1",
+            "profile_id": "tiny-public-certification",
+            "status": "passed",
+            "failed_phase": None,
+            "phases": [
+                {
+                    "phase": "ingest",
+                    "status": "passed",
+                    "duration_ms": 1,
+                    "peak_rss_bytes": 0,
+                    "exit_code": 0,
+                    "receipts": [
+                        {
+                            "contract": "graphforge-import-session/1",
+                            "outcome": "validated",
+                            "operation_timings": timings,
+                        }
+                    ],
+                }
+            ],
+        }
+        validator.validate(document)
+        for key, value in [
+            ("elapsed_ns", -1),
+            ("elapsed_ns", 2**64),
+            ("elapsed_ns", "private"),
+            ("calls", True),
+            ("calls", 1.5),
+            ("path", 0),
+        ]:
+            candidate = deepcopy(document)
+            candidate["phases"][0]["receipts"][0]["operation_timings"]["append"][key] = value
+            self.assertFalse(validator.is_valid(candidate), (key, value))
+        for phase, key in [("resume", "elapsed_ns"), ("resume", "errors")]:
+            candidate = deepcopy(document)
+            candidate["phases"][0]["receipts"][0]["operation_timings"][phase][key] = 1
+            self.assertFalse(validator.is_valid(candidate))
+        candidate = deepcopy(document)
+        del candidate["phases"][0]["receipts"][0]["operation_timings"]["seal"]
+        self.assertFalse(validator.is_valid(candidate))
+        candidate = deepcopy(document)
+        candidate["phases"][0]["receipts"][0]["outcome"] = "registered"
+        self.assertFalse(validator.is_valid(candidate))
+
     def test_checked_in_fixtures_are_discoverable(self) -> None:
         discovered = discover_fixtures()
         self.assertEqual(set(discovered), set(FIXTURE_DIRECTORIES))

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -328,12 +328,53 @@ struct SessionManifest {
     updated_unix_millis: u64,
 }
 
+/// Monotonic wall time for attempted calls, including returned errors.
+/// These observations are not durable progress or performance limits.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct ImportCallTiming {
+    /// Number of attempted calls.
+    pub calls: u64,
+    /// Calls that returned an error.
+    pub errors: u64,
+    /// Sum of elapsed nanoseconds around these calls.
+    pub elapsed_ns: u64,
+}
+
+impl ImportCallTiming {
+    fn record(&mut self, started: Instant, failed: bool) {
+        self.elapsed_ns = self
+            .elapsed_ns
+            .saturating_add(u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX));
+        self.calls = self.calls.saturating_add(1);
+        self.errors = self.errors.saturating_add(u64::from(failed));
+    }
+}
+
+/// Disjoint call timings from the latest import validation or commit invocation.
+/// Reset before either operation, including precondition errors; never persisted.
+/// Lost-process work and source decoding, normalization, and checkpoints outside
+/// these calls are not measured. The sum is not whole-import elapsed time.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct ImportOperationTimings {
+    /// Fresh construction creation, excluding the import manifest checkpoint.
+    pub begin: ImportCallTiming,
+    /// Resumed construction authentication/reconciliation, excluding facade open.
+    pub resume: ImportCallTiming,
+    /// Construction append calls, including idempotent replay attempts.
+    pub append: ImportCallTiming,
+    /// Validation and sealing of construction artifacts.
+    pub seal: ImportCallTiming,
+    /// Publication, including work inside the public seal-and-publish call.
+    pub publish: ImportCallTiming,
+}
+
 /// Owned handle for a durable staged import. The handle contains no live rows.
 pub struct GraphImportSession {
     allocation_operation: Option<graphforge_storage::StorageAllocationOperation>,
     root: PathBuf,
     manifest: SessionManifest,
     observed: Instant,
+    operation_timings: ImportOperationTimings,
 }
 
 impl GraphForge {
@@ -376,6 +417,7 @@ impl GraphForge {
             root,
             manifest,
             observed: Instant::now(),
+            operation_timings: ImportOperationTimings::default(),
         })
     }
 
@@ -397,6 +439,7 @@ impl GraphForge {
             root,
             manifest,
             observed: Instant::now(),
+            operation_timings: ImportOperationTimings::default(),
         })
     }
 
@@ -445,6 +488,7 @@ impl GraphForge {
                 root,
                 manifest,
                 observed: Instant::now(),
+                operation_timings: ImportOperationTimings::default(),
             }
             .abort(self)?;
             cleaned = cleaned.saturating_add(1);
@@ -454,6 +498,12 @@ impl GraphForge {
 }
 
 impl GraphImportSession {
+    /// Timings from the latest validation or commit on this handle, including
+    /// calls that returned errors. Reading these observations performs no I/O.
+    #[must_use]
+    pub const fn operation_timings(&self) -> ImportOperationTimings {
+        self.operation_timings
+    }
     fn publish_source(&self, temporary: &Path, destination: &Path) -> Result<(), GfError> {
         let observed = if let Some(allocation) = &self.allocation_operation {
             let directory = graphforge_filesystem::StableDirectory::open(
@@ -651,6 +701,7 @@ impl GraphImportSession {
         graph: &GraphForge,
         cancellation: Option<&CancellationToken>,
     ) -> Result<ImportProgress, GfError> {
+        self.operation_timings = ImportOperationTimings::default();
         self.ensure_open()?;
         self.ensure_base(graph)?;
         let mut construction = self.open_construction(graph)?;
@@ -694,6 +745,7 @@ impl GraphImportSession {
                         self.persist_manifest()?;
                     }
                     let chunk_id = format!("import-{:020}-{:020}", source.sequence, batch_index);
+                    let started = Instant::now();
                     let staged = match (input_kind, cancellation) {
                         (BulkInputKind::Node, Some(token)) => {
                             construction.append_nodes_with_cancellation(&chunk_id, &batch, token)
@@ -704,6 +756,9 @@ impl GraphImportSession {
                         }
                         (BulkInputKind::Edge, None) => construction.append_edges(&chunk_id, &batch),
                     };
+                    self.operation_timings
+                        .append
+                        .record(started, staged.is_err());
                     if let Err(error) = staged {
                         self.manifest.sources[source_index].inflight_batch = None;
                         let remaining = self
@@ -742,7 +797,10 @@ impl GraphImportSession {
                 self.persist_manifest()?;
             }
         }
-        construction.validate_and_seal(cancellation)?;
+        let started = Instant::now();
+        let sealed = construction.validate_and_seal(cancellation);
+        self.operation_timings.seal.record(started, sealed.is_err());
+        sealed?;
         self.update_construction_progress(&construction.progress())?;
         self.manifest.phase = ImportPhase::Validated;
         self.checkpoint()
@@ -785,6 +843,7 @@ impl GraphImportSession {
         graph: &GraphForge,
         cancellation: Option<&CancellationToken>,
     ) -> Result<Uuid, GfError> {
+        self.operation_timings = ImportOperationTimings::default();
         if self.manifest.phase != ImportPhase::Validated
             || self.manifest.progress.files_pending != 0
         {
@@ -792,10 +851,15 @@ impl GraphImportSession {
         }
         self.ensure_base(graph)?;
         let mut construction = self.open_construction(graph)?;
+        let started = Instant::now();
         let publication = match cancellation {
-            Some(token) => construction.seal_and_publish_with_cancellation(token)?,
-            None => construction.seal_and_publish()?,
+            Some(token) => construction.seal_and_publish_with_cancellation(token),
+            None => construction.seal_and_publish(),
         };
+        self.operation_timings
+            .publish
+            .record(started, publication.is_err());
+        let publication = publication?;
         self.update_construction_progress(&construction.progress())?;
         self.manifest.phase = ImportPhase::Committed;
         self.checkpoint()?;
@@ -838,10 +902,19 @@ impl GraphImportSession {
         graph: &'a GraphForge,
     ) -> Result<crate::GraphConstructionSession<'a>, GfError> {
         let budgets = self.construction_budgets();
+        let started = Instant::now();
         if let Some(session_uuid) = self.manifest.construction_session_uuid {
-            return graph.resume_graph_construction(session_uuid, budgets);
+            let resumed = graph.resume_graph_construction(session_uuid, budgets);
+            self.operation_timings
+                .resume
+                .record(started, resumed.is_err());
+            return resumed;
         }
-        let session = graph.begin_graph_construction(budgets)?;
+        let session = graph.begin_graph_construction(budgets);
+        self.operation_timings
+            .begin
+            .record(started, session.is_err());
+        let session = session?;
         self.manifest.construction_session_uuid = Some(session.session_uuid());
         self.persist_manifest()?;
         Ok(session)
@@ -1358,6 +1431,117 @@ mod tests {
             .container_root()
             .join(".graphforge-construction")
             .join(session_uuid.simple().to_string())
+    }
+
+    #[test]
+    fn operation_timings_are_scoped_non_durable_and_preserve_cancelled_commit() {
+        let (_directory, _project, graph) = fixture();
+        let mut session = graph
+            .begin_import_session(
+                OperationId(Uuid::now_v7()),
+                ImportSessionLimits {
+                    batch_rows: 1,
+                    ..ImportSessionLimits::default()
+                },
+            )
+            .unwrap();
+        let ids = [Uuid::now_v7(), Uuid::now_v7()];
+        session
+            .append_arrow(BulkInputKind::Node, &[nodes(&ids[..1]), nodes(&ids[1..])])
+            .unwrap();
+        session
+            .append_arrow(
+                BulkInputKind::Edge,
+                &[edges(Uuid::now_v7(), ids[0], ids[1])],
+            )
+            .unwrap();
+        let prior = *graph.current_generation_uuid.lock().unwrap();
+        session.validate(&graph).unwrap();
+        let timing = session.operation_timings();
+        assert_eq!(
+            (
+                timing.begin.calls,
+                timing.resume.calls,
+                timing.append.calls,
+                timing.seal.calls,
+                timing.publish.calls
+            ),
+            (1, 0, 3, 1, 0)
+        );
+        for call in [timing.begin, timing.append, timing.seal] {
+            assert_eq!(call.errors, 0);
+        }
+        session.validate(&graph).unwrap();
+        let timing = session.operation_timings();
+        assert_eq!(
+            (
+                timing.begin.calls,
+                timing.resume.calls,
+                timing.append.calls,
+                timing.seal.calls
+            ),
+            (0, 1, 0, 1)
+        );
+        let manifest_path = session.root.join(MANIFEST);
+        let persisted = fs::read(&manifest_path).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&persisted).unwrap();
+        assert!(!value.to_string().contains("elapsed_ns"));
+        assert!(!value.to_string().contains("operation_timings"));
+        let session_uuid = session.session_uuid();
+        drop(session);
+        let mut session = graph.resume_import_session(session_uuid).unwrap();
+        assert_eq!(
+            session.operation_timings(),
+            ImportOperationTimings::default()
+        );
+        assert_eq!(fs::read(&manifest_path).unwrap(), persisted);
+        let cancelled = CancellationToken::new();
+        cancelled.cancel();
+        let error = session.commit(&graph, Some(&cancelled)).unwrap_err();
+        assert_eq!(error.code(), "GF_CANCELLED");
+        let timing = session.operation_timings();
+        assert_eq!(
+            (
+                timing.resume.calls,
+                timing.publish.calls,
+                timing.publish.errors
+            ),
+            (1, 1, 1)
+        );
+        assert_eq!(*graph.current_generation_uuid.lock().unwrap(), prior);
+        assert_eq!(session.status().0, ImportPhase::Validated);
+        assert_eq!(fs::read(&manifest_path).unwrap(), persisted);
+        session.commit(&graph, None).unwrap();
+        let timing = session.operation_timings();
+        assert_eq!(
+            (
+                timing.begin.calls,
+                timing.resume.calls,
+                timing.append.calls,
+                timing.seal.calls,
+                timing.publish.calls,
+                timing.publish.errors
+            ),
+            (0, 1, 0, 0, 1, 0)
+        );
+        assert_eq!(graph.node_count("Person").unwrap(), 2);
+        let result = graph
+            .execute("MATCH ()-[r:KNOWS]->() RETURN count(r) AS n")
+            .unwrap();
+        assert_eq!(
+            result.batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::Int64Array>()
+                .unwrap()
+                .value(0),
+            1
+        );
+        assert!(session.commit(&graph, None).is_err());
+        assert_eq!(
+            session.operation_timings(),
+            ImportOperationTimings::default()
+        );
     }
 
     #[test]

--- a/crates/graphforge-api/src/import_session.rs
+++ b/crates/graphforge-api/src/import_session.rs
@@ -501,7 +501,7 @@ impl GraphImportSession {
     /// Timings from the latest validation or commit on this handle, including
     /// calls that returned errors. Reading these observations performs no I/O.
     #[must_use]
-    pub const fn operation_timings(&self) -> ImportOperationTimings {
+    pub fn operation_timings(&self) -> ImportOperationTimings {
         self.operation_timings
     }
     fn publish_source(&self, temporary: &Path, destination: &Path) -> Result<(), GfError> {
@@ -797,6 +797,14 @@ impl GraphImportSession {
                 self.persist_manifest()?;
             }
         }
+        self.seal_construction(&mut construction, cancellation)
+    }
+
+    fn seal_construction(
+        &mut self,
+        construction: &mut crate::GraphConstructionSession<'_>,
+        cancellation: Option<&CancellationToken>,
+    ) -> Result<ImportProgress, GfError> {
         let started = Instant::now();
         let sealed = construction.validate_and_seal(cancellation);
         self.operation_timings.seal.record(started, sealed.is_err());

--- a/crates/graphforge-api/src/lib.rs
+++ b/crates/graphforge-api/src/lib.rs
@@ -230,8 +230,8 @@ pub use graphforge_core::{
     SpatialCoordinates, SpatialCrs, SpatialGeometryType, SpatialType, SpatialValue, TemporalValue,
 };
 pub use import_session::{
-    GraphImportSession, ImportConstructionEvidence, ImportPhase, ImportProgress,
-    ImportSessionLimits, ImportSourceKind, PublicationWorkComponents,
+    GraphImportSession, ImportCallTiming, ImportConstructionEvidence, ImportOperationTimings,
+    ImportPhase, ImportProgress, ImportSessionLimits, ImportSourceKind, PublicationWorkComponents,
 };
 pub use query_evidence::{
     QueryExecutionEvidence, QueryHopEvidence, QueryOperatorRssEvidence, QuerySinkEvidenceReceipt,

--- a/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
+++ b/crates/graphforge-bindings-node/tests/non-cypher-parity-policy.json
@@ -1,8 +1,8 @@
 {
   "contractVersion": 1,
   "rustManifest": "../../../tests/contracts/non-cypher-rust-surface.json",
-  "releaseSurfaceCount": 267,
-  "releaseSurfaceDigest": "9c5cda8accc92758d15741874439ad5d194e4e64483a275f36c2ef7c5aedfe49",
+  "releaseSurfaceCount": 268,
+  "releaseSurfaceDigest": "b1356b7e0931bf1e71d8dc8f893e45303b3700f5153c649f68827f0a430a419c",
   "requiredEquivalent": [
     "GraphForge.adopt_ontology",
     "GraphForge.clear_ontology",
@@ -313,7 +313,8 @@
       "GraphConstructionSession": "Resumable graph construction is not yet shipped through the Node product facade; all session operations remain explicitly Rust-only.",
       "GraphForge": "No shipped Node member exists for this Rust facade entry; adding one requires an explicit parity decision.",
       "OpenRouterProviderSession": "Rust provider sessions are not exported; Node owns a configured native provider adapter instead.",
-      "RepositoryContext": "Rust owns repository lifecycle behavior; the Node command wrapper parity is delivered by issue #226."
+      "RepositoryContext": "Rust owns repository lifecycle behavior; the Node command wrapper parity is delivered by issue #226.",
+      "GraphImportSession": "Per-operation timing observations are Rust/CLI diagnostics; the Node import adapter keeps its explicitly mapped lifecycle methods."
     }
   },
   "evidence": {

--- a/crates/graphforge-bindings-py/tests/non_cypher_release.py
+++ b/crates/graphforge-bindings-py/tests/non_cypher_release.py
@@ -23,8 +23,8 @@ ROOT = Path(__file__).resolve().parents[3]
 RUST_MANIFEST = ROOT / "tests/contracts/non-cypher-rust-surface.json"
 RUST_GATE = ROOT / "scripts/ci/non-cypher-surface-gate.py"
 PYO3_SOURCE = ROOT / "crates/graphforge-bindings-py/src/lib.rs"
-EXPECTED_RUST_DIGEST = "3199148900ac01b875528b26e6d900423998dcaaa5cc40014c200e55400afc13"
-EXPECTED_RELEASE_DIGEST = "9c5cda8accc92758d15741874439ad5d194e4e64483a275f36c2ef7c5aedfe49"
+EXPECTED_RUST_DIGEST = "3862aaa8a3f03efbf83a3360a97352a576611b94761af5d2a87891007fd41be6"
+EXPECTED_RELEASE_DIGEST = "b1356b7e0931bf1e71d8dc8f893e45303b3700f5153c649f68827f0a430a419c"
 
 PYTHON_ONLY_METHODS = frozenset(
     {
@@ -257,7 +257,7 @@ def _classification_report() -> dict[str, object]:
         for group in manifest["method_evidence_groups"].values()
         for method_id in group["ids"]
     }
-    assert len(release_methods) == 267
+    assert len(release_methods) == 268
     assert _digest(release_methods) == EXPECTED_RELEASE_DIGEST
     assert set(EVIDENCE) == set(manifest["method_evidence_groups"])
 
@@ -316,6 +316,9 @@ def _classification_report() -> dict[str, object]:
         if python_id in python_methods:
             classification = "equivalent"
             reason = "same receiver operation delegates through the compiled PyO3 extension"
+        elif rust_id == "GraphImportSession.operation_timings":
+            classification = "not-exposed"
+            reason = "per-operation timing observations are Rust/CLI diagnostics"
         elif rust_id.startswith("OpenRouterProviderSession."):
             classification = "intentionally-language-specific"
             reason = (

--- a/crates/graphforge-cli/src/portable_cli.rs
+++ b/crates/graphforge-cli/src/portable_cli.rs
@@ -662,27 +662,7 @@ pub(crate) fn run_import_session(
         ImportSessionCommand::Commit(args) => {
             let mut session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
             let generation = session.commit(graph, None)?;
-            let (_, progress) = session.status();
-            if json {
-                write_json(
-                    &serde_json::json!({
-                        "contract": "graphforge-import-session/1",
-                        "outcome": "committed",
-                        "session_uuid": session.session_uuid(),
-                        "generation_uuid": generation,
-                        "construction": progress.construction,
-                        "operation_timings": session.operation_timings(),
-                    }),
-                    output,
-                )
-            } else {
-                writeln!(
-                    output,
-                    "committed session {} generation {generation}",
-                    session.session_uuid()
-                )
-                .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))
-            }
+            write_import_commit(&session, generation, json, output)
         }
         ImportSessionCommand::Abort(args) => {
             let session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
@@ -706,6 +686,35 @@ pub(crate) fn run_import_session(
                     .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))
             }
         }
+    }
+}
+
+fn write_import_commit(
+    session: &graphforge_api::GraphImportSession,
+    generation: Uuid,
+    json: bool,
+    output: &mut dyn Write,
+) -> Result<(), graphforge_api::GfError> {
+    let (_, progress) = session.status();
+    if json {
+        write_json(
+            &serde_json::json!({
+                "contract": "graphforge-import-session/1",
+                "outcome": "committed",
+                "session_uuid": session.session_uuid(),
+                "generation_uuid": generation,
+                "construction": progress.construction,
+                "operation_timings": session.operation_timings(),
+            }),
+            output,
+        )
+    } else {
+        writeln!(
+            output,
+            "committed session {} generation {generation}",
+            session.session_uuid()
+        )
+        .map_err(|error| graphforge_api::GfError::Execution(error.to_string()))
     }
 }
 

--- a/crates/graphforge-cli/src/portable_cli.rs
+++ b/crates/graphforge-cli/src/portable_cli.rs
@@ -621,6 +621,7 @@ pub(crate) fn run_import_session(
                 session_uuid,
                 &format!("{phase:?}").to_ascii_lowercase(),
                 &progress,
+                None,
                 json,
                 output,
             )
@@ -641,6 +642,7 @@ pub(crate) fn run_import_session(
                 session.session_uuid(),
                 "checkpointed",
                 &progress,
+                None,
                 json,
                 output,
             )
@@ -648,7 +650,14 @@ pub(crate) fn run_import_session(
         ImportSessionCommand::Validate(args) => {
             let mut session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
             let progress = session.validate(graph)?;
-            write_progress(session.session_uuid(), "validated", &progress, json, output)
+            write_progress(
+                session.session_uuid(),
+                "validated",
+                &progress,
+                Some(session.operation_timings()),
+                json,
+                output,
+            )
         }
         ImportSessionCommand::Commit(args) => {
             let mut session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
@@ -662,6 +671,7 @@ pub(crate) fn run_import_session(
                         "session_uuid": session.session_uuid(),
                         "generation_uuid": generation,
                         "construction": progress.construction,
+                        "operation_timings": session.operation_timings(),
                     }),
                     output,
                 )
@@ -678,7 +688,7 @@ pub(crate) fn run_import_session(
             let session = graph.resume_import_session(canonical_uuid(&args.session_uuid)?)?;
             let session_uuid = session.session_uuid();
             let progress = session.abort(graph)?;
-            write_progress(session_uuid, "aborted", &progress, json, output)
+            write_progress(session_uuid, "aborted", &progress, None, json, output)
         }
         ImportSessionCommand::Cleanup(args) => {
             let removed =
@@ -724,22 +734,24 @@ fn write_progress(
     session_uuid: Uuid,
     outcome: &str,
     progress: &graphforge_api::ImportProgress,
+    timings: Option<graphforge_api::ImportOperationTimings>,
     json: bool,
     output: &mut dyn Write,
 ) -> Result<(), graphforge_api::GfError> {
     if json {
-        write_json(
-            &serde_json::json!({
-                "contract": "graphforge-import-session/1",
-                "outcome": outcome,
-                "session_uuid": session_uuid,
-                "rows_accepted": progress.rows_accepted,
-                "rows_rejected": progress.rows_rejected,
-                "bytes_accepted": progress.bytes_accepted,
-                "construction": progress.construction,
-            }),
-            output,
-        )
+        let mut receipt = serde_json::json!({
+            "contract": "graphforge-import-session/1",
+            "outcome": outcome,
+            "session_uuid": session_uuid,
+            "rows_accepted": progress.rows_accepted,
+            "rows_rejected": progress.rows_rejected,
+            "bytes_accepted": progress.bytes_accepted,
+            "construction": progress.construction,
+        });
+        if let Some(timings) = timings {
+            receipt["operation_timings"] = serde_json::json!(timings);
+        }
+        write_json(&receipt, output)
     } else {
         writeln!(
             output,

--- a/crates/graphforge-cli/tests/portable.rs
+++ b/crates/graphforge-cli/tests/portable.rs
@@ -496,3 +496,113 @@ fn shared_verification_golden_matches_real_facade_and_cli() {
         assert_eq!(json(&cli), expected[key]);
     }
 }
+
+#[test]
+fn import_operation_timings_survive_separate_cli_processes() {
+    use arrow::array::{FixedSizeBinaryArray, StringArray};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use std::sync::Arc;
+    let root = TempDir::new().unwrap();
+    let project = root.path().join("project");
+    fs::create_dir(&project).unwrap();
+    let input = root.path().join("nodes.parquet");
+    let ids = [uuid::Uuid::now_v7(), uuid::Uuid::now_v7()];
+    let batch = RecordBatch::try_new(
+        graphforge_api::bulk_node_input_schema(Vec::new()).unwrap(),
+        vec![
+            Arc::new(
+                FixedSizeBinaryArray::try_from_iter(ids.iter().map(|id| id.as_bytes().as_slice()))
+                    .unwrap(),
+            ),
+            Arc::new(StringArray::from(vec!["Person", "Person"])),
+        ],
+    )
+    .unwrap();
+    let mut writer =
+        ArrowWriter::try_new(fs::File::create(&input).unwrap(), batch.schema(), None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+    let operation = uuid::Uuid::now_v7().to_string();
+    let begun = json(&gf(
+        &project,
+        &[
+            "--json",
+            "import-session",
+            "begin",
+            "--operation-uuid",
+            &operation,
+        ],
+    ));
+    let session = begun["session_uuid"].as_str().unwrap();
+    json(&gf(
+        &project,
+        &[
+            "--json",
+            "import-session",
+            "register-parquet",
+            "--session-uuid",
+            session,
+            "--kind",
+            "nodes",
+            "--path",
+            input.to_str().unwrap(),
+        ],
+    ));
+    let validated = json(&gf(
+        &project,
+        &[
+            "--json",
+            "import-session",
+            "validate",
+            "--session-uuid",
+            session,
+        ],
+    ));
+    let timing = &validated["operation_timings"];
+    assert_eq!(timing["begin"]["calls"], 1);
+    assert_eq!(timing["resume"]["calls"], 0);
+    assert_eq!(timing["append"]["calls"], 1);
+    assert_eq!(timing["seal"]["calls"], 1);
+    assert_eq!(timing["publish"]["calls"], 0);
+    for phase in ["begin", "append", "seal"] {
+        assert!(timing[phase]["elapsed_ns"].as_u64().is_some());
+        assert_eq!(timing[phase]["errors"], 0);
+    }
+    let committed = json(&gf(
+        &project,
+        &[
+            "--json",
+            "import-session",
+            "commit",
+            "--session-uuid",
+            session,
+        ],
+    ));
+    let timing = &committed["operation_timings"];
+    assert_eq!(timing["begin"]["calls"], 0);
+    assert_eq!(timing["resume"]["calls"], 1);
+    assert_eq!(timing["append"]["calls"], 0);
+    assert_eq!(timing["seal"]["calls"], 0);
+    assert_eq!(timing["publish"]["calls"], 1);
+    assert!(timing["resume"]["elapsed_ns"].as_u64().is_some());
+    assert!(timing["publish"]["elapsed_ns"].as_u64().is_some());
+    assert_eq!(committed["construction"]["input_rows"], 2);
+    assert_eq!(committed["construction"]["publication_committed"], true);
+    let status = json(&gf(
+        &project,
+        &[
+            "--json",
+            "import-session",
+            "status",
+            "--session-uuid",
+            session,
+        ],
+    ));
+    assert!(
+        status.get("operation_timings").is_none(),
+        "durable status must not replay timings"
+    );
+    let graph = graphforge_api::GraphForge::new(project.to_str()).unwrap();
+    assert_eq!(graph.node_count("Person").unwrap(), 2);
+}

--- a/docs/guide/graph-construction.md
+++ b/docs/guide/graph-construction.md
@@ -257,3 +257,36 @@ If reader preparation fails after durable publication, the error still reports
 `committed=true` and recovery by reopen or resume. The facade retains its prior
 workspace until all replacement readers are ready; exact retry adopts the
 already committed generation.
+
+### Import operation timing receipts
+
+`import-session validate` and `import-session commit` JSON receipts include
+`operation_timings`. Each of the five closed rows (`begin`, `resume`, `append`,
+`seal`, `publish`) contains `calls`, `errors`, and `elapsed_ns`. These are
+monotonic wall-time observations around disjoint public construction calls.
+`GraphImportSession::operation_timings()` exposes the same observations after
+the latest validation or commit, including returned errors. Each invocation
+resets them before checking preconditions; a repeated operation cannot replay
+previously reported time.
+
+`begin` measures fresh construction creation; `resume` measures reopening and
+reconciling construction authority. `append` covers construction append calls,
+`seal` covers validation/sealing, and `publish` covers seal-and-publication.
+Internal authentication performed within those calls belongs to that call's
+wall time: the timing rows do not have the same boundaries as the durable
+`application_io` attribution rows. In particular, `resume` is not the total time
+of every recovery-authentication read elsewhere in sealing or publication.
+
+Source decoding, normalization, facade opening and import-manifest checkpoints
+outside those calls are excluded. The sum therefore does not equal whole-ingest
+time. These values are observations, not performance limits or CPU measurements.
+The certifier preserves only the closed numeric timing object; it rejects
+unknown fields and invalid counters.
+
+Timings are held only by the live handle and never written into import or
+construction manifests. Durable `status` does not return old operation timings.
+Successful CLI validate/commit receipts can be summed for an invocation sequence.
+A failed CLI command does not emit a progress receipt, and a lost process cannot
+report its missing time; neither duration is reconstructed from persisted state.
+Existing durable I/O, allocation, accepted-row and recovery evidence remains
+independent of these timing observations.

--- a/docs/guide/graph-construction.md
+++ b/docs/guide/graph-construction.md
@@ -264,6 +264,7 @@ already committed generation.
 `operation_timings`. Each of the five closed rows (`begin`, `resume`, `append`,
 `seal`, `publish`) contains `calls`, `errors`, and `elapsed_ns`. These are
 monotonic wall-time observations around disjoint public construction calls.
+These diagnostics are exposed through Rust and the CLI.
 `GraphImportSession::operation_timings()` exposes the same observations after
 the latest validation or commit, including returned errors. Each invocation
 resets them before checking preconditions; a repeated operation cannot replay

--- a/scripts/ci/test-non-cypher-surface-gate.py
+++ b/scripts/ci/test-non-cypher-surface-gate.py
@@ -29,7 +29,7 @@ class SurfaceGateTests(unittest.TestCase):
 
     def test_checked_in_inventory_is_complete(self) -> None:
         self.assertEqual(GATE.validate(), [])
-        self.assertEqual(len(GATE.public_methods()), 385)
+        self.assertEqual(len(GATE.public_methods()), 386)
         self.assertEqual(len(GATE.algorithm_registry()), 94)
 
     def test_new_or_removed_public_method_fails_frozen_digest(self) -> None:

--- a/tests/contracts/non-cypher-rust-surface.json
+++ b/tests/contracts/non-cypher-rust-surface.json
@@ -1,7 +1,7 @@
 {
   "contract_version": 1,
   "scope": "Rust non-Cypher public release surface",
-  "public_method_digest": "3199148900ac01b875528b26e6d900423998dcaaa5cc40014c200e55400afc13",
+  "public_method_digest": "3862aaa8a3f03efbf83a3360a97352a576611b94761af5d2a87891007fd41be6",
   "method_policy": {
     "receiver_defaults": {
       "PortableV2ImportResult": "release-tested",
@@ -25,9 +25,9 @@
       "CancellationToken": "introspection",
       "FindExecutionResult": "introspection",
       "InvocationDescriptor": "introspection",
-    "InvocationError": "introspection",
-    "MultiOntologyError": "introspection",
-    "PageToken": "introspection",
+      "InvocationError": "introspection",
+      "MultiOntologyError": "introspection",
+      "PageToken": "introspection",
       "ProviderRerankedFindResult": "introspection",
       "ResolvedBeliefProjection": "introspection",
       "SearchIndexOptions": "introspection",
@@ -912,6 +912,7 @@
         "GraphImportSession.append_arrow",
         "GraphImportSession.checkpoint",
         "GraphImportSession.commit",
+        "GraphImportSession.operation_timings",
         "GraphImportSession.register_parquet",
         "GraphImportSession.status",
         "GraphImportSession.validate",
@@ -937,6 +938,10 @@
         {
           "path": "crates/graphforge-api/src/import_session.rs",
           "symbol": "interrupted_batch_replays_and_stale_cleanup_removes_private_artifacts"
+        },
+        {
+          "path": "crates/graphforge-api/src/import_session.rs",
+          "symbol": "operation_timings_are_scoped_non_durable_and_preserve_cancelled_commit"
         }
       ]
     },


### PR DESCRIPTION
The ordinary host construction receipts recorded whole-ingest wall time but omitted the append, seal and resumed-construction durations required by #901. Import validation and commit now expose per-invocation wall-time observations for construction begin, resume, append, seal and publication, with attempted-call and error counts.

Timing state resets before each operation, records returned errors and stays out of durable manifests. Successful CLI receipts expose the closed numeric object; the existing certifier preserves it and rejects malformed counters or extra fields. Documentation distinguishes these scopes from durable phase I/O, CPU and whole-ingest time, including work that failed commands or lost processes cannot report.

Direct regressions cover repeated validation, persisted manifests, cancelled publication and successful retry with an immediate same-facade relationship query, plus separate-process CLI validate/commit/status receipts. The existing tiny/growth lifecycle also asserts that actual CLI receipts retain the expected timings through the certifier. The new accessor is included in the public method inventory with its direct regression and explicitly classified as a Rust/CLI diagnostic in Python and Node parity inventories.

Validation:
- Full API library: 739 passed; 118 BDD scenarios and preceding integration/CLI suites passed.
- Direct timing/cancellation regression and separate-process CLI receipt regression: passed.
- Certifier tests: 28 passed; schema smoke: 8 passed; public surface policy: 12 passed; binding parity policy: passed; gate registry: 14 passed.
- Workspace and certifier Clippy, formatting, fast checks and changed Python Ruff checks: passed.
- Existing tiny lifecycle using frozen CLI/certifier/generator: all 10 phases passed, expected timing call counts preserved, executable hashes unchanged.
- Full `make pre-push` stopped only at existing #1192: the hardcoded-`/tmp` socket fixture receives `GF_UNSUPPORTED_FILESYSTEM` (storage 1,097 passed, 1 failed, 2 existing ignored). Later local stages were not reached; no full local gate pass is claimed.

Closes #1256.
