### PR TITLE
docs: complete construction gate with integrated S20/S22 evidence

### DIFF
--- a/docs/book/architecture/storage.md
+++ b/docs/book/architecture/storage.md
@@ -1134,7 +1134,9 @@ superseded fixture attempts. No incomparable baseline improvement is claimed.
 
 This ledger maps ordinary implementation criteria to their existing tests. It
 adds no release-certification requirement and does not claim final capacity
-completion; integrated S20/S22 evidence remains under #1194.
+completion. The [integrated #1194 report](../../development/integrated-storage-1194.md)
+reconciles the merged repairs, admitted S20/S22 measurements, physical owners,
+resource tradeoffs and the separate final-capacity outcome.
 
 ### Bounded manifest allocation evidence (#1204)
 

--- a/docs/development/evidence/integrated-storage-1194.json
+++ b/docs/development/evidence/integrated-storage-1194.json
@@ -1,0 +1,1375 @@
+{
+  "contract": "graphforge-integrated-storage-1194/1",
+  "source": "24ca688c516a86a68de9cffaab2d5a9215291256",
+  "tree": "54976786eedee511b0f6b5b0023281d3c9b3cb5b",
+  "frozen_at_utc": "2026-09-11T12:48:23.903798+00:00",
+  "executables": {
+    "gf": {
+      "sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+      "bytes": 184276760
+    },
+    "graphforge-benchmark-certify": {
+      "sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+      "bytes": 11845616
+    },
+    "graphforge-benchmark-graph500-generator": {
+      "sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+      "bytes": 9675776
+    }
+  },
+  "toolchain": "rustc 1.96.0 (ac68faa20 2026-05-25)",
+  "lockfiles": {
+    "Cargo.lock": "d80355162144c38a02b5df9787cc1d81e7a0299dc385bde1f342d0bdb06e4ba1",
+    "benchmarks/Cargo.lock": "1c1e58085c53aef2d50affdabcdcbc7fac7b6b77bc4d90b07af0065acbf39bb6",
+    "benchmarks/uv.lock": "f18d1f7ed87d466917bb7a94ce79f9c74ac3090ee5ca5cdc22de44ae6edea527"
+  },
+  "maximum_scale": 22,
+  "reserved_headroom_bytes": 141258578535,
+  "filesystem_total_bytes": 941723856896,
+  "available_bytes_at_freeze": 633410076672,
+  "observations": [
+    {
+      "scale": 18,
+      "live_nodes": 262144,
+      "live_edges": 4194304,
+      "metrics": {
+        "logical_read_bytes": 11360063649,
+        "logical_write_bytes": 5117151595,
+        "peak_rss_bytes": 182611968,
+        "physical_read_bytes": 54517145600,
+        "physical_write_bytes": 18559918080,
+        "publication_work_units": 63163,
+        "reader_calls": 122479,
+        "retained_storage_bytes": 1065082880,
+        "transient_peak_storage_bytes": 2974519296,
+        "wall_seconds": 97
+      },
+      "benchexec_authority": {
+        "cpu_seconds": 80.257677,
+        "peak_rss_bytes": 819265536,
+        "pressure_cpu_seconds": 0.105651,
+        "pressure_io_seconds": 8.071899,
+        "pressure_memory_seconds": 0.0,
+        "read_bytes": 54517145600,
+        "wall_seconds": 96.24521505401935,
+        "write_bytes": 18559918080
+      },
+      "phase_wall_milliseconds": {
+        "admission": 10,
+        "generate": 1633,
+        "ingest": 56944,
+        "reopen": 3479,
+        "recount": 2159,
+        "query": 9961,
+        "export": 2092,
+        "verify": 242,
+        "clean_import": 2654,
+        "reopen_proof": 14452
+      },
+      "operation_timings": [
+        {
+          "outcome": "validated",
+          "operation_timings": {
+            "append": {
+              "calls": 68,
+              "elapsed_ns": 4226577176,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 1,
+              "elapsed_ns": 940518,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 1,
+              "elapsed_ns": 44331662036,
+              "errors": 0
+            }
+          }
+        },
+        {
+          "outcome": "committed",
+          "operation_timings": {
+            "append": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 1,
+              "elapsed_ns": 2492120075,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 1,
+              "elapsed_ns": 256419162,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            }
+          }
+        }
+      ],
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 205594624,
+            "logical_bytes": 205584915,
+            "logical_references": 2,
+            "physical_logical_bytes": 205584915,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 163364864,
+            "logical_bytes": 162629401,
+            "logical_references": 273,
+            "physical_logical_bytes": 162629401,
+            "physical_objects": 273
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 162566144,
+            "logical_bytes": 162560000,
+            "logical_references": 1,
+            "physical_logical_bytes": 162560000,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 164478976,
+            "logical_bytes": 162870632,
+            "logical_references": 503,
+            "physical_logical_bytes": 162870632,
+            "physical_objects": 503
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 205602816,
+            "logical_bytes": 205589045,
+            "logical_references": 3,
+            "physical_logical_bytes": 205589045,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 163368960,
+            "logical_bytes": 162629401,
+            "logical_references": 273,
+            "physical_logical_bytes": 162629401,
+            "physical_objects": 273
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "source_project_current_allocated_bytes": 163368960,
+      "artifact_sha256": {
+        "benchexec_sha256": "7b88b93271a1e2013ec0279f282d3d42be5eb8b0e53367b2e1734fa40e1e18d6",
+        "graphforge_sha256": "e86d63effe5da0659cf36077241efa1f081a6d367ff1034b84a204aec9ead65d",
+        "plan_sha256": "c7dfd2b1c3183eace121eda9cc5556dbdcb2e33366543d7b8683e99d428e0de2",
+        "rung_sha256": "52da4ffdd53137b0aa282a47da5abbdecfa6c1d4115d6f09eb6cfe674fdefd82"
+      }
+    },
+    {
+      "scale": 19,
+      "live_nodes": 524288,
+      "live_edges": 8388608,
+      "metrics": {
+        "logical_read_bytes": 22770347285,
+        "logical_write_bytes": 10248668711,
+        "peak_rss_bytes": 188862464,
+        "physical_read_bytes": 110290894848,
+        "physical_write_bytes": 37230034944,
+        "publication_work_units": 126894,
+        "reader_calls": 245352,
+        "retained_storage_bytes": 2159190016,
+        "transient_peak_storage_bytes": 5948940288,
+        "wall_seconds": 192
+      },
+      "benchexec_authority": {
+        "cpu_seconds": 161.155301,
+        "peak_rss_bytes": 1577000960,
+        "pressure_cpu_seconds": 0.253316,
+        "pressure_io_seconds": 18.085786,
+        "pressure_memory_seconds": 0.0,
+        "read_bytes": 110290894848,
+        "wall_seconds": 191.47780643799342,
+        "write_bytes": 37230034944
+      },
+      "phase_wall_milliseconds": {
+        "admission": 10,
+        "generate": 3277,
+        "ingest": 112917,
+        "reopen": 6626,
+        "recount": 4046,
+        "query": 19626,
+        "export": 4291,
+        "verify": 483,
+        "clean_import": 5605,
+        "reopen_proof": 29295
+      },
+      "operation_timings": [
+        {
+          "outcome": "validated",
+          "operation_timings": {
+            "append": {
+              "calls": 136,
+              "elapsed_ns": 8291116143,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 1,
+              "elapsed_ns": 974568,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 1,
+              "elapsed_ns": 87657475192,
+              "errors": 0
+            }
+          }
+        },
+        {
+          "outcome": "committed",
+          "operation_timings": {
+            "append": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 1,
+              "elapsed_ns": 4929676569,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 1,
+              "elapsed_ns": 483101323,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            }
+          }
+        }
+      ],
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 411181056,
+            "logical_bytes": 411169177,
+            "logical_references": 2,
+            "physical_logical_bytes": 411169177,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 334139392,
+            "logical_bytes": 332462979,
+            "logical_references": 559,
+            "physical_logical_bytes": 332462979,
+            "physical_objects": 559
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 332263424,
+            "logical_bytes": 332256768,
+            "logical_references": 1,
+            "physical_logical_bytes": 332256768,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 336171008,
+            "logical_bytes": 332870981,
+            "logical_references": 975,
+            "physical_logical_bytes": 332870981,
+            "physical_objects": 975
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 411189248,
+            "logical_bytes": 411173328,
+            "logical_references": 3,
+            "physical_logical_bytes": 411173328,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 334139392,
+            "logical_bytes": 332462979,
+            "logical_references": 559,
+            "physical_logical_bytes": 332462979,
+            "physical_objects": 559
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "source_project_current_allocated_bytes": 334139392,
+      "artifact_sha256": {
+        "benchexec_sha256": "441872543db32f7d65fb2b48a2518710df462a9e415584d72a407862c8f1d9f4",
+        "graphforge_sha256": "5df01d75f9312dff89e611837aa8739a2dc78f3e7fc4213d1ce75b8c75d80d46",
+        "plan_sha256": "cdf5307917c805182209f29ce3c22f9c08b00b833601205a53680d32291b9e2f",
+        "rung_sha256": "019f21dd1fcb92228a55b57e7612336b3f96eadd66c3d8590e47704f99ea924d"
+      }
+    },
+    {
+      "scale": 20,
+      "live_nodes": 1048576,
+      "live_edges": 16777216,
+      "metrics": {
+        "logical_read_bytes": 45635825144,
+        "logical_write_bytes": 20524507070,
+        "peak_rss_bytes": 200232960,
+        "physical_read_bytes": 222907678720,
+        "physical_write_bytes": 74677432320,
+        "publication_work_units": 255934,
+        "reader_calls": 491135,
+        "retained_storage_bytes": 4372516864,
+        "transient_peak_storage_bytes": 11897737216,
+        "wall_seconds": 385
+      },
+      "benchexec_authority": {
+        "cpu_seconds": 327.278453,
+        "peak_rss_bytes": 3118157824,
+        "pressure_cpu_seconds": 0.49856,
+        "pressure_io_seconds": 35.844997,
+        "pressure_memory_seconds": 0.0,
+        "read_bytes": 222907678720,
+        "wall_seconds": 384.6858612350188,
+        "write_bytes": 74677432320
+      },
+      "phase_wall_milliseconds": {
+        "admission": 10,
+        "generate": 6626,
+        "ingest": 228672,
+        "reopen": 12622,
+        "recount": 7970,
+        "query": 40136,
+        "export": 7901,
+        "verify": 973,
+        "clean_import": 10841,
+        "reopen_proof": 58618
+      },
+      "operation_timings": [
+        {
+          "outcome": "validated",
+          "operation_timings": {
+            "append": {
+              "calls": 272,
+              "elapsed_ns": 16737040531,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 1,
+              "elapsed_ns": 954668,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 1,
+              "elapsed_ns": 177088074484,
+              "errors": 0
+            }
+          }
+        },
+        {
+          "outcome": "committed",
+          "operation_timings": {
+            "append": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 1,
+              "elapsed_ns": 9436727862,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 1,
+              "elapsed_ns": 975586822,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            }
+          }
+        }
+      ],
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 822345728,
+            "logical_bytes": 822337680,
+            "logical_references": 2,
+            "physical_logical_bytes": 822337680,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 681910272,
+            "logical_bytes": 678499741,
+            "logical_references": 1127,
+            "physical_logical_bytes": 678499741,
+            "physical_objects": 1127
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 678088704,
+            "logical_bytes": 678083072,
+            "logical_references": 1,
+            "physical_logical_bytes": 678083072,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 685801472,
+            "logical_bytes": 679305946,
+            "logical_references": 1919,
+            "physical_logical_bytes": 679305946,
+            "physical_objects": 1919
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 822353920,
+            "logical_bytes": 822341855,
+            "logical_references": 3,
+            "physical_logical_bytes": 822341855,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 681910272,
+            "logical_bytes": 678499741,
+            "logical_references": 1127,
+            "physical_logical_bytes": 678499741,
+            "physical_objects": 1127
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "source_project_current_allocated_bytes": 681910272,
+      "artifact_sha256": {
+        "benchexec_sha256": "3e224e4e224f315e31414858ce02d09740ecfb17b831547bfd63a1eb84d60132",
+        "graphforge_sha256": "179160f338d7b4f9fb39a84e340bc678c73fb651956cf6b90f201ac4d5188d1c",
+        "plan_sha256": "69e334d2586557b1facdcb7c9e94b76fc3e2874d1d682b2df0656e3f17faa7a4",
+        "rung_sha256": "374699d6477e48b82d1fa22aa798b46f8c0b6ca5ab40abf7b9070e435179569e"
+      }
+    },
+    {
+      "scale": 22,
+      "live_nodes": 4194304,
+      "live_edges": 67108864,
+      "metrics": {
+        "logical_read_bytes": 193069289732,
+        "logical_write_bytes": 92215886265,
+        "peak_rss_bytes": 263090176,
+        "physical_read_bytes": 947578322944,
+        "physical_write_bytes": 414307926016,
+        "publication_work_units": 1039028,
+        "reader_calls": 2287487,
+        "retained_storage_bytes": 17813295104,
+        "transient_peak_storage_bytes": 47657119744,
+        "wall_seconds": 1776
+      },
+      "benchexec_authority": {
+        "cpu_seconds": 1551.681826,
+        "peak_rss_bytes": 12474519552,
+        "pressure_cpu_seconds": 2.245113,
+        "pressure_io_seconds": 151.176027,
+        "pressure_memory_seconds": 0.0,
+        "read_bytes": 947578322944,
+        "wall_seconds": 1775.591135450988,
+        "write_bytes": 414307926016
+      },
+      "phase_wall_milliseconds": {
+        "admission": 10,
+        "generate": 26392,
+        "ingest": 1139389,
+        "reopen": 51299,
+        "recount": 32395,
+        "query": 170095,
+        "export": 31842,
+        "verify": 4474,
+        "clean_import": 43675,
+        "reopen_proof": 237623
+      },
+      "operation_timings": [
+        {
+          "outcome": "validated",
+          "operation_timings": {
+            "append": {
+              "calls": 1088,
+              "elapsed_ns": 68519418772,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 1,
+              "elapsed_ns": 919977,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 1,
+              "elapsed_ns": 923237335509,
+              "errors": 0
+            }
+          }
+        },
+        {
+          "outcome": "committed",
+          "operation_timings": {
+            "append": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 1,
+              "elapsed_ns": 38586566084,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 1,
+              "elapsed_ns": 3811642482,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            }
+          }
+        }
+      ],
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 3289362432,
+            "logical_bytes": 3289349601,
+            "logical_references": 2,
+            "physical_logical_bytes": 3289349601,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 2808377344,
+            "logical_bytes": 2796153411,
+            "logical_references": 4443,
+            "physical_logical_bytes": 2796153411,
+            "physical_objects": 4443
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 2793910272,
+            "logical_bytes": 2793903104,
+            "logical_references": 1,
+            "physical_logical_bytes": 2793903104,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 2823782400,
+            "logical_bytes": 2798775908,
+            "logical_references": 7583,
+            "physical_logical_bytes": 2798775908,
+            "physical_objects": 7583
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 3289370624,
+            "logical_bytes": 3289353824,
+            "logical_references": 3,
+            "physical_logical_bytes": 3289353824,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 2808385536,
+            "logical_bytes": 2796153411,
+            "logical_references": 4443,
+            "physical_logical_bytes": 2796153411,
+            "physical_objects": 4443
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "source_project_current_allocated_bytes": 2808385536,
+      "artifact_sha256": {
+        "benchexec_sha256": "8469a85e7dfe21d1d6de78db20f31e34592a9c045410f1191f60e1d7a7102b7b",
+        "graphforge_sha256": "69a33b9d2d8fb90dd501e95d902cdbdff3f615bd9dceb7920a6f85cb275cf332",
+        "plan_sha256": "c7cf566bb13c2f9a4982f48623cb4e25d3f88bbe399f1c315f1c4a19666ded08",
+        "rung_sha256": "44aeb767186712b8baefdeb33f8beb7a2e62d917819878591b91087023c84076"
+      }
+    }
+  ],
+  "historical_baselines": [
+    {
+      "scale": 20,
+      "commit": "3868e3c751ba0c94928033378d2ddc2b5401cd55",
+      "metrics": {
+        "logical_read_bytes": 30749598402,
+        "logical_write_bytes": 22864246562,
+        "peak_rss_bytes": 202928128,
+        "physical_read_bytes": 366526144512,
+        "physical_write_bytes": 92225392640,
+        "publication_work_units": 425058,
+        "reader_calls": 499464,
+        "retained_storage_bytes": 18242637824,
+        "transient_peak_storage_bytes": 20090777600,
+        "wall_seconds": 441
+      },
+      "source_project_current_allocated_bytes": 1852637184,
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 822345728,
+            "logical_bytes": 822337680,
+            "logical_references": 2,
+            "physical_logical_bytes": 822337680,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 1852637184,
+            "logical_bytes": 1848371632,
+            "logical_references": 1377,
+            "physical_logical_bytes": 1848371632,
+            "physical_objects": 1377
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 1847996416,
+            "logical_bytes": 1847989760,
+            "logical_references": 1,
+            "physical_logical_bytes": 1847989760,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 11044560896,
+            "logical_bytes": 11037728267,
+            "logical_references": 2999,
+            "physical_logical_bytes": 11037728267,
+            "physical_objects": 2999
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 822353920,
+            "logical_bytes": 822341858,
+            "logical_references": 3,
+            "physical_logical_bytes": 822341858,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 1852637184,
+            "logical_bytes": 1848371632,
+            "logical_references": 1377,
+            "physical_logical_bytes": 1848371632,
+            "physical_objects": 1377
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "benchexec_authority": {
+        "cpu_seconds": 374.798612,
+        "peak_rss_bytes": 5641248768,
+        "pressure_cpu_seconds": 0.554389,
+        "pressure_io_seconds": 42.60387,
+        "pressure_memory_seconds": 0.0,
+        "read_bytes": 366526144512,
+        "wall_seconds": 440.87992319697514,
+        "write_bytes": 92225392640
+      },
+      "result_sha256": "2ea9059767240173148d2d1e601596246f2a51776dc80b4fe63bc7c232891a98",
+      "rung_sha256": "625e3ccd854c0116530148842cbf38b7a5e37201ab0d2f65a9d9efe9e634a627",
+      "profile_identities_unchanged": true
+    },
+    {
+      "scale": 22,
+      "commit": "3868e3c751ba0c94928033378d2ddc2b5401cd55",
+      "metrics": {
+        "logical_read_bytes": 133452797715,
+        "logical_write_bytes": 101744829105,
+        "peak_rss_bytes": 264278016,
+        "physical_read_bytes": 1547175919616,
+        "physical_write_bytes": 466245177344,
+        "publication_work_units": 1734104,
+        "reader_calls": 2322875,
+        "retained_storage_bytes": 73638645760,
+        "transient_peak_storage_bytes": 81197961216,
+        "wall_seconds": 1955
+      },
+      "source_project_current_allocated_bytes": 7578365952,
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 3289358336,
+            "logical_bytes": 3289349601,
+            "logical_references": 2,
+            "physical_logical_bytes": 3289349601,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 7578365952,
+            "logical_bytes": 7560661703,
+            "logical_references": 5746,
+            "physical_logical_bytes": 7560661703,
+            "physical_objects": 5746
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 7558496256,
+            "logical_bytes": 7558490624,
+            "logical_references": 1,
+            "physical_logical_bytes": 7558490624,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 44344586240,
+            "logical_bytes": 44317415409,
+            "logical_references": 11879,
+            "physical_logical_bytes": 44317415409,
+            "physical_objects": 11879
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 3289366528,
+            "logical_bytes": 3289353821,
+            "logical_references": 3,
+            "physical_logical_bytes": 3289353821,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 7578365952,
+            "logical_bytes": 7560661703,
+            "logical_references": 5746,
+            "physical_logical_bytes": 7560661703,
+            "physical_objects": 5746
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "benchexec_authority": {
+        "cpu_seconds": 1747.748051,
+        "peak_rss_bytes": 15500419072,
+        "pressure_cpu_seconds": 2.484156,
+        "pressure_io_seconds": 140.275402,
+        "pressure_memory_seconds": 0.702274,
+        "read_bytes": 1547175919616,
+        "wall_seconds": 1954.184934421035,
+        "write_bytes": 466245177344
+      },
+      "result_sha256": "d9fe70a9dbddbfeb2604399bed540eaeb0f9bc7ec0c66afe75aefa80a46d93a7",
+      "rung_sha256": "8a57c7bb93d9e92603334bad246d37642bd857501e2617d8523d694a6b205e51",
+      "profile_identities_unchanged": true
+    }
+  ],
+  "qualification": {
+    "decision": "refuse",
+    "headroom_bytes": 0,
+    "projected_canonical_edge_bytes": 20213858304,
+    "projected_canonical_node_bytes": 268435456,
+    "projected_lifecycle_peak_bytes": 762866827264,
+    "rate": {
+      "denominator_count": 50331648,
+      "numerator_bytes": 35759382528
+    },
+    "reserved_headroom_bytes": 141258578535,
+    "source_rungs": [
+      "S20",
+      "S22"
+    ],
+    "target": "S26",
+    "volume_bytes": 633354096640
+  },
+  "limitations": [
+    "Engineering evidence only; no S24/S26 execution or release certification.",
+    "Single host observations do not establish variance or isolate each repair contribution.",
+    "BenchExec peak_rss_bytes authority is cgroup memory including charged page cache, not process VmHWM.",
+    "Historical logical I/O instrumentation differs, including recovery attribution.",
+    "Named owner and component inventories overlap; do not sum them with the retained physical union.",
+    "Final owner inventories do not decompose an earlier temporal peak.",
+    "Timing rows measure disjoint public calls, exclude outside decode/checkpoint/open work, and are not CPU or whole-ingest time."
+  ]
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-benchexec.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-benchexec.json
@@ -1,0 +1,1252 @@
+{
+  "authority": {
+    "cpu_seconds": 374.798612,
+    "peak_rss_bytes": 5641248768,
+    "pressure_cpu_seconds": 0.554389,
+    "pressure_io_seconds": 42.60387,
+    "pressure_memory_seconds": 0.0,
+    "read_bytes": 366526144512,
+    "wall_seconds": 440.87992319697514,
+    "write_bytes": 92225392640
+  },
+  "disagreements": [],
+  "exit_code": 0,
+  "graphforge": {
+    "failed_phase": null,
+    "phases": [
+      {
+        "duration_ms": 10,
+        "exit_code": 0,
+        "peak_rss_bytes": 81920,
+        "phase": "admission",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 6536,
+        "exit_code": 0,
+        "peak_rss_bytes": 73179136,
+        "phase": "generate",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 218875,
+        "exit_code": 0,
+        "peak_rss_bytes": 149282816,
+        "phase": "ingest",
+        "receipts": [
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "begun"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "bytes_accepted": 822337680,
+            "construction": {
+              "accepted_chunks": 272,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 272,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 3629690464,
+                    "write_calls": 8528
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 637,
+                    "object_count": 0,
+                    "read_bytes": 7783958163,
+                    "read_calls": 165338,
+                    "write_bytes": 2669960942,
+                    "write_calls": 155756
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 10020,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 28731,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 19227027175,
+                    "read_calls": 275017,
+                    "write_bytes": 14674255191,
+                    "write_calls": 17698
+                  }
+                },
+                "totals": {
+                  "block_count": 28731,
+                  "fsync_calls": 10657,
+                  "object_count": 272,
+                  "read_bytes": 27010985338,
+                  "read_calls": 440355,
+                  "write_bytes": 20973906597,
+                  "write_calls": 181982
+                }
+              },
+              "cache_release_operations": 42228,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 59903496370,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 11037175808,
+                "logical_bytes": 11036068832,
+                "logical_references": 1368,
+                "physical_logical_bytes": 11036068832,
+                "physical_objects": 1368
+              },
+              "construction_staging_transient_peak_allocated_bytes": 11037175808,
+              "fsync_operations": 3488,
+              "immutable_artifacts": 1072,
+              "input_batches": 272,
+              "input_rows": 17825792,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": false,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 637,
+                  "object_count": 0,
+                  "read_bytes": 7783958163,
+                  "read_calls": 165338,
+                  "write_bytes": 2669960942,
+                  "write_calls": 155756
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 10020,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 331751
+              },
+              "transient_peak_allocated_bytes": 11037175808,
+              "write_bytes": 3629690464,
+              "write_operations": 8528
+            },
+            "contract": "graphforge-import-session/1",
+            "outcome": "validated",
+            "rows_accepted": 17825792,
+            "rows_rejected": 0
+          },
+          {
+            "construction": {
+              "accepted_chunks": 272,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 272,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 3629690464,
+                    "write_calls": 8528
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 4117,
+                    "object_count": 0,
+                    "read_bytes": 1848928295,
+                    "read_calls": 30121,
+                    "write_bytes": 1848368216,
+                    "write_calls": 29427
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 637,
+                    "object_count": 0,
+                    "read_bytes": 7783958163,
+                    "read_calls": 165338,
+                    "write_bytes": 2669960942,
+                    "write_calls": 155756
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 10020,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 12,
+                    "object_count": 0,
+                    "read_bytes": 1889603222,
+                    "read_calls": 28986,
+                    "write_bytes": 41971749,
+                    "write_calls": 642
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 81547,
+                    "read_calls": 2,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 28731,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 19227027175,
+                    "read_calls": 275017,
+                    "write_bytes": 14674255191,
+                    "write_calls": 17698
+                  }
+                },
+                "totals": {
+                  "block_count": 28731,
+                  "fsync_calls": 14786,
+                  "object_count": 272,
+                  "read_bytes": 30749598402,
+                  "read_calls": 499464,
+                  "write_bytes": 22864246562,
+                  "write_calls": 212051
+                }
+              },
+              "cache_release_operations": 42228,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 59903496370,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 11037175808,
+                "logical_bytes": 11036068832,
+                "logical_references": 1368,
+                "physical_logical_bytes": 11036068832,
+                "physical_objects": 1368
+              },
+              "construction_staging_transient_peak_allocated_bytes": 11037175808,
+              "fsync_operations": 3488,
+              "immutable_artifacts": 1072,
+              "input_batches": 272,
+              "input_rows": 17825792,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": true,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 4117,
+                  "object_count": 0,
+                  "read_bytes": 1848928295,
+                  "read_calls": 30121,
+                  "write_bytes": 1848368216,
+                  "write_calls": 29427
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 637,
+                  "object_count": 0,
+                  "read_bytes": 7783958163,
+                  "read_calls": 165338,
+                  "write_bytes": 2669960942,
+                  "write_calls": 155756
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 10020,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 12,
+                  "object_count": 0,
+                  "read_bytes": 1889603222,
+                  "read_calls": 28986,
+                  "write_bytes": 41971749,
+                  "write_calls": 642
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 81547,
+                  "read_calls": 2,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 425058
+              },
+              "transient_peak_allocated_bytes": 11037175808,
+              "write_bytes": 3629690464,
+              "write_operations": 8528
+            },
+            "contract": "graphforge-import-session/1",
+            "outcome": "committed"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 25028,
+        "exit_code": 0,
+        "peak_rss_bytes": 38367232,
+        "phase": "reopen",
+        "receipts": [
+          {
+            "aborted_journals": 0,
+            "deferred": null,
+            "elapsed_ms": 0,
+            "kind": "project_open",
+            "preserved_unknown_entries": 0,
+            "removed_generations": 0,
+            "repaired_journals": 0,
+            "selected_generation_class": "committed_current",
+            "work_detected": false
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 1849782272,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 1630208,
+                  "logical_bytes": 181916,
+                  "logical_references": 398,
+                  "physical_logical_bytes": 181916,
+                  "physical_objects": 398
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 1183129600,
+                  "logical_bytes": 1182672040,
+                  "logical_references": 256,
+                  "physical_logical_bytes": 1182672040,
+                  "physical_objects": 256
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 27328512,
+                  "logical_bytes": 27277120,
+                  "logical_references": 16,
+                  "physical_logical_bytes": 27277120,
+                  "physical_objects": 16
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 637693952,
+                  "logical_bytes": 637679918,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 637679918,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 1847810994,
+              "logical_references": 682,
+              "physical_objects": 679,
+              "retained_logical_eof_bytes": 1847810994
+            }
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 15357,
+        "exit_code": 0,
+        "peak_rss_bytes": 81981440,
+        "phase": "recount",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "d41814e11f492a8c36191b100c805a370de2b4bdbe6ca88c7eef41360ef53066",
+            "rows": 1,
+            "scalar_u64": 1048576
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 79294464,
+                  "before_bytes": 78639104,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 79294464
+                }
+              ],
+              "peak_rss_bytes": 79294464,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 79294464,
+              "sorts": []
+            },
+            "result_sha256": "3daeda0e54a362622ffdc547a631479e3f18cd0f7fa1b28c3b1fce9b7e88a150",
+            "rows": 1,
+            "scalar_u64": 16777216
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 38658,
+        "exit_code": 0,
+        "peak_rss_bytes": 202928128,
+        "phase": "query",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 78,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 71104,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 43,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 143634432,
+                  "before_bytes": 78254080,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 143634432
+                }
+              ],
+              "peak_rss_bytes": 143634432,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 143634432,
+              "sorts": []
+            },
+            "result_sha256": "da48cf8bd82d136635cba999906d07a783deabf66427e13128f645d756adb116",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 6,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 131072,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 2,
+                  "identity_reader_calls": 2,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 2,
+                  "projected_columns": 1,
+                  "projected_rows": 2,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 165707776,
+                  "before_bytes": 69480448,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 165707776
+                }
+              ],
+              "peak_rss_bytes": 165707776,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 165707776,
+              "sorts": []
+            },
+            "result_sha256": "404560fda0d6c2f6988aa4cee9c8d1d465c7254181b8c760e659e00b3f1bd255",
+            "rows": 1000,
+            "scalar_u64": null
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 17782,
+        "exit_code": 0,
+        "peak_rss_bytes": 39960576,
+        "phase": "export",
+        "receipts": [
+          {
+            "allocation_allocated_bytes": 1847996416,
+            "allocation_logical_bytes": 1847989760,
+            "allocation_physical_objects": 1,
+            "contract": "graphforge-portable-export/2",
+            "entry_count": 296,
+            "package_digest": "sha256:b98fee52ecb450d83e29a1644c83ffe1ad6c28a06d01621ed3b5e9984ba715e2",
+            "payload_bytes": 1847632999,
+            "representation": "bundle",
+            "selection_fingerprint": "sha256:188ac1809a7f1767fff36f14870d478b0025f9766a5765986b466b1520eabb91",
+            "transport_digest": "sha256:af11c0cbf1188b462811872e828cb48d11ab7eafd5447b72d3228545f3a9f9dd"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 2223,
+        "exit_code": 0,
+        "peak_rss_bytes": 24793088,
+        "phase": "verify",
+        "receipts": [
+          {
+            "compatibility": "supported",
+            "contract": "graphforge-portable-verify/2",
+            "entry_count": 296,
+            "integrity": "verified",
+            "package_digest": "sha256:b98fee52ecb450d83e29a1644c83ffe1ad6c28a06d01621ed3b5e9984ba715e2",
+            "payload_bytes": 1847763463,
+            "representation": "bundle",
+            "transport_digest": "sha256:af11c0cbf1188b462811872e828cb48d11ab7eafd5447b72d3228545f3a9f9dd"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 22572,
+        "exit_code": 0,
+        "peak_rss_bytes": 40603648,
+        "phase": "clean_import",
+        "receipts": [
+          {
+            "contract": "graphforge-portable-import/2",
+            "idempotent_replay": false,
+            "package_digest": "sha256:b98fee52ecb450d83e29a1644c83ffe1ad6c28a06d01621ed3b5e9984ba715e2",
+            "transient_peak_allocated_bytes": 3700826112,
+            "transport_digest": "sha256:af11c0cbf1188b462811872e828cb48d11ab7eafd5447b72d3228545f3a9f9dd"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 72435,
+        "exit_code": 0,
+        "peak_rss_bytes": 202919936,
+        "phase": "reopen_proof",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "d41814e11f492a8c36191b100c805a370de2b4bdbe6ca88c7eef41360ef53066",
+            "rows": 1,
+            "scalar_u64": 1048576
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 80347136,
+                  "before_bytes": 79626240,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 80347136
+                }
+              ],
+              "peak_rss_bytes": 80347136,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 80347136,
+              "sorts": []
+            },
+            "result_sha256": "3daeda0e54a362622ffdc547a631479e3f18cd0f7fa1b28c3b1fce9b7e88a150",
+            "rows": 1,
+            "scalar_u64": 16777216
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 78,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 71104,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 43,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 143994880,
+                  "before_bytes": 78684160,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 143994880
+                }
+              ],
+              "peak_rss_bytes": 143994880,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 143994880,
+              "sorts": []
+            },
+            "result_sha256": "da48cf8bd82d136635cba999906d07a783deabf66427e13128f645d756adb116",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 6,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 131072,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 2,
+                  "identity_reader_calls": 2,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 2,
+                  "projected_columns": 1,
+                  "projected_rows": 2,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 167071744,
+                  "before_bytes": 80830464,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 167071744
+                }
+              ],
+              "peak_rss_bytes": 167071744,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 167071744,
+              "sorts": []
+            },
+            "result_sha256": "404560fda0d6c2f6988aa4cee9c8d1d465c7254181b8c760e659e00b3f1bd255",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 1849782272,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 1630208,
+                  "logical_bytes": 181916,
+                  "logical_references": 398,
+                  "physical_logical_bytes": 181916,
+                  "physical_objects": 398
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 1183129600,
+                  "logical_bytes": 1182672040,
+                  "logical_references": 256,
+                  "physical_logical_bytes": 1182672040,
+                  "physical_objects": 256
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 27328512,
+                  "logical_bytes": 27277120,
+                  "logical_references": 16,
+                  "physical_logical_bytes": 27277120,
+                  "physical_objects": 16
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 637693952,
+                  "logical_bytes": 637679918,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 637679918,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 1847810994,
+              "logical_references": 682,
+              "physical_objects": 679,
+              "retained_logical_eof_bytes": 1847810994
+            }
+          },
+          {
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": {
+              "generated-inputs": {
+                "totals": {
+                  "allocated_bytes": 822345728,
+                  "logical_bytes": 822337680,
+                  "logical_references": 2,
+                  "physical_logical_bytes": 822337680,
+                  "physical_objects": 2
+                }
+              },
+              "imported-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "imported-project-construction": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-import": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "imported-project-published": {
+                "totals": {
+                  "allocated_bytes": 1852637184,
+                  "logical_bytes": 1848371632,
+                  "logical_references": 1377,
+                  "physical_logical_bytes": 1848371632,
+                  "physical_objects": 1377
+                }
+              },
+              "imported-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              },
+              "portable-package": {
+                "totals": {
+                  "allocated_bytes": 1847996416,
+                  "logical_bytes": 1847989760,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 1847989760,
+                  "physical_objects": 1
+                }
+              },
+              "query-results": {
+                "totals": {
+                  "allocated_bytes": 98304,
+                  "logical_bytes": 71228,
+                  "logical_references": 8,
+                  "physical_logical_bytes": 71228,
+                  "physical_objects": 8
+                }
+              },
+              "source-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "source-project-construction": {
+                "totals": {
+                  "allocated_bytes": 11044560896,
+                  "logical_bytes": 11037728267,
+                  "logical_references": 2999,
+                  "physical_logical_bytes": 11037728267,
+                  "physical_objects": 2999
+                }
+              },
+              "source-project-import": {
+                "totals": {
+                  "allocated_bytes": 822353920,
+                  "logical_bytes": 822341858,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 822341858,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-published": {
+                "totals": {
+                  "allocated_bytes": 1852637184,
+                  "logical_bytes": 1848371632,
+                  "logical_references": 1377,
+                  "physical_logical_bytes": 1848371632,
+                  "physical_objects": 1377
+                }
+              },
+              "source-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              }
+            },
+            "retained_storage_bytes": 18242637824,
+            "source_project_current_allocated_bytes": 1852637184,
+            "transient_peak_storage_bytes": 20090777600
+          }
+        ],
+        "status": "passed"
+      }
+    ],
+    "profile_id": "graph500-s20-provider",
+    "schema": "graphforge-public-certification/1",
+    "status": "passed"
+  },
+  "limits": {
+    "cores": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "cpu_seconds": 14400.0,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400.0
+  },
+  "outcome": "passed",
+  "schema": "graphforge-benchexec-run/1",
+  "signal": null
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-graphforge.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-graphforge.json
@@ -1,0 +1,1212 @@
+{
+  "failed_phase": null,
+  "phases": [
+    {
+      "duration_ms": 10,
+      "exit_code": 0,
+      "peak_rss_bytes": 81920,
+      "phase": "admission",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 6536,
+      "exit_code": 0,
+      "peak_rss_bytes": 73179136,
+      "phase": "generate",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 218875,
+      "exit_code": 0,
+      "peak_rss_bytes": 149282816,
+      "phase": "ingest",
+      "receipts": [
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "begun"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "bytes_accepted": 822337680,
+          "construction": {
+            "accepted_chunks": 272,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 272,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 3629690464,
+                  "write_calls": 8528
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 637,
+                  "object_count": 0,
+                  "read_bytes": 7783958163,
+                  "read_calls": 165338,
+                  "write_bytes": 2669960942,
+                  "write_calls": 155756
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 10020,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 28731,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 19227027175,
+                  "read_calls": 275017,
+                  "write_bytes": 14674255191,
+                  "write_calls": 17698
+                }
+              },
+              "totals": {
+                "block_count": 28731,
+                "fsync_calls": 10657,
+                "object_count": 272,
+                "read_bytes": 27010985338,
+                "read_calls": 440355,
+                "write_bytes": 20973906597,
+                "write_calls": 181982
+              }
+            },
+            "cache_release_operations": 42228,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 59903496370,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 11037175808,
+              "logical_bytes": 11036068832,
+              "logical_references": 1368,
+              "physical_logical_bytes": 11036068832,
+              "physical_objects": 1368
+            },
+            "construction_staging_transient_peak_allocated_bytes": 11037175808,
+            "fsync_operations": 3488,
+            "immutable_artifacts": 1072,
+            "input_batches": 272,
+            "input_rows": 17825792,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": false,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 637,
+                "object_count": 0,
+                "read_bytes": 7783958163,
+                "read_calls": 165338,
+                "write_bytes": 2669960942,
+                "write_calls": 155756
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 10020,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 331751
+            },
+            "transient_peak_allocated_bytes": 11037175808,
+            "write_bytes": 3629690464,
+            "write_operations": 8528
+          },
+          "contract": "graphforge-import-session/1",
+          "outcome": "validated",
+          "rows_accepted": 17825792,
+          "rows_rejected": 0
+        },
+        {
+          "construction": {
+            "accepted_chunks": 272,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 272,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 3629690464,
+                  "write_calls": 8528
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 4117,
+                  "object_count": 0,
+                  "read_bytes": 1848928295,
+                  "read_calls": 30121,
+                  "write_bytes": 1848368216,
+                  "write_calls": 29427
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 637,
+                  "object_count": 0,
+                  "read_bytes": 7783958163,
+                  "read_calls": 165338,
+                  "write_bytes": 2669960942,
+                  "write_calls": 155756
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 10020,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 12,
+                  "object_count": 0,
+                  "read_bytes": 1889603222,
+                  "read_calls": 28986,
+                  "write_bytes": 41971749,
+                  "write_calls": 642
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 81547,
+                  "read_calls": 2,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 28731,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 19227027175,
+                  "read_calls": 275017,
+                  "write_bytes": 14674255191,
+                  "write_calls": 17698
+                }
+              },
+              "totals": {
+                "block_count": 28731,
+                "fsync_calls": 14786,
+                "object_count": 272,
+                "read_bytes": 30749598402,
+                "read_calls": 499464,
+                "write_bytes": 22864246562,
+                "write_calls": 212051
+              }
+            },
+            "cache_release_operations": 42228,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 59903496370,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 11037175808,
+              "logical_bytes": 11036068832,
+              "logical_references": 1368,
+              "physical_logical_bytes": 11036068832,
+              "physical_objects": 1368
+            },
+            "construction_staging_transient_peak_allocated_bytes": 11037175808,
+            "fsync_operations": 3488,
+            "immutable_artifacts": 1072,
+            "input_batches": 272,
+            "input_rows": 17825792,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": true,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 4117,
+                "object_count": 0,
+                "read_bytes": 1848928295,
+                "read_calls": 30121,
+                "write_bytes": 1848368216,
+                "write_calls": 29427
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 637,
+                "object_count": 0,
+                "read_bytes": 7783958163,
+                "read_calls": 165338,
+                "write_bytes": 2669960942,
+                "write_calls": 155756
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 10020,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 12,
+                "object_count": 0,
+                "read_bytes": 1889603222,
+                "read_calls": 28986,
+                "write_bytes": 41971749,
+                "write_calls": 642
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 81547,
+                "read_calls": 2,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 425058
+            },
+            "transient_peak_allocated_bytes": 11037175808,
+            "write_bytes": 3629690464,
+            "write_operations": 8528
+          },
+          "contract": "graphforge-import-session/1",
+          "outcome": "committed"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 25028,
+      "exit_code": 0,
+      "peak_rss_bytes": 38367232,
+      "phase": "reopen",
+      "receipts": [
+        {
+          "aborted_journals": 0,
+          "deferred": null,
+          "elapsed_ms": 0,
+          "kind": "project_open",
+          "preserved_unknown_entries": 0,
+          "removed_generations": 0,
+          "repaired_journals": 0,
+          "selected_generation_class": "committed_current",
+          "work_detected": false
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 1849782272,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 1630208,
+                "logical_bytes": 181916,
+                "logical_references": 398,
+                "physical_logical_bytes": 181916,
+                "physical_objects": 398
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 1183129600,
+                "logical_bytes": 1182672040,
+                "logical_references": 256,
+                "physical_logical_bytes": 1182672040,
+                "physical_objects": 256
+              },
+              "topology_nodes": {
+                "allocated_bytes": 27328512,
+                "logical_bytes": 27277120,
+                "logical_references": 16,
+                "physical_logical_bytes": 27277120,
+                "physical_objects": 16
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 637693952,
+                "logical_bytes": 637679918,
+                "logical_references": 12,
+                "physical_logical_bytes": 637679918,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 1847810994,
+            "logical_references": 682,
+            "physical_objects": 679,
+            "retained_logical_eof_bytes": 1847810994
+          }
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 15357,
+      "exit_code": 0,
+      "peak_rss_bytes": 81981440,
+      "phase": "recount",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "d41814e11f492a8c36191b100c805a370de2b4bdbe6ca88c7eef41360ef53066",
+          "rows": 1,
+          "scalar_u64": 1048576
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 79294464,
+                "before_bytes": 78639104,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 79294464
+              }
+            ],
+            "peak_rss_bytes": 79294464,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 79294464,
+            "sorts": []
+          },
+          "result_sha256": "3daeda0e54a362622ffdc547a631479e3f18cd0f7fa1b28c3b1fce9b7e88a150",
+          "rows": 1,
+          "scalar_u64": 16777216
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 38658,
+      "exit_code": 0,
+      "peak_rss_bytes": 202928128,
+      "phase": "query",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 78,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 71104,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 43,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 143634432,
+                "before_bytes": 78254080,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 143634432
+              }
+            ],
+            "peak_rss_bytes": 143634432,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 143634432,
+            "sorts": []
+          },
+          "result_sha256": "da48cf8bd82d136635cba999906d07a783deabf66427e13128f645d756adb116",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 6,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 131072,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 2,
+                "identity_reader_calls": 2,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 2,
+                "projected_columns": 1,
+                "projected_rows": 2,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 165707776,
+                "before_bytes": 69480448,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 165707776
+              }
+            ],
+            "peak_rss_bytes": 165707776,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 165707776,
+            "sorts": []
+          },
+          "result_sha256": "404560fda0d6c2f6988aa4cee9c8d1d465c7254181b8c760e659e00b3f1bd255",
+          "rows": 1000,
+          "scalar_u64": null
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 17782,
+      "exit_code": 0,
+      "peak_rss_bytes": 39960576,
+      "phase": "export",
+      "receipts": [
+        {
+          "allocation_allocated_bytes": 1847996416,
+          "allocation_logical_bytes": 1847989760,
+          "allocation_physical_objects": 1,
+          "contract": "graphforge-portable-export/2",
+          "entry_count": 296,
+          "package_digest": "sha256:b98fee52ecb450d83e29a1644c83ffe1ad6c28a06d01621ed3b5e9984ba715e2",
+          "payload_bytes": 1847632999,
+          "representation": "bundle",
+          "selection_fingerprint": "sha256:188ac1809a7f1767fff36f14870d478b0025f9766a5765986b466b1520eabb91",
+          "transport_digest": "sha256:af11c0cbf1188b462811872e828cb48d11ab7eafd5447b72d3228545f3a9f9dd"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 2223,
+      "exit_code": 0,
+      "peak_rss_bytes": 24793088,
+      "phase": "verify",
+      "receipts": [
+        {
+          "compatibility": "supported",
+          "contract": "graphforge-portable-verify/2",
+          "entry_count": 296,
+          "integrity": "verified",
+          "package_digest": "sha256:b98fee52ecb450d83e29a1644c83ffe1ad6c28a06d01621ed3b5e9984ba715e2",
+          "payload_bytes": 1847763463,
+          "representation": "bundle",
+          "transport_digest": "sha256:af11c0cbf1188b462811872e828cb48d11ab7eafd5447b72d3228545f3a9f9dd"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 22572,
+      "exit_code": 0,
+      "peak_rss_bytes": 40603648,
+      "phase": "clean_import",
+      "receipts": [
+        {
+          "contract": "graphforge-portable-import/2",
+          "idempotent_replay": false,
+          "package_digest": "sha256:b98fee52ecb450d83e29a1644c83ffe1ad6c28a06d01621ed3b5e9984ba715e2",
+          "transient_peak_allocated_bytes": 3700826112,
+          "transport_digest": "sha256:af11c0cbf1188b462811872e828cb48d11ab7eafd5447b72d3228545f3a9f9dd"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 72435,
+      "exit_code": 0,
+      "peak_rss_bytes": 202919936,
+      "phase": "reopen_proof",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "d41814e11f492a8c36191b100c805a370de2b4bdbe6ca88c7eef41360ef53066",
+          "rows": 1,
+          "scalar_u64": 1048576
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 80347136,
+                "before_bytes": 79626240,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 80347136
+              }
+            ],
+            "peak_rss_bytes": 80347136,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 80347136,
+            "sorts": []
+          },
+          "result_sha256": "3daeda0e54a362622ffdc547a631479e3f18cd0f7fa1b28c3b1fce9b7e88a150",
+          "rows": 1,
+          "scalar_u64": 16777216
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 78,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 71104,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 43,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 143994880,
+                "before_bytes": 78684160,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 143994880
+              }
+            ],
+            "peak_rss_bytes": 143994880,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 143994880,
+            "sorts": []
+          },
+          "result_sha256": "da48cf8bd82d136635cba999906d07a783deabf66427e13128f645d756adb116",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 6,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 131072,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 2,
+                "identity_reader_calls": 2,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 2,
+                "projected_columns": 1,
+                "projected_rows": 2,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 167071744,
+                "before_bytes": 80830464,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 167071744
+              }
+            ],
+            "peak_rss_bytes": 167071744,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 167071744,
+            "sorts": []
+          },
+          "result_sha256": "404560fda0d6c2f6988aa4cee9c8d1d465c7254181b8c760e659e00b3f1bd255",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 1849782272,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 1630208,
+                "logical_bytes": 181916,
+                "logical_references": 398,
+                "physical_logical_bytes": 181916,
+                "physical_objects": 398
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 1183129600,
+                "logical_bytes": 1182672040,
+                "logical_references": 256,
+                "physical_logical_bytes": 1182672040,
+                "physical_objects": 256
+              },
+              "topology_nodes": {
+                "allocated_bytes": 27328512,
+                "logical_bytes": 27277120,
+                "logical_references": 16,
+                "physical_logical_bytes": 27277120,
+                "physical_objects": 16
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 637693952,
+                "logical_bytes": 637679918,
+                "logical_references": 12,
+                "physical_logical_bytes": 637679918,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 1847810994,
+            "logical_references": 682,
+            "physical_objects": 679,
+            "retained_logical_eof_bytes": 1847810994
+          }
+        },
+        {
+          "contract": "graphforge-lifecycle-storage/2",
+          "retained_owners": {
+            "generated-inputs": {
+              "totals": {
+                "allocated_bytes": 822345728,
+                "logical_bytes": 822337680,
+                "logical_references": 2,
+                "physical_logical_bytes": 822337680,
+                "physical_objects": 2
+              }
+            },
+            "imported-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "imported-project-construction": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-import": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "imported-project-published": {
+              "totals": {
+                "allocated_bytes": 1852637184,
+                "logical_bytes": 1848371632,
+                "logical_references": 1377,
+                "physical_logical_bytes": 1848371632,
+                "physical_objects": 1377
+              }
+            },
+            "imported-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            },
+            "portable-package": {
+              "totals": {
+                "allocated_bytes": 1847996416,
+                "logical_bytes": 1847989760,
+                "logical_references": 1,
+                "physical_logical_bytes": 1847989760,
+                "physical_objects": 1
+              }
+            },
+            "query-results": {
+              "totals": {
+                "allocated_bytes": 98304,
+                "logical_bytes": 71228,
+                "logical_references": 8,
+                "physical_logical_bytes": 71228,
+                "physical_objects": 8
+              }
+            },
+            "source-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "source-project-construction": {
+              "totals": {
+                "allocated_bytes": 11044560896,
+                "logical_bytes": 11037728267,
+                "logical_references": 2999,
+                "physical_logical_bytes": 11037728267,
+                "physical_objects": 2999
+              }
+            },
+            "source-project-import": {
+              "totals": {
+                "allocated_bytes": 822353920,
+                "logical_bytes": 822341858,
+                "logical_references": 3,
+                "physical_logical_bytes": 822341858,
+                "physical_objects": 3
+              }
+            },
+            "source-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "source-project-published": {
+              "totals": {
+                "allocated_bytes": 1852637184,
+                "logical_bytes": 1848371632,
+                "logical_references": 1377,
+                "physical_logical_bytes": 1848371632,
+                "physical_objects": 1377
+              }
+            },
+            "source-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            }
+          },
+          "retained_storage_bytes": 18242637824,
+          "source_project_current_allocated_bytes": 1852637184,
+          "transient_peak_storage_bytes": 20090777600
+        }
+      ],
+      "status": "passed"
+    }
+  ],
+  "profile_id": "graph500-s20-provider",
+  "schema": "graphforge-public-certification/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-plan.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-plan.json
@@ -1,0 +1,37 @@
+{
+  "claim": "engineering_evidence_only",
+  "execution": "native_linux_benchexec_host",
+  "identities": {
+    "admitted_projection_sha256": "cde01bde574c154eb5fc5004ca957679ec258825e5fb97d34f2756b1c4394679",
+    "benchexec_python_sha256": "b8d8288faefdd300201f43fcf00f6f539a27218eeed3a3dff5ab10b9c4c99700",
+    "benchexec_version": "3.35",
+    "certify_sha256": "0f09a5020a9ede0c6e6d7451384cf6473414e5e448a939e4bcb9aeeeddb19ab1",
+    "commit": "3868e3c751ba0c94928033378d2ddc2b5401cd55",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "678cdd89ad68485402841d05302eab9403efad6fbf3ec02f73b84558bef54886",
+    "gf_sha256": "e94d8e762bb6b4139e20ab3ee21677d9197228b471bc904f8d8f3ec5dca4ab03",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "a2911040377d4b992754d206b94895b8aea7c97d0dcee2d163ece83e8183d540",
+    "profile_id": "graph500-s20-provider",
+    "profile_sha256": "922533672e46f4dad2ac96ebd0c4ebdf215ec0214d534bea713b8e4e6cf62700"
+  },
+  "limits": {
+    "cores": 16,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400
+  },
+  "outputs": [
+    "s20-plan.json",
+    "s20-benchexec.json",
+    "s20-graphforge.json",
+    "s20-rung.json",
+    "s20-result.json"
+  ],
+  "rung": "S20",
+  "schema": "graphforge-progressive-host-run-plan/1",
+  "work_root_capacity": {
+    "free_bytes": 374553010176,
+    "reserved_headroom_bytes": 141258578535
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-projection.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-projection.json
@@ -1,0 +1,83 @@
+{
+  "checks": {
+    "correctness": true,
+    "io_reader_publication_capacity_measured": true,
+    "io_reader_publication_headroom": true,
+    "retained_storage_headroom": true,
+    "rss_bounded_or_plateaued": true,
+    "rss_headroom": true,
+    "storage_headroom": true,
+    "time_headroom": true,
+    "transient_storage_headroom": true
+  },
+  "claim": "engineering_evidence_only",
+  "decision": "admitted",
+  "headroom": {
+    "rss_fraction": 0.2,
+    "storage_fraction": 0.37713908231206983,
+    "time_fraction": 0.2
+  },
+  "limits": {
+    "rss_bytes": 4294967296,
+    "volume_bytes": 374553010176,
+    "wall_seconds": 14400
+  },
+  "native_capacity": {
+    "free_bytes": 374553010176,
+    "observed_rates": {
+      "physical_read_bytes_per_second": {
+        "wall_seconds": 221,
+        "work_units": 181354160128
+      },
+      "physical_write_bytes_per_second": {
+        "wall_seconds": 221,
+        "work_units": 45928562688
+      },
+      "publication_work_per_second": {
+        "wall_seconds": 221,
+        "work_units": 210510
+      },
+      "reader_calls_per_second": {
+        "wall_seconds": 221,
+        "work_units": 249607
+      }
+    },
+    "rate_source": "completed_adjacent_rungs",
+    "reserved_headroom_bytes": 141258578535
+  },
+  "projected": {
+    "logical_read_bytes": 30711711327,
+    "logical_write_bytes": 22839003669,
+    "peak_rss_bytes": 193314816,
+    "physical_read_bytes": 364498837504,
+    "physical_write_bytes": 92022874112,
+    "publication_work_units": 422276,
+    "reader_calls": 499214,
+    "retained_storage_bytes": 18192076800,
+    "storage_peak_bytes": 20027781120,
+    "transient_peak_storage_bytes": 20027781120,
+    "wall_seconds": 445
+  },
+  "provider_capacity": null,
+  "required_rates": {
+    "physical_read_bytes_per_second": 31640525,
+    "physical_write_bytes_per_second": 7988097,
+    "publication_work_per_second": 37,
+    "reader_calls_per_second": 44
+  },
+  "rss_growth_fraction": 0.012176064591743717,
+  "schema": "graphforge-progressive-qualification-evidence/1",
+  "slopes_observed": {
+    "logical_read_bytes": 7686207273,
+    "logical_write_bytes": 5715269862,
+    "physical_read_bytes": 91572338688,
+    "physical_write_bytes": 23047155712,
+    "publication_work_units": 105883,
+    "reader_calls": 124777
+  },
+  "source_scales": [
+    18,
+    19
+  ],
+  "target": "S20"
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-result.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-result.json
@@ -1,0 +1,28 @@
+{
+  "artifacts": {
+    "benchexec_sha256": "0353e390a809bb2cb6f4e7b1b0a5fedea2a2e246d94df804cba611b04f7d37e0",
+    "graphforge_sha256": "64deb7d489df18cc675378e9c53faa5fe8c4c1acb4f63bd95ea13b975c14cbd7",
+    "plan_sha256": "15adf80e7893913911568984289debc33c94f16bfe6d04bf6d204e118021d3da",
+    "rung_sha256": "625e3ccd854c0116530148842cbf38b7a5e37201ab0d2f65a9d9efe9e634a627"
+  },
+  "claim": "engineering_evidence_only",
+  "failure": null,
+  "identities": {
+    "admitted_projection_sha256": "cde01bde574c154eb5fc5004ca957679ec258825e5fb97d34f2756b1c4394679",
+    "benchexec_python_sha256": "b8d8288faefdd300201f43fcf00f6f539a27218eeed3a3dff5ab10b9c4c99700",
+    "benchexec_version": "3.35",
+    "certify_sha256": "0f09a5020a9ede0c6e6d7451384cf6473414e5e448a939e4bcb9aeeeddb19ab1",
+    "commit": "3868e3c751ba0c94928033378d2ddc2b5401cd55",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "678cdd89ad68485402841d05302eab9403efad6fbf3ec02f73b84558bef54886",
+    "gf_sha256": "e94d8e762bb6b4139e20ab3ee21677d9197228b471bc904f8d8f3ec5dca4ab03",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "a2911040377d4b992754d206b94895b8aea7c97d0dcee2d163ece83e8183d540",
+    "profile_id": "graph500-s20-provider",
+    "profile_sha256": "922533672e46f4dad2ac96ebd0c4ebdf215ec0214d534bea713b8e4e6cf62700"
+  },
+  "rung": "S20",
+  "schema": "graphforge-progressive-host-run-result/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-rung.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s20-rung.json
@@ -1,0 +1,490 @@
+{
+  "assembly_contract": "graphforge-progressive-rung-assembly/3",
+  "correctness": true,
+  "failure": null,
+  "live_edges": 16777216,
+  "metric_sources": {
+    "benchexec": [
+      "wall_seconds",
+      "physical_read_bytes",
+      "physical_write_bytes"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
+    ],
+    "query_qualification": [
+      "live_edges",
+      "correctness"
+    ],
+    "storage_attribution": [
+      "retained_storage_bytes",
+      "transient_peak_storage_bytes",
+      "logical_read_bytes",
+      "logical_write_bytes",
+      "reader_calls",
+      "publication_work_units"
+    ]
+  },
+  "metrics": {
+    "logical_read_bytes": 30749598402,
+    "logical_write_bytes": 22864246562,
+    "peak_rss_bytes": 202928128,
+    "physical_read_bytes": 366526144512,
+    "physical_write_bytes": 92225392640,
+    "publication_work_units": 425058,
+    "reader_calls": 499464,
+    "retained_storage_bytes": 18242637824,
+    "transient_peak_storage_bytes": 20090777600,
+    "wall_seconds": 441
+  },
+  "phases": [
+    "admission",
+    "generate",
+    "ingest",
+    "reopen",
+    "recount",
+    "query",
+    "export",
+    "verify",
+    "clean_import",
+    "reopen_proof"
+  ],
+  "profile_id": "graph500-s20-provider",
+  "scale": 20,
+  "source": "canonical_ladder",
+  "status": "passed",
+  "storage_attribution": {
+    "construction": {
+      "application_io": {
+        "phases": {
+          "append_merge": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 272,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 3629690464,
+            "write_calls": 8528
+          },
+          "cas_install_read_write": {
+            "block_count": 0,
+            "fsync_calls": 4117,
+            "object_count": 0,
+            "read_bytes": 1848928295,
+            "read_calls": 30121,
+            "write_bytes": 1848368216,
+            "write_calls": 29427
+          },
+          "encode_write_postwrite_authentication": {
+            "block_count": 0,
+            "fsync_calls": 637,
+            "object_count": 0,
+            "read_bytes": 7783958163,
+            "read_calls": 165338,
+            "write_bytes": 2669960942,
+            "write_calls": 155756
+          },
+          "fsync_synchronization": {
+            "block_count": 0,
+            "fsync_calls": 10020,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "hydration_verification": {
+            "block_count": 0,
+            "fsync_calls": 12,
+            "object_count": 0,
+            "read_bytes": 1889603222,
+            "read_calls": 28986,
+            "write_bytes": 41971749,
+            "write_calls": 642
+          },
+          "publication_preauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 81547,
+            "read_calls": 2,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "recovery_reauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "seal_authentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "shape_consume_reauthentication": {
+            "block_count": 28731,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 19227027175,
+            "read_calls": 275017,
+            "write_bytes": 14674255191,
+            "write_calls": 17698
+          }
+        },
+        "totals": {
+          "block_count": 28731,
+          "fsync_calls": 14786,
+          "object_count": 272,
+          "read_bytes": 30749598402,
+          "read_calls": 499464,
+          "write_bytes": 22864246562,
+          "write_calls": 212051
+        }
+      },
+      "staging": {
+        "allocated_bytes": 11037175808,
+        "logical_bytes": 11036068832,
+        "logical_references": 1368,
+        "physical_logical_bytes": 11036068832,
+        "physical_objects": 1368
+      },
+      "staging_transient_peak_allocated_bytes": 11037175808,
+      "transient_peak_allocated_bytes": 11037175808
+    },
+    "counts": {
+      "imported_edges": 16777216,
+      "imported_nodes": 1048576,
+      "source_edges": 16777216,
+      "source_nodes": 1048576
+    },
+    "imported": {
+      "allocated_physical_bytes": 1849782272,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 1630208,
+          "logical_bytes": 181916,
+          "logical_references": 398,
+          "physical_logical_bytes": 181916,
+          "physical_objects": 398
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 1183129600,
+          "logical_bytes": 1182672040,
+          "logical_references": 256,
+          "physical_logical_bytes": 1182672040,
+          "physical_objects": 256
+        },
+        "topology_nodes": {
+          "allocated_bytes": 27328512,
+          "logical_bytes": 27277120,
+          "logical_references": 16,
+          "physical_logical_bytes": 27277120,
+          "physical_objects": 16
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 637693952,
+          "logical_bytes": 637679918,
+          "logical_references": 12,
+          "physical_logical_bytes": 637679918,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 1847810994,
+      "logical_references": 682,
+      "physical_objects": 679,
+      "retained_logical_eof_bytes": 1847810994
+    },
+    "lifecycle": {
+      "contract": "graphforge-lifecycle-storage/2",
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 822345728,
+            "logical_bytes": 822337680,
+            "logical_references": 2,
+            "physical_logical_bytes": 822337680,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 1852637184,
+            "logical_bytes": 1848371632,
+            "logical_references": 1377,
+            "physical_logical_bytes": 1848371632,
+            "physical_objects": 1377
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 1847996416,
+            "logical_bytes": 1847989760,
+            "logical_references": 1,
+            "physical_logical_bytes": 1847989760,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 11044560896,
+            "logical_bytes": 11037728267,
+            "logical_references": 2999,
+            "physical_logical_bytes": 11037728267,
+            "physical_objects": 2999
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 822353920,
+            "logical_bytes": 822341858,
+            "logical_references": 3,
+            "physical_logical_bytes": 822341858,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 1852637184,
+            "logical_bytes": 1848371632,
+            "logical_references": 1377,
+            "physical_logical_bytes": 1848371632,
+            "physical_objects": 1377
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "retained_storage_bytes": 18242637824,
+      "source_project_current_allocated_bytes": 1852637184,
+      "transient_peak_storage_bytes": 20090777600
+    },
+    "portable_package": {
+      "allocation_allocated_bytes": 1847996416,
+      "allocation_logical_bytes": 1847989760,
+      "allocation_physical_objects": 1,
+      "contract": "graphforge-portable-export/2"
+    },
+    "source": {
+      "allocated_physical_bytes": 1849782272,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 1630208,
+          "logical_bytes": 181916,
+          "logical_references": 398,
+          "physical_logical_bytes": 181916,
+          "physical_objects": 398
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 1183129600,
+          "logical_bytes": 1182672040,
+          "logical_references": 256,
+          "physical_logical_bytes": 1182672040,
+          "physical_objects": 256
+        },
+        "topology_nodes": {
+          "allocated_bytes": 27328512,
+          "logical_bytes": 27277120,
+          "logical_references": 16,
+          "physical_logical_bytes": 27277120,
+          "physical_objects": 16
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 637693952,
+          "logical_bytes": 637679918,
+          "logical_references": 12,
+          "physical_logical_bytes": 637679918,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 1847810994,
+      "logical_references": 682,
+      "physical_objects": 679,
+      "retained_logical_eof_bytes": 1847810994
+    }
+  },
+  "storage_components": {
+    "imported_allocated_physical_bytes": 1849782272,
+    "imported_retained_logical_eof_bytes": 1847810994,
+    "logical_read_bytes": 30749598402,
+    "logical_write_bytes": 22864246562,
+    "publication_work_units": 425058,
+    "reader_calls": 499464,
+    "source_allocated_physical_bytes": 1849782272,
+    "source_project_current_allocated_bytes": 1852637184,
+    "source_retained_logical_eof_bytes": 1847810994,
+    "transient_peak_allocated_bytes": 11037175808
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-benchexec.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-benchexec.json
@@ -1,0 +1,1252 @@
+{
+  "authority": {
+    "cpu_seconds": 1747.748051,
+    "peak_rss_bytes": 15500419072,
+    "pressure_cpu_seconds": 2.484156,
+    "pressure_io_seconds": 140.275402,
+    "pressure_memory_seconds": 0.702274,
+    "read_bytes": 1547175919616,
+    "wall_seconds": 1954.184934421035,
+    "write_bytes": 466245177344
+  },
+  "disagreements": [],
+  "exit_code": 0,
+  "graphforge": {
+    "failed_phase": null,
+    "phases": [
+      {
+        "duration_ms": 10,
+        "exit_code": 0,
+        "peak_rss_bytes": 20480,
+        "phase": "admission",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 26979,
+        "exit_code": 0,
+        "peak_rss_bytes": 73416704,
+        "phase": "generate",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 1095437,
+        "exit_code": 0,
+        "peak_rss_bytes": 182325248,
+        "phase": "ingest",
+        "receipts": [
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "begun"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "bytes_accepted": 3289349601,
+            "construction": {
+              "accepted_chunks": 1088,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 1088,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 14518761856,
+                    "write_calls": 34112
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 2433,
+                    "object_count": 0,
+                    "read_bytes": 31302429687,
+                    "read_calls": 659883,
+                    "write_bytes": 10846455483,
+                    "write_calls": 643437
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 46974,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 127633,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 86861533025,
+                    "read_calls": 1421617,
+                    "write_bytes": 68651068899,
+                    "write_calls": 87238
+                  }
+                },
+                "totals": {
+                  "block_count": 127633,
+                  "fsync_calls": 49407,
+                  "object_count": 1088,
+                  "read_bytes": 118163962712,
+                  "read_calls": 2081500,
+                  "write_bytes": 94016286238,
+                  "write_calls": 764787
+                }
+              },
+              "cache_release_operations": 208945,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 274562152697,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 44315299840,
+                "logical_bytes": 44310888140,
+                "logical_references": 5400,
+                "physical_logical_bytes": 44310888140,
+                "physical_objects": 5400
+              },
+              "construction_staging_transient_peak_allocated_bytes": 44315299840,
+              "fsync_operations": 13952,
+              "immutable_artifacts": 4288,
+              "input_batches": 1088,
+              "input_rows": 71303168,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": false,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 2433,
+                  "object_count": 0,
+                  "read_bytes": 31302429687,
+                  "read_calls": 659883,
+                  "write_bytes": 10846455483,
+                  "write_calls": 643437
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 46974,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 1352727
+              },
+              "transient_peak_allocated_bytes": 44315299840,
+              "write_bytes": 14518761856,
+              "write_operations": 34112
+            },
+            "contract": "graphforge-import-session/1",
+            "outcome": "validated",
+            "rows_accepted": 71303168,
+            "rows_rejected": 0
+          },
+          {
+            "construction": {
+              "accepted_chunks": 1088,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 1088,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 14518761856,
+                    "write_calls": 34112
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 17280,
+                    "object_count": 0,
+                    "read_bytes": 7563491640,
+                    "read_calls": 123301,
+                    "write_bytes": 7560658285,
+                    "write_calls": 120144
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 2433,
+                    "object_count": 0,
+                    "read_bytes": 31302429687,
+                    "read_calls": 659883,
+                    "write_bytes": 10846455483,
+                    "write_calls": 643437
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 46974,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 15,
+                    "object_count": 0,
+                    "read_bytes": 7725031008,
+                    "read_calls": 118071,
+                    "write_bytes": 167884582,
+                    "write_calls": 2563
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 312355,
+                    "read_calls": 3,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 127633,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 86861533025,
+                    "read_calls": 1421617,
+                    "write_bytes": 68651068899,
+                    "write_calls": 87238
+                  }
+                },
+                "totals": {
+                  "block_count": 127633,
+                  "fsync_calls": 66702,
+                  "object_count": 1088,
+                  "read_bytes": 133452797715,
+                  "read_calls": 2322875,
+                  "write_bytes": 101744829105,
+                  "write_calls": 887494
+                }
+              },
+              "cache_release_operations": 208945,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 274562152697,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 44315299840,
+                "logical_bytes": 44310888140,
+                "logical_references": 5400,
+                "physical_logical_bytes": 44310888140,
+                "physical_objects": 5400
+              },
+              "construction_staging_transient_peak_allocated_bytes": 44315299840,
+              "fsync_operations": 13952,
+              "immutable_artifacts": 4288,
+              "input_batches": 1088,
+              "input_rows": 71303168,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": true,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 17280,
+                  "object_count": 0,
+                  "read_bytes": 7563491640,
+                  "read_calls": 123301,
+                  "write_bytes": 7560658285,
+                  "write_calls": 120144
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 2433,
+                  "object_count": 0,
+                  "read_bytes": 31302429687,
+                  "read_calls": 659883,
+                  "write_bytes": 10846455483,
+                  "write_calls": 643437
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 46974,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 15,
+                  "object_count": 0,
+                  "read_bytes": 7725031008,
+                  "read_calls": 118071,
+                  "write_bytes": 167884582,
+                  "write_calls": 2563
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 312355,
+                  "read_calls": 3,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 1734104
+              },
+              "transient_peak_allocated_bytes": 44315299840,
+              "write_bytes": 14518761856,
+              "write_operations": 34112
+            },
+            "contract": "graphforge-import-session/1",
+            "outcome": "committed"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 85915,
+        "exit_code": 0,
+        "peak_rss_bytes": 48599040,
+        "phase": "reopen",
+        "receipts": [
+          {
+            "aborted_journals": 0,
+            "deferred": null,
+            "elapsed_ms": 0,
+            "kind": "project_open",
+            "preserved_unknown_entries": 0,
+            "removed_generations": 0,
+            "repaired_journals": 0,
+            "selected_generation_class": "committed_current",
+            "work_detected": false
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 7565422592,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 6094848,
+                  "logical_bytes": 683758,
+                  "logical_references": 1488,
+                  "physical_logical_bytes": 683758,
+                  "physical_objects": 1488
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 4899287040,
+                  "logical_bytes": 4897322832,
+                  "logical_references": 1024,
+                  "physical_logical_bytes": 4897322832,
+                  "physical_objects": 1024
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 109314048,
+                  "logical_bytes": 109108480,
+                  "logical_references": 64,
+                  "physical_logical_bytes": 109108480,
+                  "physical_objects": 64
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 2550726656,
+                  "logical_bytes": 2550712719,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 2550712719,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 7557827789,
+              "logical_references": 2588,
+              "physical_objects": 2585,
+              "retained_logical_eof_bytes": 7557827789
+            }
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 51983,
+        "exit_code": 0,
+        "peak_rss_bytes": 93093888,
+        "phase": "recount",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "15563dc5ecd48bd37d48ccfe0da1d66be7da3fd4dd8c79d2d064e78657a0d228",
+            "rows": 1,
+            "scalar_u64": 4194304
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 90185728,
+                  "before_bytes": 89595904,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 90185728
+                }
+              ],
+              "peak_rss_bytes": 90185728,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 90185728,
+              "sorts": []
+            },
+            "result_sha256": "979e01bd5c8760c4e606da882ea550a6711605f6d555f64a9ae6e431789cb2fc",
+            "rows": 1,
+            "scalar_u64": 67108864
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 148597,
+        "exit_code": 0,
+        "peak_rss_bytes": 261992448,
+        "phase": "query",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 122,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 73280,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 60,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 146296832,
+                  "before_bytes": 87642112,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 146296832
+                }
+              ],
+              "peak_rss_bytes": 146296832,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 146296832,
+              "sorts": []
+            },
+            "result_sha256": "6b5348f6b35d2767a928b8c5e7aa018deca41e318056d45edd31cdbf43dc3579",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 6,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 131072,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 2,
+                  "identity_reader_calls": 2,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 2,
+                  "projected_columns": 1,
+                  "projected_rows": 2,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 169934848,
+                  "before_bytes": 86380544,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 169934848
+                }
+              ],
+              "peak_rss_bytes": 169934848,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 169934848,
+              "sorts": []
+            },
+            "result_sha256": "ecddd3def5e9f5114b6c626cef4ce1629b51bfe4fe48323b5d40ebcf4a5da0f3",
+            "rows": 1000,
+            "scalar_u64": null
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 69024,
+        "exit_code": 0,
+        "peak_rss_bytes": 50810880,
+        "phase": "export",
+        "receipts": [
+          {
+            "allocation_allocated_bytes": 7558496256,
+            "allocation_logical_bytes": 7558490624,
+            "allocation_physical_objects": 1,
+            "contract": "graphforge-portable-export/2",
+            "entry_count": 1112,
+            "package_digest": "sha256:931112e6d32e84805b92dc7d9b691f94696f5575b945f34de5fc35821fb8f9fc",
+            "payload_bytes": 7557147954,
+            "representation": "bundle",
+            "selection_fingerprint": "sha256:125b96c56b833a9e0644576e0474f87340f0ce277d4ffd8bf518f385d5a913a5",
+            "transport_digest": "sha256:f88e1a2968cec5cd474bbee6d4d188318c17ae3b103e992a7607d9fb4edc4219"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 9329,
+        "exit_code": 0,
+        "peak_rss_bytes": 35942400,
+        "phase": "verify",
+        "receipts": [
+          {
+            "compatibility": "supported",
+            "contract": "graphforge-portable-verify/2",
+            "entry_count": 1112,
+            "integrity": "verified",
+            "package_digest": "sha256:931112e6d32e84805b92dc7d9b691f94696f5575b945f34de5fc35821fb8f9fc",
+            "payload_bytes": 7557642742,
+            "representation": "bundle",
+            "transport_digest": "sha256:f88e1a2968cec5cd474bbee6d4d188318c17ae3b103e992a7607d9fb4edc4219"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 92536,
+        "exit_code": 0,
+        "peak_rss_bytes": 53276672,
+        "phase": "clean_import",
+        "receipts": [
+          {
+            "contract": "graphforge-portable-import/2",
+            "idempotent_replay": false,
+            "package_digest": "sha256:931112e6d32e84805b92dc7d9b691f94696f5575b945f34de5fc35821fb8f9fc",
+            "transient_peak_allocated_bytes": 15137730560,
+            "transport_digest": "sha256:f88e1a2968cec5cd474bbee6d4d188318c17ae3b103e992a7607d9fb4edc4219"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 293427,
+        "exit_code": 0,
+        "peak_rss_bytes": 264278016,
+        "phase": "reopen_proof",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "15563dc5ecd48bd37d48ccfe0da1d66be7da3fd4dd8c79d2d064e78657a0d228",
+            "rows": 1,
+            "scalar_u64": 4194304
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 83120128,
+                  "before_bytes": 81973248,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 83120128
+                }
+              ],
+              "peak_rss_bytes": 83120128,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 83120128,
+              "sorts": []
+            },
+            "result_sha256": "979e01bd5c8760c4e606da882ea550a6711605f6d555f64a9ae6e431789cb2fc",
+            "rows": 1,
+            "scalar_u64": 67108864
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 122,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 73280,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 60,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 146882560,
+                  "before_bytes": 86929408,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 146882560
+                }
+              ],
+              "peak_rss_bytes": 146882560,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 146882560,
+              "sorts": []
+            },
+            "result_sha256": "6b5348f6b35d2767a928b8c5e7aa018deca41e318056d45edd31cdbf43dc3579",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 6,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 131072,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 2,
+                  "identity_reader_calls": 2,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 2,
+                  "projected_columns": 1,
+                  "projected_rows": 2,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 181661696,
+                  "before_bytes": 88707072,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 181661696
+                }
+              ],
+              "peak_rss_bytes": 181661696,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 181661696,
+              "sorts": []
+            },
+            "result_sha256": "ecddd3def5e9f5114b6c626cef4ce1629b51bfe4fe48323b5d40ebcf4a5da0f3",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 7565422592,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 6094848,
+                  "logical_bytes": 683758,
+                  "logical_references": 1488,
+                  "physical_logical_bytes": 683758,
+                  "physical_objects": 1488
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 4899287040,
+                  "logical_bytes": 4897322832,
+                  "logical_references": 1024,
+                  "physical_logical_bytes": 4897322832,
+                  "physical_objects": 1024
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 109314048,
+                  "logical_bytes": 109108480,
+                  "logical_references": 64,
+                  "physical_logical_bytes": 109108480,
+                  "physical_objects": 64
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 2550726656,
+                  "logical_bytes": 2550712719,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 2550712719,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 7557827789,
+              "logical_references": 2588,
+              "physical_objects": 2585,
+              "retained_logical_eof_bytes": 7557827789
+            }
+          },
+          {
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": {
+              "generated-inputs": {
+                "totals": {
+                  "allocated_bytes": 3289358336,
+                  "logical_bytes": 3289349601,
+                  "logical_references": 2,
+                  "physical_logical_bytes": 3289349601,
+                  "physical_objects": 2
+                }
+              },
+              "imported-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "imported-project-construction": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-import": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "imported-project-published": {
+                "totals": {
+                  "allocated_bytes": 7578365952,
+                  "logical_bytes": 7560661703,
+                  "logical_references": 5746,
+                  "physical_logical_bytes": 7560661703,
+                  "physical_objects": 5746
+                }
+              },
+              "imported-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              },
+              "portable-package": {
+                "totals": {
+                  "allocated_bytes": 7558496256,
+                  "logical_bytes": 7558490624,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 7558490624,
+                  "physical_objects": 1
+                }
+              },
+              "query-results": {
+                "totals": {
+                  "allocated_bytes": 98304,
+                  "logical_bytes": 71228,
+                  "logical_references": 8,
+                  "physical_logical_bytes": 71228,
+                  "physical_objects": 8
+                }
+              },
+              "source-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "source-project-construction": {
+                "totals": {
+                  "allocated_bytes": 44344586240,
+                  "logical_bytes": 44317415409,
+                  "logical_references": 11879,
+                  "physical_logical_bytes": 44317415409,
+                  "physical_objects": 11879
+                }
+              },
+              "source-project-import": {
+                "totals": {
+                  "allocated_bytes": 3289366528,
+                  "logical_bytes": 3289353821,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 3289353821,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-published": {
+                "totals": {
+                  "allocated_bytes": 7578365952,
+                  "logical_bytes": 7560661703,
+                  "logical_references": 5746,
+                  "physical_logical_bytes": 7560661703,
+                  "physical_objects": 5746
+                }
+              },
+              "source-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              }
+            },
+            "retained_storage_bytes": 73638645760,
+            "source_project_current_allocated_bytes": 7578365952,
+            "transient_peak_storage_bytes": 81197961216
+          }
+        ],
+        "status": "passed"
+      }
+    ],
+    "profile_id": "graph500-s22-provider",
+    "schema": "graphforge-public-certification/1",
+    "status": "passed"
+  },
+  "limits": {
+    "cores": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "cpu_seconds": 14400.0,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400.0
+  },
+  "outcome": "passed",
+  "schema": "graphforge-benchexec-run/1",
+  "signal": null
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-graphforge.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-graphforge.json
@@ -1,0 +1,1212 @@
+{
+  "failed_phase": null,
+  "phases": [
+    {
+      "duration_ms": 10,
+      "exit_code": 0,
+      "peak_rss_bytes": 20480,
+      "phase": "admission",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 26979,
+      "exit_code": 0,
+      "peak_rss_bytes": 73416704,
+      "phase": "generate",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 1095437,
+      "exit_code": 0,
+      "peak_rss_bytes": 182325248,
+      "phase": "ingest",
+      "receipts": [
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "begun"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "bytes_accepted": 3289349601,
+          "construction": {
+            "accepted_chunks": 1088,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 1088,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 14518761856,
+                  "write_calls": 34112
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 2433,
+                  "object_count": 0,
+                  "read_bytes": 31302429687,
+                  "read_calls": 659883,
+                  "write_bytes": 10846455483,
+                  "write_calls": 643437
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 46974,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 127633,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 86861533025,
+                  "read_calls": 1421617,
+                  "write_bytes": 68651068899,
+                  "write_calls": 87238
+                }
+              },
+              "totals": {
+                "block_count": 127633,
+                "fsync_calls": 49407,
+                "object_count": 1088,
+                "read_bytes": 118163962712,
+                "read_calls": 2081500,
+                "write_bytes": 94016286238,
+                "write_calls": 764787
+              }
+            },
+            "cache_release_operations": 208945,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 274562152697,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 44315299840,
+              "logical_bytes": 44310888140,
+              "logical_references": 5400,
+              "physical_logical_bytes": 44310888140,
+              "physical_objects": 5400
+            },
+            "construction_staging_transient_peak_allocated_bytes": 44315299840,
+            "fsync_operations": 13952,
+            "immutable_artifacts": 4288,
+            "input_batches": 1088,
+            "input_rows": 71303168,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": false,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 2433,
+                "object_count": 0,
+                "read_bytes": 31302429687,
+                "read_calls": 659883,
+                "write_bytes": 10846455483,
+                "write_calls": 643437
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 46974,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 1352727
+            },
+            "transient_peak_allocated_bytes": 44315299840,
+            "write_bytes": 14518761856,
+            "write_operations": 34112
+          },
+          "contract": "graphforge-import-session/1",
+          "outcome": "validated",
+          "rows_accepted": 71303168,
+          "rows_rejected": 0
+        },
+        {
+          "construction": {
+            "accepted_chunks": 1088,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 1088,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 14518761856,
+                  "write_calls": 34112
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 17280,
+                  "object_count": 0,
+                  "read_bytes": 7563491640,
+                  "read_calls": 123301,
+                  "write_bytes": 7560658285,
+                  "write_calls": 120144
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 2433,
+                  "object_count": 0,
+                  "read_bytes": 31302429687,
+                  "read_calls": 659883,
+                  "write_bytes": 10846455483,
+                  "write_calls": 643437
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 46974,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 15,
+                  "object_count": 0,
+                  "read_bytes": 7725031008,
+                  "read_calls": 118071,
+                  "write_bytes": 167884582,
+                  "write_calls": 2563
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 312355,
+                  "read_calls": 3,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 127633,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 86861533025,
+                  "read_calls": 1421617,
+                  "write_bytes": 68651068899,
+                  "write_calls": 87238
+                }
+              },
+              "totals": {
+                "block_count": 127633,
+                "fsync_calls": 66702,
+                "object_count": 1088,
+                "read_bytes": 133452797715,
+                "read_calls": 2322875,
+                "write_bytes": 101744829105,
+                "write_calls": 887494
+              }
+            },
+            "cache_release_operations": 208945,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 274562152697,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 44315299840,
+              "logical_bytes": 44310888140,
+              "logical_references": 5400,
+              "physical_logical_bytes": 44310888140,
+              "physical_objects": 5400
+            },
+            "construction_staging_transient_peak_allocated_bytes": 44315299840,
+            "fsync_operations": 13952,
+            "immutable_artifacts": 4288,
+            "input_batches": 1088,
+            "input_rows": 71303168,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": true,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 17280,
+                "object_count": 0,
+                "read_bytes": 7563491640,
+                "read_calls": 123301,
+                "write_bytes": 7560658285,
+                "write_calls": 120144
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 2433,
+                "object_count": 0,
+                "read_bytes": 31302429687,
+                "read_calls": 659883,
+                "write_bytes": 10846455483,
+                "write_calls": 643437
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 46974,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 15,
+                "object_count": 0,
+                "read_bytes": 7725031008,
+                "read_calls": 118071,
+                "write_bytes": 167884582,
+                "write_calls": 2563
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 312355,
+                "read_calls": 3,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 1734104
+            },
+            "transient_peak_allocated_bytes": 44315299840,
+            "write_bytes": 14518761856,
+            "write_operations": 34112
+          },
+          "contract": "graphforge-import-session/1",
+          "outcome": "committed"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 85915,
+      "exit_code": 0,
+      "peak_rss_bytes": 48599040,
+      "phase": "reopen",
+      "receipts": [
+        {
+          "aborted_journals": 0,
+          "deferred": null,
+          "elapsed_ms": 0,
+          "kind": "project_open",
+          "preserved_unknown_entries": 0,
+          "removed_generations": 0,
+          "repaired_journals": 0,
+          "selected_generation_class": "committed_current",
+          "work_detected": false
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 7565422592,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 6094848,
+                "logical_bytes": 683758,
+                "logical_references": 1488,
+                "physical_logical_bytes": 683758,
+                "physical_objects": 1488
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 4899287040,
+                "logical_bytes": 4897322832,
+                "logical_references": 1024,
+                "physical_logical_bytes": 4897322832,
+                "physical_objects": 1024
+              },
+              "topology_nodes": {
+                "allocated_bytes": 109314048,
+                "logical_bytes": 109108480,
+                "logical_references": 64,
+                "physical_logical_bytes": 109108480,
+                "physical_objects": 64
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 2550726656,
+                "logical_bytes": 2550712719,
+                "logical_references": 12,
+                "physical_logical_bytes": 2550712719,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 7557827789,
+            "logical_references": 2588,
+            "physical_objects": 2585,
+            "retained_logical_eof_bytes": 7557827789
+          }
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 51983,
+      "exit_code": 0,
+      "peak_rss_bytes": 93093888,
+      "phase": "recount",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "15563dc5ecd48bd37d48ccfe0da1d66be7da3fd4dd8c79d2d064e78657a0d228",
+          "rows": 1,
+          "scalar_u64": 4194304
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 90185728,
+                "before_bytes": 89595904,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 90185728
+              }
+            ],
+            "peak_rss_bytes": 90185728,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 90185728,
+            "sorts": []
+          },
+          "result_sha256": "979e01bd5c8760c4e606da882ea550a6711605f6d555f64a9ae6e431789cb2fc",
+          "rows": 1,
+          "scalar_u64": 67108864
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 148597,
+      "exit_code": 0,
+      "peak_rss_bytes": 261992448,
+      "phase": "query",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 122,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 73280,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 60,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 146296832,
+                "before_bytes": 87642112,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 146296832
+              }
+            ],
+            "peak_rss_bytes": 146296832,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 146296832,
+            "sorts": []
+          },
+          "result_sha256": "6b5348f6b35d2767a928b8c5e7aa018deca41e318056d45edd31cdbf43dc3579",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 6,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 131072,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 2,
+                "identity_reader_calls": 2,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 2,
+                "projected_columns": 1,
+                "projected_rows": 2,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 169934848,
+                "before_bytes": 86380544,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 169934848
+              }
+            ],
+            "peak_rss_bytes": 169934848,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 169934848,
+            "sorts": []
+          },
+          "result_sha256": "ecddd3def5e9f5114b6c626cef4ce1629b51bfe4fe48323b5d40ebcf4a5da0f3",
+          "rows": 1000,
+          "scalar_u64": null
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 69024,
+      "exit_code": 0,
+      "peak_rss_bytes": 50810880,
+      "phase": "export",
+      "receipts": [
+        {
+          "allocation_allocated_bytes": 7558496256,
+          "allocation_logical_bytes": 7558490624,
+          "allocation_physical_objects": 1,
+          "contract": "graphforge-portable-export/2",
+          "entry_count": 1112,
+          "package_digest": "sha256:931112e6d32e84805b92dc7d9b691f94696f5575b945f34de5fc35821fb8f9fc",
+          "payload_bytes": 7557147954,
+          "representation": "bundle",
+          "selection_fingerprint": "sha256:125b96c56b833a9e0644576e0474f87340f0ce277d4ffd8bf518f385d5a913a5",
+          "transport_digest": "sha256:f88e1a2968cec5cd474bbee6d4d188318c17ae3b103e992a7607d9fb4edc4219"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 9329,
+      "exit_code": 0,
+      "peak_rss_bytes": 35942400,
+      "phase": "verify",
+      "receipts": [
+        {
+          "compatibility": "supported",
+          "contract": "graphforge-portable-verify/2",
+          "entry_count": 1112,
+          "integrity": "verified",
+          "package_digest": "sha256:931112e6d32e84805b92dc7d9b691f94696f5575b945f34de5fc35821fb8f9fc",
+          "payload_bytes": 7557642742,
+          "representation": "bundle",
+          "transport_digest": "sha256:f88e1a2968cec5cd474bbee6d4d188318c17ae3b103e992a7607d9fb4edc4219"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 92536,
+      "exit_code": 0,
+      "peak_rss_bytes": 53276672,
+      "phase": "clean_import",
+      "receipts": [
+        {
+          "contract": "graphforge-portable-import/2",
+          "idempotent_replay": false,
+          "package_digest": "sha256:931112e6d32e84805b92dc7d9b691f94696f5575b945f34de5fc35821fb8f9fc",
+          "transient_peak_allocated_bytes": 15137730560,
+          "transport_digest": "sha256:f88e1a2968cec5cd474bbee6d4d188318c17ae3b103e992a7607d9fb4edc4219"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 293427,
+      "exit_code": 0,
+      "peak_rss_bytes": 264278016,
+      "phase": "reopen_proof",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "15563dc5ecd48bd37d48ccfe0da1d66be7da3fd4dd8c79d2d064e78657a0d228",
+          "rows": 1,
+          "scalar_u64": 4194304
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 83120128,
+                "before_bytes": 81973248,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 83120128
+              }
+            ],
+            "peak_rss_bytes": 83120128,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 83120128,
+            "sorts": []
+          },
+          "result_sha256": "979e01bd5c8760c4e606da882ea550a6711605f6d555f64a9ae6e431789cb2fc",
+          "rows": 1,
+          "scalar_u64": 67108864
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 122,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 73280,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 60,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 146882560,
+                "before_bytes": 86929408,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 146882560
+              }
+            ],
+            "peak_rss_bytes": 146882560,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 146882560,
+            "sorts": []
+          },
+          "result_sha256": "6b5348f6b35d2767a928b8c5e7aa018deca41e318056d45edd31cdbf43dc3579",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 6,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 131072,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 2,
+                "identity_reader_calls": 2,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 2,
+                "projected_columns": 1,
+                "projected_rows": 2,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 181661696,
+                "before_bytes": 88707072,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 181661696
+              }
+            ],
+            "peak_rss_bytes": 181661696,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 181661696,
+            "sorts": []
+          },
+          "result_sha256": "ecddd3def5e9f5114b6c626cef4ce1629b51bfe4fe48323b5d40ebcf4a5da0f3",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 7565422592,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 6094848,
+                "logical_bytes": 683758,
+                "logical_references": 1488,
+                "physical_logical_bytes": 683758,
+                "physical_objects": 1488
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 4899287040,
+                "logical_bytes": 4897322832,
+                "logical_references": 1024,
+                "physical_logical_bytes": 4897322832,
+                "physical_objects": 1024
+              },
+              "topology_nodes": {
+                "allocated_bytes": 109314048,
+                "logical_bytes": 109108480,
+                "logical_references": 64,
+                "physical_logical_bytes": 109108480,
+                "physical_objects": 64
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 2550726656,
+                "logical_bytes": 2550712719,
+                "logical_references": 12,
+                "physical_logical_bytes": 2550712719,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 7557827789,
+            "logical_references": 2588,
+            "physical_objects": 2585,
+            "retained_logical_eof_bytes": 7557827789
+          }
+        },
+        {
+          "contract": "graphforge-lifecycle-storage/2",
+          "retained_owners": {
+            "generated-inputs": {
+              "totals": {
+                "allocated_bytes": 3289358336,
+                "logical_bytes": 3289349601,
+                "logical_references": 2,
+                "physical_logical_bytes": 3289349601,
+                "physical_objects": 2
+              }
+            },
+            "imported-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "imported-project-construction": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-import": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "imported-project-published": {
+              "totals": {
+                "allocated_bytes": 7578365952,
+                "logical_bytes": 7560661703,
+                "logical_references": 5746,
+                "physical_logical_bytes": 7560661703,
+                "physical_objects": 5746
+              }
+            },
+            "imported-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            },
+            "portable-package": {
+              "totals": {
+                "allocated_bytes": 7558496256,
+                "logical_bytes": 7558490624,
+                "logical_references": 1,
+                "physical_logical_bytes": 7558490624,
+                "physical_objects": 1
+              }
+            },
+            "query-results": {
+              "totals": {
+                "allocated_bytes": 98304,
+                "logical_bytes": 71228,
+                "logical_references": 8,
+                "physical_logical_bytes": 71228,
+                "physical_objects": 8
+              }
+            },
+            "source-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "source-project-construction": {
+              "totals": {
+                "allocated_bytes": 44344586240,
+                "logical_bytes": 44317415409,
+                "logical_references": 11879,
+                "physical_logical_bytes": 44317415409,
+                "physical_objects": 11879
+              }
+            },
+            "source-project-import": {
+              "totals": {
+                "allocated_bytes": 3289366528,
+                "logical_bytes": 3289353821,
+                "logical_references": 3,
+                "physical_logical_bytes": 3289353821,
+                "physical_objects": 3
+              }
+            },
+            "source-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "source-project-published": {
+              "totals": {
+                "allocated_bytes": 7578365952,
+                "logical_bytes": 7560661703,
+                "logical_references": 5746,
+                "physical_logical_bytes": 7560661703,
+                "physical_objects": 5746
+              }
+            },
+            "source-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            }
+          },
+          "retained_storage_bytes": 73638645760,
+          "source_project_current_allocated_bytes": 7578365952,
+          "transient_peak_storage_bytes": 81197961216
+        }
+      ],
+      "status": "passed"
+    }
+  ],
+  "profile_id": "graph500-s22-provider",
+  "schema": "graphforge-public-certification/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-plan.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-plan.json
@@ -1,0 +1,37 @@
+{
+  "claim": "engineering_evidence_only",
+  "execution": "native_linux_benchexec_host",
+  "identities": {
+    "admitted_projection_sha256": "db61ef3e3f248e55cfbbfff085db9e600b93becb86f17bd7f49a0853bde3cff0",
+    "benchexec_python_sha256": "b8d8288faefdd300201f43fcf00f6f539a27218eeed3a3dff5ab10b9c4c99700",
+    "benchexec_version": "3.35",
+    "certify_sha256": "0f09a5020a9ede0c6e6d7451384cf6473414e5e448a939e4bcb9aeeeddb19ab1",
+    "commit": "3868e3c751ba0c94928033378d2ddc2b5401cd55",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "678cdd89ad68485402841d05302eab9403efad6fbf3ec02f73b84558bef54886",
+    "gf_sha256": "e94d8e762bb6b4139e20ab3ee21677d9197228b471bc904f8d8f3ec5dca4ab03",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "a2911040377d4b992754d206b94895b8aea7c97d0dcee2d163ece83e8183d540",
+    "profile_id": "graph500-s22-provider",
+    "profile_sha256": "57b7401694903b887d57345623581b6e73dd368b589bb8da1db7074b166db0b6"
+  },
+  "limits": {
+    "cores": 16,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400
+  },
+  "outputs": [
+    "s22-plan.json",
+    "s22-benchexec.json",
+    "s22-graphforge.json",
+    "s22-rung.json",
+    "s22-result.json"
+  ],
+  "rung": "S22",
+  "schema": "graphforge-progressive-host-run-plan/1",
+  "work_root_capacity": {
+    "free_bytes": 374503690240,
+    "reserved_headroom_bytes": 141258578535
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-projection.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-projection.json
@@ -1,0 +1,83 @@
+{
+  "checks": {
+    "correctness": true,
+    "io_reader_publication_capacity_measured": true,
+    "io_reader_publication_headroom": true,
+    "retained_storage_headroom": true,
+    "rss_bounded_or_plateaued": true,
+    "rss_headroom": true,
+    "storage_headroom": true,
+    "time_headroom": true,
+    "transient_storage_headroom": true
+  },
+  "claim": "engineering_evidence_only",
+  "decision": "admitted",
+  "headroom": {
+    "rss_fraction": 0.2,
+    "storage_fraction": 0.37718874931372426,
+    "time_fraction": 0.2
+  },
+  "limits": {
+    "rss_bytes": 4294967296,
+    "volume_bytes": 374503690240,
+    "wall_seconds": 14400
+  },
+  "native_capacity": {
+    "free_bytes": 374503690240,
+    "observed_rates": {
+      "physical_read_bytes_per_second": {
+        "wall_seconds": 221,
+        "work_units": 181354160128
+      },
+      "physical_write_bytes_per_second": {
+        "wall_seconds": 221,
+        "work_units": 45928562688
+      },
+      "publication_work_per_second": {
+        "wall_seconds": 221,
+        "work_units": 210510
+      },
+      "reader_calls_per_second": {
+        "wall_seconds": 221,
+        "work_units": 249607
+      }
+    },
+    "rate_source": "completed_adjacent_rungs",
+    "reserved_headroom_bytes": 141258578535
+  },
+  "projected": {
+    "logical_read_bytes": 123211408128,
+    "logical_write_bytes": 91598942264,
+    "peak_rss_bytes": 214839296,
+    "physical_read_bytes": 1477558050816,
+    "physical_write_bytes": 370006372352,
+    "publication_work_units": 1712346,
+    "reader_calls": 1998606,
+    "retained_storage_bytes": 73252622336,
+    "storage_peak_bytes": 80715640832,
+    "transient_peak_storage_bytes": 80715640832,
+    "wall_seconds": 1764
+  },
+  "provider_capacity": null,
+  "required_rates": {
+    "physical_read_bytes_per_second": 128260248,
+    "physical_write_bytes_per_second": 32118609,
+    "publication_work_per_second": 149,
+    "reader_calls_per_second": 174
+  },
+  "rss_growth_fraction": 0.062356599120831996,
+  "schema": "graphforge-progressive-qualification-evidence/1",
+  "slopes_observed": {
+    "logical_read_bytes": 15410301621,
+    "logical_write_bytes": 11455782617,
+    "physical_read_bytes": 185171984384,
+    "physical_write_bytes": 46296829952,
+    "publication_work_units": 214548,
+    "reader_calls": 249857
+  },
+  "source_scales": [
+    19,
+    20
+  ],
+  "target": "S22"
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-result.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-result.json
@@ -1,0 +1,28 @@
+{
+  "artifacts": {
+    "benchexec_sha256": "df4c78c48567d7e7e34357771707cddd29021f566efa70180361b62a05cb03ca",
+    "graphforge_sha256": "2da2721f7ec87b0841e1b673d66b3c76d11841273b21d790a920085404dd7d6c",
+    "plan_sha256": "7f6d2dd1b729cd99903d9fbb353c317b937051b77690c0a446dcf5a7c8f7b447",
+    "rung_sha256": "8a57c7bb93d9e92603334bad246d37642bd857501e2617d8523d694a6b205e51"
+  },
+  "claim": "engineering_evidence_only",
+  "failure": null,
+  "identities": {
+    "admitted_projection_sha256": "db61ef3e3f248e55cfbbfff085db9e600b93becb86f17bd7f49a0853bde3cff0",
+    "benchexec_python_sha256": "b8d8288faefdd300201f43fcf00f6f539a27218eeed3a3dff5ab10b9c4c99700",
+    "benchexec_version": "3.35",
+    "certify_sha256": "0f09a5020a9ede0c6e6d7451384cf6473414e5e448a939e4bcb9aeeeddb19ab1",
+    "commit": "3868e3c751ba0c94928033378d2ddc2b5401cd55",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "678cdd89ad68485402841d05302eab9403efad6fbf3ec02f73b84558bef54886",
+    "gf_sha256": "e94d8e762bb6b4139e20ab3ee21677d9197228b471bc904f8d8f3ec5dca4ab03",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "a2911040377d4b992754d206b94895b8aea7c97d0dcee2d163ece83e8183d540",
+    "profile_id": "graph500-s22-provider",
+    "profile_sha256": "57b7401694903b887d57345623581b6e73dd368b589bb8da1db7074b166db0b6"
+  },
+  "rung": "S22",
+  "schema": "graphforge-progressive-host-run-result/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-rung.json
+++ b/docs/development/evidence/integrated-storage-1194/historical-3868e3c7/s22-rung.json
@@ -1,0 +1,490 @@
+{
+  "assembly_contract": "graphforge-progressive-rung-assembly/3",
+  "correctness": true,
+  "failure": null,
+  "live_edges": 67108864,
+  "metric_sources": {
+    "benchexec": [
+      "wall_seconds",
+      "physical_read_bytes",
+      "physical_write_bytes"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
+    ],
+    "query_qualification": [
+      "live_edges",
+      "correctness"
+    ],
+    "storage_attribution": [
+      "retained_storage_bytes",
+      "transient_peak_storage_bytes",
+      "logical_read_bytes",
+      "logical_write_bytes",
+      "reader_calls",
+      "publication_work_units"
+    ]
+  },
+  "metrics": {
+    "logical_read_bytes": 133452797715,
+    "logical_write_bytes": 101744829105,
+    "peak_rss_bytes": 264278016,
+    "physical_read_bytes": 1547175919616,
+    "physical_write_bytes": 466245177344,
+    "publication_work_units": 1734104,
+    "reader_calls": 2322875,
+    "retained_storage_bytes": 73638645760,
+    "transient_peak_storage_bytes": 81197961216,
+    "wall_seconds": 1955
+  },
+  "phases": [
+    "admission",
+    "generate",
+    "ingest",
+    "reopen",
+    "recount",
+    "query",
+    "export",
+    "verify",
+    "clean_import",
+    "reopen_proof"
+  ],
+  "profile_id": "graph500-s22-provider",
+  "scale": 22,
+  "source": "canonical_ladder",
+  "status": "passed",
+  "storage_attribution": {
+    "construction": {
+      "application_io": {
+        "phases": {
+          "append_merge": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 1088,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 14518761856,
+            "write_calls": 34112
+          },
+          "cas_install_read_write": {
+            "block_count": 0,
+            "fsync_calls": 17280,
+            "object_count": 0,
+            "read_bytes": 7563491640,
+            "read_calls": 123301,
+            "write_bytes": 7560658285,
+            "write_calls": 120144
+          },
+          "encode_write_postwrite_authentication": {
+            "block_count": 0,
+            "fsync_calls": 2433,
+            "object_count": 0,
+            "read_bytes": 31302429687,
+            "read_calls": 659883,
+            "write_bytes": 10846455483,
+            "write_calls": 643437
+          },
+          "fsync_synchronization": {
+            "block_count": 0,
+            "fsync_calls": 46974,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "hydration_verification": {
+            "block_count": 0,
+            "fsync_calls": 15,
+            "object_count": 0,
+            "read_bytes": 7725031008,
+            "read_calls": 118071,
+            "write_bytes": 167884582,
+            "write_calls": 2563
+          },
+          "publication_preauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 312355,
+            "read_calls": 3,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "recovery_reauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "seal_authentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "shape_consume_reauthentication": {
+            "block_count": 127633,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 86861533025,
+            "read_calls": 1421617,
+            "write_bytes": 68651068899,
+            "write_calls": 87238
+          }
+        },
+        "totals": {
+          "block_count": 127633,
+          "fsync_calls": 66702,
+          "object_count": 1088,
+          "read_bytes": 133452797715,
+          "read_calls": 2322875,
+          "write_bytes": 101744829105,
+          "write_calls": 887494
+        }
+      },
+      "staging": {
+        "allocated_bytes": 44315299840,
+        "logical_bytes": 44310888140,
+        "logical_references": 5400,
+        "physical_logical_bytes": 44310888140,
+        "physical_objects": 5400
+      },
+      "staging_transient_peak_allocated_bytes": 44315299840,
+      "transient_peak_allocated_bytes": 44315299840
+    },
+    "counts": {
+      "imported_edges": 67108864,
+      "imported_nodes": 4194304,
+      "source_edges": 67108864,
+      "source_nodes": 4194304
+    },
+    "imported": {
+      "allocated_physical_bytes": 7565422592,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 6094848,
+          "logical_bytes": 683758,
+          "logical_references": 1488,
+          "physical_logical_bytes": 683758,
+          "physical_objects": 1488
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 4899287040,
+          "logical_bytes": 4897322832,
+          "logical_references": 1024,
+          "physical_logical_bytes": 4897322832,
+          "physical_objects": 1024
+        },
+        "topology_nodes": {
+          "allocated_bytes": 109314048,
+          "logical_bytes": 109108480,
+          "logical_references": 64,
+          "physical_logical_bytes": 109108480,
+          "physical_objects": 64
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2550726656,
+          "logical_bytes": 2550712719,
+          "logical_references": 12,
+          "physical_logical_bytes": 2550712719,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 7557827789,
+      "logical_references": 2588,
+      "physical_objects": 2585,
+      "retained_logical_eof_bytes": 7557827789
+    },
+    "lifecycle": {
+      "contract": "graphforge-lifecycle-storage/2",
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 3289358336,
+            "logical_bytes": 3289349601,
+            "logical_references": 2,
+            "physical_logical_bytes": 3289349601,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 7578365952,
+            "logical_bytes": 7560661703,
+            "logical_references": 5746,
+            "physical_logical_bytes": 7560661703,
+            "physical_objects": 5746
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 7558496256,
+            "logical_bytes": 7558490624,
+            "logical_references": 1,
+            "physical_logical_bytes": 7558490624,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 44344586240,
+            "logical_bytes": 44317415409,
+            "logical_references": 11879,
+            "physical_logical_bytes": 44317415409,
+            "physical_objects": 11879
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 3289366528,
+            "logical_bytes": 3289353821,
+            "logical_references": 3,
+            "physical_logical_bytes": 3289353821,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 7578365952,
+            "logical_bytes": 7560661703,
+            "logical_references": 5746,
+            "physical_logical_bytes": 7560661703,
+            "physical_objects": 5746
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "retained_storage_bytes": 73638645760,
+      "source_project_current_allocated_bytes": 7578365952,
+      "transient_peak_storage_bytes": 81197961216
+    },
+    "portable_package": {
+      "allocation_allocated_bytes": 7558496256,
+      "allocation_logical_bytes": 7558490624,
+      "allocation_physical_objects": 1,
+      "contract": "graphforge-portable-export/2"
+    },
+    "source": {
+      "allocated_physical_bytes": 7565422592,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 6094848,
+          "logical_bytes": 683758,
+          "logical_references": 1488,
+          "physical_logical_bytes": 683758,
+          "physical_objects": 1488
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 4899287040,
+          "logical_bytes": 4897322832,
+          "logical_references": 1024,
+          "physical_logical_bytes": 4897322832,
+          "physical_objects": 1024
+        },
+        "topology_nodes": {
+          "allocated_bytes": 109314048,
+          "logical_bytes": 109108480,
+          "logical_references": 64,
+          "physical_logical_bytes": 109108480,
+          "physical_objects": 64
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 2550726656,
+          "logical_bytes": 2550712719,
+          "logical_references": 12,
+          "physical_logical_bytes": 2550712719,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 7557827789,
+      "logical_references": 2588,
+      "physical_objects": 2585,
+      "retained_logical_eof_bytes": 7557827789
+    }
+  },
+  "storage_components": {
+    "imported_allocated_physical_bytes": 7565422592,
+    "imported_retained_logical_eof_bytes": 7557827789,
+    "logical_read_bytes": 133452797715,
+    "logical_write_bytes": 101744829105,
+    "publication_work_units": 1734104,
+    "reader_calls": 2322875,
+    "source_allocated_physical_bytes": 7565422592,
+    "source_project_current_allocated_bytes": 7578365952,
+    "source_retained_logical_eof_bytes": 7557827789,
+    "transient_peak_allocated_bytes": 44315299840
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/s18-benchexec.json
+++ b/docs/development/evidence/integrated-storage-1194/s18-benchexec.json
@@ -1,0 +1,1306 @@
+{
+  "authority": {
+    "cpu_seconds": 80.257677,
+    "peak_rss_bytes": 819265536,
+    "pressure_cpu_seconds": 0.105651,
+    "pressure_io_seconds": 8.071899,
+    "pressure_memory_seconds": 0.0,
+    "read_bytes": 54517145600,
+    "wall_seconds": 96.24521505401935,
+    "write_bytes": 18559918080
+  },
+  "disagreements": [],
+  "exit_code": 0,
+  "graphforge": {
+    "failed_phase": null,
+    "phases": [
+      {
+        "duration_ms": 10,
+        "exit_code": 0,
+        "peak_rss_bytes": 114688,
+        "phase": "admission",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 1633,
+        "exit_code": 0,
+        "peak_rss_bytes": 73129984,
+        "phase": "generate",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 56944,
+        "exit_code": 0,
+        "peak_rss_bytes": 150233088,
+        "phase": "ingest",
+        "receipts": [
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "begun"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "bytes_accepted": 205584915,
+            "construction": {
+              "accepted_chunks": 68,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 68,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 907422616,
+                    "write_calls": 2132
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 188,
+                    "object_count": 0,
+                    "read_bytes": 1581779667,
+                    "read_calls": 41350,
+                    "write_bytes": 368025637,
+                    "write_calls": 9805
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 2679,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 4148411273,
+                    "read_calls": 4094,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 7185,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 4806759233,
+                    "read_calls": 68692,
+                    "write_bytes": 3668566063,
+                    "write_calls": 4280
+                  }
+                },
+                "totals": {
+                  "block_count": 7185,
+                  "fsync_calls": 2867,
+                  "object_count": 68,
+                  "read_bytes": 10536950173,
+                  "read_calls": 114136,
+                  "write_bytes": 4944014316,
+                  "write_calls": 16217
+                }
+              },
+              "cache_release_operations": 10771,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 18455842290,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 162582528,
+                "logical_bytes": 162440730,
+                "logical_references": 84,
+                "physical_logical_bytes": 162440730,
+                "physical_objects": 84
+              },
+              "construction_staging_transient_peak_allocated_bytes": 2561527808,
+              "fsync_operations": 872,
+              "immutable_artifacts": 268,
+              "input_batches": 68,
+              "input_rows": 4456448,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": false,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 188,
+                  "object_count": 0,
+                  "read_bytes": 1581779667,
+                  "read_calls": 41350,
+                  "write_bytes": 368025637,
+                  "write_calls": 9805
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 2679,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 54022
+              },
+              "transient_peak_allocated_bytes": 2561527808,
+              "write_bytes": 907422616,
+              "write_operations": 2132
+            },
+            "contract": "graphforge-import-session/1",
+            "operation_timings": {
+              "append": {
+                "calls": 68,
+                "elapsed_ns": 4226577176,
+                "errors": 0
+              },
+              "begin": {
+                "calls": 1,
+                "elapsed_ns": 940518,
+                "errors": 0
+              },
+              "publish": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "resume": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "seal": {
+                "calls": 1,
+                "elapsed_ns": 44331662036,
+                "errors": 0
+              }
+            },
+            "outcome": "validated",
+            "rows_accepted": 4456448,
+            "rows_rejected": 0
+          },
+          {
+            "construction": {
+              "accepted_chunks": 68,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 68,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 907422616,
+                    "write_calls": 2132
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 791,
+                    "object_count": 0,
+                    "read_bytes": 162782947,
+                    "read_calls": 2824,
+                    "write_bytes": 162625988,
+                    "write_calls": 2674
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 188,
+                    "object_count": 0,
+                    "read_bytes": 1581779667,
+                    "read_calls": 41350,
+                    "write_bytes": 368025637,
+                    "write_calls": 9805
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 2691,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 16,
+                    "object_count": 0,
+                    "read_bytes": 172952198,
+                    "read_calls": 2657,
+                    "write_bytes": 10511291,
+                    "write_calls": 164
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 27665,
+                    "read_calls": 3,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 4635761939,
+                    "read_calls": 6953,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 7185,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 4806759233,
+                    "read_calls": 68692,
+                    "write_bytes": 3668566063,
+                    "write_calls": 4280
+                  }
+                },
+                "totals": {
+                  "block_count": 7185,
+                  "fsync_calls": 3686,
+                  "object_count": 68,
+                  "read_bytes": 11360063649,
+                  "read_calls": 122479,
+                  "write_bytes": 5117151595,
+                  "write_calls": 19055
+                }
+              },
+              "cache_release_operations": 11014,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 18943164480,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 162582528,
+                "logical_bytes": 162440730,
+                "logical_references": 84,
+                "physical_logical_bytes": 162440730,
+                "physical_objects": 84
+              },
+              "construction_staging_transient_peak_allocated_bytes": 2561527808,
+              "fsync_operations": 872,
+              "immutable_artifacts": 268,
+              "input_batches": 68,
+              "input_rows": 4456448,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": true,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 791,
+                  "object_count": 0,
+                  "read_bytes": 162782947,
+                  "read_calls": 2824,
+                  "write_bytes": 162625988,
+                  "write_calls": 2674
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 188,
+                  "object_count": 0,
+                  "read_bytes": 1581779667,
+                  "read_calls": 41350,
+                  "write_bytes": 368025637,
+                  "write_calls": 9805
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 2691,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 16,
+                  "object_count": 0,
+                  "read_bytes": 172952198,
+                  "read_calls": 2657,
+                  "write_bytes": 10511291,
+                  "write_calls": 164
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 27665,
+                  "read_calls": 3,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 63163
+              },
+              "transient_peak_allocated_bytes": 2561527808,
+              "write_bytes": 907422616,
+              "write_operations": 2132
+            },
+            "contract": "graphforge-import-session/1",
+            "operation_timings": {
+              "append": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "begin": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "publish": {
+                "calls": 1,
+                "elapsed_ns": 2492120075,
+                "errors": 0
+              },
+              "resume": {
+                "calls": 1,
+                "elapsed_ns": 256419162,
+                "errors": 0
+              },
+              "seal": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              }
+            },
+            "outcome": "committed"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 3479,
+        "exit_code": 0,
+        "peak_rss_bytes": 37408768,
+        "phase": "reopen",
+        "receipts": [
+          {
+            "aborted_journals": 0,
+            "deferred": null,
+            "elapsed_ms": 0,
+            "kind": "project_open",
+            "preserved_unknown_entries": 0,
+            "removed_generations": 0,
+            "repaired_journals": 0,
+            "selected_generation_class": "committed_current",
+            "work_detected": false
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 162734080,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 163840,
+                  "logical_bytes": 32887,
+                  "logical_references": 40,
+                  "physical_logical_bytes": 32887,
+                  "physical_objects": 40
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 66846720,
+                  "logical_bytes": 66737485,
+                  "logical_references": 64,
+                  "physical_logical_bytes": 66737485,
+                  "physical_objects": 64
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 1048576,
+                  "logical_bytes": 1040395,
+                  "logical_references": 4,
+                  "physical_logical_bytes": 1040395,
+                  "physical_objects": 4
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 94674944,
+                  "logical_bytes": 94660150,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 94660150,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 162470917,
+              "logical_references": 120,
+              "physical_objects": 117,
+              "retained_logical_eof_bytes": 162470917
+            }
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 2159,
+        "exit_code": 0,
+        "peak_rss_bytes": 79835136,
+        "phase": "recount",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "3943ce07cba5fc8b1b779daf479b68f69c81d1b0427e0ac49c8433fe53b17e8f",
+            "rows": 1,
+            "scalar_u64": 262144
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 77656064,
+                  "before_bytes": 76435456,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 77656064
+                }
+              ],
+              "peak_rss_bytes": 77656064,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 77656064,
+              "sorts": []
+            },
+            "result_sha256": "2cb98d6493038230f3d574b16c2cbe283c07e43471b8764f6dfb59bea0aca486",
+            "rows": 1,
+            "scalar_u64": 4194304
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 9961,
+        "exit_code": 0,
+        "peak_rss_bytes": 182546432,
+        "phase": "query",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 46,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 68928,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 26,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 126226432,
+                  "before_bytes": 76132352,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 126226432
+                }
+              ],
+              "peak_rss_bytes": 126226432,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 126226432,
+              "sorts": []
+            },
+            "result_sha256": "b73a4441b8a7358838773819082202e4055f965637f36d4e1b43d3c2b9635c28",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 4,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 1,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 142749696,
+                  "before_bytes": 76939264,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 142749696
+                }
+              ],
+              "peak_rss_bytes": 142749696,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 142749696,
+              "sorts": []
+            },
+            "result_sha256": "3541076a1d4b4914fa1686264d88f0595f95fa45d10578dec497b3936be8bd60",
+            "rows": 1000,
+            "scalar_u64": null
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 2092,
+        "exit_code": 0,
+        "peak_rss_bytes": 36511744,
+        "phase": "export",
+        "receipts": [
+          {
+            "allocation_allocated_bytes": 162566144,
+            "allocation_logical_bytes": 162560000,
+            "allocation_physical_objects": 1,
+            "contract": "graphforge-portable-export/2",
+            "entry_count": 93,
+            "package_digest": "sha256:3438c6d1e9c08b88e6f63dba910407351656b61ed5f03afaceeb6eea2dcb31a4",
+            "payload_bytes": 162442253,
+            "representation": "bundle",
+            "selection_fingerprint": "sha256:f4a36ab6da276270a93abe1ebb43e26820d78f528c32cd4cd2dbaf3c65a75423",
+            "transport_digest": "sha256:6d6093393e44a1af87ee2e6dc086606210649d8cf7ae53c2e2e7951bc506c5b0"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 242,
+        "exit_code": 0,
+        "peak_rss_bytes": 22069248,
+        "phase": "verify",
+        "receipts": [
+          {
+            "compatibility": "supported",
+            "contract": "graphforge-portable-verify/2",
+            "entry_count": 93,
+            "integrity": "verified",
+            "package_digest": "sha256:3438c6d1e9c08b88e6f63dba910407351656b61ed5f03afaceeb6eea2dcb31a4",
+            "payload_bytes": 162488855,
+            "representation": "bundle",
+            "transport_digest": "sha256:6d6093393e44a1af87ee2e6dc086606210649d8cf7ae53c2e2e7951bc506c5b0"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 2654,
+        "exit_code": 0,
+        "peak_rss_bytes": 33447936,
+        "phase": "clean_import",
+        "receipts": [
+          {
+            "contract": "graphforge-portable-import/2",
+            "idempotent_replay": false,
+            "package_digest": "sha256:3438c6d1e9c08b88e6f63dba910407351656b61ed5f03afaceeb6eea2dcb31a4",
+            "transient_peak_allocated_bytes": 325971968,
+            "transport_digest": "sha256:6d6093393e44a1af87ee2e6dc086606210649d8cf7ae53c2e2e7951bc506c5b0"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 14452,
+        "exit_code": 0,
+        "peak_rss_bytes": 182611968,
+        "phase": "reopen_proof",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "3943ce07cba5fc8b1b779daf479b68f69c81d1b0427e0ac49c8433fe53b17e8f",
+            "rows": 1,
+            "scalar_u64": 262144
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 77635584,
+                  "before_bytes": 76693504,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 77635584
+                }
+              ],
+              "peak_rss_bytes": 77635584,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 77635584,
+              "sorts": []
+            },
+            "result_sha256": "2cb98d6493038230f3d574b16c2cbe283c07e43471b8764f6dfb59bea0aca486",
+            "rows": 1,
+            "scalar_u64": 4194304
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 46,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 68928,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 26,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 125800448,
+                  "before_bytes": 75776000,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 125800448
+                }
+              ],
+              "peak_rss_bytes": 125800448,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 125800448,
+              "sorts": []
+            },
+            "result_sha256": "b73a4441b8a7358838773819082202e4055f965637f36d4e1b43d3c2b9635c28",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 4,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 1,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 142819328,
+                  "before_bytes": 77090816,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 142819328
+                }
+              ],
+              "peak_rss_bytes": 142819328,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 142819328,
+              "sorts": []
+            },
+            "result_sha256": "3541076a1d4b4914fa1686264d88f0595f95fa45d10578dec497b3936be8bd60",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 162729984,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 163840,
+                  "logical_bytes": 32887,
+                  "logical_references": 40,
+                  "physical_logical_bytes": 32887,
+                  "physical_objects": 40
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 66846720,
+                  "logical_bytes": 66737485,
+                  "logical_references": 64,
+                  "physical_logical_bytes": 66737485,
+                  "physical_objects": 64
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 1048576,
+                  "logical_bytes": 1040395,
+                  "logical_references": 4,
+                  "physical_logical_bytes": 1040395,
+                  "physical_objects": 4
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 94670848,
+                  "logical_bytes": 94660150,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 94660150,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 162470917,
+              "logical_references": 120,
+              "physical_objects": 117,
+              "retained_logical_eof_bytes": 162470917
+            }
+          },
+          {
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": {
+              "generated-inputs": {
+                "totals": {
+                  "allocated_bytes": 205594624,
+                  "logical_bytes": 205584915,
+                  "logical_references": 2,
+                  "physical_logical_bytes": 205584915,
+                  "physical_objects": 2
+                }
+              },
+              "imported-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "imported-project-construction": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-import": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "imported-project-published": {
+                "totals": {
+                  "allocated_bytes": 163364864,
+                  "logical_bytes": 162629401,
+                  "logical_references": 273,
+                  "physical_logical_bytes": 162629401,
+                  "physical_objects": 273
+                }
+              },
+              "imported-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              },
+              "portable-package": {
+                "totals": {
+                  "allocated_bytes": 162566144,
+                  "logical_bytes": 162560000,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 162560000,
+                  "physical_objects": 1
+                }
+              },
+              "query-results": {
+                "totals": {
+                  "allocated_bytes": 98304,
+                  "logical_bytes": 71228,
+                  "logical_references": 8,
+                  "physical_logical_bytes": 71228,
+                  "physical_objects": 8
+                }
+              },
+              "source-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "source-project-construction": {
+                "totals": {
+                  "allocated_bytes": 164478976,
+                  "logical_bytes": 162870632,
+                  "logical_references": 503,
+                  "physical_logical_bytes": 162870632,
+                  "physical_objects": 503
+                }
+              },
+              "source-project-import": {
+                "totals": {
+                  "allocated_bytes": 205602816,
+                  "logical_bytes": 205589045,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 205589045,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-published": {
+                "totals": {
+                  "allocated_bytes": 163368960,
+                  "logical_bytes": 162629401,
+                  "logical_references": 273,
+                  "physical_logical_bytes": 162629401,
+                  "physical_objects": 273
+                }
+              },
+              "source-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              }
+            },
+            "retained_storage_bytes": 1065082880,
+            "source_project_current_allocated_bytes": 163368960,
+            "transient_peak_storage_bytes": 2974519296
+          }
+        ],
+        "status": "passed"
+      }
+    ],
+    "profile_id": "graph500-s18-local",
+    "schema": "graphforge-public-certification/1",
+    "status": "passed"
+  },
+  "limits": {
+    "cores": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "cpu_seconds": 14400.0,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400.0
+  },
+  "outcome": "passed",
+  "schema": "graphforge-benchexec-run/1",
+  "signal": null
+}

--- a/docs/development/evidence/integrated-storage-1194/s18-graphforge.json
+++ b/docs/development/evidence/integrated-storage-1194/s18-graphforge.json
@@ -1,0 +1,1266 @@
+{
+  "failed_phase": null,
+  "phases": [
+    {
+      "duration_ms": 10,
+      "exit_code": 0,
+      "peak_rss_bytes": 114688,
+      "phase": "admission",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 1633,
+      "exit_code": 0,
+      "peak_rss_bytes": 73129984,
+      "phase": "generate",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 56944,
+      "exit_code": 0,
+      "peak_rss_bytes": 150233088,
+      "phase": "ingest",
+      "receipts": [
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "begun"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "bytes_accepted": 205584915,
+          "construction": {
+            "accepted_chunks": 68,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 68,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 907422616,
+                  "write_calls": 2132
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 188,
+                  "object_count": 0,
+                  "read_bytes": 1581779667,
+                  "read_calls": 41350,
+                  "write_bytes": 368025637,
+                  "write_calls": 9805
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 2679,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 4148411273,
+                  "read_calls": 4094,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 7185,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 4806759233,
+                  "read_calls": 68692,
+                  "write_bytes": 3668566063,
+                  "write_calls": 4280
+                }
+              },
+              "totals": {
+                "block_count": 7185,
+                "fsync_calls": 2867,
+                "object_count": 68,
+                "read_bytes": 10536950173,
+                "read_calls": 114136,
+                "write_bytes": 4944014316,
+                "write_calls": 16217
+              }
+            },
+            "cache_release_operations": 10771,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 18455842290,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 162582528,
+              "logical_bytes": 162440730,
+              "logical_references": 84,
+              "physical_logical_bytes": 162440730,
+              "physical_objects": 84
+            },
+            "construction_staging_transient_peak_allocated_bytes": 2561527808,
+            "fsync_operations": 872,
+            "immutable_artifacts": 268,
+            "input_batches": 68,
+            "input_rows": 4456448,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": false,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 188,
+                "object_count": 0,
+                "read_bytes": 1581779667,
+                "read_calls": 41350,
+                "write_bytes": 368025637,
+                "write_calls": 9805
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 2679,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 54022
+            },
+            "transient_peak_allocated_bytes": 2561527808,
+            "write_bytes": 907422616,
+            "write_operations": 2132
+          },
+          "contract": "graphforge-import-session/1",
+          "operation_timings": {
+            "append": {
+              "calls": 68,
+              "elapsed_ns": 4226577176,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 1,
+              "elapsed_ns": 940518,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 1,
+              "elapsed_ns": 44331662036,
+              "errors": 0
+            }
+          },
+          "outcome": "validated",
+          "rows_accepted": 4456448,
+          "rows_rejected": 0
+        },
+        {
+          "construction": {
+            "accepted_chunks": 68,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 68,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 907422616,
+                  "write_calls": 2132
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 791,
+                  "object_count": 0,
+                  "read_bytes": 162782947,
+                  "read_calls": 2824,
+                  "write_bytes": 162625988,
+                  "write_calls": 2674
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 188,
+                  "object_count": 0,
+                  "read_bytes": 1581779667,
+                  "read_calls": 41350,
+                  "write_bytes": 368025637,
+                  "write_calls": 9805
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 2691,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 16,
+                  "object_count": 0,
+                  "read_bytes": 172952198,
+                  "read_calls": 2657,
+                  "write_bytes": 10511291,
+                  "write_calls": 164
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 27665,
+                  "read_calls": 3,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 4635761939,
+                  "read_calls": 6953,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 7185,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 4806759233,
+                  "read_calls": 68692,
+                  "write_bytes": 3668566063,
+                  "write_calls": 4280
+                }
+              },
+              "totals": {
+                "block_count": 7185,
+                "fsync_calls": 3686,
+                "object_count": 68,
+                "read_bytes": 11360063649,
+                "read_calls": 122479,
+                "write_bytes": 5117151595,
+                "write_calls": 19055
+              }
+            },
+            "cache_release_operations": 11014,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 18943164480,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 162582528,
+              "logical_bytes": 162440730,
+              "logical_references": 84,
+              "physical_logical_bytes": 162440730,
+              "physical_objects": 84
+            },
+            "construction_staging_transient_peak_allocated_bytes": 2561527808,
+            "fsync_operations": 872,
+            "immutable_artifacts": 268,
+            "input_batches": 68,
+            "input_rows": 4456448,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": true,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 791,
+                "object_count": 0,
+                "read_bytes": 162782947,
+                "read_calls": 2824,
+                "write_bytes": 162625988,
+                "write_calls": 2674
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 188,
+                "object_count": 0,
+                "read_bytes": 1581779667,
+                "read_calls": 41350,
+                "write_bytes": 368025637,
+                "write_calls": 9805
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 2691,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 16,
+                "object_count": 0,
+                "read_bytes": 172952198,
+                "read_calls": 2657,
+                "write_bytes": 10511291,
+                "write_calls": 164
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 27665,
+                "read_calls": 3,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 63163
+            },
+            "transient_peak_allocated_bytes": 2561527808,
+            "write_bytes": 907422616,
+            "write_operations": 2132
+          },
+          "contract": "graphforge-import-session/1",
+          "operation_timings": {
+            "append": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 1,
+              "elapsed_ns": 2492120075,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 1,
+              "elapsed_ns": 256419162,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            }
+          },
+          "outcome": "committed"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 3479,
+      "exit_code": 0,
+      "peak_rss_bytes": 37408768,
+      "phase": "reopen",
+      "receipts": [
+        {
+          "aborted_journals": 0,
+          "deferred": null,
+          "elapsed_ms": 0,
+          "kind": "project_open",
+          "preserved_unknown_entries": 0,
+          "removed_generations": 0,
+          "repaired_journals": 0,
+          "selected_generation_class": "committed_current",
+          "work_detected": false
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 162734080,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 163840,
+                "logical_bytes": 32887,
+                "logical_references": 40,
+                "physical_logical_bytes": 32887,
+                "physical_objects": 40
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 66846720,
+                "logical_bytes": 66737485,
+                "logical_references": 64,
+                "physical_logical_bytes": 66737485,
+                "physical_objects": 64
+              },
+              "topology_nodes": {
+                "allocated_bytes": 1048576,
+                "logical_bytes": 1040395,
+                "logical_references": 4,
+                "physical_logical_bytes": 1040395,
+                "physical_objects": 4
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 94674944,
+                "logical_bytes": 94660150,
+                "logical_references": 12,
+                "physical_logical_bytes": 94660150,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 162470917,
+            "logical_references": 120,
+            "physical_objects": 117,
+            "retained_logical_eof_bytes": 162470917
+          }
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 2159,
+      "exit_code": 0,
+      "peak_rss_bytes": 79835136,
+      "phase": "recount",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "3943ce07cba5fc8b1b779daf479b68f69c81d1b0427e0ac49c8433fe53b17e8f",
+          "rows": 1,
+          "scalar_u64": 262144
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 77656064,
+                "before_bytes": 76435456,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 77656064
+              }
+            ],
+            "peak_rss_bytes": 77656064,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 77656064,
+            "sorts": []
+          },
+          "result_sha256": "2cb98d6493038230f3d574b16c2cbe283c07e43471b8764f6dfb59bea0aca486",
+          "rows": 1,
+          "scalar_u64": 4194304
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 9961,
+      "exit_code": 0,
+      "peak_rss_bytes": 182546432,
+      "phase": "query",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 46,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 68928,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 26,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 126226432,
+                "before_bytes": 76132352,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 126226432
+              }
+            ],
+            "peak_rss_bytes": 126226432,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 126226432,
+            "sorts": []
+          },
+          "result_sha256": "b73a4441b8a7358838773819082202e4055f965637f36d4e1b43d3c2b9635c28",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 4,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 1,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 142749696,
+                "before_bytes": 76939264,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 142749696
+              }
+            ],
+            "peak_rss_bytes": 142749696,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 142749696,
+            "sorts": []
+          },
+          "result_sha256": "3541076a1d4b4914fa1686264d88f0595f95fa45d10578dec497b3936be8bd60",
+          "rows": 1000,
+          "scalar_u64": null
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 2092,
+      "exit_code": 0,
+      "peak_rss_bytes": 36511744,
+      "phase": "export",
+      "receipts": [
+        {
+          "allocation_allocated_bytes": 162566144,
+          "allocation_logical_bytes": 162560000,
+          "allocation_physical_objects": 1,
+          "contract": "graphforge-portable-export/2",
+          "entry_count": 93,
+          "package_digest": "sha256:3438c6d1e9c08b88e6f63dba910407351656b61ed5f03afaceeb6eea2dcb31a4",
+          "payload_bytes": 162442253,
+          "representation": "bundle",
+          "selection_fingerprint": "sha256:f4a36ab6da276270a93abe1ebb43e26820d78f528c32cd4cd2dbaf3c65a75423",
+          "transport_digest": "sha256:6d6093393e44a1af87ee2e6dc086606210649d8cf7ae53c2e2e7951bc506c5b0"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 242,
+      "exit_code": 0,
+      "peak_rss_bytes": 22069248,
+      "phase": "verify",
+      "receipts": [
+        {
+          "compatibility": "supported",
+          "contract": "graphforge-portable-verify/2",
+          "entry_count": 93,
+          "integrity": "verified",
+          "package_digest": "sha256:3438c6d1e9c08b88e6f63dba910407351656b61ed5f03afaceeb6eea2dcb31a4",
+          "payload_bytes": 162488855,
+          "representation": "bundle",
+          "transport_digest": "sha256:6d6093393e44a1af87ee2e6dc086606210649d8cf7ae53c2e2e7951bc506c5b0"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 2654,
+      "exit_code": 0,
+      "peak_rss_bytes": 33447936,
+      "phase": "clean_import",
+      "receipts": [
+        {
+          "contract": "graphforge-portable-import/2",
+          "idempotent_replay": false,
+          "package_digest": "sha256:3438c6d1e9c08b88e6f63dba910407351656b61ed5f03afaceeb6eea2dcb31a4",
+          "transient_peak_allocated_bytes": 325971968,
+          "transport_digest": "sha256:6d6093393e44a1af87ee2e6dc086606210649d8cf7ae53c2e2e7951bc506c5b0"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 14452,
+      "exit_code": 0,
+      "peak_rss_bytes": 182611968,
+      "phase": "reopen_proof",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "3943ce07cba5fc8b1b779daf479b68f69c81d1b0427e0ac49c8433fe53b17e8f",
+          "rows": 1,
+          "scalar_u64": 262144
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 77635584,
+                "before_bytes": 76693504,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 77635584
+              }
+            ],
+            "peak_rss_bytes": 77635584,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 77635584,
+            "sorts": []
+          },
+          "result_sha256": "2cb98d6493038230f3d574b16c2cbe283c07e43471b8764f6dfb59bea0aca486",
+          "rows": 1,
+          "scalar_u64": 4194304
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 46,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 68928,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 26,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 125800448,
+                "before_bytes": 75776000,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 125800448
+              }
+            ],
+            "peak_rss_bytes": 125800448,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 125800448,
+            "sorts": []
+          },
+          "result_sha256": "b73a4441b8a7358838773819082202e4055f965637f36d4e1b43d3c2b9635c28",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 4,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 1,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 142819328,
+                "before_bytes": 77090816,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 142819328
+              }
+            ],
+            "peak_rss_bytes": 142819328,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 142819328,
+            "sorts": []
+          },
+          "result_sha256": "3541076a1d4b4914fa1686264d88f0595f95fa45d10578dec497b3936be8bd60",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 162729984,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 163840,
+                "logical_bytes": 32887,
+                "logical_references": 40,
+                "physical_logical_bytes": 32887,
+                "physical_objects": 40
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 66846720,
+                "logical_bytes": 66737485,
+                "logical_references": 64,
+                "physical_logical_bytes": 66737485,
+                "physical_objects": 64
+              },
+              "topology_nodes": {
+                "allocated_bytes": 1048576,
+                "logical_bytes": 1040395,
+                "logical_references": 4,
+                "physical_logical_bytes": 1040395,
+                "physical_objects": 4
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 94670848,
+                "logical_bytes": 94660150,
+                "logical_references": 12,
+                "physical_logical_bytes": 94660150,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 162470917,
+            "logical_references": 120,
+            "physical_objects": 117,
+            "retained_logical_eof_bytes": 162470917
+          }
+        },
+        {
+          "contract": "graphforge-lifecycle-storage/2",
+          "retained_owners": {
+            "generated-inputs": {
+              "totals": {
+                "allocated_bytes": 205594624,
+                "logical_bytes": 205584915,
+                "logical_references": 2,
+                "physical_logical_bytes": 205584915,
+                "physical_objects": 2
+              }
+            },
+            "imported-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "imported-project-construction": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-import": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "imported-project-published": {
+              "totals": {
+                "allocated_bytes": 163364864,
+                "logical_bytes": 162629401,
+                "logical_references": 273,
+                "physical_logical_bytes": 162629401,
+                "physical_objects": 273
+              }
+            },
+            "imported-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            },
+            "portable-package": {
+              "totals": {
+                "allocated_bytes": 162566144,
+                "logical_bytes": 162560000,
+                "logical_references": 1,
+                "physical_logical_bytes": 162560000,
+                "physical_objects": 1
+              }
+            },
+            "query-results": {
+              "totals": {
+                "allocated_bytes": 98304,
+                "logical_bytes": 71228,
+                "logical_references": 8,
+                "physical_logical_bytes": 71228,
+                "physical_objects": 8
+              }
+            },
+            "source-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "source-project-construction": {
+              "totals": {
+                "allocated_bytes": 164478976,
+                "logical_bytes": 162870632,
+                "logical_references": 503,
+                "physical_logical_bytes": 162870632,
+                "physical_objects": 503
+              }
+            },
+            "source-project-import": {
+              "totals": {
+                "allocated_bytes": 205602816,
+                "logical_bytes": 205589045,
+                "logical_references": 3,
+                "physical_logical_bytes": 205589045,
+                "physical_objects": 3
+              }
+            },
+            "source-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "source-project-published": {
+              "totals": {
+                "allocated_bytes": 163368960,
+                "logical_bytes": 162629401,
+                "logical_references": 273,
+                "physical_logical_bytes": 162629401,
+                "physical_objects": 273
+              }
+            },
+            "source-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            }
+          },
+          "retained_storage_bytes": 1065082880,
+          "source_project_current_allocated_bytes": 163368960,
+          "transient_peak_storage_bytes": 2974519296
+        }
+      ],
+      "status": "passed"
+    }
+  ],
+  "profile_id": "graph500-s18-local",
+  "schema": "graphforge-public-certification/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/s18-plan.json
+++ b/docs/development/evidence/integrated-storage-1194/s18-plan.json
@@ -1,0 +1,36 @@
+{
+  "claim": "engineering_evidence_only",
+  "execution": "native_linux_benchexec_host",
+  "identities": {
+    "benchexec_python_sha256": "52e0a13e60a981d8c4b6478be2ba5176f69da07948a056bf49cf6f077e30cb41",
+    "benchexec_version": "3.35",
+    "certify_sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+    "commit": "24ca688c516a86a68de9cffaab2d5a9215291256",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+    "gf_sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "5ca3af64ae7a0a45221cdafdcabce2bfa700975e19f1ccb9557269cecef92bf1",
+    "profile_id": "graph500-s18-local",
+    "profile_sha256": "afe7bd59a9afca076d877580352457710b26d79bc16cd38ae999af864f31cd96"
+  },
+  "limits": {
+    "cores": 16,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400
+  },
+  "outputs": [
+    "s18-plan.json",
+    "s18-benchexec.json",
+    "s18-graphforge.json",
+    "s18-rung.json",
+    "s18-result.json"
+  ],
+  "rung": "S18",
+  "schema": "graphforge-progressive-host-run-plan/1",
+  "work_root_capacity": {
+    "free_bytes": 633409593344,
+    "reserved_headroom_bytes": 141258578535
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/s18-result.json
+++ b/docs/development/evidence/integrated-storage-1194/s18-result.json
@@ -1,0 +1,27 @@
+{
+  "artifacts": {
+    "benchexec_sha256": "7b88b93271a1e2013ec0279f282d3d42be5eb8b0e53367b2e1734fa40e1e18d6",
+    "graphforge_sha256": "e86d63effe5da0659cf36077241efa1f081a6d367ff1034b84a204aec9ead65d",
+    "plan_sha256": "c7dfd2b1c3183eace121eda9cc5556dbdcb2e33366543d7b8683e99d428e0de2",
+    "rung_sha256": "52da4ffdd53137b0aa282a47da5abbdecfa6c1d4115d6f09eb6cfe674fdefd82"
+  },
+  "claim": "engineering_evidence_only",
+  "failure": null,
+  "identities": {
+    "benchexec_python_sha256": "52e0a13e60a981d8c4b6478be2ba5176f69da07948a056bf49cf6f077e30cb41",
+    "benchexec_version": "3.35",
+    "certify_sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+    "commit": "24ca688c516a86a68de9cffaab2d5a9215291256",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+    "gf_sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "5ca3af64ae7a0a45221cdafdcabce2bfa700975e19f1ccb9557269cecef92bf1",
+    "profile_id": "graph500-s18-local",
+    "profile_sha256": "afe7bd59a9afca076d877580352457710b26d79bc16cd38ae999af864f31cd96"
+  },
+  "rung": "S18",
+  "schema": "graphforge-progressive-host-run-result/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/s18-rung.json
+++ b/docs/development/evidence/integrated-storage-1194/s18-rung.json
@@ -1,0 +1,490 @@
+{
+  "assembly_contract": "graphforge-progressive-rung-assembly/3",
+  "correctness": true,
+  "failure": null,
+  "live_edges": 4194304,
+  "metric_sources": {
+    "benchexec": [
+      "wall_seconds",
+      "physical_read_bytes",
+      "physical_write_bytes"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
+    ],
+    "query_qualification": [
+      "live_edges",
+      "correctness"
+    ],
+    "storage_attribution": [
+      "retained_storage_bytes",
+      "transient_peak_storage_bytes",
+      "logical_read_bytes",
+      "logical_write_bytes",
+      "reader_calls",
+      "publication_work_units"
+    ]
+  },
+  "metrics": {
+    "logical_read_bytes": 11360063649,
+    "logical_write_bytes": 5117151595,
+    "peak_rss_bytes": 182611968,
+    "physical_read_bytes": 54517145600,
+    "physical_write_bytes": 18559918080,
+    "publication_work_units": 63163,
+    "reader_calls": 122479,
+    "retained_storage_bytes": 1065082880,
+    "transient_peak_storage_bytes": 2974519296,
+    "wall_seconds": 97
+  },
+  "phases": [
+    "admission",
+    "generate",
+    "ingest",
+    "reopen",
+    "recount",
+    "query",
+    "export",
+    "verify",
+    "clean_import",
+    "reopen_proof"
+  ],
+  "profile_id": "graph500-s18-local",
+  "scale": 18,
+  "source": "progressive_profile",
+  "status": "passed",
+  "storage_attribution": {
+    "construction": {
+      "application_io": {
+        "phases": {
+          "append_merge": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 68,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 907422616,
+            "write_calls": 2132
+          },
+          "cas_install_read_write": {
+            "block_count": 0,
+            "fsync_calls": 791,
+            "object_count": 0,
+            "read_bytes": 162782947,
+            "read_calls": 2824,
+            "write_bytes": 162625988,
+            "write_calls": 2674
+          },
+          "encode_write_postwrite_authentication": {
+            "block_count": 0,
+            "fsync_calls": 188,
+            "object_count": 0,
+            "read_bytes": 1581779667,
+            "read_calls": 41350,
+            "write_bytes": 368025637,
+            "write_calls": 9805
+          },
+          "fsync_synchronization": {
+            "block_count": 0,
+            "fsync_calls": 2691,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "hydration_verification": {
+            "block_count": 0,
+            "fsync_calls": 16,
+            "object_count": 0,
+            "read_bytes": 172952198,
+            "read_calls": 2657,
+            "write_bytes": 10511291,
+            "write_calls": 164
+          },
+          "publication_preauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 27665,
+            "read_calls": 3,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "recovery_reauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 4635761939,
+            "read_calls": 6953,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "seal_authentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "shape_consume_reauthentication": {
+            "block_count": 7185,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 4806759233,
+            "read_calls": 68692,
+            "write_bytes": 3668566063,
+            "write_calls": 4280
+          }
+        },
+        "totals": {
+          "block_count": 7185,
+          "fsync_calls": 3686,
+          "object_count": 68,
+          "read_bytes": 11360063649,
+          "read_calls": 122479,
+          "write_bytes": 5117151595,
+          "write_calls": 19055
+        }
+      },
+      "staging": {
+        "allocated_bytes": 162582528,
+        "logical_bytes": 162440730,
+        "logical_references": 84,
+        "physical_logical_bytes": 162440730,
+        "physical_objects": 84
+      },
+      "staging_transient_peak_allocated_bytes": 2561527808,
+      "transient_peak_allocated_bytes": 2561527808
+    },
+    "counts": {
+      "imported_edges": 4194304,
+      "imported_nodes": 262144,
+      "source_edges": 4194304,
+      "source_nodes": 262144
+    },
+    "imported": {
+      "allocated_physical_bytes": 162729984,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 163840,
+          "logical_bytes": 32887,
+          "logical_references": 40,
+          "physical_logical_bytes": 32887,
+          "physical_objects": 40
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 66846720,
+          "logical_bytes": 66737485,
+          "logical_references": 64,
+          "physical_logical_bytes": 66737485,
+          "physical_objects": 64
+        },
+        "topology_nodes": {
+          "allocated_bytes": 1048576,
+          "logical_bytes": 1040395,
+          "logical_references": 4,
+          "physical_logical_bytes": 1040395,
+          "physical_objects": 4
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 94670848,
+          "logical_bytes": 94660150,
+          "logical_references": 12,
+          "physical_logical_bytes": 94660150,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 162470917,
+      "logical_references": 120,
+      "physical_objects": 117,
+      "retained_logical_eof_bytes": 162470917
+    },
+    "lifecycle": {
+      "contract": "graphforge-lifecycle-storage/2",
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 205594624,
+            "logical_bytes": 205584915,
+            "logical_references": 2,
+            "physical_logical_bytes": 205584915,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 163364864,
+            "logical_bytes": 162629401,
+            "logical_references": 273,
+            "physical_logical_bytes": 162629401,
+            "physical_objects": 273
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 162566144,
+            "logical_bytes": 162560000,
+            "logical_references": 1,
+            "physical_logical_bytes": 162560000,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 164478976,
+            "logical_bytes": 162870632,
+            "logical_references": 503,
+            "physical_logical_bytes": 162870632,
+            "physical_objects": 503
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 205602816,
+            "logical_bytes": 205589045,
+            "logical_references": 3,
+            "physical_logical_bytes": 205589045,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 163368960,
+            "logical_bytes": 162629401,
+            "logical_references": 273,
+            "physical_logical_bytes": 162629401,
+            "physical_objects": 273
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "retained_storage_bytes": 1065082880,
+      "source_project_current_allocated_bytes": 163368960,
+      "transient_peak_storage_bytes": 2974519296
+    },
+    "portable_package": {
+      "allocation_allocated_bytes": 162566144,
+      "allocation_logical_bytes": 162560000,
+      "allocation_physical_objects": 1,
+      "contract": "graphforge-portable-export/2"
+    },
+    "source": {
+      "allocated_physical_bytes": 162734080,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 163840,
+          "logical_bytes": 32887,
+          "logical_references": 40,
+          "physical_logical_bytes": 32887,
+          "physical_objects": 40
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 66846720,
+          "logical_bytes": 66737485,
+          "logical_references": 64,
+          "physical_logical_bytes": 66737485,
+          "physical_objects": 64
+        },
+        "topology_nodes": {
+          "allocated_bytes": 1048576,
+          "logical_bytes": 1040395,
+          "logical_references": 4,
+          "physical_logical_bytes": 1040395,
+          "physical_objects": 4
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 94674944,
+          "logical_bytes": 94660150,
+          "logical_references": 12,
+          "physical_logical_bytes": 94660150,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 162470917,
+      "logical_references": 120,
+      "physical_objects": 117,
+      "retained_logical_eof_bytes": 162470917
+    }
+  },
+  "storage_components": {
+    "imported_allocated_physical_bytes": 162729984,
+    "imported_retained_logical_eof_bytes": 162470917,
+    "logical_read_bytes": 11360063649,
+    "logical_write_bytes": 5117151595,
+    "publication_work_units": 63163,
+    "reader_calls": 122479,
+    "source_allocated_physical_bytes": 162734080,
+    "source_project_current_allocated_bytes": 163368960,
+    "source_retained_logical_eof_bytes": 162470917,
+    "transient_peak_allocated_bytes": 2561527808
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/s19-benchexec.json
+++ b/docs/development/evidence/integrated-storage-1194/s19-benchexec.json
@@ -1,0 +1,1306 @@
+{
+  "authority": {
+    "cpu_seconds": 161.155301,
+    "peak_rss_bytes": 1577000960,
+    "pressure_cpu_seconds": 0.253316,
+    "pressure_io_seconds": 18.085786,
+    "pressure_memory_seconds": 0.0,
+    "read_bytes": 110290894848,
+    "wall_seconds": 191.47780643799342,
+    "write_bytes": 37230034944
+  },
+  "disagreements": [],
+  "exit_code": 0,
+  "graphforge": {
+    "failed_phase": null,
+    "phases": [
+      {
+        "duration_ms": 10,
+        "exit_code": 0,
+        "peak_rss_bytes": 16384,
+        "phase": "admission",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 3277,
+        "exit_code": 0,
+        "peak_rss_bytes": 73453568,
+        "phase": "generate",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 112917,
+        "exit_code": 0,
+        "peak_rss_bytes": 153358336,
+        "phase": "ingest",
+        "receipts": [
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "begun"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "bytes_accepted": 411169177,
+            "construction": {
+              "accepted_chunks": 136,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 136,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 1814845232,
+                    "write_calls": 4264
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 333,
+                    "object_count": 0,
+                    "read_bytes": 3170717177,
+                    "read_calls": 82300,
+                    "write_bytes": 743214697,
+                    "write_calls": 20122
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 5401,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 8303980393,
+                    "read_calls": 8295,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 14367,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 9613515213,
+                    "read_calls": 137410,
+                    "write_bytes": 7337129155,
+                    "write_calls": 8667
+                  }
+                },
+                "totals": {
+                  "block_count": 14367,
+                  "fsync_calls": 5734,
+                  "object_count": 136,
+                  "read_bytes": 21088212783,
+                  "read_calls": 228005,
+                  "write_bytes": 9895189084,
+                  "write_calls": 33053
+                }
+              },
+              "cache_release_operations": 21601,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 36939479340,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 332464128,
+                "logical_bytes": 332048220,
+                "logical_references": 152,
+                "physical_logical_bytes": 332048220,
+                "physical_objects": 152
+              },
+              "construction_staging_transient_peak_allocated_bytes": 5123039232,
+              "fsync_operations": 1744,
+              "immutable_artifacts": 536,
+              "input_batches": 136,
+              "input_rows": 8912896,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": false,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 333,
+                  "object_count": 0,
+                  "read_bytes": 3170717177,
+                  "read_calls": 82300,
+                  "write_bytes": 743214697,
+                  "write_calls": 20122
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 5401,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 108156
+              },
+              "transient_peak_allocated_bytes": 5123039232,
+              "write_bytes": 1814845232,
+              "write_operations": 4264
+            },
+            "contract": "graphforge-import-session/1",
+            "operation_timings": {
+              "append": {
+                "calls": 136,
+                "elapsed_ns": 8291116143,
+                "errors": 0
+              },
+              "begin": {
+                "calls": 1,
+                "elapsed_ns": 974568,
+                "errors": 0
+              },
+              "publish": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "resume": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "seal": {
+                "calls": 1,
+                "elapsed_ns": 87657475192,
+                "errors": 0
+              }
+            },
+            "outcome": "validated",
+            "rows_accepted": 8912896,
+            "rows_rejected": 0
+          },
+          {
+            "construction": {
+              "accepted_chunks": 136,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 136,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 1814845232,
+                    "write_calls": 4264
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 1651,
+                    "object_count": 0,
+                    "read_bytes": 332806943,
+                    "read_calls": 5799,
+                    "write_bytes": 332459564,
+                    "write_calls": 5504
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 333,
+                    "object_count": 0,
+                    "read_bytes": 3170717177,
+                    "read_calls": 82300,
+                    "write_bytes": 743214697,
+                    "write_calls": 20122
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 5413,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 16,
+                    "object_count": 0,
+                    "read_bytes": 353068460,
+                    "read_calls": 5429,
+                    "write_bytes": 21020063,
+                    "write_calls": 324
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 50297,
+                    "read_calls": 3,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 9300189195,
+                    "read_calls": 14411,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 14367,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 9613515213,
+                    "read_calls": 137410,
+                    "write_bytes": 7337129155,
+                    "write_calls": 8667
+                  }
+                },
+                "totals": {
+                  "block_count": 14367,
+                  "fsync_calls": 7413,
+                  "object_count": 136,
+                  "read_bytes": 22770347285,
+                  "read_calls": 245352,
+                  "write_bytes": 10248668711,
+                  "write_calls": 38881
+                }
+              },
+              "cache_release_operations": 22051,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 37935624000,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 332464128,
+                "logical_bytes": 332048220,
+                "logical_references": 152,
+                "physical_logical_bytes": 332048220,
+                "physical_objects": 152
+              },
+              "construction_staging_transient_peak_allocated_bytes": 5123039232,
+              "fsync_operations": 1744,
+              "immutable_artifacts": 536,
+              "input_batches": 136,
+              "input_rows": 8912896,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": true,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 1651,
+                  "object_count": 0,
+                  "read_bytes": 332806943,
+                  "read_calls": 5799,
+                  "write_bytes": 332459564,
+                  "write_calls": 5504
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 333,
+                  "object_count": 0,
+                  "read_bytes": 3170717177,
+                  "read_calls": 82300,
+                  "write_bytes": 743214697,
+                  "write_calls": 20122
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 5413,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 16,
+                  "object_count": 0,
+                  "read_bytes": 353068460,
+                  "read_calls": 5429,
+                  "write_bytes": 21020063,
+                  "write_calls": 324
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 50297,
+                  "read_calls": 3,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 126894
+              },
+              "transient_peak_allocated_bytes": 5123039232,
+              "write_bytes": 1814845232,
+              "write_operations": 4264
+            },
+            "contract": "graphforge-import-session/1",
+            "operation_timings": {
+              "append": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "begin": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "publish": {
+                "calls": 1,
+                "elapsed_ns": 4929676569,
+                "errors": 0
+              },
+              "resume": {
+                "calls": 1,
+                "elapsed_ns": 483101323,
+                "errors": 0
+              },
+              "seal": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              }
+            },
+            "outcome": "committed"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 6626,
+        "exit_code": 0,
+        "peak_rss_bytes": 37339136,
+        "phase": "reopen",
+        "receipts": [
+          {
+            "aborted_journals": 0,
+            "deferred": null,
+            "elapsed_ms": 0,
+            "kind": "project_open",
+            "preserved_unknown_entries": 0,
+            "removed_generations": 0,
+            "repaired_journals": 0,
+            "selected_generation_class": "committed_current",
+            "work_detected": false
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 332910592,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 462848,
+                  "logical_bytes": 68555,
+                  "logical_references": 113,
+                  "physical_logical_bytes": 68555,
+                  "physical_objects": 113
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 141017088,
+                  "logical_bytes": 140648263,
+                  "logical_references": 128,
+                  "physical_logical_bytes": 140648263,
+                  "physical_objects": 128
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 2097152,
+                  "logical_bytes": 2080111,
+                  "logical_references": 8,
+                  "physical_logical_bytes": 2080111,
+                  "physical_objects": 8
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 189333504,
+                  "logical_bytes": 189317146,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 189317146,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 332114075,
+              "logical_references": 261,
+              "physical_objects": 258,
+              "retained_logical_eof_bytes": 332114075
+            }
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 4046,
+        "exit_code": 0,
+        "peak_rss_bytes": 85757952,
+        "phase": "recount",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "4e0d83ac4f39024a66341b361c0e788c18cc166d8521218e74abf8acc1e33e45",
+            "rows": 1,
+            "scalar_u64": 524288
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 78278656,
+                  "before_bytes": 77271040,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 78278656
+                }
+              ],
+              "peak_rss_bytes": 78278656,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 78278656,
+              "sorts": []
+            },
+            "result_sha256": "24c9d3c08d04ec974fa8a6246cd2e2d99c3284a313f03ffca20bc0c479b2e987",
+            "rows": 1,
+            "scalar_u64": 8388608
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 19626,
+        "exit_code": 0,
+        "peak_rss_bytes": 188862464,
+        "phase": "query",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 46,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 68928,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 26,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 126992384,
+                  "before_bytes": 77414400,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 126992384
+                }
+              ],
+              "peak_rss_bytes": 126992384,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 126992384,
+              "sorts": []
+            },
+            "result_sha256": "46b96c2f5a4b01d3b4ea0b0fb18d92b8be2380ba809b803b1cb9ee14e8084fc4",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 4,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 1,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 144392192,
+                  "before_bytes": 77565952,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 144392192
+                }
+              ],
+              "peak_rss_bytes": 144392192,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 144392192,
+              "sorts": []
+            },
+            "result_sha256": "3541076a1d4b4914fa1686264d88f0595f95fa45d10578dec497b3936be8bd60",
+            "rows": 1000,
+            "scalar_u64": null
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 4291,
+        "exit_code": 0,
+        "peak_rss_bytes": 38055936,
+        "phase": "export",
+        "receipts": [
+          {
+            "allocation_allocated_bytes": 332263424,
+            "allocation_logical_bytes": 332256768,
+            "allocation_physical_objects": 1,
+            "contract": "graphforge-portable-export/2",
+            "entry_count": 161,
+            "package_digest": "sha256:fe08ccf52cb983baeef37564ed09aea7e9adde38a1c86ca5a9f293be2c9276d2",
+            "payload_bytes": 332049745,
+            "representation": "bundle",
+            "selection_fingerprint": "sha256:675ae054abab86c1280dcab7259d4ff2f7129cc22af54d05f1a9f1be147ac1cc",
+            "transport_digest": "sha256:b11c86e5b71a8d967ebacc896f72a5646bea60adb879fd6e3cbc6c1b2b93cd81"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 483,
+        "exit_code": 0,
+        "peak_rss_bytes": 23080960,
+        "phase": "verify",
+        "receipts": [
+          {
+            "compatibility": "supported",
+            "contract": "graphforge-portable-verify/2",
+            "entry_count": 161,
+            "integrity": "verified",
+            "package_digest": "sha256:fe08ccf52cb983baeef37564ed09aea7e9adde38a1c86ca5a9f293be2c9276d2",
+            "payload_bytes": 332133619,
+            "representation": "bundle",
+            "transport_digest": "sha256:b11c86e5b71a8d967ebacc896f72a5646bea60adb879fd6e3cbc6c1b2b93cd81"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 5605,
+        "exit_code": 0,
+        "peak_rss_bytes": 34471936,
+        "phase": "clean_import",
+        "receipts": [
+          {
+            "contract": "graphforge-portable-import/2",
+            "idempotent_replay": false,
+            "package_digest": "sha256:fe08ccf52cb983baeef37564ed09aea7e9adde38a1c86ca5a9f293be2c9276d2",
+            "transient_peak_allocated_bytes": 666628096,
+            "transport_digest": "sha256:b11c86e5b71a8d967ebacc896f72a5646bea60adb879fd6e3cbc6c1b2b93cd81"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 29295,
+        "exit_code": 0,
+        "peak_rss_bytes": 188383232,
+        "phase": "reopen_proof",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "4e0d83ac4f39024a66341b361c0e788c18cc166d8521218e74abf8acc1e33e45",
+            "rows": 1,
+            "scalar_u64": 524288
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 78516224,
+                  "before_bytes": 77336576,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 78516224
+                }
+              ],
+              "peak_rss_bytes": 78516224,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 78516224,
+              "sorts": []
+            },
+            "result_sha256": "24c9d3c08d04ec974fa8a6246cd2e2d99c3284a313f03ffca20bc0c479b2e987",
+            "rows": 1,
+            "scalar_u64": 8388608
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 46,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 68928,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 26,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 126058496,
+                  "before_bytes": 76783616,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 126058496
+                }
+              ],
+              "peak_rss_bytes": 126058496,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 126058496,
+              "sorts": []
+            },
+            "result_sha256": "46b96c2f5a4b01d3b4ea0b0fb18d92b8be2380ba809b803b1cb9ee14e8084fc4",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 4,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 1,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 145158144,
+                  "before_bytes": 78655488,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 145158144
+                }
+              ],
+              "peak_rss_bytes": 145158144,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 145158144,
+              "sorts": []
+            },
+            "result_sha256": "3541076a1d4b4914fa1686264d88f0595f95fa45d10578dec497b3936be8bd60",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 332910592,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 462848,
+                  "logical_bytes": 68555,
+                  "logical_references": 113,
+                  "physical_logical_bytes": 68555,
+                  "physical_objects": 113
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 141017088,
+                  "logical_bytes": 140648263,
+                  "logical_references": 128,
+                  "physical_logical_bytes": 140648263,
+                  "physical_objects": 128
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 2097152,
+                  "logical_bytes": 2080111,
+                  "logical_references": 8,
+                  "physical_logical_bytes": 2080111,
+                  "physical_objects": 8
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 189333504,
+                  "logical_bytes": 189317146,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 189317146,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 332114075,
+              "logical_references": 261,
+              "physical_objects": 258,
+              "retained_logical_eof_bytes": 332114075
+            }
+          },
+          {
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": {
+              "generated-inputs": {
+                "totals": {
+                  "allocated_bytes": 411181056,
+                  "logical_bytes": 411169177,
+                  "logical_references": 2,
+                  "physical_logical_bytes": 411169177,
+                  "physical_objects": 2
+                }
+              },
+              "imported-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "imported-project-construction": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-import": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "imported-project-published": {
+                "totals": {
+                  "allocated_bytes": 334139392,
+                  "logical_bytes": 332462979,
+                  "logical_references": 559,
+                  "physical_logical_bytes": 332462979,
+                  "physical_objects": 559
+                }
+              },
+              "imported-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              },
+              "portable-package": {
+                "totals": {
+                  "allocated_bytes": 332263424,
+                  "logical_bytes": 332256768,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 332256768,
+                  "physical_objects": 1
+                }
+              },
+              "query-results": {
+                "totals": {
+                  "allocated_bytes": 98304,
+                  "logical_bytes": 71228,
+                  "logical_references": 8,
+                  "physical_logical_bytes": 71228,
+                  "physical_objects": 8
+                }
+              },
+              "source-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "source-project-construction": {
+                "totals": {
+                  "allocated_bytes": 336171008,
+                  "logical_bytes": 332870981,
+                  "logical_references": 975,
+                  "physical_logical_bytes": 332870981,
+                  "physical_objects": 975
+                }
+              },
+              "source-project-import": {
+                "totals": {
+                  "allocated_bytes": 411189248,
+                  "logical_bytes": 411173328,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 411173328,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-published": {
+                "totals": {
+                  "allocated_bytes": 334139392,
+                  "logical_bytes": 332462979,
+                  "logical_references": 559,
+                  "physical_logical_bytes": 332462979,
+                  "physical_objects": 559
+                }
+              },
+              "source-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              }
+            },
+            "retained_storage_bytes": 2159190016,
+            "source_project_current_allocated_bytes": 334139392,
+            "transient_peak_storage_bytes": 5948940288
+          }
+        ],
+        "status": "passed"
+      }
+    ],
+    "profile_id": "graph500-s19-local",
+    "schema": "graphforge-public-certification/1",
+    "status": "passed"
+  },
+  "limits": {
+    "cores": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "cpu_seconds": 14400.0,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400.0
+  },
+  "outcome": "passed",
+  "schema": "graphforge-benchexec-run/1",
+  "signal": null
+}

--- a/docs/development/evidence/integrated-storage-1194/s19-graphforge.json
+++ b/docs/development/evidence/integrated-storage-1194/s19-graphforge.json
@@ -1,0 +1,1266 @@
+{
+  "failed_phase": null,
+  "phases": [
+    {
+      "duration_ms": 10,
+      "exit_code": 0,
+      "peak_rss_bytes": 16384,
+      "phase": "admission",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 3277,
+      "exit_code": 0,
+      "peak_rss_bytes": 73453568,
+      "phase": "generate",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 112917,
+      "exit_code": 0,
+      "peak_rss_bytes": 153358336,
+      "phase": "ingest",
+      "receipts": [
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "begun"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "bytes_accepted": 411169177,
+          "construction": {
+            "accepted_chunks": 136,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 136,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 1814845232,
+                  "write_calls": 4264
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 333,
+                  "object_count": 0,
+                  "read_bytes": 3170717177,
+                  "read_calls": 82300,
+                  "write_bytes": 743214697,
+                  "write_calls": 20122
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 5401,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 8303980393,
+                  "read_calls": 8295,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 14367,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 9613515213,
+                  "read_calls": 137410,
+                  "write_bytes": 7337129155,
+                  "write_calls": 8667
+                }
+              },
+              "totals": {
+                "block_count": 14367,
+                "fsync_calls": 5734,
+                "object_count": 136,
+                "read_bytes": 21088212783,
+                "read_calls": 228005,
+                "write_bytes": 9895189084,
+                "write_calls": 33053
+              }
+            },
+            "cache_release_operations": 21601,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 36939479340,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 332464128,
+              "logical_bytes": 332048220,
+              "logical_references": 152,
+              "physical_logical_bytes": 332048220,
+              "physical_objects": 152
+            },
+            "construction_staging_transient_peak_allocated_bytes": 5123039232,
+            "fsync_operations": 1744,
+            "immutable_artifacts": 536,
+            "input_batches": 136,
+            "input_rows": 8912896,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": false,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 333,
+                "object_count": 0,
+                "read_bytes": 3170717177,
+                "read_calls": 82300,
+                "write_bytes": 743214697,
+                "write_calls": 20122
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 5401,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 108156
+            },
+            "transient_peak_allocated_bytes": 5123039232,
+            "write_bytes": 1814845232,
+            "write_operations": 4264
+          },
+          "contract": "graphforge-import-session/1",
+          "operation_timings": {
+            "append": {
+              "calls": 136,
+              "elapsed_ns": 8291116143,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 1,
+              "elapsed_ns": 974568,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 1,
+              "elapsed_ns": 87657475192,
+              "errors": 0
+            }
+          },
+          "outcome": "validated",
+          "rows_accepted": 8912896,
+          "rows_rejected": 0
+        },
+        {
+          "construction": {
+            "accepted_chunks": 136,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 136,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 1814845232,
+                  "write_calls": 4264
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 1651,
+                  "object_count": 0,
+                  "read_bytes": 332806943,
+                  "read_calls": 5799,
+                  "write_bytes": 332459564,
+                  "write_calls": 5504
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 333,
+                  "object_count": 0,
+                  "read_bytes": 3170717177,
+                  "read_calls": 82300,
+                  "write_bytes": 743214697,
+                  "write_calls": 20122
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 5413,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 16,
+                  "object_count": 0,
+                  "read_bytes": 353068460,
+                  "read_calls": 5429,
+                  "write_bytes": 21020063,
+                  "write_calls": 324
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 50297,
+                  "read_calls": 3,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 9300189195,
+                  "read_calls": 14411,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 14367,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 9613515213,
+                  "read_calls": 137410,
+                  "write_bytes": 7337129155,
+                  "write_calls": 8667
+                }
+              },
+              "totals": {
+                "block_count": 14367,
+                "fsync_calls": 7413,
+                "object_count": 136,
+                "read_bytes": 22770347285,
+                "read_calls": 245352,
+                "write_bytes": 10248668711,
+                "write_calls": 38881
+              }
+            },
+            "cache_release_operations": 22051,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 37935624000,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 332464128,
+              "logical_bytes": 332048220,
+              "logical_references": 152,
+              "physical_logical_bytes": 332048220,
+              "physical_objects": 152
+            },
+            "construction_staging_transient_peak_allocated_bytes": 5123039232,
+            "fsync_operations": 1744,
+            "immutable_artifacts": 536,
+            "input_batches": 136,
+            "input_rows": 8912896,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": true,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 1651,
+                "object_count": 0,
+                "read_bytes": 332806943,
+                "read_calls": 5799,
+                "write_bytes": 332459564,
+                "write_calls": 5504
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 333,
+                "object_count": 0,
+                "read_bytes": 3170717177,
+                "read_calls": 82300,
+                "write_bytes": 743214697,
+                "write_calls": 20122
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 5413,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 16,
+                "object_count": 0,
+                "read_bytes": 353068460,
+                "read_calls": 5429,
+                "write_bytes": 21020063,
+                "write_calls": 324
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 50297,
+                "read_calls": 3,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 126894
+            },
+            "transient_peak_allocated_bytes": 5123039232,
+            "write_bytes": 1814845232,
+            "write_operations": 4264
+          },
+          "contract": "graphforge-import-session/1",
+          "operation_timings": {
+            "append": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 1,
+              "elapsed_ns": 4929676569,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 1,
+              "elapsed_ns": 483101323,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            }
+          },
+          "outcome": "committed"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 6626,
+      "exit_code": 0,
+      "peak_rss_bytes": 37339136,
+      "phase": "reopen",
+      "receipts": [
+        {
+          "aborted_journals": 0,
+          "deferred": null,
+          "elapsed_ms": 0,
+          "kind": "project_open",
+          "preserved_unknown_entries": 0,
+          "removed_generations": 0,
+          "repaired_journals": 0,
+          "selected_generation_class": "committed_current",
+          "work_detected": false
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 332910592,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 462848,
+                "logical_bytes": 68555,
+                "logical_references": 113,
+                "physical_logical_bytes": 68555,
+                "physical_objects": 113
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 141017088,
+                "logical_bytes": 140648263,
+                "logical_references": 128,
+                "physical_logical_bytes": 140648263,
+                "physical_objects": 128
+              },
+              "topology_nodes": {
+                "allocated_bytes": 2097152,
+                "logical_bytes": 2080111,
+                "logical_references": 8,
+                "physical_logical_bytes": 2080111,
+                "physical_objects": 8
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 189333504,
+                "logical_bytes": 189317146,
+                "logical_references": 12,
+                "physical_logical_bytes": 189317146,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 332114075,
+            "logical_references": 261,
+            "physical_objects": 258,
+            "retained_logical_eof_bytes": 332114075
+          }
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 4046,
+      "exit_code": 0,
+      "peak_rss_bytes": 85757952,
+      "phase": "recount",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "4e0d83ac4f39024a66341b361c0e788c18cc166d8521218e74abf8acc1e33e45",
+          "rows": 1,
+          "scalar_u64": 524288
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 78278656,
+                "before_bytes": 77271040,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 78278656
+              }
+            ],
+            "peak_rss_bytes": 78278656,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 78278656,
+            "sorts": []
+          },
+          "result_sha256": "24c9d3c08d04ec974fa8a6246cd2e2d99c3284a313f03ffca20bc0c479b2e987",
+          "rows": 1,
+          "scalar_u64": 8388608
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 19626,
+      "exit_code": 0,
+      "peak_rss_bytes": 188862464,
+      "phase": "query",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 46,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 68928,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 26,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 126992384,
+                "before_bytes": 77414400,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 126992384
+              }
+            ],
+            "peak_rss_bytes": 126992384,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 126992384,
+            "sorts": []
+          },
+          "result_sha256": "46b96c2f5a4b01d3b4ea0b0fb18d92b8be2380ba809b803b1cb9ee14e8084fc4",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 4,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 1,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 144392192,
+                "before_bytes": 77565952,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 144392192
+              }
+            ],
+            "peak_rss_bytes": 144392192,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 144392192,
+            "sorts": []
+          },
+          "result_sha256": "3541076a1d4b4914fa1686264d88f0595f95fa45d10578dec497b3936be8bd60",
+          "rows": 1000,
+          "scalar_u64": null
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 4291,
+      "exit_code": 0,
+      "peak_rss_bytes": 38055936,
+      "phase": "export",
+      "receipts": [
+        {
+          "allocation_allocated_bytes": 332263424,
+          "allocation_logical_bytes": 332256768,
+          "allocation_physical_objects": 1,
+          "contract": "graphforge-portable-export/2",
+          "entry_count": 161,
+          "package_digest": "sha256:fe08ccf52cb983baeef37564ed09aea7e9adde38a1c86ca5a9f293be2c9276d2",
+          "payload_bytes": 332049745,
+          "representation": "bundle",
+          "selection_fingerprint": "sha256:675ae054abab86c1280dcab7259d4ff2f7129cc22af54d05f1a9f1be147ac1cc",
+          "transport_digest": "sha256:b11c86e5b71a8d967ebacc896f72a5646bea60adb879fd6e3cbc6c1b2b93cd81"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 483,
+      "exit_code": 0,
+      "peak_rss_bytes": 23080960,
+      "phase": "verify",
+      "receipts": [
+        {
+          "compatibility": "supported",
+          "contract": "graphforge-portable-verify/2",
+          "entry_count": 161,
+          "integrity": "verified",
+          "package_digest": "sha256:fe08ccf52cb983baeef37564ed09aea7e9adde38a1c86ca5a9f293be2c9276d2",
+          "payload_bytes": 332133619,
+          "representation": "bundle",
+          "transport_digest": "sha256:b11c86e5b71a8d967ebacc896f72a5646bea60adb879fd6e3cbc6c1b2b93cd81"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 5605,
+      "exit_code": 0,
+      "peak_rss_bytes": 34471936,
+      "phase": "clean_import",
+      "receipts": [
+        {
+          "contract": "graphforge-portable-import/2",
+          "idempotent_replay": false,
+          "package_digest": "sha256:fe08ccf52cb983baeef37564ed09aea7e9adde38a1c86ca5a9f293be2c9276d2",
+          "transient_peak_allocated_bytes": 666628096,
+          "transport_digest": "sha256:b11c86e5b71a8d967ebacc896f72a5646bea60adb879fd6e3cbc6c1b2b93cd81"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 29295,
+      "exit_code": 0,
+      "peak_rss_bytes": 188383232,
+      "phase": "reopen_proof",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "4e0d83ac4f39024a66341b361c0e788c18cc166d8521218e74abf8acc1e33e45",
+          "rows": 1,
+          "scalar_u64": 524288
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 78516224,
+                "before_bytes": 77336576,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 78516224
+              }
+            ],
+            "peak_rss_bytes": 78516224,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 78516224,
+            "sorts": []
+          },
+          "result_sha256": "24c9d3c08d04ec974fa8a6246cd2e2d99c3284a313f03ffca20bc0c479b2e987",
+          "rows": 1,
+          "scalar_u64": 8388608
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 46,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 68928,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 26,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 126058496,
+                "before_bytes": 76783616,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 126058496
+              }
+            ],
+            "peak_rss_bytes": 126058496,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 126058496,
+            "sorts": []
+          },
+          "result_sha256": "46b96c2f5a4b01d3b4ea0b0fb18d92b8be2380ba809b803b1cb9ee14e8084fc4",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 4,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 1,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 145158144,
+                "before_bytes": 78655488,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 145158144
+              }
+            ],
+            "peak_rss_bytes": 145158144,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 145158144,
+            "sorts": []
+          },
+          "result_sha256": "3541076a1d4b4914fa1686264d88f0595f95fa45d10578dec497b3936be8bd60",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 332910592,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 462848,
+                "logical_bytes": 68555,
+                "logical_references": 113,
+                "physical_logical_bytes": 68555,
+                "physical_objects": 113
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 141017088,
+                "logical_bytes": 140648263,
+                "logical_references": 128,
+                "physical_logical_bytes": 140648263,
+                "physical_objects": 128
+              },
+              "topology_nodes": {
+                "allocated_bytes": 2097152,
+                "logical_bytes": 2080111,
+                "logical_references": 8,
+                "physical_logical_bytes": 2080111,
+                "physical_objects": 8
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 189333504,
+                "logical_bytes": 189317146,
+                "logical_references": 12,
+                "physical_logical_bytes": 189317146,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 332114075,
+            "logical_references": 261,
+            "physical_objects": 258,
+            "retained_logical_eof_bytes": 332114075
+          }
+        },
+        {
+          "contract": "graphforge-lifecycle-storage/2",
+          "retained_owners": {
+            "generated-inputs": {
+              "totals": {
+                "allocated_bytes": 411181056,
+                "logical_bytes": 411169177,
+                "logical_references": 2,
+                "physical_logical_bytes": 411169177,
+                "physical_objects": 2
+              }
+            },
+            "imported-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "imported-project-construction": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-import": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "imported-project-published": {
+              "totals": {
+                "allocated_bytes": 334139392,
+                "logical_bytes": 332462979,
+                "logical_references": 559,
+                "physical_logical_bytes": 332462979,
+                "physical_objects": 559
+              }
+            },
+            "imported-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            },
+            "portable-package": {
+              "totals": {
+                "allocated_bytes": 332263424,
+                "logical_bytes": 332256768,
+                "logical_references": 1,
+                "physical_logical_bytes": 332256768,
+                "physical_objects": 1
+              }
+            },
+            "query-results": {
+              "totals": {
+                "allocated_bytes": 98304,
+                "logical_bytes": 71228,
+                "logical_references": 8,
+                "physical_logical_bytes": 71228,
+                "physical_objects": 8
+              }
+            },
+            "source-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "source-project-construction": {
+              "totals": {
+                "allocated_bytes": 336171008,
+                "logical_bytes": 332870981,
+                "logical_references": 975,
+                "physical_logical_bytes": 332870981,
+                "physical_objects": 975
+              }
+            },
+            "source-project-import": {
+              "totals": {
+                "allocated_bytes": 411189248,
+                "logical_bytes": 411173328,
+                "logical_references": 3,
+                "physical_logical_bytes": 411173328,
+                "physical_objects": 3
+              }
+            },
+            "source-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "source-project-published": {
+              "totals": {
+                "allocated_bytes": 334139392,
+                "logical_bytes": 332462979,
+                "logical_references": 559,
+                "physical_logical_bytes": 332462979,
+                "physical_objects": 559
+              }
+            },
+            "source-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            }
+          },
+          "retained_storage_bytes": 2159190016,
+          "source_project_current_allocated_bytes": 334139392,
+          "transient_peak_storage_bytes": 5948940288
+        }
+      ],
+      "status": "passed"
+    }
+  ],
+  "profile_id": "graph500-s19-local",
+  "schema": "graphforge-public-certification/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/s19-plan.json
+++ b/docs/development/evidence/integrated-storage-1194/s19-plan.json
@@ -1,0 +1,36 @@
+{
+  "claim": "engineering_evidence_only",
+  "execution": "native_linux_benchexec_host",
+  "identities": {
+    "benchexec_python_sha256": "52e0a13e60a981d8c4b6478be2ba5176f69da07948a056bf49cf6f077e30cb41",
+    "benchexec_version": "3.35",
+    "certify_sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+    "commit": "24ca688c516a86a68de9cffaab2d5a9215291256",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+    "gf_sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "5ca3af64ae7a0a45221cdafdcabce2bfa700975e19f1ccb9557269cecef92bf1",
+    "profile_id": "graph500-s19-local",
+    "profile_sha256": "63213dc0c7d6fe95280dbe1149dd7a39bc21a880a9d5f2a98d1f226b4a251d00"
+  },
+  "limits": {
+    "cores": 16,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400
+  },
+  "outputs": [
+    "s19-plan.json",
+    "s19-benchexec.json",
+    "s19-graphforge.json",
+    "s19-rung.json",
+    "s19-result.json"
+  ],
+  "rung": "S19",
+  "schema": "graphforge-progressive-host-run-plan/1",
+  "work_root_capacity": {
+    "free_bytes": 633357365248,
+    "reserved_headroom_bytes": 141258578535
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/s19-result.json
+++ b/docs/development/evidence/integrated-storage-1194/s19-result.json
@@ -1,0 +1,27 @@
+{
+  "artifacts": {
+    "benchexec_sha256": "441872543db32f7d65fb2b48a2518710df462a9e415584d72a407862c8f1d9f4",
+    "graphforge_sha256": "5df01d75f9312dff89e611837aa8739a2dc78f3e7fc4213d1ce75b8c75d80d46",
+    "plan_sha256": "cdf5307917c805182209f29ce3c22f9c08b00b833601205a53680d32291b9e2f",
+    "rung_sha256": "019f21dd1fcb92228a55b57e7612336b3f96eadd66c3d8590e47704f99ea924d"
+  },
+  "claim": "engineering_evidence_only",
+  "failure": null,
+  "identities": {
+    "benchexec_python_sha256": "52e0a13e60a981d8c4b6478be2ba5176f69da07948a056bf49cf6f077e30cb41",
+    "benchexec_version": "3.35",
+    "certify_sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+    "commit": "24ca688c516a86a68de9cffaab2d5a9215291256",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+    "gf_sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "5ca3af64ae7a0a45221cdafdcabce2bfa700975e19f1ccb9557269cecef92bf1",
+    "profile_id": "graph500-s19-local",
+    "profile_sha256": "63213dc0c7d6fe95280dbe1149dd7a39bc21a880a9d5f2a98d1f226b4a251d00"
+  },
+  "rung": "S19",
+  "schema": "graphforge-progressive-host-run-result/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/s19-rung.json
+++ b/docs/development/evidence/integrated-storage-1194/s19-rung.json
@@ -1,0 +1,490 @@
+{
+  "assembly_contract": "graphforge-progressive-rung-assembly/3",
+  "correctness": true,
+  "failure": null,
+  "live_edges": 8388608,
+  "metric_sources": {
+    "benchexec": [
+      "wall_seconds",
+      "physical_read_bytes",
+      "physical_write_bytes"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
+    ],
+    "query_qualification": [
+      "live_edges",
+      "correctness"
+    ],
+    "storage_attribution": [
+      "retained_storage_bytes",
+      "transient_peak_storage_bytes",
+      "logical_read_bytes",
+      "logical_write_bytes",
+      "reader_calls",
+      "publication_work_units"
+    ]
+  },
+  "metrics": {
+    "logical_read_bytes": 22770347285,
+    "logical_write_bytes": 10248668711,
+    "peak_rss_bytes": 188862464,
+    "physical_read_bytes": 110290894848,
+    "physical_write_bytes": 37230034944,
+    "publication_work_units": 126894,
+    "reader_calls": 245352,
+    "retained_storage_bytes": 2159190016,
+    "transient_peak_storage_bytes": 5948940288,
+    "wall_seconds": 192
+  },
+  "phases": [
+    "admission",
+    "generate",
+    "ingest",
+    "reopen",
+    "recount",
+    "query",
+    "export",
+    "verify",
+    "clean_import",
+    "reopen_proof"
+  ],
+  "profile_id": "graph500-s19-local",
+  "scale": 19,
+  "source": "progressive_profile",
+  "status": "passed",
+  "storage_attribution": {
+    "construction": {
+      "application_io": {
+        "phases": {
+          "append_merge": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 136,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 1814845232,
+            "write_calls": 4264
+          },
+          "cas_install_read_write": {
+            "block_count": 0,
+            "fsync_calls": 1651,
+            "object_count": 0,
+            "read_bytes": 332806943,
+            "read_calls": 5799,
+            "write_bytes": 332459564,
+            "write_calls": 5504
+          },
+          "encode_write_postwrite_authentication": {
+            "block_count": 0,
+            "fsync_calls": 333,
+            "object_count": 0,
+            "read_bytes": 3170717177,
+            "read_calls": 82300,
+            "write_bytes": 743214697,
+            "write_calls": 20122
+          },
+          "fsync_synchronization": {
+            "block_count": 0,
+            "fsync_calls": 5413,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "hydration_verification": {
+            "block_count": 0,
+            "fsync_calls": 16,
+            "object_count": 0,
+            "read_bytes": 353068460,
+            "read_calls": 5429,
+            "write_bytes": 21020063,
+            "write_calls": 324
+          },
+          "publication_preauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 50297,
+            "read_calls": 3,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "recovery_reauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 9300189195,
+            "read_calls": 14411,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "seal_authentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "shape_consume_reauthentication": {
+            "block_count": 14367,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 9613515213,
+            "read_calls": 137410,
+            "write_bytes": 7337129155,
+            "write_calls": 8667
+          }
+        },
+        "totals": {
+          "block_count": 14367,
+          "fsync_calls": 7413,
+          "object_count": 136,
+          "read_bytes": 22770347285,
+          "read_calls": 245352,
+          "write_bytes": 10248668711,
+          "write_calls": 38881
+        }
+      },
+      "staging": {
+        "allocated_bytes": 332464128,
+        "logical_bytes": 332048220,
+        "logical_references": 152,
+        "physical_logical_bytes": 332048220,
+        "physical_objects": 152
+      },
+      "staging_transient_peak_allocated_bytes": 5123039232,
+      "transient_peak_allocated_bytes": 5123039232
+    },
+    "counts": {
+      "imported_edges": 8388608,
+      "imported_nodes": 524288,
+      "source_edges": 8388608,
+      "source_nodes": 524288
+    },
+    "imported": {
+      "allocated_physical_bytes": 332910592,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 462848,
+          "logical_bytes": 68555,
+          "logical_references": 113,
+          "physical_logical_bytes": 68555,
+          "physical_objects": 113
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 141017088,
+          "logical_bytes": 140648263,
+          "logical_references": 128,
+          "physical_logical_bytes": 140648263,
+          "physical_objects": 128
+        },
+        "topology_nodes": {
+          "allocated_bytes": 2097152,
+          "logical_bytes": 2080111,
+          "logical_references": 8,
+          "physical_logical_bytes": 2080111,
+          "physical_objects": 8
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 189333504,
+          "logical_bytes": 189317146,
+          "logical_references": 12,
+          "physical_logical_bytes": 189317146,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 332114075,
+      "logical_references": 261,
+      "physical_objects": 258,
+      "retained_logical_eof_bytes": 332114075
+    },
+    "lifecycle": {
+      "contract": "graphforge-lifecycle-storage/2",
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 411181056,
+            "logical_bytes": 411169177,
+            "logical_references": 2,
+            "physical_logical_bytes": 411169177,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 334139392,
+            "logical_bytes": 332462979,
+            "logical_references": 559,
+            "physical_logical_bytes": 332462979,
+            "physical_objects": 559
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 332263424,
+            "logical_bytes": 332256768,
+            "logical_references": 1,
+            "physical_logical_bytes": 332256768,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 336171008,
+            "logical_bytes": 332870981,
+            "logical_references": 975,
+            "physical_logical_bytes": 332870981,
+            "physical_objects": 975
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 411189248,
+            "logical_bytes": 411173328,
+            "logical_references": 3,
+            "physical_logical_bytes": 411173328,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 334139392,
+            "logical_bytes": 332462979,
+            "logical_references": 559,
+            "physical_logical_bytes": 332462979,
+            "physical_objects": 559
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "retained_storage_bytes": 2159190016,
+      "source_project_current_allocated_bytes": 334139392,
+      "transient_peak_storage_bytes": 5948940288
+    },
+    "portable_package": {
+      "allocation_allocated_bytes": 332263424,
+      "allocation_logical_bytes": 332256768,
+      "allocation_physical_objects": 1,
+      "contract": "graphforge-portable-export/2"
+    },
+    "source": {
+      "allocated_physical_bytes": 332910592,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 462848,
+          "logical_bytes": 68555,
+          "logical_references": 113,
+          "physical_logical_bytes": 68555,
+          "physical_objects": 113
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 141017088,
+          "logical_bytes": 140648263,
+          "logical_references": 128,
+          "physical_logical_bytes": 140648263,
+          "physical_objects": 128
+        },
+        "topology_nodes": {
+          "allocated_bytes": 2097152,
+          "logical_bytes": 2080111,
+          "logical_references": 8,
+          "physical_logical_bytes": 2080111,
+          "physical_objects": 8
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 189333504,
+          "logical_bytes": 189317146,
+          "logical_references": 12,
+          "physical_logical_bytes": 189317146,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 332114075,
+      "logical_references": 261,
+      "physical_objects": 258,
+      "retained_logical_eof_bytes": 332114075
+    }
+  },
+  "storage_components": {
+    "imported_allocated_physical_bytes": 332910592,
+    "imported_retained_logical_eof_bytes": 332114075,
+    "logical_read_bytes": 22770347285,
+    "logical_write_bytes": 10248668711,
+    "publication_work_units": 126894,
+    "reader_calls": 245352,
+    "source_allocated_physical_bytes": 332910592,
+    "source_project_current_allocated_bytes": 334139392,
+    "source_retained_logical_eof_bytes": 332114075,
+    "transient_peak_allocated_bytes": 5123039232
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/s20-benchexec.json
+++ b/docs/development/evidence/integrated-storage-1194/s20-benchexec.json
@@ -1,0 +1,1306 @@
+{
+  "authority": {
+    "cpu_seconds": 327.278453,
+    "peak_rss_bytes": 3118157824,
+    "pressure_cpu_seconds": 0.49856,
+    "pressure_io_seconds": 35.844997,
+    "pressure_memory_seconds": 0.0,
+    "read_bytes": 222907678720,
+    "wall_seconds": 384.6858612350188,
+    "write_bytes": 74677432320
+  },
+  "disagreements": [],
+  "exit_code": 0,
+  "graphforge": {
+    "failed_phase": null,
+    "phases": [
+      {
+        "duration_ms": 10,
+        "exit_code": 0,
+        "peak_rss_bytes": 16384,
+        "phase": "admission",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 6626,
+        "exit_code": 0,
+        "peak_rss_bytes": 73936896,
+        "phase": "generate",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 228672,
+        "exit_code": 0,
+        "peak_rss_bytes": 153645056,
+        "phase": "ingest",
+        "receipts": [
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "begun"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "bytes_accepted": 822337680,
+            "construction": {
+              "accepted_chunks": 272,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 272,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 3629690464,
+                    "write_calls": 8528
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 627,
+                    "object_count": 0,
+                    "read_bytes": 6355026379,
+                    "read_calls": 164070,
+                    "write_bytes": 1500026997,
+                    "write_calls": 41765
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 11119,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 16621552773,
+                    "read_calls": 16569,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 28731,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 19227027175,
+                    "read_calls": 275017,
+                    "write_bytes": 14674255319,
+                    "write_calls": 17698
+                  }
+                },
+                "totals": {
+                  "block_count": 28731,
+                  "fsync_calls": 11746,
+                  "object_count": 272,
+                  "read_bytes": 42203606327,
+                  "read_calls": 455656,
+                  "write_bytes": 19803972780,
+                  "write_calls": 67991
+                }
+              },
+              "cache_release_operations": 43769,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 73926234525,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 678465536,
+                "logical_bytes": 677697400,
+                "logical_references": 288,
+                "physical_logical_bytes": 677697400,
+                "physical_objects": 288
+              },
+              "construction_staging_transient_peak_allocated_bytes": 10246037504,
+              "fsync_operations": 3488,
+              "immutable_artifacts": 1072,
+              "input_batches": 272,
+              "input_rows": 17825792,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": false,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 627,
+                  "object_count": 0,
+                  "read_bytes": 6355026379,
+                  "read_calls": 164070,
+                  "write_bytes": 1500026997,
+                  "write_calls": 41765
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 11119,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 217581
+              },
+              "transient_peak_allocated_bytes": 10246037504,
+              "write_bytes": 3629690464,
+              "write_operations": 8528
+            },
+            "contract": "graphforge-import-session/1",
+            "operation_timings": {
+              "append": {
+                "calls": 272,
+                "elapsed_ns": 16737040531,
+                "errors": 0
+              },
+              "begin": {
+                "calls": 1,
+                "elapsed_ns": 954668,
+                "errors": 0
+              },
+              "publish": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "resume": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "seal": {
+                "calls": 1,
+                "elapsed_ns": 177088074484,
+                "errors": 0
+              }
+            },
+            "outcome": "validated",
+            "rows_accepted": 17825792,
+            "rows_rejected": 0
+          },
+          {
+            "construction": {
+              "accepted_chunks": 272,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 272,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 3629690464,
+                    "write_calls": 8528
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 3360,
+                    "object_count": 0,
+                    "read_bytes": 679174824,
+                    "read_calls": 11925,
+                    "write_bytes": 678496326,
+                    "write_calls": 11289
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 627,
+                    "object_count": 0,
+                    "read_bytes": 6355026379,
+                    "read_calls": 164070,
+                    "write_bytes": 1500026997,
+                    "write_calls": 41765
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 11131,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 16,
+                    "object_count": 0,
+                    "read_bytes": 719735541,
+                    "read_calls": 11103,
+                    "write_bytes": 42037964,
+                    "write_calls": 645
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 95647,
+                    "read_calls": 3,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 18654765578,
+                    "read_calls": 29017,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 28731,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 19227027175,
+                    "read_calls": 275017,
+                    "write_bytes": 14674255319,
+                    "write_calls": 17698
+                  }
+                },
+                "totals": {
+                  "block_count": 28731,
+                  "fsync_calls": 15134,
+                  "object_count": 272,
+                  "read_bytes": 45635825144,
+                  "read_calls": 491135,
+                  "write_bytes": 20524507070,
+                  "write_calls": 79925
+                }
+              },
+              "cache_release_operations": 44633,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 75959326725,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 678465536,
+                "logical_bytes": 677697400,
+                "logical_references": 288,
+                "physical_logical_bytes": 677697400,
+                "physical_objects": 288
+              },
+              "construction_staging_transient_peak_allocated_bytes": 10246037504,
+              "fsync_operations": 3488,
+              "immutable_artifacts": 1072,
+              "input_batches": 272,
+              "input_rows": 17825792,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": true,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 3360,
+                  "object_count": 0,
+                  "read_bytes": 679174824,
+                  "read_calls": 11925,
+                  "write_bytes": 678496326,
+                  "write_calls": 11289
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 627,
+                  "object_count": 0,
+                  "read_bytes": 6355026379,
+                  "read_calls": 164070,
+                  "write_bytes": 1500026997,
+                  "write_calls": 41765
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 11131,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 16,
+                  "object_count": 0,
+                  "read_bytes": 719735541,
+                  "read_calls": 11103,
+                  "write_bytes": 42037964,
+                  "write_calls": 645
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 95647,
+                  "read_calls": 3,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 255934
+              },
+              "transient_peak_allocated_bytes": 10246037504,
+              "write_bytes": 3629690464,
+              "write_operations": 8528
+            },
+            "contract": "graphforge-import-session/1",
+            "operation_timings": {
+              "append": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "begin": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "publish": {
+                "calls": 1,
+                "elapsed_ns": 9436727862,
+                "errors": 0
+              },
+              "resume": {
+                "calls": 1,
+                "elapsed_ns": 975586822,
+                "errors": 0
+              },
+              "seal": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              }
+            },
+            "outcome": "committed"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 12622,
+        "exit_code": 0,
+        "peak_rss_bytes": 38563840,
+        "phase": "reopen",
+        "receipts": [
+          {
+            "aborted_journals": 0,
+            "deferred": null,
+            "elapsed_ms": 0,
+            "kind": "project_open",
+            "preserved_unknown_entries": 0,
+            "removed_generations": 0,
+            "repaired_journals": 0,
+            "selected_generation_class": "committed_current",
+            "work_detected": false
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 679284736,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 835584,
+                  "logical_bytes": 125018,
+                  "logical_references": 204,
+                  "physical_logical_bytes": 125018,
+                  "physical_objects": 204
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 295608320,
+                  "logical_bytes": 294903662,
+                  "logical_references": 256,
+                  "physical_logical_bytes": 294903662,
+                  "physical_objects": 256
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 4194304,
+                  "logical_bytes": 4159543,
+                  "logical_references": 16,
+                  "physical_logical_bytes": 4159543,
+                  "physical_objects": 16
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 378646528,
+                  "logical_bytes": 378631495,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 378631495,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 677819718,
+              "logical_references": 488,
+              "physical_objects": 485,
+              "retained_logical_eof_bytes": 677819718
+            }
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 7970,
+        "exit_code": 0,
+        "peak_rss_bytes": 78213120,
+        "phase": "recount",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "d41814e11f492a8c36191b100c805a370de2b4bdbe6ca88c7eef41360ef53066",
+            "rows": 1,
+            "scalar_u64": 1048576
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 79118336,
+                  "before_bytes": 78082048,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 79118336
+                }
+              ],
+              "peak_rss_bytes": 79118336,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 79118336,
+              "sorts": []
+            },
+            "result_sha256": "3daeda0e54a362622ffdc547a631479e3f18cd0f7fa1b28c3b1fce9b7e88a150",
+            "rows": 1,
+            "scalar_u64": 16777216
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 40136,
+        "exit_code": 0,
+        "peak_rss_bytes": 199983104,
+        "phase": "query",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 78,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 71104,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 43,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 127995904,
+                  "before_bytes": 78024704,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 127995904
+                }
+              ],
+              "peak_rss_bytes": 127995904,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 127995904,
+              "sorts": []
+            },
+            "result_sha256": "da48cf8bd82d136635cba999906d07a783deabf66427e13128f645d756adb116",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 6,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 131072,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 2,
+                  "identity_reader_calls": 2,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 2,
+                  "projected_columns": 1,
+                  "projected_rows": 2,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 146006016,
+                  "before_bytes": 78983168,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 146006016
+                }
+              ],
+              "peak_rss_bytes": 146006016,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 146006016,
+              "sorts": []
+            },
+            "result_sha256": "404560fda0d6c2f6988aa4cee9c8d1d465c7254181b8c760e659e00b3f1bd255",
+            "rows": 1000,
+            "scalar_u64": null
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 7901,
+        "exit_code": 0,
+        "peak_rss_bytes": 38801408,
+        "phase": "export",
+        "receipts": [
+          {
+            "allocation_allocated_bytes": 678088704,
+            "allocation_logical_bytes": 678083072,
+            "allocation_physical_objects": 1,
+            "contract": "graphforge-portable-export/2",
+            "entry_count": 297,
+            "package_digest": "sha256:9d1fe7ab1792ff6e01b2cccb64d4678206b7025521b8f7d04c0d5e3258c8f809",
+            "payload_bytes": 677698925,
+            "representation": "bundle",
+            "selection_fingerprint": "sha256:8f77409edf74ad451d8db71f041782ab54cf9b9724bd120bc02fd5c19122a16d",
+            "transport_digest": "sha256:091718eef991e3af4105de546493bcfb73710be7aca638d35a734e8fef221972"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 973,
+        "exit_code": 0,
+        "peak_rss_bytes": 24481792,
+        "phase": "verify",
+        "receipts": [
+          {
+            "compatibility": "supported",
+            "contract": "graphforge-portable-verify/2",
+            "entry_count": 297,
+            "integrity": "verified",
+            "package_digest": "sha256:9d1fe7ab1792ff6e01b2cccb64d4678206b7025521b8f7d04c0d5e3258c8f809",
+            "payload_bytes": 677857336,
+            "representation": "bundle",
+            "transport_digest": "sha256:091718eef991e3af4105de546493bcfb73710be7aca638d35a734e8fef221972"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 10841,
+        "exit_code": 0,
+        "peak_rss_bytes": 40542208,
+        "phase": "clean_import",
+        "receipts": [
+          {
+            "contract": "graphforge-portable-import/2",
+            "idempotent_replay": false,
+            "package_digest": "sha256:9d1fe7ab1792ff6e01b2cccb64d4678206b7025521b8f7d04c0d5e3258c8f809",
+            "transient_peak_allocated_bytes": 1360400384,
+            "transport_digest": "sha256:091718eef991e3af4105de546493bcfb73710be7aca638d35a734e8fef221972"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 58618,
+        "exit_code": 0,
+        "peak_rss_bytes": 200232960,
+        "phase": "reopen_proof",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "d41814e11f492a8c36191b100c805a370de2b4bdbe6ca88c7eef41360ef53066",
+            "rows": 1,
+            "scalar_u64": 1048576
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 80351232,
+                  "before_bytes": 79237120,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 80351232
+                }
+              ],
+              "peak_rss_bytes": 80351232,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 80351232,
+              "sorts": []
+            },
+            "result_sha256": "3daeda0e54a362622ffdc547a631479e3f18cd0f7fa1b28c3b1fce9b7e88a150",
+            "rows": 1,
+            "scalar_u64": 16777216
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 78,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 71104,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 43,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 128458752,
+                  "before_bytes": 78262272,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 128458752
+                }
+              ],
+              "peak_rss_bytes": 128458752,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 128458752,
+              "sorts": []
+            },
+            "result_sha256": "da48cf8bd82d136635cba999906d07a783deabf66427e13128f645d756adb116",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 6,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 131072,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 2,
+                  "identity_reader_calls": 2,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 2,
+                  "projected_columns": 1,
+                  "projected_rows": 2,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 146726912,
+                  "before_bytes": 79597568,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 146726912
+                }
+              ],
+              "peak_rss_bytes": 146726912,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 146726912,
+              "sorts": []
+            },
+            "result_sha256": "404560fda0d6c2f6988aa4cee9c8d1d465c7254181b8c760e659e00b3f1bd255",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 679284736,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 835584,
+                  "logical_bytes": 125018,
+                  "logical_references": 204,
+                  "physical_logical_bytes": 125018,
+                  "physical_objects": 204
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 295608320,
+                  "logical_bytes": 294903662,
+                  "logical_references": 256,
+                  "physical_logical_bytes": 294903662,
+                  "physical_objects": 256
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 4194304,
+                  "logical_bytes": 4159543,
+                  "logical_references": 16,
+                  "physical_logical_bytes": 4159543,
+                  "physical_objects": 16
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 378646528,
+                  "logical_bytes": 378631495,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 378631495,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 677819718,
+              "logical_references": 488,
+              "physical_objects": 485,
+              "retained_logical_eof_bytes": 677819718
+            }
+          },
+          {
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": {
+              "generated-inputs": {
+                "totals": {
+                  "allocated_bytes": 822345728,
+                  "logical_bytes": 822337680,
+                  "logical_references": 2,
+                  "physical_logical_bytes": 822337680,
+                  "physical_objects": 2
+                }
+              },
+              "imported-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "imported-project-construction": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-import": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "imported-project-published": {
+                "totals": {
+                  "allocated_bytes": 681910272,
+                  "logical_bytes": 678499741,
+                  "logical_references": 1127,
+                  "physical_logical_bytes": 678499741,
+                  "physical_objects": 1127
+                }
+              },
+              "imported-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              },
+              "portable-package": {
+                "totals": {
+                  "allocated_bytes": 678088704,
+                  "logical_bytes": 678083072,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 678083072,
+                  "physical_objects": 1
+                }
+              },
+              "query-results": {
+                "totals": {
+                  "allocated_bytes": 98304,
+                  "logical_bytes": 71228,
+                  "logical_references": 8,
+                  "physical_logical_bytes": 71228,
+                  "physical_objects": 8
+                }
+              },
+              "source-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "source-project-construction": {
+                "totals": {
+                  "allocated_bytes": 685801472,
+                  "logical_bytes": 679305946,
+                  "logical_references": 1919,
+                  "physical_logical_bytes": 679305946,
+                  "physical_objects": 1919
+                }
+              },
+              "source-project-import": {
+                "totals": {
+                  "allocated_bytes": 822353920,
+                  "logical_bytes": 822341855,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 822341855,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-published": {
+                "totals": {
+                  "allocated_bytes": 681910272,
+                  "logical_bytes": 678499741,
+                  "logical_references": 1127,
+                  "physical_logical_bytes": 678499741,
+                  "physical_objects": 1127
+                }
+              },
+              "source-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              }
+            },
+            "retained_storage_bytes": 4372516864,
+            "source_project_current_allocated_bytes": 681910272,
+            "transient_peak_storage_bytes": 11897737216
+          }
+        ],
+        "status": "passed"
+      }
+    ],
+    "profile_id": "graph500-s20-provider",
+    "schema": "graphforge-public-certification/1",
+    "status": "passed"
+  },
+  "limits": {
+    "cores": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "cpu_seconds": 14400.0,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400.0
+  },
+  "outcome": "passed",
+  "schema": "graphforge-benchexec-run/1",
+  "signal": null
+}

--- a/docs/development/evidence/integrated-storage-1194/s20-graphforge.json
+++ b/docs/development/evidence/integrated-storage-1194/s20-graphforge.json
@@ -1,0 +1,1266 @@
+{
+  "failed_phase": null,
+  "phases": [
+    {
+      "duration_ms": 10,
+      "exit_code": 0,
+      "peak_rss_bytes": 16384,
+      "phase": "admission",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 6626,
+      "exit_code": 0,
+      "peak_rss_bytes": 73936896,
+      "phase": "generate",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 228672,
+      "exit_code": 0,
+      "peak_rss_bytes": 153645056,
+      "phase": "ingest",
+      "receipts": [
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "begun"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "bytes_accepted": 822337680,
+          "construction": {
+            "accepted_chunks": 272,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 272,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 3629690464,
+                  "write_calls": 8528
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 627,
+                  "object_count": 0,
+                  "read_bytes": 6355026379,
+                  "read_calls": 164070,
+                  "write_bytes": 1500026997,
+                  "write_calls": 41765
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 11119,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 16621552773,
+                  "read_calls": 16569,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 28731,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 19227027175,
+                  "read_calls": 275017,
+                  "write_bytes": 14674255319,
+                  "write_calls": 17698
+                }
+              },
+              "totals": {
+                "block_count": 28731,
+                "fsync_calls": 11746,
+                "object_count": 272,
+                "read_bytes": 42203606327,
+                "read_calls": 455656,
+                "write_bytes": 19803972780,
+                "write_calls": 67991
+              }
+            },
+            "cache_release_operations": 43769,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 73926234525,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 678465536,
+              "logical_bytes": 677697400,
+              "logical_references": 288,
+              "physical_logical_bytes": 677697400,
+              "physical_objects": 288
+            },
+            "construction_staging_transient_peak_allocated_bytes": 10246037504,
+            "fsync_operations": 3488,
+            "immutable_artifacts": 1072,
+            "input_batches": 272,
+            "input_rows": 17825792,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": false,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 627,
+                "object_count": 0,
+                "read_bytes": 6355026379,
+                "read_calls": 164070,
+                "write_bytes": 1500026997,
+                "write_calls": 41765
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 11119,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 217581
+            },
+            "transient_peak_allocated_bytes": 10246037504,
+            "write_bytes": 3629690464,
+            "write_operations": 8528
+          },
+          "contract": "graphforge-import-session/1",
+          "operation_timings": {
+            "append": {
+              "calls": 272,
+              "elapsed_ns": 16737040531,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 1,
+              "elapsed_ns": 954668,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 1,
+              "elapsed_ns": 177088074484,
+              "errors": 0
+            }
+          },
+          "outcome": "validated",
+          "rows_accepted": 17825792,
+          "rows_rejected": 0
+        },
+        {
+          "construction": {
+            "accepted_chunks": 272,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 272,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 3629690464,
+                  "write_calls": 8528
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 3360,
+                  "object_count": 0,
+                  "read_bytes": 679174824,
+                  "read_calls": 11925,
+                  "write_bytes": 678496326,
+                  "write_calls": 11289
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 627,
+                  "object_count": 0,
+                  "read_bytes": 6355026379,
+                  "read_calls": 164070,
+                  "write_bytes": 1500026997,
+                  "write_calls": 41765
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 11131,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 16,
+                  "object_count": 0,
+                  "read_bytes": 719735541,
+                  "read_calls": 11103,
+                  "write_bytes": 42037964,
+                  "write_calls": 645
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 95647,
+                  "read_calls": 3,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 18654765578,
+                  "read_calls": 29017,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 28731,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 19227027175,
+                  "read_calls": 275017,
+                  "write_bytes": 14674255319,
+                  "write_calls": 17698
+                }
+              },
+              "totals": {
+                "block_count": 28731,
+                "fsync_calls": 15134,
+                "object_count": 272,
+                "read_bytes": 45635825144,
+                "read_calls": 491135,
+                "write_bytes": 20524507070,
+                "write_calls": 79925
+              }
+            },
+            "cache_release_operations": 44633,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 75959326725,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 678465536,
+              "logical_bytes": 677697400,
+              "logical_references": 288,
+              "physical_logical_bytes": 677697400,
+              "physical_objects": 288
+            },
+            "construction_staging_transient_peak_allocated_bytes": 10246037504,
+            "fsync_operations": 3488,
+            "immutable_artifacts": 1072,
+            "input_batches": 272,
+            "input_rows": 17825792,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": true,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 3360,
+                "object_count": 0,
+                "read_bytes": 679174824,
+                "read_calls": 11925,
+                "write_bytes": 678496326,
+                "write_calls": 11289
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 627,
+                "object_count": 0,
+                "read_bytes": 6355026379,
+                "read_calls": 164070,
+                "write_bytes": 1500026997,
+                "write_calls": 41765
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 11131,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 16,
+                "object_count": 0,
+                "read_bytes": 719735541,
+                "read_calls": 11103,
+                "write_bytes": 42037964,
+                "write_calls": 645
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 95647,
+                "read_calls": 3,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 255934
+            },
+            "transient_peak_allocated_bytes": 10246037504,
+            "write_bytes": 3629690464,
+            "write_operations": 8528
+          },
+          "contract": "graphforge-import-session/1",
+          "operation_timings": {
+            "append": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 1,
+              "elapsed_ns": 9436727862,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 1,
+              "elapsed_ns": 975586822,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            }
+          },
+          "outcome": "committed"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 12622,
+      "exit_code": 0,
+      "peak_rss_bytes": 38563840,
+      "phase": "reopen",
+      "receipts": [
+        {
+          "aborted_journals": 0,
+          "deferred": null,
+          "elapsed_ms": 0,
+          "kind": "project_open",
+          "preserved_unknown_entries": 0,
+          "removed_generations": 0,
+          "repaired_journals": 0,
+          "selected_generation_class": "committed_current",
+          "work_detected": false
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 679284736,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 835584,
+                "logical_bytes": 125018,
+                "logical_references": 204,
+                "physical_logical_bytes": 125018,
+                "physical_objects": 204
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 295608320,
+                "logical_bytes": 294903662,
+                "logical_references": 256,
+                "physical_logical_bytes": 294903662,
+                "physical_objects": 256
+              },
+              "topology_nodes": {
+                "allocated_bytes": 4194304,
+                "logical_bytes": 4159543,
+                "logical_references": 16,
+                "physical_logical_bytes": 4159543,
+                "physical_objects": 16
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 378646528,
+                "logical_bytes": 378631495,
+                "logical_references": 12,
+                "physical_logical_bytes": 378631495,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 677819718,
+            "logical_references": 488,
+            "physical_objects": 485,
+            "retained_logical_eof_bytes": 677819718
+          }
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 7970,
+      "exit_code": 0,
+      "peak_rss_bytes": 78213120,
+      "phase": "recount",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "d41814e11f492a8c36191b100c805a370de2b4bdbe6ca88c7eef41360ef53066",
+          "rows": 1,
+          "scalar_u64": 1048576
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 79118336,
+                "before_bytes": 78082048,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 79118336
+              }
+            ],
+            "peak_rss_bytes": 79118336,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 79118336,
+            "sorts": []
+          },
+          "result_sha256": "3daeda0e54a362622ffdc547a631479e3f18cd0f7fa1b28c3b1fce9b7e88a150",
+          "rows": 1,
+          "scalar_u64": 16777216
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 40136,
+      "exit_code": 0,
+      "peak_rss_bytes": 199983104,
+      "phase": "query",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 78,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 71104,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 43,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 127995904,
+                "before_bytes": 78024704,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 127995904
+              }
+            ],
+            "peak_rss_bytes": 127995904,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 127995904,
+            "sorts": []
+          },
+          "result_sha256": "da48cf8bd82d136635cba999906d07a783deabf66427e13128f645d756adb116",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 6,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 131072,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 2,
+                "identity_reader_calls": 2,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 2,
+                "projected_columns": 1,
+                "projected_rows": 2,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 146006016,
+                "before_bytes": 78983168,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 146006016
+              }
+            ],
+            "peak_rss_bytes": 146006016,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 146006016,
+            "sorts": []
+          },
+          "result_sha256": "404560fda0d6c2f6988aa4cee9c8d1d465c7254181b8c760e659e00b3f1bd255",
+          "rows": 1000,
+          "scalar_u64": null
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 7901,
+      "exit_code": 0,
+      "peak_rss_bytes": 38801408,
+      "phase": "export",
+      "receipts": [
+        {
+          "allocation_allocated_bytes": 678088704,
+          "allocation_logical_bytes": 678083072,
+          "allocation_physical_objects": 1,
+          "contract": "graphforge-portable-export/2",
+          "entry_count": 297,
+          "package_digest": "sha256:9d1fe7ab1792ff6e01b2cccb64d4678206b7025521b8f7d04c0d5e3258c8f809",
+          "payload_bytes": 677698925,
+          "representation": "bundle",
+          "selection_fingerprint": "sha256:8f77409edf74ad451d8db71f041782ab54cf9b9724bd120bc02fd5c19122a16d",
+          "transport_digest": "sha256:091718eef991e3af4105de546493bcfb73710be7aca638d35a734e8fef221972"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 973,
+      "exit_code": 0,
+      "peak_rss_bytes": 24481792,
+      "phase": "verify",
+      "receipts": [
+        {
+          "compatibility": "supported",
+          "contract": "graphforge-portable-verify/2",
+          "entry_count": 297,
+          "integrity": "verified",
+          "package_digest": "sha256:9d1fe7ab1792ff6e01b2cccb64d4678206b7025521b8f7d04c0d5e3258c8f809",
+          "payload_bytes": 677857336,
+          "representation": "bundle",
+          "transport_digest": "sha256:091718eef991e3af4105de546493bcfb73710be7aca638d35a734e8fef221972"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 10841,
+      "exit_code": 0,
+      "peak_rss_bytes": 40542208,
+      "phase": "clean_import",
+      "receipts": [
+        {
+          "contract": "graphforge-portable-import/2",
+          "idempotent_replay": false,
+          "package_digest": "sha256:9d1fe7ab1792ff6e01b2cccb64d4678206b7025521b8f7d04c0d5e3258c8f809",
+          "transient_peak_allocated_bytes": 1360400384,
+          "transport_digest": "sha256:091718eef991e3af4105de546493bcfb73710be7aca638d35a734e8fef221972"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 58618,
+      "exit_code": 0,
+      "peak_rss_bytes": 200232960,
+      "phase": "reopen_proof",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "d41814e11f492a8c36191b100c805a370de2b4bdbe6ca88c7eef41360ef53066",
+          "rows": 1,
+          "scalar_u64": 1048576
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 80351232,
+                "before_bytes": 79237120,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 80351232
+              }
+            ],
+            "peak_rss_bytes": 80351232,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 80351232,
+            "sorts": []
+          },
+          "result_sha256": "3daeda0e54a362622ffdc547a631479e3f18cd0f7fa1b28c3b1fce9b7e88a150",
+          "rows": 1,
+          "scalar_u64": 16777216
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 78,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 71104,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 43,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 128458752,
+                "before_bytes": 78262272,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 128458752
+              }
+            ],
+            "peak_rss_bytes": 128458752,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 128458752,
+            "sorts": []
+          },
+          "result_sha256": "da48cf8bd82d136635cba999906d07a783deabf66427e13128f645d756adb116",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 6,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 131072,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 2,
+                "identity_reader_calls": 2,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 2,
+                "projected_columns": 1,
+                "projected_rows": 2,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 146726912,
+                "before_bytes": 79597568,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 146726912
+              }
+            ],
+            "peak_rss_bytes": 146726912,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 146726912,
+            "sorts": []
+          },
+          "result_sha256": "404560fda0d6c2f6988aa4cee9c8d1d465c7254181b8c760e659e00b3f1bd255",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 679284736,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 835584,
+                "logical_bytes": 125018,
+                "logical_references": 204,
+                "physical_logical_bytes": 125018,
+                "physical_objects": 204
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 295608320,
+                "logical_bytes": 294903662,
+                "logical_references": 256,
+                "physical_logical_bytes": 294903662,
+                "physical_objects": 256
+              },
+              "topology_nodes": {
+                "allocated_bytes": 4194304,
+                "logical_bytes": 4159543,
+                "logical_references": 16,
+                "physical_logical_bytes": 4159543,
+                "physical_objects": 16
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 378646528,
+                "logical_bytes": 378631495,
+                "logical_references": 12,
+                "physical_logical_bytes": 378631495,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 677819718,
+            "logical_references": 488,
+            "physical_objects": 485,
+            "retained_logical_eof_bytes": 677819718
+          }
+        },
+        {
+          "contract": "graphforge-lifecycle-storage/2",
+          "retained_owners": {
+            "generated-inputs": {
+              "totals": {
+                "allocated_bytes": 822345728,
+                "logical_bytes": 822337680,
+                "logical_references": 2,
+                "physical_logical_bytes": 822337680,
+                "physical_objects": 2
+              }
+            },
+            "imported-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "imported-project-construction": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-import": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "imported-project-published": {
+              "totals": {
+                "allocated_bytes": 681910272,
+                "logical_bytes": 678499741,
+                "logical_references": 1127,
+                "physical_logical_bytes": 678499741,
+                "physical_objects": 1127
+              }
+            },
+            "imported-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            },
+            "portable-package": {
+              "totals": {
+                "allocated_bytes": 678088704,
+                "logical_bytes": 678083072,
+                "logical_references": 1,
+                "physical_logical_bytes": 678083072,
+                "physical_objects": 1
+              }
+            },
+            "query-results": {
+              "totals": {
+                "allocated_bytes": 98304,
+                "logical_bytes": 71228,
+                "logical_references": 8,
+                "physical_logical_bytes": 71228,
+                "physical_objects": 8
+              }
+            },
+            "source-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "source-project-construction": {
+              "totals": {
+                "allocated_bytes": 685801472,
+                "logical_bytes": 679305946,
+                "logical_references": 1919,
+                "physical_logical_bytes": 679305946,
+                "physical_objects": 1919
+              }
+            },
+            "source-project-import": {
+              "totals": {
+                "allocated_bytes": 822353920,
+                "logical_bytes": 822341855,
+                "logical_references": 3,
+                "physical_logical_bytes": 822341855,
+                "physical_objects": 3
+              }
+            },
+            "source-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "source-project-published": {
+              "totals": {
+                "allocated_bytes": 681910272,
+                "logical_bytes": 678499741,
+                "logical_references": 1127,
+                "physical_logical_bytes": 678499741,
+                "physical_objects": 1127
+              }
+            },
+            "source-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            }
+          },
+          "retained_storage_bytes": 4372516864,
+          "source_project_current_allocated_bytes": 681910272,
+          "transient_peak_storage_bytes": 11897737216
+        }
+      ],
+      "status": "passed"
+    }
+  ],
+  "profile_id": "graph500-s20-provider",
+  "schema": "graphforge-public-certification/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/s20-plan.json
+++ b/docs/development/evidence/integrated-storage-1194/s20-plan.json
@@ -1,0 +1,37 @@
+{
+  "claim": "engineering_evidence_only",
+  "execution": "native_linux_benchexec_host",
+  "identities": {
+    "admitted_projection_sha256": "24fb3c6df4e0316783a8144633310dd4f410b59cd2df65a27050a704067bb090",
+    "benchexec_python_sha256": "52e0a13e60a981d8c4b6478be2ba5176f69da07948a056bf49cf6f077e30cb41",
+    "benchexec_version": "3.35",
+    "certify_sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+    "commit": "24ca688c516a86a68de9cffaab2d5a9215291256",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+    "gf_sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "5ca3af64ae7a0a45221cdafdcabce2bfa700975e19f1ccb9557269cecef92bf1",
+    "profile_id": "graph500-s20-provider",
+    "profile_sha256": "922533672e46f4dad2ac96ebd0c4ebdf215ec0214d534bea713b8e4e6cf62700"
+  },
+  "limits": {
+    "cores": 16,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400
+  },
+  "outputs": [
+    "s20-plan.json",
+    "s20-benchexec.json",
+    "s20-graphforge.json",
+    "s20-rung.json",
+    "s20-result.json"
+  ],
+  "rung": "S20",
+  "schema": "graphforge-progressive-host-run-plan/1",
+  "work_root_capacity": {
+    "free_bytes": 633355468800,
+    "reserved_headroom_bytes": 141258578535
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/s20-projection.json
+++ b/docs/development/evidence/integrated-storage-1194/s20-projection.json
@@ -1,0 +1,83 @@
+{
+  "checks": {
+    "correctness": true,
+    "io_reader_publication_capacity_measured": true,
+    "io_reader_publication_headroom": true,
+    "retained_storage_headroom": true,
+    "rss_bounded_or_plateaued": true,
+    "rss_headroom": true,
+    "storage_headroom": true,
+    "time_headroom": true,
+    "transient_storage_headroom": true
+  },
+  "claim": "engineering_evidence_only",
+  "decision": "admitted",
+  "headroom": {
+    "rss_fraction": 0.2,
+    "storage_fraction": 0.22303206570970088,
+    "time_fraction": 0.2
+  },
+  "limits": {
+    "rss_bytes": 4294967296,
+    "volume_bytes": 633355468800,
+    "wall_seconds": 14400
+  },
+  "native_capacity": {
+    "free_bytes": 633355468800,
+    "observed_rates": {
+      "physical_read_bytes_per_second": {
+        "wall_seconds": 97,
+        "work_units": 54517145600
+      },
+      "physical_write_bytes_per_second": {
+        "wall_seconds": 97,
+        "work_units": 18559918080
+      },
+      "publication_work_per_second": {
+        "wall_seconds": 97,
+        "work_units": 63163
+      },
+      "reader_calls_per_second": {
+        "wall_seconds": 97,
+        "work_units": 122479
+      }
+    },
+    "rate_source": "completed_adjacent_rungs",
+    "reserved_headroom_bytes": 141258578535
+  },
+  "projected": {
+    "logical_read_bytes": 45590914557,
+    "logical_write_bytes": 20511702943,
+    "peak_rss_bytes": 195112960,
+    "physical_read_bytes": 221838393344,
+    "physical_write_bytes": 74570268672,
+    "publication_work_units": 254356,
+    "reader_calls": 491098,
+    "retained_storage_bytes": 4347404288,
+    "storage_peak_bytes": 11897880576,
+    "transient_peak_storage_bytes": 11897880576,
+    "wall_seconds": 384
+  },
+  "provider_capacity": null,
+  "required_rates": {
+    "physical_read_bytes_per_second": 19256805,
+    "physical_write_bytes_per_second": 6473114,
+    "publication_work_per_second": 23,
+    "reader_calls_per_second": 43
+  },
+  "rss_growth_fraction": 0.03422829329565081,
+  "schema": "graphforge-progressive-qualification-evidence/1",
+  "slopes_observed": {
+    "logical_read_bytes": 11410283636,
+    "logical_write_bytes": 5131517116,
+    "physical_read_bytes": 55773749248,
+    "physical_write_bytes": 18670116864,
+    "publication_work_units": 63731,
+    "reader_calls": 122873
+  },
+  "source_scales": [
+    18,
+    19
+  ],
+  "target": "S20"
+}

--- a/docs/development/evidence/integrated-storage-1194/s20-result.json
+++ b/docs/development/evidence/integrated-storage-1194/s20-result.json
@@ -1,0 +1,28 @@
+{
+  "artifacts": {
+    "benchexec_sha256": "3e224e4e224f315e31414858ce02d09740ecfb17b831547bfd63a1eb84d60132",
+    "graphforge_sha256": "179160f338d7b4f9fb39a84e340bc678c73fb651956cf6b90f201ac4d5188d1c",
+    "plan_sha256": "69e334d2586557b1facdcb7c9e94b76fc3e2874d1d682b2df0656e3f17faa7a4",
+    "rung_sha256": "374699d6477e48b82d1fa22aa798b46f8c0b6ca5ab40abf7b9070e435179569e"
+  },
+  "claim": "engineering_evidence_only",
+  "failure": null,
+  "identities": {
+    "admitted_projection_sha256": "24fb3c6df4e0316783a8144633310dd4f410b59cd2df65a27050a704067bb090",
+    "benchexec_python_sha256": "52e0a13e60a981d8c4b6478be2ba5176f69da07948a056bf49cf6f077e30cb41",
+    "benchexec_version": "3.35",
+    "certify_sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+    "commit": "24ca688c516a86a68de9cffaab2d5a9215291256",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+    "gf_sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "5ca3af64ae7a0a45221cdafdcabce2bfa700975e19f1ccb9557269cecef92bf1",
+    "profile_id": "graph500-s20-provider",
+    "profile_sha256": "922533672e46f4dad2ac96ebd0c4ebdf215ec0214d534bea713b8e4e6cf62700"
+  },
+  "rung": "S20",
+  "schema": "graphforge-progressive-host-run-result/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/s20-rung.json
+++ b/docs/development/evidence/integrated-storage-1194/s20-rung.json
@@ -1,0 +1,490 @@
+{
+  "assembly_contract": "graphforge-progressive-rung-assembly/3",
+  "correctness": true,
+  "failure": null,
+  "live_edges": 16777216,
+  "metric_sources": {
+    "benchexec": [
+      "wall_seconds",
+      "physical_read_bytes",
+      "physical_write_bytes"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
+    ],
+    "query_qualification": [
+      "live_edges",
+      "correctness"
+    ],
+    "storage_attribution": [
+      "retained_storage_bytes",
+      "transient_peak_storage_bytes",
+      "logical_read_bytes",
+      "logical_write_bytes",
+      "reader_calls",
+      "publication_work_units"
+    ]
+  },
+  "metrics": {
+    "logical_read_bytes": 45635825144,
+    "logical_write_bytes": 20524507070,
+    "peak_rss_bytes": 200232960,
+    "physical_read_bytes": 222907678720,
+    "physical_write_bytes": 74677432320,
+    "publication_work_units": 255934,
+    "reader_calls": 491135,
+    "retained_storage_bytes": 4372516864,
+    "transient_peak_storage_bytes": 11897737216,
+    "wall_seconds": 385
+  },
+  "phases": [
+    "admission",
+    "generate",
+    "ingest",
+    "reopen",
+    "recount",
+    "query",
+    "export",
+    "verify",
+    "clean_import",
+    "reopen_proof"
+  ],
+  "profile_id": "graph500-s20-provider",
+  "scale": 20,
+  "source": "canonical_ladder",
+  "status": "passed",
+  "storage_attribution": {
+    "construction": {
+      "application_io": {
+        "phases": {
+          "append_merge": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 272,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 3629690464,
+            "write_calls": 8528
+          },
+          "cas_install_read_write": {
+            "block_count": 0,
+            "fsync_calls": 3360,
+            "object_count": 0,
+            "read_bytes": 679174824,
+            "read_calls": 11925,
+            "write_bytes": 678496326,
+            "write_calls": 11289
+          },
+          "encode_write_postwrite_authentication": {
+            "block_count": 0,
+            "fsync_calls": 627,
+            "object_count": 0,
+            "read_bytes": 6355026379,
+            "read_calls": 164070,
+            "write_bytes": 1500026997,
+            "write_calls": 41765
+          },
+          "fsync_synchronization": {
+            "block_count": 0,
+            "fsync_calls": 11131,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "hydration_verification": {
+            "block_count": 0,
+            "fsync_calls": 16,
+            "object_count": 0,
+            "read_bytes": 719735541,
+            "read_calls": 11103,
+            "write_bytes": 42037964,
+            "write_calls": 645
+          },
+          "publication_preauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 95647,
+            "read_calls": 3,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "recovery_reauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 18654765578,
+            "read_calls": 29017,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "seal_authentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "shape_consume_reauthentication": {
+            "block_count": 28731,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 19227027175,
+            "read_calls": 275017,
+            "write_bytes": 14674255319,
+            "write_calls": 17698
+          }
+        },
+        "totals": {
+          "block_count": 28731,
+          "fsync_calls": 15134,
+          "object_count": 272,
+          "read_bytes": 45635825144,
+          "read_calls": 491135,
+          "write_bytes": 20524507070,
+          "write_calls": 79925
+        }
+      },
+      "staging": {
+        "allocated_bytes": 678465536,
+        "logical_bytes": 677697400,
+        "logical_references": 288,
+        "physical_logical_bytes": 677697400,
+        "physical_objects": 288
+      },
+      "staging_transient_peak_allocated_bytes": 10246037504,
+      "transient_peak_allocated_bytes": 10246037504
+    },
+    "counts": {
+      "imported_edges": 16777216,
+      "imported_nodes": 1048576,
+      "source_edges": 16777216,
+      "source_nodes": 1048576
+    },
+    "imported": {
+      "allocated_physical_bytes": 679284736,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 835584,
+          "logical_bytes": 125018,
+          "logical_references": 204,
+          "physical_logical_bytes": 125018,
+          "physical_objects": 204
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 295608320,
+          "logical_bytes": 294903662,
+          "logical_references": 256,
+          "physical_logical_bytes": 294903662,
+          "physical_objects": 256
+        },
+        "topology_nodes": {
+          "allocated_bytes": 4194304,
+          "logical_bytes": 4159543,
+          "logical_references": 16,
+          "physical_logical_bytes": 4159543,
+          "physical_objects": 16
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 378646528,
+          "logical_bytes": 378631495,
+          "logical_references": 12,
+          "physical_logical_bytes": 378631495,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 677819718,
+      "logical_references": 488,
+      "physical_objects": 485,
+      "retained_logical_eof_bytes": 677819718
+    },
+    "lifecycle": {
+      "contract": "graphforge-lifecycle-storage/2",
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 822345728,
+            "logical_bytes": 822337680,
+            "logical_references": 2,
+            "physical_logical_bytes": 822337680,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 681910272,
+            "logical_bytes": 678499741,
+            "logical_references": 1127,
+            "physical_logical_bytes": 678499741,
+            "physical_objects": 1127
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 678088704,
+            "logical_bytes": 678083072,
+            "logical_references": 1,
+            "physical_logical_bytes": 678083072,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 685801472,
+            "logical_bytes": 679305946,
+            "logical_references": 1919,
+            "physical_logical_bytes": 679305946,
+            "physical_objects": 1919
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 822353920,
+            "logical_bytes": 822341855,
+            "logical_references": 3,
+            "physical_logical_bytes": 822341855,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 681910272,
+            "logical_bytes": 678499741,
+            "logical_references": 1127,
+            "physical_logical_bytes": 678499741,
+            "physical_objects": 1127
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "retained_storage_bytes": 4372516864,
+      "source_project_current_allocated_bytes": 681910272,
+      "transient_peak_storage_bytes": 11897737216
+    },
+    "portable_package": {
+      "allocation_allocated_bytes": 678088704,
+      "allocation_logical_bytes": 678083072,
+      "allocation_physical_objects": 1,
+      "contract": "graphforge-portable-export/2"
+    },
+    "source": {
+      "allocated_physical_bytes": 679284736,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 835584,
+          "logical_bytes": 125018,
+          "logical_references": 204,
+          "physical_logical_bytes": 125018,
+          "physical_objects": 204
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 295608320,
+          "logical_bytes": 294903662,
+          "logical_references": 256,
+          "physical_logical_bytes": 294903662,
+          "physical_objects": 256
+        },
+        "topology_nodes": {
+          "allocated_bytes": 4194304,
+          "logical_bytes": 4159543,
+          "logical_references": 16,
+          "physical_logical_bytes": 4159543,
+          "physical_objects": 16
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 378646528,
+          "logical_bytes": 378631495,
+          "logical_references": 12,
+          "physical_logical_bytes": 378631495,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 677819718,
+      "logical_references": 488,
+      "physical_objects": 485,
+      "retained_logical_eof_bytes": 677819718
+    }
+  },
+  "storage_components": {
+    "imported_allocated_physical_bytes": 679284736,
+    "imported_retained_logical_eof_bytes": 677819718,
+    "logical_read_bytes": 45635825144,
+    "logical_write_bytes": 20524507070,
+    "publication_work_units": 255934,
+    "reader_calls": 491135,
+    "source_allocated_physical_bytes": 679284736,
+    "source_project_current_allocated_bytes": 681910272,
+    "source_retained_logical_eof_bytes": 677819718,
+    "transient_peak_allocated_bytes": 10246037504
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/s20-s22-storage-qualification.json
+++ b/docs/development/evidence/integrated-storage-1194/s20-s22-storage-qualification.json
@@ -1,0 +1,787 @@
+{
+  "projection": {
+    "decision": "refuse",
+    "headroom_bytes": 0,
+    "projected_canonical_edge_bytes": 20213858304,
+    "projected_canonical_node_bytes": 268435456,
+    "projected_lifecycle_peak_bytes": 762866827264,
+    "rate": {
+      "denominator_count": 50331648,
+      "numerator_bytes": 35759382528
+    },
+    "reserved_headroom_bytes": 141258578535,
+    "source_rungs": [
+      "S20",
+      "S22"
+    ],
+    "target": "S26",
+    "volume_bytes": 633354096640
+  },
+  "rungs": [
+    {
+      "artifacts": [
+        {
+          "allocated_bytes": 4194304,
+          "category": "canonical_node_topology",
+          "current_retained_bytes": 4194304,
+          "logical_bytes": 4159543,
+          "logical_references": 16,
+          "physical_objects": 16,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 4194304
+        },
+        {
+          "allocated_bytes": 295608320,
+          "category": "canonical_edge_topology",
+          "current_retained_bytes": 295608320,
+          "logical_bytes": 294903662,
+          "logical_references": 256,
+          "physical_objects": 256,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 295608320
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "properties",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_objects": 0,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 378646528,
+          "category": "uuid_surrogate_indexes",
+          "current_retained_bytes": 378646528,
+          "logical_bytes": 378631495,
+          "logical_references": 12,
+          "physical_objects": 9,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 378646528
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "adjacency_csr",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_objects": 0,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 835584,
+          "category": "catalog_manifests",
+          "current_retained_bytes": 835584,
+          "logical_bytes": 125018,
+          "logical_references": 204,
+          "physical_objects": 204,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 835584
+        },
+        {
+          "allocated_bytes": 685801472,
+          "category": "source-project-construction",
+          "current_retained_bytes": 685801472,
+          "logical_bytes": 679305946,
+          "logical_references": 1919,
+          "physical_objects": 1919,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 685801472
+        },
+        {
+          "allocated_bytes": 822353920,
+          "category": "source-project-import",
+          "current_retained_bytes": 822353920,
+          "logical_bytes": 822341855,
+          "logical_references": 3,
+          "physical_objects": 3,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 822353920
+        },
+        {
+          "allocated_bytes": 4096,
+          "category": "source-project-transactions",
+          "current_retained_bytes": 4096,
+          "logical_bytes": 628,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 4096
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "source-project-locks",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 3,
+          "physical_objects": 3,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "source-project-admission_lock",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 681910272,
+          "category": "source-project-published",
+          "current_retained_bytes": 681910272,
+          "logical_bytes": 678499741,
+          "logical_references": 1127,
+          "physical_objects": 1127,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 681910272
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "imported-project-construction",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_objects": 0,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "imported-project-import",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_objects": 0,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 4096,
+          "category": "imported-project-transactions",
+          "current_retained_bytes": 4096,
+          "logical_bytes": 628,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 4096
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "imported-project-locks",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 3,
+          "physical_objects": 3,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "imported-project-admission_lock",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 681910272,
+          "category": "imported-project-published",
+          "current_retained_bytes": 681910272,
+          "logical_bytes": 678499741,
+          "logical_references": 1127,
+          "physical_objects": 1127,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 681910272
+        },
+        {
+          "allocated_bytes": 822345728,
+          "category": "generated-inputs",
+          "current_retained_bytes": 822345728,
+          "logical_bytes": 822337680,
+          "logical_references": 2,
+          "physical_objects": 2,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 822345728
+        },
+        {
+          "allocated_bytes": 98304,
+          "category": "query-results",
+          "current_retained_bytes": 98304,
+          "logical_bytes": 71228,
+          "logical_references": 8,
+          "physical_objects": 8,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 98304
+        },
+        {
+          "allocated_bytes": 678088704,
+          "category": "portable-package",
+          "current_retained_bytes": 678088704,
+          "logical_bytes": 678083072,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 678088704
+        },
+        {
+          "allocated_bytes": 678465536,
+          "category": "construction_staging_spill",
+          "current_retained_bytes": 678465536,
+          "logical_bytes": 677697400,
+          "logical_references": 288,
+          "physical_objects": 288,
+          "source": "construction_receipts",
+          "transient_peak_allocated_bytes": 10246037504
+        },
+        {
+          "allocated_bytes": 678088704,
+          "category": "portable_package",
+          "current_retained_bytes": 678088704,
+          "logical_bytes": 678083072,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "exact_descriptor",
+          "transient_peak_allocated_bytes": 678088704
+        },
+        {
+          "allocated_bytes": 679284736,
+          "category": "clean_imported_project",
+          "current_retained_bytes": 679284736,
+          "logical_bytes": 677819718,
+          "logical_references": 488,
+          "physical_objects": 485,
+          "source": "clean_import_snapshot",
+          "transient_peak_allocated_bytes": 679284736
+        }
+      ],
+      "id": "S20",
+      "live_edges": 16777216,
+      "live_nodes": 1048576,
+      "phases": [
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 0,
+          "object_count": 272,
+          "phase": "append_merge",
+          "read_bytes": 0,
+          "read_calls": 0,
+          "write_bytes": 3629690464,
+          "write_calls": 8528
+        },
+        {
+          "applicable": false,
+          "block_count": 0,
+          "fsync_calls": 0,
+          "object_count": 0,
+          "phase": "seal_authentication",
+          "read_bytes": 0,
+          "read_calls": 0,
+          "write_bytes": 0,
+          "write_calls": 0
+        },
+        {
+          "applicable": true,
+          "block_count": 28731,
+          "fsync_calls": 0,
+          "object_count": 0,
+          "phase": "shape_consume_reauthentication",
+          "read_bytes": 19227027175,
+          "read_calls": 275017,
+          "write_bytes": 14674255319,
+          "write_calls": 17698
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 627,
+          "object_count": 0,
+          "phase": "encode_write_postwrite_authentication",
+          "read_bytes": 6355026379,
+          "read_calls": 164070,
+          "write_bytes": 1500026997,
+          "write_calls": 41765
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 0,
+          "object_count": 0,
+          "phase": "publication_preauthentication",
+          "read_bytes": 95647,
+          "read_calls": 3,
+          "write_bytes": 0,
+          "write_calls": 0
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 3360,
+          "object_count": 0,
+          "phase": "cas_install_read_write",
+          "read_bytes": 679174824,
+          "read_calls": 11925,
+          "write_bytes": 678496326,
+          "write_calls": 11289
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 16,
+          "object_count": 0,
+          "phase": "hydration_verification",
+          "read_bytes": 719735541,
+          "read_calls": 11103,
+          "write_bytes": 42037964,
+          "write_calls": 645
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 11131,
+          "object_count": 0,
+          "phase": "fsync_synchronization",
+          "read_bytes": 0,
+          "read_calls": 0,
+          "write_bytes": 0,
+          "write_calls": 0
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 0,
+          "object_count": 0,
+          "phase": "recovery_reauthentication",
+          "read_bytes": 18654765578,
+          "read_calls": 29017,
+          "write_bytes": 0,
+          "write_calls": 0
+        }
+      ],
+      "ratios": {
+        "authoritative_project_bytes_per_live_edge": {
+          "denominator_count": 16777216,
+          "numerator_bytes": 681910272
+        },
+        "canonical_edge_bytes_per_live_edge": {
+          "denominator_count": 16777216,
+          "numerator_bytes": 294903662
+        },
+        "canonical_node_bytes_per_live_node": {
+          "denominator_count": 1048576,
+          "numerator_bytes": 4159543
+        },
+        "full_lifecycle_peak_bytes_per_live_edge": {
+          "denominator_count": 16777216,
+          "numerator_bytes": 11897737216
+        }
+      },
+      "scale": 20,
+      "source_project_current_allocated_bytes": 681910272,
+      "totals": {
+        "allocated_bytes": 7087640576,
+        "current_retained_bytes": 4372516864,
+        "logical_bytes": 7070560427,
+        "phase_block_count": 28731,
+        "phase_fsync_calls": 15134,
+        "phase_object_count": 272,
+        "phase_read_bytes": 45635825144,
+        "phase_read_calls": 491135,
+        "phase_write_bytes": 20524507070,
+        "phase_write_calls": 79925,
+        "transient_peak_allocated_bytes": 11897737216
+      },
+      "workspace_current_allocated_bytes": 4372516864
+    },
+    {
+      "artifacts": [
+        {
+          "allocated_bytes": 16777216,
+          "category": "canonical_node_topology",
+          "current_retained_bytes": 16777216,
+          "logical_bytes": 16636135,
+          "logical_references": 64,
+          "physical_objects": 64,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 16777216
+        },
+        {
+          "allocated_bytes": 1263366144,
+          "category": "canonical_edge_topology",
+          "current_retained_bytes": 1263366144,
+          "logical_bytes": 1261294928,
+          "logical_references": 1024,
+          "physical_objects": 1024,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 1263366144
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "properties",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_objects": 0,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 1514541056,
+          "category": "uuid_surrogate_indexes",
+          "current_retained_bytes": 1514541056,
+          "logical_bytes": 1514517330,
+          "logical_references": 12,
+          "physical_objects": 9,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 1514541056
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "adjacency_csr",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_objects": 0,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 1339392,
+          "category": "catalog_manifests",
+          "current_retained_bytes": 1339392,
+          "logical_bytes": 367277,
+          "logical_references": 327,
+          "physical_objects": 327,
+          "source": "storage_owned_snapshot",
+          "transient_peak_allocated_bytes": 1339392
+        },
+        {
+          "allocated_bytes": 2823782400,
+          "category": "source-project-construction",
+          "current_retained_bytes": 2823782400,
+          "logical_bytes": 2798775908,
+          "logical_references": 7583,
+          "physical_objects": 7583,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 2823782400
+        },
+        {
+          "allocated_bytes": 3289370624,
+          "category": "source-project-import",
+          "current_retained_bytes": 3289370624,
+          "logical_bytes": 3289353824,
+          "logical_references": 3,
+          "physical_objects": 3,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 3289370624
+        },
+        {
+          "allocated_bytes": 4096,
+          "category": "source-project-transactions",
+          "current_retained_bytes": 4096,
+          "logical_bytes": 628,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 4096
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "source-project-locks",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 3,
+          "physical_objects": 3,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "source-project-admission_lock",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 2808385536,
+          "category": "source-project-published",
+          "current_retained_bytes": 2808385536,
+          "logical_bytes": 2796153411,
+          "logical_references": 4443,
+          "physical_objects": 4443,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 2808385536
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "imported-project-construction",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_objects": 0,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "imported-project-import",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_objects": 0,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 4096,
+          "category": "imported-project-transactions",
+          "current_retained_bytes": 4096,
+          "logical_bytes": 628,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 4096
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "imported-project-locks",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 3,
+          "physical_objects": 3,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 0,
+          "category": "imported-project-admission_lock",
+          "current_retained_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 0
+        },
+        {
+          "allocated_bytes": 2808377344,
+          "category": "imported-project-published",
+          "current_retained_bytes": 2808377344,
+          "logical_bytes": 2796153411,
+          "logical_references": 4443,
+          "physical_objects": 4443,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 2808377344
+        },
+        {
+          "allocated_bytes": 3289362432,
+          "category": "generated-inputs",
+          "current_retained_bytes": 3289362432,
+          "logical_bytes": 3289349601,
+          "logical_references": 2,
+          "physical_objects": 2,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 3289362432
+        },
+        {
+          "allocated_bytes": 98304,
+          "category": "query-results",
+          "current_retained_bytes": 98304,
+          "logical_bytes": 71228,
+          "logical_references": 8,
+          "physical_objects": 8,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 98304
+        },
+        {
+          "allocated_bytes": 2793910272,
+          "category": "portable-package",
+          "current_retained_bytes": 2793910272,
+          "logical_bytes": 2793903104,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "lifecycle_owner_snapshot",
+          "transient_peak_allocated_bytes": 2793910272
+        },
+        {
+          "allocated_bytes": 2794696704,
+          "category": "construction_staging_spill",
+          "current_retained_bytes": 2794696704,
+          "logical_bytes": 2792451093,
+          "logical_references": 1104,
+          "physical_objects": 1104,
+          "source": "construction_receipts",
+          "transient_peak_allocated_bytes": 41050935296
+        },
+        {
+          "allocated_bytes": 2793910272,
+          "category": "portable_package",
+          "current_retained_bytes": 2793910272,
+          "logical_bytes": 2793903104,
+          "logical_references": 1,
+          "physical_objects": 1,
+          "source": "exact_descriptor",
+          "transient_peak_allocated_bytes": 2793910272
+        },
+        {
+          "allocated_bytes": 2796015616,
+          "category": "clean_imported_project",
+          "current_retained_bytes": 2796015616,
+          "logical_bytes": 2792815670,
+          "logical_references": 1427,
+          "physical_objects": 1424,
+          "source": "clean_import_snapshot",
+          "transient_peak_allocated_bytes": 2796015616
+        }
+      ],
+      "id": "S22",
+      "live_edges": 67108864,
+      "live_nodes": 4194304,
+      "phases": [
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 0,
+          "object_count": 1088,
+          "phase": "append_merge",
+          "read_bytes": 0,
+          "read_calls": 0,
+          "write_bytes": 14518761856,
+          "write_calls": 34112
+        },
+        {
+          "applicable": false,
+          "block_count": 0,
+          "fsync_calls": 0,
+          "object_count": 0,
+          "phase": "seal_authentication",
+          "read_bytes": 0,
+          "read_calls": 0,
+          "write_bytes": 0,
+          "write_calls": 0
+        },
+        {
+          "applicable": true,
+          "block_count": 127633,
+          "fsync_calls": 0,
+          "object_count": 0,
+          "phase": "shape_consume_reauthentication",
+          "read_bytes": 86861533025,
+          "read_calls": 1421617,
+          "write_bytes": 68651069027,
+          "write_calls": 87238
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 2388,
+          "object_count": 0,
+          "phase": "encode_write_postwrite_authentication",
+          "read_bytes": 25501741827,
+          "read_calls": 654795,
+          "write_bytes": 6081760278,
+          "write_calls": 173882
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 0,
+          "object_count": 0,
+          "phase": "publication_preauthentication",
+          "read_bytes": 367883,
+          "read_calls": 4,
+          "write_bytes": 0,
+          "write_calls": 0
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 13341,
+          "object_count": 0,
+          "phase": "cas_install_read_write",
+          "read_bytes": 2799486209,
+          "read_calls": 49173,
+          "write_bytes": 2796149993,
+          "write_calls": 46160
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 19,
+          "object_count": 0,
+          "phase": "hydration_verification",
+          "read_bytes": 2960596381,
+          "read_calls": 45397,
+          "write_bytes": 168145111,
+          "write_calls": 2568
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 51301,
+          "object_count": 0,
+          "phase": "fsync_synchronization",
+          "read_bytes": 0,
+          "read_calls": 0,
+          "write_bytes": 0,
+          "write_calls": 0
+        },
+        {
+          "applicable": true,
+          "block_count": 0,
+          "fsync_calls": 0,
+          "object_count": 0,
+          "phase": "recovery_reauthentication",
+          "read_bytes": 74945564407,
+          "read_calls": 116501,
+          "write_bytes": 0,
+          "write_calls": 0
+        }
+      ],
+      "ratios": {
+        "authoritative_project_bytes_per_live_edge": {
+          "denominator_count": 67108864,
+          "numerator_bytes": 2808385536
+        },
+        "canonical_edge_bytes_per_live_edge": {
+          "denominator_count": 67108864,
+          "numerator_bytes": 1261294928
+        },
+        "canonical_node_bytes_per_live_node": {
+          "denominator_count": 4194304,
+          "numerator_bytes": 16636135
+        },
+        "full_lifecycle_peak_bytes_per_live_edge": {
+          "denominator_count": 67108864,
+          "numerator_bytes": 47657119744
+        }
+      },
+      "scale": 22,
+      "source_project_current_allocated_bytes": 2808385536,
+      "totals": {
+        "allocated_bytes": 28993941504,
+        "current_retained_bytes": 17813295104,
+        "logical_bytes": 28935747280,
+        "phase_block_count": 127633,
+        "phase_fsync_calls": 67049,
+        "phase_object_count": 1088,
+        "phase_read_bytes": 193069289732,
+        "phase_read_calls": 2287487,
+        "phase_write_bytes": 92215886265,
+        "phase_write_calls": 343960,
+        "transient_peak_allocated_bytes": 47657119744
+      },
+      "workspace_current_allocated_bytes": 17813295104
+    }
+  ],
+  "schema": "graphforge-g500-ladder-qualification/4"
+}

--- a/docs/development/evidence/integrated-storage-1194/s22-benchexec.json
+++ b/docs/development/evidence/integrated-storage-1194/s22-benchexec.json
@@ -1,0 +1,1306 @@
+{
+  "authority": {
+    "cpu_seconds": 1551.681826,
+    "peak_rss_bytes": 12474519552,
+    "pressure_cpu_seconds": 2.245113,
+    "pressure_io_seconds": 151.176027,
+    "pressure_memory_seconds": 0.0,
+    "read_bytes": 947578322944,
+    "wall_seconds": 1775.591135450988,
+    "write_bytes": 414307926016
+  },
+  "disagreements": [],
+  "exit_code": 0,
+  "graphforge": {
+    "failed_phase": null,
+    "phases": [
+      {
+        "duration_ms": 10,
+        "exit_code": 0,
+        "peak_rss_bytes": 81920,
+        "phase": "admission",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 26392,
+        "exit_code": 0,
+        "peak_rss_bytes": 74797056,
+        "phase": "generate",
+        "status": "passed"
+      },
+      {
+        "duration_ms": 1139389,
+        "exit_code": 0,
+        "peak_rss_bytes": 183681024,
+        "phase": "ingest",
+        "receipts": [
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "begun"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "contract": "graphforge-import-session/1",
+            "outcome": "registered"
+          },
+          {
+            "bytes_accepted": 3289349601,
+            "construction": {
+              "accepted_chunks": 1088,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 1088,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 14518761856,
+                    "write_calls": 34112
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 2388,
+                    "object_count": 0,
+                    "read_bytes": 25501741827,
+                    "read_calls": 654795,
+                    "write_bytes": 6081760278,
+                    "write_calls": 173882
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 51289,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 66567848267,
+                    "read_calls": 66225,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 127633,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 86861533025,
+                    "read_calls": 1421617,
+                    "write_bytes": 68651069027,
+                    "write_calls": 87238
+                  }
+                },
+                "totals": {
+                  "block_count": 127633,
+                  "fsync_calls": 53677,
+                  "object_count": 1088,
+                  "read_bytes": 178931123119,
+                  "read_calls": 2142637,
+                  "write_bytes": 89251591161,
+                  "write_calls": 295232
+                }
+              },
+              "cache_release_operations": 215024,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 330564821160,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 2794696704,
+                "logical_bytes": 2792451093,
+                "logical_references": 1104,
+                "physical_logical_bytes": 2792451093,
+                "physical_objects": 1104
+              },
+              "construction_staging_transient_peak_allocated_bytes": 41050935296,
+              "fsync_operations": 13952,
+              "immutable_artifacts": 4288,
+              "input_batches": 1088,
+              "input_rows": 71303168,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": false,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 2388,
+                  "object_count": 0,
+                  "read_bytes": 25501741827,
+                  "read_calls": 654795,
+                  "write_bytes": 6081760278,
+                  "write_calls": 173882
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 51289,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 882354
+              },
+              "transient_peak_allocated_bytes": 41050935296,
+              "write_bytes": 14518761856,
+              "write_operations": 34112
+            },
+            "contract": "graphforge-import-session/1",
+            "operation_timings": {
+              "append": {
+                "calls": 1088,
+                "elapsed_ns": 68519418772,
+                "errors": 0
+              },
+              "begin": {
+                "calls": 1,
+                "elapsed_ns": 919977,
+                "errors": 0
+              },
+              "publish": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "resume": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "seal": {
+                "calls": 1,
+                "elapsed_ns": 923237335509,
+                "errors": 0
+              }
+            },
+            "outcome": "validated",
+            "rows_accepted": 71303168,
+            "rows_rejected": 0
+          },
+          {
+            "construction": {
+              "accepted_chunks": 1088,
+              "application_io": {
+                "phases": {
+                  "append_merge": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 1088,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 14518761856,
+                    "write_calls": 34112
+                  },
+                  "cas_install_read_write": {
+                    "block_count": 0,
+                    "fsync_calls": 13341,
+                    "object_count": 0,
+                    "read_bytes": 2799486209,
+                    "read_calls": 49173,
+                    "write_bytes": 2796149993,
+                    "write_calls": 46160
+                  },
+                  "encode_write_postwrite_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 2388,
+                    "object_count": 0,
+                    "read_bytes": 25501741827,
+                    "read_calls": 654795,
+                    "write_bytes": 6081760278,
+                    "write_calls": 173882
+                  },
+                  "fsync_synchronization": {
+                    "block_count": 0,
+                    "fsync_calls": 51301,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "hydration_verification": {
+                    "block_count": 0,
+                    "fsync_calls": 19,
+                    "object_count": 0,
+                    "read_bytes": 2960596381,
+                    "read_calls": 45397,
+                    "write_bytes": 168145111,
+                    "write_calls": 2568
+                  },
+                  "publication_preauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 367883,
+                    "read_calls": 4,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "recovery_reauthentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 74945564407,
+                    "read_calls": 116501,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "seal_authentication": {
+                    "block_count": 0,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 0,
+                    "read_calls": 0,
+                    "write_bytes": 0,
+                    "write_calls": 0
+                  },
+                  "shape_consume_reauthentication": {
+                    "block_count": 127633,
+                    "fsync_calls": 0,
+                    "object_count": 0,
+                    "read_bytes": 86861533025,
+                    "read_calls": 1421617,
+                    "write_bytes": 68651069027,
+                    "write_calls": 87238
+                  }
+                },
+                "totals": {
+                  "block_count": 127633,
+                  "fsync_calls": 67049,
+                  "object_count": 1088,
+                  "read_bytes": 193069289732,
+                  "read_calls": 2287487,
+                  "write_bytes": 92215886265,
+                  "write_calls": 343960
+                }
+              },
+              "cache_release_operations": 218384,
+              "cache_release_unsupported_operations": 0,
+              "cache_released_bytes": 338942174439,
+              "configured_batch_rows": 65536,
+              "construction_staging": {
+                "allocated_bytes": 2794696704,
+                "logical_bytes": 2792451093,
+                "logical_references": 1104,
+                "physical_logical_bytes": 2792451093,
+                "physical_objects": 1104
+              },
+              "construction_staging_transient_peak_allocated_bytes": 41050935296,
+              "fsync_operations": 13952,
+              "immutable_artifacts": 4288,
+              "input_batches": 1088,
+              "input_rows": 71303168,
+              "peak_batch_bytes": 3670536,
+              "peak_batch_rows": 65536,
+              "peak_cache_release_window_bytes": 67108864,
+              "publication_committed": true,
+              "publication_work": {
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 13341,
+                  "object_count": 0,
+                  "read_bytes": 2799486209,
+                  "read_calls": 49173,
+                  "write_bytes": 2796149993,
+                  "write_calls": 46160
+                },
+                "contract": "graphforge-publication-work/1",
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 2388,
+                  "object_count": 0,
+                  "read_bytes": 25501741827,
+                  "read_calls": 654795,
+                  "write_bytes": 6081760278,
+                  "write_calls": 173882
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 51301,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 19,
+                  "object_count": 0,
+                  "read_bytes": 2960596381,
+                  "read_calls": 45397,
+                  "write_bytes": 168145111,
+                  "write_calls": 2568
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 367883,
+                  "read_calls": 4,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "semantic_total_operations": 1039028
+              },
+              "transient_peak_allocated_bytes": 41050935296,
+              "write_bytes": 14518761856,
+              "write_operations": 34112
+            },
+            "contract": "graphforge-import-session/1",
+            "operation_timings": {
+              "append": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "begin": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              },
+              "publish": {
+                "calls": 1,
+                "elapsed_ns": 38586566084,
+                "errors": 0
+              },
+              "resume": {
+                "calls": 1,
+                "elapsed_ns": 3811642482,
+                "errors": 0
+              },
+              "seal": {
+                "calls": 0,
+                "elapsed_ns": 0,
+                "errors": 0
+              }
+            },
+            "outcome": "committed"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 51299,
+        "exit_code": 0,
+        "peak_rss_bytes": 45703168,
+        "phase": "reopen",
+        "receipts": [
+          {
+            "aborted_journals": 0,
+            "deferred": null,
+            "elapsed_ms": 0,
+            "kind": "project_open",
+            "preserved_unknown_entries": 0,
+            "removed_generations": 0,
+            "repaired_journals": 0,
+            "selected_generation_class": "committed_current",
+            "work_detected": false
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 2796023808,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 1339392,
+                  "logical_bytes": 367277,
+                  "logical_references": 327,
+                  "physical_logical_bytes": 367277,
+                  "physical_objects": 327
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 1263366144,
+                  "logical_bytes": 1261294928,
+                  "logical_references": 1024,
+                  "physical_logical_bytes": 1261294928,
+                  "physical_objects": 1024
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 16777216,
+                  "logical_bytes": 16636135,
+                  "logical_references": 64,
+                  "physical_logical_bytes": 16636135,
+                  "physical_objects": 64
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 1514541056,
+                  "logical_bytes": 1514517330,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 1514517330,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 2792815670,
+              "logical_references": 1427,
+              "physical_objects": 1424,
+              "retained_logical_eof_bytes": 2792815670
+            }
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 32395,
+        "exit_code": 0,
+        "peak_rss_bytes": 96276480,
+        "phase": "recount",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "15563dc5ecd48bd37d48ccfe0da1d66be7da3fd4dd8c79d2d064e78657a0d228",
+            "rows": 1,
+            "scalar_u64": 4194304
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 87068672,
+                  "before_bytes": 86085632,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 87068672
+                }
+              ],
+              "peak_rss_bytes": 87068672,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 87068672,
+              "sorts": []
+            },
+            "result_sha256": "979e01bd5c8760c4e606da882ea550a6711605f6d555f64a9ae6e431789cb2fc",
+            "rows": 1,
+            "scalar_u64": 67108864
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 170095,
+        "exit_code": 0,
+        "peak_rss_bytes": 259203072,
+        "phase": "query",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 122,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 73280,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 60,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 135467008,
+                  "before_bytes": 85876736,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 135467008
+                }
+              ],
+              "peak_rss_bytes": 135467008,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 135467008,
+              "sorts": []
+            },
+            "result_sha256": "6b5348f6b35d2767a928b8c5e7aa018deca41e318056d45edd31cdbf43dc3579",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 6,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 131072,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 2,
+                  "identity_reader_calls": 2,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 2,
+                  "projected_columns": 1,
+                  "projected_rows": 2,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 153595904,
+                  "before_bytes": 86470656,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 153595904
+                }
+              ],
+              "peak_rss_bytes": 153595904,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 153595904,
+              "sorts": []
+            },
+            "result_sha256": "ecddd3def5e9f5114b6c626cef4ce1629b51bfe4fe48323b5d40ebcf4a5da0f3",
+            "rows": 1000,
+            "scalar_u64": null
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 31842,
+        "exit_code": 0,
+        "peak_rss_bytes": 49283072,
+        "phase": "export",
+        "receipts": [
+          {
+            "allocation_allocated_bytes": 2793910272,
+            "allocation_logical_bytes": 2793903104,
+            "allocation_physical_objects": 1,
+            "contract": "graphforge-portable-export/2",
+            "entry_count": 1113,
+            "package_digest": "sha256:5728f619e840cac56c1b1d18f0973981aae791a81334dfee145d385abd81a171",
+            "payload_bytes": 2792452621,
+            "representation": "bundle",
+            "selection_fingerprint": "sha256:9e80a42f893eb6766a361060ad4b72d934517e75189264ff3f66b1c907fbaa73",
+            "transport_digest": "sha256:0f3cc775232e024e9a6bf130ca593dc9879bff034869c0fce9fba2e8feb396cf"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 4474,
+        "exit_code": 0,
+        "peak_rss_bytes": 34066432,
+        "phase": "verify",
+        "receipts": [
+          {
+            "compatibility": "supported",
+            "contract": "graphforge-portable-verify/2",
+            "entry_count": 1113,
+            "integrity": "verified",
+            "package_digest": "sha256:5728f619e840cac56c1b1d18f0973981aae791a81334dfee145d385abd81a171",
+            "payload_bytes": 2793058253,
+            "representation": "bundle",
+            "transport_digest": "sha256:0f3cc775232e024e9a6bf130ca593dc9879bff034869c0fce9fba2e8feb396cf"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 43675,
+        "exit_code": 0,
+        "peak_rss_bytes": 51363840,
+        "phase": "clean_import",
+        "receipts": [
+          {
+            "contract": "graphforge-portable-import/2",
+            "idempotent_replay": false,
+            "package_digest": "sha256:5728f619e840cac56c1b1d18f0973981aae791a81334dfee145d385abd81a171",
+            "transient_peak_allocated_bytes": 5603090432,
+            "transport_digest": "sha256:0f3cc775232e024e9a6bf130ca593dc9879bff034869c0fce9fba2e8feb396cf"
+          }
+        ],
+        "status": "passed"
+      },
+      {
+        "duration_ms": 237623,
+        "exit_code": 0,
+        "peak_rss_bytes": 263090176,
+        "phase": "reopen_proof",
+        "receipts": [
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [],
+              "peak_rss_bytes": 0,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 0,
+              "sorts": []
+            },
+            "result_sha256": "15563dc5ecd48bd37d48ccfe0da1d66be7da3fd4dd8c79d2d064e78657a0d228",
+            "rows": 1,
+            "scalar_u64": 4194304
+          },
+          {
+            "batches": 1,
+            "bytes": 917,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 0,
+                  "candidates_generated": 0,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 0,
+                  "identity_peak_buffer_bytes": 0,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 0,
+                  "identity_reader_calls": 0,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 0,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 0,
+                  "projected_columns": 0,
+                  "projected_rows": 0,
+                  "rows_emitted": 1
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 91041792,
+                  "before_bytes": 90247168,
+                  "operator": "edge_count",
+                  "ordinal": 0,
+                  "peak_bytes": 91041792
+                }
+              ],
+              "peak_rss_bytes": 91041792,
+              "returned_batch_bytes": 104,
+              "rss_after_release_bytes": 91041792,
+              "sorts": []
+            },
+            "result_sha256": "979e01bd5c8760c4e606da882ea550a6711605f6d555f64a9ae6e431789cb2fc",
+            "rows": 1,
+            "scalar_u64": 67108864
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 122,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 65536,
+                  "identity_peak_buffer_bytes": 73280,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 1,
+                  "identity_reader_calls": 1,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 1,
+                  "projected_columns": 1,
+                  "projected_rows": 60,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 138231808,
+                  "before_bytes": 88178688,
+                  "operator": "ordered_one_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 138231808
+                }
+              ],
+              "peak_rss_bytes": 138231808,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 138231808,
+              "sorts": []
+            },
+            "result_sha256": "6b5348f6b35d2767a928b8c5e7aa018deca41e318056d45edd31cdbf43dc3579",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "batches": 1,
+            "bytes": 16890,
+            "complete": true,
+            "contract": "graphforge-result-sink/2",
+            "format": "Parquet",
+            "query_evidence": {
+              "contract": "graphforge-query-evidence/1",
+              "execution_batch_rows": 8192,
+              "hops": [
+                {
+                  "adjacency_rows_examined": 6,
+                  "candidates_generated": 1000,
+                  "edge_full_reads": 0,
+                  "edge_logical_rows_scanned": 0,
+                  "edge_projected_columns": 0,
+                  "edge_reader_calls": 0,
+                  "edge_rows_returned": 0,
+                  "identity_logical_bytes": 131072,
+                  "identity_peak_buffer_bytes": 65728,
+                  "identity_per_record_seeks": 0,
+                  "identity_ranges_selected": 2,
+                  "identity_reader_calls": 2,
+                  "identity_revalidation_bytes": 0,
+                  "identity_revalidation_calls": 11,
+                  "input_batches": 0,
+                  "input_rows": 0,
+                  "node_full_reads": 0,
+                  "node_logical_rows_scanned": 0,
+                  "node_projected_columns": 0,
+                  "node_reader_calls": 0,
+                  "node_rows_returned": 0,
+                  "ordinal": 0,
+                  "projected_chunks": 2,
+                  "projected_columns": 1,
+                  "projected_rows": 2,
+                  "rows_emitted": 1000
+                }
+              ],
+              "max_in_flight_reads": 0,
+              "memory_reserved_after": 0,
+              "memory_reserved_before": 0,
+              "operator_rss": [
+                {
+                  "after_bytes": 156737536,
+                  "before_bytes": 89464832,
+                  "operator": "ordered_two_hop",
+                  "ordinal": 0,
+                  "peak_bytes": 156737536
+                }
+              ],
+              "peak_rss_bytes": 156737536,
+              "returned_batch_bytes": 16112,
+              "rss_after_release_bytes": 156737536,
+              "sorts": []
+            },
+            "result_sha256": "ecddd3def5e9f5114b6c626cef4ce1629b51bfe4fe48323b5d40ebcf4a5da0f3",
+            "rows": 1000,
+            "scalar_u64": null
+          },
+          {
+            "contract": "graphforge-storage-attribution-command/1",
+            "reopen_agrees": true,
+            "storage": {
+              "allocated_physical_bytes": 2796015616,
+              "categories": {
+                "adjacency": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "catalog_and_manifests": {
+                  "allocated_bytes": 1339392,
+                  "logical_bytes": 367277,
+                  "logical_references": 327,
+                  "physical_logical_bytes": 367277,
+                  "physical_objects": 327
+                },
+                "clean_imported_project": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "construction_staging": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "other": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "portable_package": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "properties": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                },
+                "topology_edges": {
+                  "allocated_bytes": 1263366144,
+                  "logical_bytes": 1261294928,
+                  "logical_references": 1024,
+                  "physical_logical_bytes": 1261294928,
+                  "physical_objects": 1024
+                },
+                "topology_nodes": {
+                  "allocated_bytes": 16777216,
+                  "logical_bytes": 16636135,
+                  "logical_references": 64,
+                  "physical_logical_bytes": 16636135,
+                  "physical_objects": 64
+                },
+                "uuid_and_surrogates": {
+                  "allocated_bytes": 1514532864,
+                  "logical_bytes": 1514517330,
+                  "logical_references": 12,
+                  "physical_logical_bytes": 1514517330,
+                  "physical_objects": 9
+                }
+              },
+              "contract": "graphforge-storage-attribution/1",
+              "logical_bytes": 2792815670,
+              "logical_references": 1427,
+              "physical_objects": 1424,
+              "retained_logical_eof_bytes": 2792815670
+            }
+          },
+          {
+            "contract": "graphforge-lifecycle-storage/2",
+            "retained_owners": {
+              "generated-inputs": {
+                "totals": {
+                  "allocated_bytes": 3289362432,
+                  "logical_bytes": 3289349601,
+                  "logical_references": 2,
+                  "physical_logical_bytes": 3289349601,
+                  "physical_objects": 2
+                }
+              },
+              "imported-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "imported-project-construction": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-import": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 0,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 0
+                }
+              },
+              "imported-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "imported-project-published": {
+                "totals": {
+                  "allocated_bytes": 2808377344,
+                  "logical_bytes": 2796153411,
+                  "logical_references": 4443,
+                  "physical_logical_bytes": 2796153411,
+                  "physical_objects": 4443
+                }
+              },
+              "imported-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              },
+              "portable-package": {
+                "totals": {
+                  "allocated_bytes": 2793910272,
+                  "logical_bytes": 2793903104,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 2793903104,
+                  "physical_objects": 1
+                }
+              },
+              "query-results": {
+                "totals": {
+                  "allocated_bytes": 98304,
+                  "logical_bytes": 71228,
+                  "logical_references": 8,
+                  "physical_logical_bytes": 71228,
+                  "physical_objects": 8
+                }
+              },
+              "source-project-admission_lock": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 1
+                }
+              },
+              "source-project-construction": {
+                "totals": {
+                  "allocated_bytes": 2823782400,
+                  "logical_bytes": 2798775908,
+                  "logical_references": 7583,
+                  "physical_logical_bytes": 2798775908,
+                  "physical_objects": 7583
+                }
+              },
+              "source-project-import": {
+                "totals": {
+                  "allocated_bytes": 3289370624,
+                  "logical_bytes": 3289353824,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 3289353824,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-locks": {
+                "totals": {
+                  "allocated_bytes": 0,
+                  "logical_bytes": 0,
+                  "logical_references": 3,
+                  "physical_logical_bytes": 0,
+                  "physical_objects": 3
+                }
+              },
+              "source-project-published": {
+                "totals": {
+                  "allocated_bytes": 2808385536,
+                  "logical_bytes": 2796153411,
+                  "logical_references": 4443,
+                  "physical_logical_bytes": 2796153411,
+                  "physical_objects": 4443
+                }
+              },
+              "source-project-transactions": {
+                "totals": {
+                  "allocated_bytes": 4096,
+                  "logical_bytes": 628,
+                  "logical_references": 1,
+                  "physical_logical_bytes": 628,
+                  "physical_objects": 1
+                }
+              }
+            },
+            "retained_storage_bytes": 17813295104,
+            "source_project_current_allocated_bytes": 2808385536,
+            "transient_peak_storage_bytes": 47657119744
+          }
+        ],
+        "status": "passed"
+      }
+    ],
+    "profile_id": "graph500-s22-provider",
+    "schema": "graphforge-public-certification/1",
+    "status": "passed"
+  },
+  "limits": {
+    "cores": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    "cpu_seconds": 14400.0,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400.0
+  },
+  "outcome": "passed",
+  "schema": "graphforge-benchexec-run/1",
+  "signal": null
+}

--- a/docs/development/evidence/integrated-storage-1194/s22-graphforge.json
+++ b/docs/development/evidence/integrated-storage-1194/s22-graphforge.json
@@ -1,0 +1,1266 @@
+{
+  "failed_phase": null,
+  "phases": [
+    {
+      "duration_ms": 10,
+      "exit_code": 0,
+      "peak_rss_bytes": 81920,
+      "phase": "admission",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 26392,
+      "exit_code": 0,
+      "peak_rss_bytes": 74797056,
+      "phase": "generate",
+      "status": "passed"
+    },
+    {
+      "duration_ms": 1139389,
+      "exit_code": 0,
+      "peak_rss_bytes": 183681024,
+      "phase": "ingest",
+      "receipts": [
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "begun"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "contract": "graphforge-import-session/1",
+          "outcome": "registered"
+        },
+        {
+          "bytes_accepted": 3289349601,
+          "construction": {
+            "accepted_chunks": 1088,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 1088,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 14518761856,
+                  "write_calls": 34112
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 2388,
+                  "object_count": 0,
+                  "read_bytes": 25501741827,
+                  "read_calls": 654795,
+                  "write_bytes": 6081760278,
+                  "write_calls": 173882
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 51289,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 66567848267,
+                  "read_calls": 66225,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 127633,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 86861533025,
+                  "read_calls": 1421617,
+                  "write_bytes": 68651069027,
+                  "write_calls": 87238
+                }
+              },
+              "totals": {
+                "block_count": 127633,
+                "fsync_calls": 53677,
+                "object_count": 1088,
+                "read_bytes": 178931123119,
+                "read_calls": 2142637,
+                "write_bytes": 89251591161,
+                "write_calls": 295232
+              }
+            },
+            "cache_release_operations": 215024,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 330564821160,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 2794696704,
+              "logical_bytes": 2792451093,
+              "logical_references": 1104,
+              "physical_logical_bytes": 2792451093,
+              "physical_objects": 1104
+            },
+            "construction_staging_transient_peak_allocated_bytes": 41050935296,
+            "fsync_operations": 13952,
+            "immutable_artifacts": 4288,
+            "input_batches": 1088,
+            "input_rows": 71303168,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": false,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 2388,
+                "object_count": 0,
+                "read_bytes": 25501741827,
+                "read_calls": 654795,
+                "write_bytes": 6081760278,
+                "write_calls": 173882
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 51289,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 882354
+            },
+            "transient_peak_allocated_bytes": 41050935296,
+            "write_bytes": 14518761856,
+            "write_operations": 34112
+          },
+          "contract": "graphforge-import-session/1",
+          "operation_timings": {
+            "append": {
+              "calls": 1088,
+              "elapsed_ns": 68519418772,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 1,
+              "elapsed_ns": 919977,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 1,
+              "elapsed_ns": 923237335509,
+              "errors": 0
+            }
+          },
+          "outcome": "validated",
+          "rows_accepted": 71303168,
+          "rows_rejected": 0
+        },
+        {
+          "construction": {
+            "accepted_chunks": 1088,
+            "application_io": {
+              "phases": {
+                "append_merge": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 1088,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 14518761856,
+                  "write_calls": 34112
+                },
+                "cas_install_read_write": {
+                  "block_count": 0,
+                  "fsync_calls": 13341,
+                  "object_count": 0,
+                  "read_bytes": 2799486209,
+                  "read_calls": 49173,
+                  "write_bytes": 2796149993,
+                  "write_calls": 46160
+                },
+                "encode_write_postwrite_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 2388,
+                  "object_count": 0,
+                  "read_bytes": 25501741827,
+                  "read_calls": 654795,
+                  "write_bytes": 6081760278,
+                  "write_calls": 173882
+                },
+                "fsync_synchronization": {
+                  "block_count": 0,
+                  "fsync_calls": 51301,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "hydration_verification": {
+                  "block_count": 0,
+                  "fsync_calls": 19,
+                  "object_count": 0,
+                  "read_bytes": 2960596381,
+                  "read_calls": 45397,
+                  "write_bytes": 168145111,
+                  "write_calls": 2568
+                },
+                "publication_preauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 367883,
+                  "read_calls": 4,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "recovery_reauthentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 74945564407,
+                  "read_calls": 116501,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "seal_authentication": {
+                  "block_count": 0,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 0,
+                  "read_calls": 0,
+                  "write_bytes": 0,
+                  "write_calls": 0
+                },
+                "shape_consume_reauthentication": {
+                  "block_count": 127633,
+                  "fsync_calls": 0,
+                  "object_count": 0,
+                  "read_bytes": 86861533025,
+                  "read_calls": 1421617,
+                  "write_bytes": 68651069027,
+                  "write_calls": 87238
+                }
+              },
+              "totals": {
+                "block_count": 127633,
+                "fsync_calls": 67049,
+                "object_count": 1088,
+                "read_bytes": 193069289732,
+                "read_calls": 2287487,
+                "write_bytes": 92215886265,
+                "write_calls": 343960
+              }
+            },
+            "cache_release_operations": 218384,
+            "cache_release_unsupported_operations": 0,
+            "cache_released_bytes": 338942174439,
+            "configured_batch_rows": 65536,
+            "construction_staging": {
+              "allocated_bytes": 2794696704,
+              "logical_bytes": 2792451093,
+              "logical_references": 1104,
+              "physical_logical_bytes": 2792451093,
+              "physical_objects": 1104
+            },
+            "construction_staging_transient_peak_allocated_bytes": 41050935296,
+            "fsync_operations": 13952,
+            "immutable_artifacts": 4288,
+            "input_batches": 1088,
+            "input_rows": 71303168,
+            "peak_batch_bytes": 3670536,
+            "peak_batch_rows": 65536,
+            "peak_cache_release_window_bytes": 67108864,
+            "publication_committed": true,
+            "publication_work": {
+              "cas_install_read_write": {
+                "block_count": 0,
+                "fsync_calls": 13341,
+                "object_count": 0,
+                "read_bytes": 2799486209,
+                "read_calls": 49173,
+                "write_bytes": 2796149993,
+                "write_calls": 46160
+              },
+              "contract": "graphforge-publication-work/1",
+              "encode_write_postwrite_authentication": {
+                "block_count": 0,
+                "fsync_calls": 2388,
+                "object_count": 0,
+                "read_bytes": 25501741827,
+                "read_calls": 654795,
+                "write_bytes": 6081760278,
+                "write_calls": 173882
+              },
+              "fsync_synchronization": {
+                "block_count": 0,
+                "fsync_calls": 51301,
+                "object_count": 0,
+                "read_bytes": 0,
+                "read_calls": 0,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "hydration_verification": {
+                "block_count": 0,
+                "fsync_calls": 19,
+                "object_count": 0,
+                "read_bytes": 2960596381,
+                "read_calls": 45397,
+                "write_bytes": 168145111,
+                "write_calls": 2568
+              },
+              "publication_preauthentication": {
+                "block_count": 0,
+                "fsync_calls": 0,
+                "object_count": 0,
+                "read_bytes": 367883,
+                "read_calls": 4,
+                "write_bytes": 0,
+                "write_calls": 0
+              },
+              "semantic_total_operations": 1039028
+            },
+            "transient_peak_allocated_bytes": 41050935296,
+            "write_bytes": 14518761856,
+            "write_operations": 34112
+          },
+          "contract": "graphforge-import-session/1",
+          "operation_timings": {
+            "append": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "begin": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            },
+            "publish": {
+              "calls": 1,
+              "elapsed_ns": 38586566084,
+              "errors": 0
+            },
+            "resume": {
+              "calls": 1,
+              "elapsed_ns": 3811642482,
+              "errors": 0
+            },
+            "seal": {
+              "calls": 0,
+              "elapsed_ns": 0,
+              "errors": 0
+            }
+          },
+          "outcome": "committed"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 51299,
+      "exit_code": 0,
+      "peak_rss_bytes": 45703168,
+      "phase": "reopen",
+      "receipts": [
+        {
+          "aborted_journals": 0,
+          "deferred": null,
+          "elapsed_ms": 0,
+          "kind": "project_open",
+          "preserved_unknown_entries": 0,
+          "removed_generations": 0,
+          "repaired_journals": 0,
+          "selected_generation_class": "committed_current",
+          "work_detected": false
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 2796023808,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 1339392,
+                "logical_bytes": 367277,
+                "logical_references": 327,
+                "physical_logical_bytes": 367277,
+                "physical_objects": 327
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 1263366144,
+                "logical_bytes": 1261294928,
+                "logical_references": 1024,
+                "physical_logical_bytes": 1261294928,
+                "physical_objects": 1024
+              },
+              "topology_nodes": {
+                "allocated_bytes": 16777216,
+                "logical_bytes": 16636135,
+                "logical_references": 64,
+                "physical_logical_bytes": 16636135,
+                "physical_objects": 64
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 1514541056,
+                "logical_bytes": 1514517330,
+                "logical_references": 12,
+                "physical_logical_bytes": 1514517330,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 2792815670,
+            "logical_references": 1427,
+            "physical_objects": 1424,
+            "retained_logical_eof_bytes": 2792815670
+          }
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 32395,
+      "exit_code": 0,
+      "peak_rss_bytes": 96276480,
+      "phase": "recount",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "15563dc5ecd48bd37d48ccfe0da1d66be7da3fd4dd8c79d2d064e78657a0d228",
+          "rows": 1,
+          "scalar_u64": 4194304
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 87068672,
+                "before_bytes": 86085632,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 87068672
+              }
+            ],
+            "peak_rss_bytes": 87068672,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 87068672,
+            "sorts": []
+          },
+          "result_sha256": "979e01bd5c8760c4e606da882ea550a6711605f6d555f64a9ae6e431789cb2fc",
+          "rows": 1,
+          "scalar_u64": 67108864
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 170095,
+      "exit_code": 0,
+      "peak_rss_bytes": 259203072,
+      "phase": "query",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 122,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 73280,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 60,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 135467008,
+                "before_bytes": 85876736,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 135467008
+              }
+            ],
+            "peak_rss_bytes": 135467008,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 135467008,
+            "sorts": []
+          },
+          "result_sha256": "6b5348f6b35d2767a928b8c5e7aa018deca41e318056d45edd31cdbf43dc3579",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 6,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 131072,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 2,
+                "identity_reader_calls": 2,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 2,
+                "projected_columns": 1,
+                "projected_rows": 2,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 153595904,
+                "before_bytes": 86470656,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 153595904
+              }
+            ],
+            "peak_rss_bytes": 153595904,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 153595904,
+            "sorts": []
+          },
+          "result_sha256": "ecddd3def5e9f5114b6c626cef4ce1629b51bfe4fe48323b5d40ebcf4a5da0f3",
+          "rows": 1000,
+          "scalar_u64": null
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 31842,
+      "exit_code": 0,
+      "peak_rss_bytes": 49283072,
+      "phase": "export",
+      "receipts": [
+        {
+          "allocation_allocated_bytes": 2793910272,
+          "allocation_logical_bytes": 2793903104,
+          "allocation_physical_objects": 1,
+          "contract": "graphforge-portable-export/2",
+          "entry_count": 1113,
+          "package_digest": "sha256:5728f619e840cac56c1b1d18f0973981aae791a81334dfee145d385abd81a171",
+          "payload_bytes": 2792452621,
+          "representation": "bundle",
+          "selection_fingerprint": "sha256:9e80a42f893eb6766a361060ad4b72d934517e75189264ff3f66b1c907fbaa73",
+          "transport_digest": "sha256:0f3cc775232e024e9a6bf130ca593dc9879bff034869c0fce9fba2e8feb396cf"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 4474,
+      "exit_code": 0,
+      "peak_rss_bytes": 34066432,
+      "phase": "verify",
+      "receipts": [
+        {
+          "compatibility": "supported",
+          "contract": "graphforge-portable-verify/2",
+          "entry_count": 1113,
+          "integrity": "verified",
+          "package_digest": "sha256:5728f619e840cac56c1b1d18f0973981aae791a81334dfee145d385abd81a171",
+          "payload_bytes": 2793058253,
+          "representation": "bundle",
+          "transport_digest": "sha256:0f3cc775232e024e9a6bf130ca593dc9879bff034869c0fce9fba2e8feb396cf"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 43675,
+      "exit_code": 0,
+      "peak_rss_bytes": 51363840,
+      "phase": "clean_import",
+      "receipts": [
+        {
+          "contract": "graphforge-portable-import/2",
+          "idempotent_replay": false,
+          "package_digest": "sha256:5728f619e840cac56c1b1d18f0973981aae791a81334dfee145d385abd81a171",
+          "transient_peak_allocated_bytes": 5603090432,
+          "transport_digest": "sha256:0f3cc775232e024e9a6bf130ca593dc9879bff034869c0fce9fba2e8feb396cf"
+        }
+      ],
+      "status": "passed"
+    },
+    {
+      "duration_ms": 237623,
+      "exit_code": 0,
+      "peak_rss_bytes": 263090176,
+      "phase": "reopen_proof",
+      "receipts": [
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [],
+            "peak_rss_bytes": 0,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 0,
+            "sorts": []
+          },
+          "result_sha256": "15563dc5ecd48bd37d48ccfe0da1d66be7da3fd4dd8c79d2d064e78657a0d228",
+          "rows": 1,
+          "scalar_u64": 4194304
+        },
+        {
+          "batches": 1,
+          "bytes": 917,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 0,
+                "candidates_generated": 0,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 0,
+                "identity_peak_buffer_bytes": 0,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 0,
+                "identity_reader_calls": 0,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 0,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 0,
+                "projected_columns": 0,
+                "projected_rows": 0,
+                "rows_emitted": 1
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 91041792,
+                "before_bytes": 90247168,
+                "operator": "edge_count",
+                "ordinal": 0,
+                "peak_bytes": 91041792
+              }
+            ],
+            "peak_rss_bytes": 91041792,
+            "returned_batch_bytes": 104,
+            "rss_after_release_bytes": 91041792,
+            "sorts": []
+          },
+          "result_sha256": "979e01bd5c8760c4e606da882ea550a6711605f6d555f64a9ae6e431789cb2fc",
+          "rows": 1,
+          "scalar_u64": 67108864
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 122,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 65536,
+                "identity_peak_buffer_bytes": 73280,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 1,
+                "identity_reader_calls": 1,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 1,
+                "projected_columns": 1,
+                "projected_rows": 60,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 138231808,
+                "before_bytes": 88178688,
+                "operator": "ordered_one_hop",
+                "ordinal": 0,
+                "peak_bytes": 138231808
+              }
+            ],
+            "peak_rss_bytes": 138231808,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 138231808,
+            "sorts": []
+          },
+          "result_sha256": "6b5348f6b35d2767a928b8c5e7aa018deca41e318056d45edd31cdbf43dc3579",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "batches": 1,
+          "bytes": 16890,
+          "complete": true,
+          "contract": "graphforge-result-sink/2",
+          "format": "Parquet",
+          "query_evidence": {
+            "contract": "graphforge-query-evidence/1",
+            "execution_batch_rows": 8192,
+            "hops": [
+              {
+                "adjacency_rows_examined": 6,
+                "candidates_generated": 1000,
+                "edge_full_reads": 0,
+                "edge_logical_rows_scanned": 0,
+                "edge_projected_columns": 0,
+                "edge_reader_calls": 0,
+                "edge_rows_returned": 0,
+                "identity_logical_bytes": 131072,
+                "identity_peak_buffer_bytes": 65728,
+                "identity_per_record_seeks": 0,
+                "identity_ranges_selected": 2,
+                "identity_reader_calls": 2,
+                "identity_revalidation_bytes": 0,
+                "identity_revalidation_calls": 11,
+                "input_batches": 0,
+                "input_rows": 0,
+                "node_full_reads": 0,
+                "node_logical_rows_scanned": 0,
+                "node_projected_columns": 0,
+                "node_reader_calls": 0,
+                "node_rows_returned": 0,
+                "ordinal": 0,
+                "projected_chunks": 2,
+                "projected_columns": 1,
+                "projected_rows": 2,
+                "rows_emitted": 1000
+              }
+            ],
+            "max_in_flight_reads": 0,
+            "memory_reserved_after": 0,
+            "memory_reserved_before": 0,
+            "operator_rss": [
+              {
+                "after_bytes": 156737536,
+                "before_bytes": 89464832,
+                "operator": "ordered_two_hop",
+                "ordinal": 0,
+                "peak_bytes": 156737536
+              }
+            ],
+            "peak_rss_bytes": 156737536,
+            "returned_batch_bytes": 16112,
+            "rss_after_release_bytes": 156737536,
+            "sorts": []
+          },
+          "result_sha256": "ecddd3def5e9f5114b6c626cef4ce1629b51bfe4fe48323b5d40ebcf4a5da0f3",
+          "rows": 1000,
+          "scalar_u64": null
+        },
+        {
+          "contract": "graphforge-storage-attribution-command/1",
+          "reopen_agrees": true,
+          "storage": {
+            "allocated_physical_bytes": 2796015616,
+            "categories": {
+              "adjacency": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "catalog_and_manifests": {
+                "allocated_bytes": 1339392,
+                "logical_bytes": 367277,
+                "logical_references": 327,
+                "physical_logical_bytes": 367277,
+                "physical_objects": 327
+              },
+              "clean_imported_project": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "construction_staging": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "other": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "portable_package": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "properties": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              },
+              "topology_edges": {
+                "allocated_bytes": 1263366144,
+                "logical_bytes": 1261294928,
+                "logical_references": 1024,
+                "physical_logical_bytes": 1261294928,
+                "physical_objects": 1024
+              },
+              "topology_nodes": {
+                "allocated_bytes": 16777216,
+                "logical_bytes": 16636135,
+                "logical_references": 64,
+                "physical_logical_bytes": 16636135,
+                "physical_objects": 64
+              },
+              "uuid_and_surrogates": {
+                "allocated_bytes": 1514532864,
+                "logical_bytes": 1514517330,
+                "logical_references": 12,
+                "physical_logical_bytes": 1514517330,
+                "physical_objects": 9
+              }
+            },
+            "contract": "graphforge-storage-attribution/1",
+            "logical_bytes": 2792815670,
+            "logical_references": 1427,
+            "physical_objects": 1424,
+            "retained_logical_eof_bytes": 2792815670
+          }
+        },
+        {
+          "contract": "graphforge-lifecycle-storage/2",
+          "retained_owners": {
+            "generated-inputs": {
+              "totals": {
+                "allocated_bytes": 3289362432,
+                "logical_bytes": 3289349601,
+                "logical_references": 2,
+                "physical_logical_bytes": 3289349601,
+                "physical_objects": 2
+              }
+            },
+            "imported-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "imported-project-construction": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-import": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 0,
+                "physical_logical_bytes": 0,
+                "physical_objects": 0
+              }
+            },
+            "imported-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "imported-project-published": {
+              "totals": {
+                "allocated_bytes": 2808377344,
+                "logical_bytes": 2796153411,
+                "logical_references": 4443,
+                "physical_logical_bytes": 2796153411,
+                "physical_objects": 4443
+              }
+            },
+            "imported-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            },
+            "portable-package": {
+              "totals": {
+                "allocated_bytes": 2793910272,
+                "logical_bytes": 2793903104,
+                "logical_references": 1,
+                "physical_logical_bytes": 2793903104,
+                "physical_objects": 1
+              }
+            },
+            "query-results": {
+              "totals": {
+                "allocated_bytes": 98304,
+                "logical_bytes": 71228,
+                "logical_references": 8,
+                "physical_logical_bytes": 71228,
+                "physical_objects": 8
+              }
+            },
+            "source-project-admission_lock": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 1,
+                "physical_logical_bytes": 0,
+                "physical_objects": 1
+              }
+            },
+            "source-project-construction": {
+              "totals": {
+                "allocated_bytes": 2823782400,
+                "logical_bytes": 2798775908,
+                "logical_references": 7583,
+                "physical_logical_bytes": 2798775908,
+                "physical_objects": 7583
+              }
+            },
+            "source-project-import": {
+              "totals": {
+                "allocated_bytes": 3289370624,
+                "logical_bytes": 3289353824,
+                "logical_references": 3,
+                "physical_logical_bytes": 3289353824,
+                "physical_objects": 3
+              }
+            },
+            "source-project-locks": {
+              "totals": {
+                "allocated_bytes": 0,
+                "logical_bytes": 0,
+                "logical_references": 3,
+                "physical_logical_bytes": 0,
+                "physical_objects": 3
+              }
+            },
+            "source-project-published": {
+              "totals": {
+                "allocated_bytes": 2808385536,
+                "logical_bytes": 2796153411,
+                "logical_references": 4443,
+                "physical_logical_bytes": 2796153411,
+                "physical_objects": 4443
+              }
+            },
+            "source-project-transactions": {
+              "totals": {
+                "allocated_bytes": 4096,
+                "logical_bytes": 628,
+                "logical_references": 1,
+                "physical_logical_bytes": 628,
+                "physical_objects": 1
+              }
+            }
+          },
+          "retained_storage_bytes": 17813295104,
+          "source_project_current_allocated_bytes": 2808385536,
+          "transient_peak_storage_bytes": 47657119744
+        }
+      ],
+      "status": "passed"
+    }
+  ],
+  "profile_id": "graph500-s22-provider",
+  "schema": "graphforge-public-certification/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/s22-plan.json
+++ b/docs/development/evidence/integrated-storage-1194/s22-plan.json
@@ -1,0 +1,37 @@
+{
+  "claim": "engineering_evidence_only",
+  "execution": "native_linux_benchexec_host",
+  "identities": {
+    "admitted_projection_sha256": "028a80d509e8edb4cfcd3b0f387a08a4b9bf80ad935516e0d5db859e58a856b6",
+    "benchexec_python_sha256": "52e0a13e60a981d8c4b6478be2ba5176f69da07948a056bf49cf6f077e30cb41",
+    "benchexec_version": "3.35",
+    "certify_sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+    "commit": "24ca688c516a86a68de9cffaab2d5a9215291256",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+    "gf_sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "5ca3af64ae7a0a45221cdafdcabce2bfa700975e19f1ccb9557269cecef92bf1",
+    "profile_id": "graph500-s22-provider",
+    "profile_sha256": "57b7401694903b887d57345623581b6e73dd368b589bb8da1db7074b166db0b6"
+  },
+  "limits": {
+    "cores": 16,
+    "memory_bytes": 4294967296,
+    "wall_seconds": 14400
+  },
+  "outputs": [
+    "s22-plan.json",
+    "s22-benchexec.json",
+    "s22-graphforge.json",
+    "s22-rung.json",
+    "s22-result.json"
+  ],
+  "rung": "S22",
+  "schema": "graphforge-progressive-host-run-plan/1",
+  "work_root_capacity": {
+    "free_bytes": 633357647872,
+    "reserved_headroom_bytes": 141258578535
+  }
+}

--- a/docs/development/evidence/integrated-storage-1194/s22-projection.json
+++ b/docs/development/evidence/integrated-storage-1194/s22-projection.json
@@ -1,0 +1,83 @@
+{
+  "checks": {
+    "correctness": true,
+    "io_reader_publication_capacity_measured": true,
+    "io_reader_publication_headroom": true,
+    "retained_storage_headroom": true,
+    "rss_bounded_or_plateaued": true,
+    "rss_headroom": true,
+    "storage_headroom": true,
+    "time_headroom": true,
+    "transient_storage_headroom": true
+  },
+  "claim": "engineering_evidence_only",
+  "decision": "admitted",
+  "headroom": {
+    "rss_fraction": 0.2,
+    "storage_fraction": 0.22303129836611368,
+    "time_fraction": 0.2
+  },
+  "limits": {
+    "rss_bytes": 4294967296,
+    "volume_bytes": 633357647872,
+    "wall_seconds": 14400
+  },
+  "native_capacity": {
+    "free_bytes": 633357647872,
+    "observed_rates": {
+      "physical_read_bytes_per_second": {
+        "wall_seconds": 192,
+        "work_units": 110290894848
+      },
+      "physical_write_bytes_per_second": {
+        "wall_seconds": 192,
+        "work_units": 37230034944
+      },
+      "publication_work_per_second": {
+        "wall_seconds": 192,
+        "work_units": 126894
+      },
+      "reader_calls_per_second": {
+        "wall_seconds": 385,
+        "work_units": 491135
+      }
+    },
+    "rate_source": "completed_adjacent_rungs",
+    "reserved_headroom_bytes": 141258578535
+  },
+  "projected": {
+    "logical_read_bytes": 182828692298,
+    "logical_write_bytes": 82179537224,
+    "peak_rss_bytes": 211603456,
+    "physical_read_bytes": 898608381952,
+    "physical_write_bytes": 299361816576,
+    "publication_work_units": 1030174,
+    "reader_calls": 1965833,
+    "retained_storage_bytes": 17652477952,
+    "storage_peak_bytes": 47590948864,
+    "transient_peak_storage_bytes": 47590948864,
+    "wall_seconds": 1543
+  },
+  "provider_capacity": null,
+  "required_rates": {
+    "physical_read_bytes_per_second": 78004200,
+    "physical_write_bytes_per_second": 25986269,
+    "publication_work_per_second": 90,
+    "reader_calls_per_second": 171
+  },
+  "rss_growth_fraction": 0.06020516601964909,
+  "schema": "graphforge-progressive-qualification-evidence/1",
+  "slopes_observed": {
+    "logical_read_bytes": 22865477859,
+    "logical_write_bytes": 10275838359,
+    "physical_read_bytes": 112616783872,
+    "physical_write_bytes": 37447397376,
+    "publication_work_units": 129040,
+    "reader_calls": 245783
+  },
+  "source_scales": [
+    19,
+    20
+  ],
+  "target": "S22"
+}

--- a/docs/development/evidence/integrated-storage-1194/s22-result.json
+++ b/docs/development/evidence/integrated-storage-1194/s22-result.json
@@ -1,0 +1,28 @@
+{
+  "artifacts": {
+    "benchexec_sha256": "8469a85e7dfe21d1d6de78db20f31e34592a9c045410f1191f60e1d7a7102b7b",
+    "graphforge_sha256": "69a33b9d2d8fb90dd501e95d902cdbdff3f615bd9dceb7920a6f85cb275cf332",
+    "plan_sha256": "c7cf566bb13c2f9a4982f48623cb4e25d3f88bbe399f1c315f1c4a19666ded08",
+    "rung_sha256": "44aeb767186712b8baefdeb33f8beb7a2e62d917819878591b91087023c84076"
+  },
+  "claim": "engineering_evidence_only",
+  "failure": null,
+  "identities": {
+    "admitted_projection_sha256": "028a80d509e8edb4cfcd3b0f387a08a4b9bf80ad935516e0d5db859e58a856b6",
+    "benchexec_python_sha256": "52e0a13e60a981d8c4b6478be2ba5176f69da07948a056bf49cf6f077e30cb41",
+    "benchexec_version": "3.35",
+    "certify_sha256": "db3440a249f51078fa0214ef1a7030d5fb03719a3fa298315ccdf1211b5ec81a",
+    "commit": "24ca688c516a86a68de9cffaab2d5a9215291256",
+    "generator": "sha256:a7cd8397ce191c48094d8812eb43dfc894084645dd439e76fb8704b35bb61fdc",
+    "generator_executable_sha256": "4829806c4666d1c21e2afd680fec3c8749588be713e493233e81b77eb2bcf551",
+    "gf_sha256": "ebb01caed1b6ee197b0fd679e24957d671f50e108f4298e4b606bf9fa3947921",
+    "host_profile_id": "local-linux-cgroups-v2",
+    "host_profile_sha256": "21cbcd01a0896ad8ed9d4aae1ab933cb143d41636fdf66297ead9bb89c3681bf",
+    "producer_sha256": "5ca3af64ae7a0a45221cdafdcabce2bfa700975e19f1ccb9557269cecef92bf1",
+    "profile_id": "graph500-s22-provider",
+    "profile_sha256": "57b7401694903b887d57345623581b6e73dd368b589bb8da1db7074b166db0b6"
+  },
+  "rung": "S22",
+  "schema": "graphforge-progressive-host-run-result/1",
+  "status": "passed"
+}

--- a/docs/development/evidence/integrated-storage-1194/s22-rung.json
+++ b/docs/development/evidence/integrated-storage-1194/s22-rung.json
@@ -1,0 +1,490 @@
+{
+  "assembly_contract": "graphforge-progressive-rung-assembly/3",
+  "correctness": true,
+  "failure": null,
+  "live_edges": 67108864,
+  "metric_sources": {
+    "benchexec": [
+      "wall_seconds",
+      "physical_read_bytes",
+      "physical_write_bytes"
+    ],
+    "graphforge_process": [
+      "peak_rss_bytes"
+    ],
+    "query_qualification": [
+      "live_edges",
+      "correctness"
+    ],
+    "storage_attribution": [
+      "retained_storage_bytes",
+      "transient_peak_storage_bytes",
+      "logical_read_bytes",
+      "logical_write_bytes",
+      "reader_calls",
+      "publication_work_units"
+    ]
+  },
+  "metrics": {
+    "logical_read_bytes": 193069289732,
+    "logical_write_bytes": 92215886265,
+    "peak_rss_bytes": 263090176,
+    "physical_read_bytes": 947578322944,
+    "physical_write_bytes": 414307926016,
+    "publication_work_units": 1039028,
+    "reader_calls": 2287487,
+    "retained_storage_bytes": 17813295104,
+    "transient_peak_storage_bytes": 47657119744,
+    "wall_seconds": 1776
+  },
+  "phases": [
+    "admission",
+    "generate",
+    "ingest",
+    "reopen",
+    "recount",
+    "query",
+    "export",
+    "verify",
+    "clean_import",
+    "reopen_proof"
+  ],
+  "profile_id": "graph500-s22-provider",
+  "scale": 22,
+  "source": "canonical_ladder",
+  "status": "passed",
+  "storage_attribution": {
+    "construction": {
+      "application_io": {
+        "phases": {
+          "append_merge": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 1088,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 14518761856,
+            "write_calls": 34112
+          },
+          "cas_install_read_write": {
+            "block_count": 0,
+            "fsync_calls": 13341,
+            "object_count": 0,
+            "read_bytes": 2799486209,
+            "read_calls": 49173,
+            "write_bytes": 2796149993,
+            "write_calls": 46160
+          },
+          "encode_write_postwrite_authentication": {
+            "block_count": 0,
+            "fsync_calls": 2388,
+            "object_count": 0,
+            "read_bytes": 25501741827,
+            "read_calls": 654795,
+            "write_bytes": 6081760278,
+            "write_calls": 173882
+          },
+          "fsync_synchronization": {
+            "block_count": 0,
+            "fsync_calls": 51301,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "hydration_verification": {
+            "block_count": 0,
+            "fsync_calls": 19,
+            "object_count": 0,
+            "read_bytes": 2960596381,
+            "read_calls": 45397,
+            "write_bytes": 168145111,
+            "write_calls": 2568
+          },
+          "publication_preauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 367883,
+            "read_calls": 4,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "recovery_reauthentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 74945564407,
+            "read_calls": 116501,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "seal_authentication": {
+            "block_count": 0,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 0,
+            "read_calls": 0,
+            "write_bytes": 0,
+            "write_calls": 0
+          },
+          "shape_consume_reauthentication": {
+            "block_count": 127633,
+            "fsync_calls": 0,
+            "object_count": 0,
+            "read_bytes": 86861533025,
+            "read_calls": 1421617,
+            "write_bytes": 68651069027,
+            "write_calls": 87238
+          }
+        },
+        "totals": {
+          "block_count": 127633,
+          "fsync_calls": 67049,
+          "object_count": 1088,
+          "read_bytes": 193069289732,
+          "read_calls": 2287487,
+          "write_bytes": 92215886265,
+          "write_calls": 343960
+        }
+      },
+      "staging": {
+        "allocated_bytes": 2794696704,
+        "logical_bytes": 2792451093,
+        "logical_references": 1104,
+        "physical_logical_bytes": 2792451093,
+        "physical_objects": 1104
+      },
+      "staging_transient_peak_allocated_bytes": 41050935296,
+      "transient_peak_allocated_bytes": 41050935296
+    },
+    "counts": {
+      "imported_edges": 67108864,
+      "imported_nodes": 4194304,
+      "source_edges": 67108864,
+      "source_nodes": 4194304
+    },
+    "imported": {
+      "allocated_physical_bytes": 2796015616,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 1339392,
+          "logical_bytes": 367277,
+          "logical_references": 327,
+          "physical_logical_bytes": 367277,
+          "physical_objects": 327
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 1263366144,
+          "logical_bytes": 1261294928,
+          "logical_references": 1024,
+          "physical_logical_bytes": 1261294928,
+          "physical_objects": 1024
+        },
+        "topology_nodes": {
+          "allocated_bytes": 16777216,
+          "logical_bytes": 16636135,
+          "logical_references": 64,
+          "physical_logical_bytes": 16636135,
+          "physical_objects": 64
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 1514532864,
+          "logical_bytes": 1514517330,
+          "logical_references": 12,
+          "physical_logical_bytes": 1514517330,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 2792815670,
+      "logical_references": 1427,
+      "physical_objects": 1424,
+      "retained_logical_eof_bytes": 2792815670
+    },
+    "lifecycle": {
+      "contract": "graphforge-lifecycle-storage/2",
+      "retained_owners": {
+        "generated-inputs": {
+          "totals": {
+            "allocated_bytes": 3289362432,
+            "logical_bytes": 3289349601,
+            "logical_references": 2,
+            "physical_logical_bytes": 3289349601,
+            "physical_objects": 2
+          }
+        },
+        "imported-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "imported-project-construction": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-import": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 0,
+            "physical_logical_bytes": 0,
+            "physical_objects": 0
+          }
+        },
+        "imported-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "imported-project-published": {
+          "totals": {
+            "allocated_bytes": 2808377344,
+            "logical_bytes": 2796153411,
+            "logical_references": 4443,
+            "physical_logical_bytes": 2796153411,
+            "physical_objects": 4443
+          }
+        },
+        "imported-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        },
+        "portable-package": {
+          "totals": {
+            "allocated_bytes": 2793910272,
+            "logical_bytes": 2793903104,
+            "logical_references": 1,
+            "physical_logical_bytes": 2793903104,
+            "physical_objects": 1
+          }
+        },
+        "query-results": {
+          "totals": {
+            "allocated_bytes": 98304,
+            "logical_bytes": 71228,
+            "logical_references": 8,
+            "physical_logical_bytes": 71228,
+            "physical_objects": 8
+          }
+        },
+        "source-project-admission_lock": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 1,
+            "physical_logical_bytes": 0,
+            "physical_objects": 1
+          }
+        },
+        "source-project-construction": {
+          "totals": {
+            "allocated_bytes": 2823782400,
+            "logical_bytes": 2798775908,
+            "logical_references": 7583,
+            "physical_logical_bytes": 2798775908,
+            "physical_objects": 7583
+          }
+        },
+        "source-project-import": {
+          "totals": {
+            "allocated_bytes": 3289370624,
+            "logical_bytes": 3289353824,
+            "logical_references": 3,
+            "physical_logical_bytes": 3289353824,
+            "physical_objects": 3
+          }
+        },
+        "source-project-locks": {
+          "totals": {
+            "allocated_bytes": 0,
+            "logical_bytes": 0,
+            "logical_references": 3,
+            "physical_logical_bytes": 0,
+            "physical_objects": 3
+          }
+        },
+        "source-project-published": {
+          "totals": {
+            "allocated_bytes": 2808385536,
+            "logical_bytes": 2796153411,
+            "logical_references": 4443,
+            "physical_logical_bytes": 2796153411,
+            "physical_objects": 4443
+          }
+        },
+        "source-project-transactions": {
+          "totals": {
+            "allocated_bytes": 4096,
+            "logical_bytes": 628,
+            "logical_references": 1,
+            "physical_logical_bytes": 628,
+            "physical_objects": 1
+          }
+        }
+      },
+      "retained_storage_bytes": 17813295104,
+      "source_project_current_allocated_bytes": 2808385536,
+      "transient_peak_storage_bytes": 47657119744
+    },
+    "portable_package": {
+      "allocation_allocated_bytes": 2793910272,
+      "allocation_logical_bytes": 2793903104,
+      "allocation_physical_objects": 1,
+      "contract": "graphforge-portable-export/2"
+    },
+    "source": {
+      "allocated_physical_bytes": 2796023808,
+      "categories": {
+        "adjacency": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "catalog_and_manifests": {
+          "allocated_bytes": 1339392,
+          "logical_bytes": 367277,
+          "logical_references": 327,
+          "physical_logical_bytes": 367277,
+          "physical_objects": 327
+        },
+        "clean_imported_project": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "construction_staging": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "other": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "portable_package": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "properties": {
+          "allocated_bytes": 0,
+          "logical_bytes": 0,
+          "logical_references": 0,
+          "physical_logical_bytes": 0,
+          "physical_objects": 0
+        },
+        "topology_edges": {
+          "allocated_bytes": 1263366144,
+          "logical_bytes": 1261294928,
+          "logical_references": 1024,
+          "physical_logical_bytes": 1261294928,
+          "physical_objects": 1024
+        },
+        "topology_nodes": {
+          "allocated_bytes": 16777216,
+          "logical_bytes": 16636135,
+          "logical_references": 64,
+          "physical_logical_bytes": 16636135,
+          "physical_objects": 64
+        },
+        "uuid_and_surrogates": {
+          "allocated_bytes": 1514541056,
+          "logical_bytes": 1514517330,
+          "logical_references": 12,
+          "physical_logical_bytes": 1514517330,
+          "physical_objects": 9
+        }
+      },
+      "contract": "graphforge-storage-attribution/1",
+      "logical_bytes": 2792815670,
+      "logical_references": 1427,
+      "physical_objects": 1424,
+      "retained_logical_eof_bytes": 2792815670
+    }
+  },
+  "storage_components": {
+    "imported_allocated_physical_bytes": 2796015616,
+    "imported_retained_logical_eof_bytes": 2792815670,
+    "logical_read_bytes": 193069289732,
+    "logical_write_bytes": 92215886265,
+    "publication_work_units": 1039028,
+    "reader_calls": 2287487,
+    "source_allocated_physical_bytes": 2796023808,
+    "source_project_current_allocated_bytes": 2808385536,
+    "source_retained_logical_eof_bytes": 2792815670,
+    "transient_peak_allocated_bytes": 41050935296
+  }
+}

--- a/docs/development/integrated-storage-1194.md
+++ b/docs/development/integrated-storage-1194.md
@@ -1,0 +1,176 @@
+# Integrated storage and query evidence for #1194
+
+The epic implemented permanent-storage reductions, one permanent Parquet encoding policy, query execution improvements, and the lifecycle repairs needed to preserve exact public behavior. The final measurement source is `24ca688c516a86a68de9cffaab2d5a9215291256`, after the construction reader repair (#1257) and operation timing repair (#1256). The final S20/S22 lifecycle passes, but the existing capacity projection returns refuse; final capacity/S26 remains the explicit open outcome.
+
+## Implemented improvements and measured costs
+
+These are separate representative workloads. Their savings must not be added or their speedups multiplied. The linked evidence retains source/executable identities, command results, budgets and unsuccessful observations.
+
+| Concern | Implemented outcome and evidence | Measured tradeoff or boundary |
+| --- | --- | --- |
+| Permanent inventory and topology/property Parquet | [#1196 census](evidence/permanent-storage-1196.json) and [#1202 repair](evidence/permanent-parquet-1202.json) cover topology, properties, identities, manifests, catalog and derived adjacency. Sequential permanent allocation fell from 8,388,608 to 4,112,384 bytes; random from 8,929,280 to 7,585,792. | Four heterogeneous/route fixtures and current-format exact lifecycle tests supplement the property-free host ladder. Whole-test CPU/RSS observations are not isolated codec costs. |
+| Membership representation | [#1203 packed membership](evidence/packed-membership-1203.json) removes reserved padding while preserving full-width identity, kind and tombstone information. | Physical savings depend on allocation rounding; exact current-format readers, recovery and corruption refusal remain required. |
+| Manifest allocation | [#1204 bounded buckets](evidence/bounded-manifest-1204.json): the same 352-entry fixture uses 209 objects / 856,064 allocated bytes instead of 483 / 1,978,368; permanent allocation falls from 9,814,016 to 8,691,712. | Bounded authenticated bucket lookup replaces separate tiny objects. The earlier 544-entry assessment is a different fixture. |
+| CSR representation | [#1205 bounded CSR](evidence/bounded-csr-1205.json): payload 4,920,564→1,324,020 bytes, allocation 4,972,544→1,363,968; cold CSR reads 35,552,246→9,577,462 bytes. | Whole-fixture RSS rises from 220,400 to 238,252 KiB; observed query time 3.855→3.891 s does not establish a latency gain. Decode windows remain bounded. |
+| Every verified permanent publisher | [#1213 shared policy](evidence/permanent-parquet-1213.json) applies Zstd level 1 across the verified publishing paths; compaction Parquet allocation 569,344→335,872 bytes on its fixture. | Preserve dictionaries-off compaction, its 8,192-row groups, and justified local streaming/memory settings. Whole-process user CPU 11.89→12.41 s and RSS 156,284→159,492 KiB rise; syscall read/write and sampled temporary allocation fall. |
+| Input predicate placement | [#1241](evidence/input-predicates-1241.json): fixed-path candidates 1,113,889→272, key rows 8,932,490→80,898; warm query median 3.850→0.254 s. | Observed CPU 31→2.1 s and RSS 153,640→101,544 KiB improve on this workload; physical filesystem input blocks are unchanged. |
+| Property projection | [#1247](evidence/property-projection-1247.json): narrow property query median 290.6→27.8 ms; CPU 1.55→0.22 s, RSS 136,192→76,692 KiB. | Full-width median 293.6→309.2 ms is slower within its preselected envelope. Physical input blocks are unchanged; avoiding overlay materialization is not permission to skip authentication. |
+| Qualified count row marker | [#1249 final implementation](evidence/count-row-marker-1249.json): count-all median 14.45→10.93 ms; affected counts avoid about 923.9 KB read and 308.8 KB write syscalls over five queries. | The explicit identity-count RSS control failed its original cap by 232 KiB. Fixed follow-up observations and the bounded disposition remain in the evidence; do not claim all final RSS caps passed. Nullable count, SUM and selective-property controls preserve their semantics. |
+
+The [five-candidate assessment](evidence/query-maintenance-assessment-1207.json) also measured optimizer statistics, Parquet layout, property Bloom filters and fragmentation/maintenance. Statistics forwarding changed plans but missed the preselected CPU threshold across seven workloads and was reverted. A 128-row-group layout reduced sparse second-pass compressed column reads from 8,094,549 to 1,012,462 bytes, excluding mandatory validation, but doubled repeated-text allocation and increased dense second-pass reads; the global change was rejected. The 16 KiB page target was byte-identical on 30/30 files. Plain strings saved 45,056 bytes for random text but breached the RSS cap and grew repeated-text allocation. Bloom filters had no false negatives in the tested present-value probes but no admitted public consumer that could skip mandatory validation, so demonstrated public read savings were zero. Existing compaction folded runs and cleanup reclaimed retained generations; approximately 14 ms warm query latency stayed flat, and compaction missed its read-I/O budget in all three cases. These quantified decisions do not substitute for the implemented opportunities above.
+
+## Public publishing and correctness
+
+The [current publishing contract](../book/architecture/storage.md#current-publishing-contract) and [#1221 evidence](evidence/publishing-contract-1221.json) cover public construction, ordinary mutation, property replay, compaction, ontology publication, projections, portable clean import and participant writers. All verified permanent Parquet publishers use the shared policy; replay and compaction retain it. Separate lifecycle implementations remain.
+
+The four `permanent_storage_budgets` publishing-contract fixtures exercise flat/sharded and exploratory/ontology-promoted graphs through real construction or CREATE, property mutation, compaction, canonical topology mutation, reopen, export, full verification, clean import and subsequent mutation. Exact UUIDs, endpoints, routes, nullable properties and allocation continuation are compared. Adjacent recovery, cancellation, retained-stream, promotion and ownership regressions cover their applicable boundaries. Unsupported topology journals fail closed; no legacy reader or compatibility fallback was added.
+
+#1257 fixes publication on the same facade: the selected workspace, property inventory, adjacency provider and ordinal resolver rotate together at stable paths. The strengthened public construction regression checks exact initial/child/replayed/reopened relationship tuples and counts, cancellation/retry, three real preparation-failure boundaries and retained lazy streams. #1249 adds exact 129-row property mutation/snapshot/reopen/export/verify/import/subsequent-mutation proof; #1253 preserves typed corruption refusal. Logical plans or wrapper tests are not the evidence for these claims.
+
+## Final admitted host run
+
+The existing `progressive_host_run` controller uses `--maximum-scale 22`, the unchanged `local-linux-cgroups-v2` profile and generator, and the original 141,258,578,535-byte reserve on OVHC-AGENCY. The native root is ext4, with 941,723,856,896 total bytes. Executables were built once from merged source, copied outside Cargo and SHA-256 frozen before any subprocess measurement; no build or other resource campaign overlapped this run. S22 may start only after S20 passes and the controller admits its measured headroom. No S24/S26 run or new certification workflow is used.
+
+The executed build was `make -C benchmarks progressive-host-ladder-binaries HOST_TARGET_DIR=/home/ubuntu/code/graphforge-target-1195`, with `TMPDIR=/home/ubuntu/graphforge-native-tmp-1195` and `CARGO_BUILD_JOBS=4`. The API, execution, relational, IR and storage release packages were invalidated before building to avoid stale shared-target dependency metadata. The [summary](evidence/integrated-storage-1194.json) records the source tree, Rust version, lockfile digests and all three frozen executable hashes.
+
+From `benchmarks`, the existing controller command was:
+
+```bash
+PYTHONPATH=harness uv run --locked python -m graphforge_bench.progressive_host_run \
+  --maximum-scale 22 \
+  --output-dir /home/ubuntu/graphforge-ladder/1194-24ca688c-evidence \
+  --work-root /home/ubuntu/graphforge-ladder/1194-24ca688c-work \
+  --gf /home/ubuntu/graphforge-ladder/1194-24ca688c-bin/gf \
+  --certify /home/ubuntu/graphforge-ladder/1194-24ca688c-bin/graphforge-benchmark-certify \
+  --generator /home/ubuntu/graphforge-ladder/1194-24ca688c-bin/graphforge-benchmark-graph500-generator \
+  --benchexec-python /usr/bin/python3 \
+  --reserved-headroom-bytes 141258578535
+```
+
+| Rung | Live edges | Wall s | CPU s | Process VmHWM B | Cgroup peak B | Retained union B | Lifecycle peak B |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| S18 | 4,194,304 | 96.245 | 80.258 | 182,611,968 | 819,265,536 | 1,065,082,880 | 2,974,519,296 |
+| S19 | 8,388,608 | 191.478 | 161.155 | 188,862,464 | 1,577,000,960 | 2,159,190,016 | 5,948,940,288 |
+| S20 | 16,777,216 | 384.686 | 327.278 | 200,232,960 | 3,118,157,824 | 4,372,516,864 | 11,897,737,216 |
+| S22 | 67,108,864 | 1775.591 | 1551.682 | 263,090,176 | 12,474,519,552 | 17,813,295,104 | 47,657,119,744 |
+
+| Rung | Logical reads B | Logical writes B | BenchExec reads B | BenchExec writes B |
+| --- | --- | --- | --- | --- |
+| S18 | 11,360,063,649 | 5,117,151,595 | 54,517,145,600 | 18,559,918,080 |
+| S19 | 22,770,347,285 | 10,248,668,711 | 110,290,894,848 | 37,230,034,944 |
+| S20 | 45,635,825,144 | 20,524,507,070 | 222,907,678,720 | 74,677,432,320 |
+| S22 | 193,069,289,732 | 92,215,886,265 | 947,578,322,944 | 414,307,926,016 |
+
+All four rungs passed all ten ordinary lifecycle phases. [Sanitized receipts](evidence/integrated-storage-1194/) and the [derived summary](evidence/integrated-storage-1194.json) retain exact byte values, identities and hashes. The shared native rung reader validated schemas, artifact hashes, phase success and equality with recomputed ordinary-receipt summaries. Frozen executable hashes were unchanged after the run.
+
+Process `VmHWM` is distinct from BenchExec cgroup memory, which includes charged page cache. Logical application bytes are distinct from process/BenchExec read and write observations. Accounted Arrow/live-state budgets are not native RSS limits. Sampled peaks are observations, not hard bounds.
+
+#1256 records disjoint public construction-call wall times for begin, resume, append, seal and publication. These successful receipt observations exclude source decoding, normalization, facade opening and import checkpoints outside those calls. Resume is not all recovery-authentication I/O, and the sum is not whole-ingest duration or CPU time. Returned errors are recorded by the live Rust handle; failed CLI commands and lost processes cannot reconstruct unreported durations. Timing observations never enter durable manifests. The existing receipts do not provide per-operation CPU or native-memory peaks; those measurements remain whole-process observations rather than inferred phase values.
+
+| Rung | Operation | Calls | Wall s | Returned errors |
+| --- | --- | --- | --- | --- |
+| S20 | begin | 1 | 0.000955 | 0 |
+| S20 | append | 272 | 16.737041 | 0 |
+| S20 | seal | 1 | 177.088074 | 0 |
+| S20 | resume | 1 | 0.975587 | 0 |
+| S20 | publish | 1 | 9.436728 | 0 |
+| S22 | begin | 1 | 0.000920 | 0 |
+| S22 | append | 1,088 | 68.519419 | 0 |
+| S22 | seal | 1 | 923.237336 | 0 |
+| S22 | resume | 1 | 3.811642 | 0 |
+| S22 | publish | 1 | 38.586566 | 0 |
+
+| Rung | Whole-ingest wall s | Reopen wall s | Export wall s | Full verify wall s | Clean import wall s |
+| --- | --- | --- | --- | --- | --- |
+| S20 | 228.672 | 12.622 | 7.901 | 0.973 | 10.841 |
+| S22 | 1139.389 | 51.299 | 31.842 | 4.474 | 43.675 |
+
+## Physical ownership and historical comparison
+
+| Rung | Allocation | Historical B | Final B | Reduction |
+| --- | --- | --- | --- | --- |
+| S20 | Selected project permanent | 1,852,637,184 | 681,910,272 | 63.19% |
+| S20 | Retained lifecycle | 18,242,637,824 | 4,372,516,864 | 76.03% |
+| S20 | Simultaneous lifecycle peak | 20,090,777,600 | 11,897,737,216 | 40.78% |
+| S22 | Selected project permanent | 7,578,365,952 | 2,808,385,536 | 62.94% |
+| S22 | Retained lifecycle | 73,638,645,760 | 17,813,295,104 | 75.81% |
+| S22 | Simultaneous lifecycle peak | 81,197,961,216 | 47,657,119,744 | 41.31% |
+
+| Rung | Allocation | Historical B/node | Final B/node | Historical B/edge | Final B/edge |
+| --- | --- | --- | --- | --- | --- |
+| S20 | Selected project permanent | 1766.812 | 650.320 | 110.426 | 40.645 |
+| S20 | Retained lifecycle | 17397.535 | 4169.957 | 1087.346 | 260.622 |
+| S20 | Simultaneous lifecycle peak | 19160.059 | 11346.566 | 1197.504 | 709.160 |
+| S22 | Selected project permanent | 1806.823 | 669.571 | 112.926 | 41.848 |
+| S22 | Retained lifecycle | 17556.821 | 4247.021 | 1097.301 | 265.439 |
+| S22 | Simultaneous lifecycle peak | 19359.103 | 11362.343 | 1209.944 | 710.146 |
+
+At S22, retained/current-project amplification is 9.717→6.343, while peak/current-project amplification is 10.714→16.970. Permanent output shrinks faster than the remaining peak, so the second ratio can rise despite the substantial absolute peak reduction. Observed whole-lifecycle wall time is 1954.185→1775.591 seconds and CPU is 1747.748→1551.682 seconds; these are single-run observations.
+
+The [older 3868e3c7 baseline receipts](evidence/integrated-storage-1194/historical-3868e3c7/) and final run use identical generator/workload/host profiles. Both sides pass the shared native reader's schema, artifact-hash, identity and recomputed-summary checks. The interim 9312a470 run is retained honestly: it completed through S22 but lacked the operation timings and preceded the same-facade reader repair. A single run per source does not establish variance or isolate each repair's contribution. Historical logical I/O instrumentation differs, including recovery attribution; changes in those totals cannot be assigned solely to a new algorithmic cost.
+
+Retained lifecycle allocation is a unique physical-file union. Component snapshots and named owners may refer to those same files, so their totals must not be added to the union. The final owner census is not a timestamped decomposition of an earlier simultaneous peak. Construction staging's retained allocation, its peak and the whole construction owner are different quantities.
+
+| S22 retained owner | Historical B | Final B |
+| --- | --- | --- |
+| source-project-import | 3,289,366,528 | 3,289,370,624 |
+| generated-inputs | 3,289,358,336 | 3,289,362,432 |
+| source-project-construction | 44,344,586,240 | 2,823,782,400 |
+| source-project-published | 7,578,365,952 | 2,808,385,536 |
+| imported-project-published | 7,578,365,952 | 2,808,377,344 |
+| portable-package | 7,558,496,256 | 2,793,910,272 |
+| query-results | 98,304 | 98,304 |
+| imported-project-transactions | 4,096 | 4,096 |
+| source-project-transactions | 4,096 | 4,096 |
+
+Construction staging peak is 44,315,299,840→41,050,935,296 bytes. The retained construction owner and the earlier staging maximum are not interchangeable: retiring intermediates removes later coexistence but cannot erase an already incurred shaping peak. The final lifecycle peak remains larger than final retained allocation by 29,843,824,640 bytes. The receipts do not provide a timestamped per-owner decomposition of that maximum.
+
+| S22 selected-source category | Allocated B | Physical logical B |
+| --- | --- | --- |
+| adjacency | 0 | 0 |
+| catalog_and_manifests | 1,339,392 | 367,277 |
+| clean_imported_project | 0 | 0 |
+| construction_staging | 0 | 0 |
+| other | 0 | 0 |
+| portable_package | 0 | 0 |
+| properties | 0 | 0 |
+| topology_edges | 1,263,366,144 | 1,261,294,928 |
+| topology_nodes | 16,777,216 | 16,636,135 |
+| uuid_and_surrogates | 1,514,541,056 | 1,514,517,330 |
+
+The host graph is property-free and does not retain a built CSR; the separate property-bearing and indexed fixtures above prove those categories. Identity authorities remain a material permanent cost because forward/reverse lookups, exact external UUIDs and ordinal access have different consumers. Generated input, the import-owned copy, the portable package and source/imported publications remain distinct measured lifecycle owners. These retained artifacts are not proof of interchangeable authority or permission to remove a consumer's data.
+
+| S22 construction I/O phase | Read B | Write B | Read calls | Write calls | Fsync calls |
+| --- | --- | --- | --- | --- | --- |
+| append_merge | 0 | 14,518,761,856 | 0 | 34,112 | 0 |
+| cas_install_read_write | 2,799,486,209 | 2,796,149,993 | 49,173 | 46,160 | 13,341 |
+| encode_write_postwrite_authentication | 25,501,741,827 | 6,081,760,278 | 654,795 | 173,882 | 2,388 |
+| fsync_synchronization | 0 | 0 | 0 | 0 | 51,301 |
+| hydration_verification | 2,960,596,381 | 168,145,111 | 45,397 | 2,568 | 19 |
+| publication_preauthentication | 367,883 | 0 | 4 | 0 | 0 |
+| recovery_reauthentication | 74,945,564,407 | 0 | 116,501 | 0 | 0 |
+| seal_authentication | 0 | 0 | 0 | 0 | 0 |
+| shape_consume_reauthentication | 86,861,533,025 | 68,651,069,027 | 1,421,617 | 87,238 | 0 |
+
+From S20 to S22, live edges grow 4×, retained bytes 4.074×, simultaneous peak 4.006×, logical reads 4.231× and writes 4.493×. The source-bound deterministic 1x/2x/4x tests assert the configured work-window and phase ceilings; these host observations do not turn sampled process peaks into hard bounds. The construction constant-factor defect is materially reduced in absolute retained and simultaneous peak allocation, while shaping and authenticated recovery remain substantial costs and final capacity remains unresolved.
+
+## Acceptance ledger and remaining capacity
+
+| #901 acceptance criterion | Direct evidence and outcome |
+| --- | --- |
+| One authoritative construction chunk budget (#979) | `million_edge_sink_uses_sixteen_durable_chunks_and_replays_stably` in `crates/graphforge-api/tests/scale_g500_ladder.rs`; real accepted chunks and replay. Final host receipts retain configured/submitted batch counts. |
+| Linear phase rows/bytes with deterministic ceilings | `construction_application_reads_reconcile_and_scale_at_one_two_four` in `resumable_construction.rs` checks 4,096/8,192/16,384-node phase reconciliation. `equivalent_full_lifecycle_1x_2x_4x_has_bounded_metric_policies` exercises the actual complete lifecycle. |
+| Resident topology bounded by work windows | `tiny_construction_ladder_resumes_and_scales_bounded_work_linearly` asserts configured batches/run/catalog windows and at most 64 MiB accounted live state, with a separate linear merge-disk bound. Process memory is observed separately in the final host table. |
+| Physical owner reconciliation (#951) | `construction_lifecycle_multilevel_allocation_baseline` in `construction_lifecycle_tests.rs`, native lifecycle owner receipts and independent tiny union/owner inventories. The final table distinguishes retained union and historical simultaneous peak. |
+| No complete prior-topology scan per batch | `journal_is_constant_control_state_and_seal_reopens_every_artifact`, `canonical_encoder_outputs_feed_ordinary_readers_index_and_adjacency`, `construction_append_publishes_current_complete_ordinal_authority`, and `reopen_recovers_surrogate_tails_without_full_topology_reads` assert direct scan/row boundaries. |
+| Authenticated immediate/recovery consumers | #971/#1195 and `shape_inventory_and_evidence_commit_recover_without_double_counting`; #1257 installs current generation readers together. Immediate authority and durable recovery authentication remain distinct. |
+| Interrupted resume, cancellation, prior authority and corruption refusal | `construction_session_reenters_across_processes`; the storage `supersession_crashes_reconcile_removed_allocations_and_replay`, `supersession_returned_errors_preserve_prior_authority_and_retry`, `supersession_corrupt_successors_and_replaced_predecessors_fail_closed`, `supersession_all_published_replay_paths_refuse_corrupt_public_payload`, and `supersession_cancellation_during_authentication_and_removal_is_recoverable` tests. |
+| Real public construction/query/reopen/export/verify/import | #1221's four publishing paths, #1249's property/snapshot lifecycle, #1257's exact same-facade construction tuples and three failure/retry boundaries, and the final ordinary CLI host lifecycle. No wrapper-only or plan-only substitution. |
+| Named-host S20, then admitted S22 with full measurements | Passed S18/S19/S20/S22 on merged source, in that order with native admission; exact receipts and observations above. Successful operation receipts record append/seal/resume wall times with the documented scopes; physical allocation, process memory, CPU and both logical/BenchExec I/O remain separately reported. |
+| Required checks and merged work | Implementation PRs #1258 and #1259 passed exact-head CI Gate before squash merge; their issues are verified closed. Earlier linked implementation evidence records its exact commands and CI. Completion also requires this focused evidence PR to pass the exact-head CI Gate and merge; #901 records that outcome. |
+
+The epic's permanent encoding, representation, publishing-path correctness and five query-opportunity concerns are fulfilled by the merged evidence above. Final storage headroom/capacity remains a distinct outcome; no assessment-only or compression-only completion is claimed.
+
+The existing [native S20/S22 qualification](evidence/integrated-storage-1194/s20-s22-storage-qualification.json) returns **refuse**: projected S26 lifecycle peak 762,866,827,264 bytes, available capacity 633,354,096,640 bytes and reserve 141,258,578,535 bytes. The deficit against available capacity after reserve is 270,771,309,159 bytes. Here the schema's `volume_bytes` field is measured **available** capacity, not the filesystem's total size. No S26 workload was executed.
+
+The native S20/S22 qualification is a capacity projection, not S26 execution or publication certification. Final capacity/S26 remains open in #1194/#900/#745 because the projection is refused and S26 is unproved. #901 closes only after its construction/lower-rung outcomes and this focused evidence PR pass their required checks and merge.


### PR DESCRIPTION
Closes #901.

The final construction gate lacked integrated host evidence after the same-facade reader and operation-timing repairs. This records the existing admitted S18/S19/S20/S22 lifecycle on frozen executables from merged `24ca688c`, alongside matched historical S20/S22 receipts and the direct acceptance-test ledger. S22 retained allocation falls 75.81% and simultaneous lifecycle peak falls 41.31%; the report separates permanent storage, overlapping owners, phase work, CPU, process/cgroup memory and unsuccessful query observations.

The existing capacity projection still refuses S26 by 270,771,309,159 bytes after reserve. #1194/#900/#745 retain final capacity/S26; no S24/S26 execution or new certification workflow was started. This PR changes documentation and sanitized evidence only.

Validation: all four final rungs and both historical rungs passed the shared native reader's schemas, artifact hashes, identities and recomputed ordinary-receipt checks; all committed JSON passed content sanitization, links resolve, and frozen executable hashes were unchanged. Gate registry: 14 tests passed. `cargo fmt --all -- --check`, workspace Clippy and `make pre-push-fast` passed. Full `make pre-push` reached 739 passing API tests, 118 BDD scenarios and 3,897 TCK scenarios, then stopped at the existing #1192 hardcoded-`/tmp` admission failure (`wave9_participant_inventory_rejects_links_and_special_files`: storage 1,097 passed / 1 failed / 2 existing ignored). Later full-gate stages did not run; full local validation is not claimed green. No test or assertion was changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/CurateLabs/codesmith/graphforge/pr/1260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791726721&installation_model_id=20486&pr_number=1260&repository=CurateLabs%2Fgraphforge&return_to=https%3A%2F%2Fgithub.com%2FCurateLabs%2Fgraphforge%2Fpull%2F1260&signature=957247a006164e940d86e5c81e312bf610c77dcf72bea7ec96a4ac7296fd237f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->